### PR TITLE
Get latest tag and push to linkedin jfrog artifactory

### DIFF
--- a/.github/workflows/build-tag-publish.yml
+++ b/.github/workflows/build-tag-publish.yml
@@ -37,3 +37,15 @@ jobs:
           DEFAULT_BUMP: patch # major, minor, patch
           DRY_RUN: false # if true, will not push tag
           INITIAL_VERSION: 0.5.0 # if no tags, will use this version
+
+      - name: Get the latest tag
+        id: get_tag
+        if: ${{ success() }}
+        run: |
+          latest_tag=$(git describe --tags --abbrev=0 main)
+          semVer=${latest_tag:1} # Remove the first character ('v')
+          echo "::set-output name=semVer::${semVer}"
+
+      - name: Publish with Gradle
+        if: ${{ success() }}
+        run: ./gradlew publish -pVersion=${{ steps.get_tag.outputs.semVer }}

--- a/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
+++ b/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
@@ -59,6 +59,16 @@ publishing {
   }
   repositories {
     mavenLocal()
+    maven {
+      name = 'LinkedInJFrog'
+      url = 'https://linkedin.jfrog.io/artifactory/openhouse'
+      if (System.getenv('JFROG_USERNAME') != null && System.getenv('JFROG_API_KEY') != null) {
+        credentials {
+          username System.getenv('JFROG_USERNAME')
+          password System.getenv('JFROG_API_KEY')
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Updated the workflow to fetche the latest tag using the git describe command, removes the leading 'v' from it, and sets it as an output. Then, it uses this output to publish with Gradle.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [X] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

## Testing
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [X] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Merge and verify if the github action is publishing correctly.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.
