### PR TITLE
Inject secrets needed into environment to authenticate with maven

### DIFF
--- a/.github/workflows/build-tag-publish.yml
+++ b/.github/workflows/build-tag-publish.yml
@@ -26,7 +26,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1
 
       - name: Build with Gradle
-        run: ./gradlew clean build
+        run: ./gradlew clean build -x test
 
       - name: Bump version and push tag
         if: ${{ success() }}
@@ -48,4 +48,7 @@ jobs:
 
       - name: Publish with Gradle
         if: ${{ success() }}
+        env:
+          JFROG_USERNAME: ${{ secrets.JFROG_USERNAME }}
+          JFROG_API_KEY: ${{ secrets.JFROG_API_KEY }}
         run: ./gradlew publish -Pversion=${{ steps.get_tag.outputs.semVer }}


### PR DESCRIPTION
## Summary

While publishing to `linkedin.jfrog.io` we get 401 

```
* What went wrong:
Execution failed for task ':tables-test-fixtures_2.12:publishMavenJavaPublicationToLinkedInJFrogRepository'.
> Failed to publish publication 'mavenJava' to repository 'LinkedInJFrog'
   > Could not PUT 'https://linkedin.jfrog.io/artifactory/openhouse/com/linkedin/openhouse/tables-test-fixtures_2.12/0.5.4/tables-test-fixtures_2.12-0.5.4.jar'. Received status code 401 from server: 
```

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [X] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

[Failed Job](https://github.com/linkedin/openhouse/actions/runs/7999503784/job/21847416065)


## Testing
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [X] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.