### PR TITLE
Fix the Gradle Publish typo

### DIFF
--- a/.github/workflows/build-tag-publish.yml
+++ b/.github/workflows/build-tag-publish.yml
@@ -48,4 +48,4 @@ jobs:
 
       - name: Publish with Gradle
         if: ${{ success() }}
-        run: ./gradlew publish -pVersion=${{ steps.get_tag.outputs.semVer }}
+        run: ./gradlew publish -Pversion=${{ steps.get_tag.outputs.semVer }}


### PR DESCRIPTION
## Summary

Typo in the gradle publish 
```./gradlew publish -Pversion```

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [X] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [X] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

https://github.com/linkedin/openhouse/actions/runs/7999164244/job/21846912648
`The specified project directory '/home/runner/work/openhouse/openhouse/Version=0.5.3' does not exist.`

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.