### PR TITLE
Test why tag actions is skipped, dryRun = true for real

### DIFF
--- a/.github/workflows/tag-openhouse.yml
+++ b/.github/workflows/tag-openhouse.yml
@@ -1,10 +1,5 @@
 name: Bump version and push tag
 on:
-  pull_request:
-    types:
-      - closed
-    branches:
-      - main
   workflow_run:
     workflows: ["Gradle Build OpenHouse"]
     types:
@@ -30,5 +25,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true # prefix for tag "v"
           DEFAULT_BUMP: patch # major, minor, patch
-          DRY_RUN: false # if true, will not push tag
+          DRY_RUN: true # if true, will not push tag
           INITIAL_VERSION: 0.5.0 # if no tags, will use this version

--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,12 @@ ext {
   spark_version = "3.1.1"
 }
 
+group = 'com.linkedin.openhouse'
+
 subprojects {
   buildDir = "${rootProject.buildDir}/${project.name}"
+  group = rootProject.group
+  version = rootProject.version
 }
 
 allprojects {


### PR DESCRIPTION
## Summary

In the previous [PR](https://github.com/linkedin/openhouse/pull/7) we saw github action for tagging skipped. Debugging why that would be the case. Also dryRun for real now, to not create tags while testing.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [X] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.