### PR TITLE
Jfrog user info for publishing

### DIFF
--- a/.github/workflows/build-tag-publish.yml
+++ b/.github/workflows/build-tag-publish.yml
@@ -47,5 +47,5 @@ jobs:
         if: ${{ success() }}
         env:
           JFROG_USERNAME: ${{ secrets.JFROG_USERNAME }}
-          JFROG_API_KEY: ${{ secrets.JFROG_API_KEY }}
+          JFROG_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
         run: ./gradlew publish -Pversion=${{ steps.get_tag.outputs.semVer }}

--- a/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
+++ b/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
@@ -62,11 +62,9 @@ publishing {
     maven {
       name = 'LinkedInJFrog'
       url = 'https://linkedin.jfrog.io/artifactory/openhouse'
-      if (System.getenv('JFROG_USERNAME') != null && System.getenv('JFROG_API_KEY') != null) {
-        credentials {
-          username System.getenv('JFROG_USERNAME')
-          password System.getenv('JFROG_API_KEY')
-        }
+      credentials {
+        username System.getenv('JFROG_USERNAME')
+        password System.getenv('JFROG_PASSWORD')
       }
     }
   }


### PR DESCRIPTION
## Summary

Still getting this error
https://github.com/linkedin/openhouse/actions/runs/7999503784/job/21847416065
```
* What went wrong:
Execution failed for task ':tables-test-fixtures_2.12:publishMavenJavaPublicationToLinkedInJFrogRepository'.
> Failed to publish publication 'mavenJava' to repository 'LinkedInJFrog'
   > Could not PUT 'https://linkedin.jfrog.io/artifactory/openhouse/com/linkedin/openhouse/tables-test-fixtures_2.12/0.5.4/tables-test-fixtures_2.12-0.5.4.jar'. Received status code 401 from server: 
```

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [X] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [X] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.