### PR TITLE
Publishing packages that are dependencies of existing published package

### DIFF
--- a/apps/spark/build.gradle
+++ b/apps/spark/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'openhouse.java-conventions'
     id 'openhouse.hadoop-conventions'
     id 'openhouse.iceberg-conventions'
+    id 'openhouse.maven-publish'
     id 'com.github.johnrengelman.shadow' version '6.0.0'
 }
 

--- a/cluster/configs/build.gradle
+++ b/cluster/configs/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'openhouse.java-conventions'
+  id 'openhouse.maven-publish'
   id 'java-library'
 }
 

--- a/cluster/metrics/build.gradle
+++ b/cluster/metrics/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'openhouse.java-conventions'
+  id 'openhouse.maven-publish'
 }
 
 dependencies {

--- a/cluster/storage/build.gradle
+++ b/cluster/storage/build.gradle
@@ -1,6 +1,7 @@
 plugins {
   id 'openhouse.java-conventions'
   id 'openhouse.hadoop-conventions'
+  id 'openhouse.maven-publish'
 }
 
 dependencies {

--- a/iceberg/openhouse/htscatalog/build.gradle
+++ b/iceberg/openhouse/htscatalog/build.gradle
@@ -2,5 +2,6 @@ plugins {
     id 'openhouse.springboot-conventions'
     id 'openhouse.hadoop-conventions'
     id 'openhouse.iceberg-conventions'
+    id 'openhouse.maven-publish'
 }
 

--- a/integrations/java/openhouse-java-itest/build.gradle
+++ b/integrations/java/openhouse-java-itest/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'openhouse.java-minimal-conventions'
+  id 'openhouse.maven-publish'
 }
 
 ext {

--- a/integrations/spark/openhouse-spark-itest/build.gradle
+++ b/integrations/spark/openhouse-spark-itest/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'openhouse.java-minimal-conventions'
+  id 'openhouse.maven-publish'
 }
 
 dependencies {

--- a/scripts/java/tools/dummytokens/build.gradle
+++ b/scripts/java/tools/dummytokens/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'openhouse.java-conventions'
+    id 'openhouse.maven-publish'
     id 'application'
 }
 apply plugin: 'application'

--- a/services/common/build.gradle
+++ b/services/common/build.gradle
@@ -2,6 +2,7 @@ plugins {
   id 'openhouse.java-conventions'
   id 'openhouse.iceberg-conventions'
   id 'openhouse.hadoop-conventions'
+  id 'openhouse.maven-publish'
   id 'java-test-fixtures'
 }
 


### PR DESCRIPTION
## Summary

We have existing published packages that depend upon other subprojects in the repo. For example,
```
Execution failed for task ':resolveDependencies'.
> Could not resolve all dependencies for configuration ':detachedConfiguration273'.
   > Could not resolve com.linkedin.openhouse:common:0.5.4.
     Required by:
         project : > com.linkedin.openhouse:tables:0.5.4
      > Could not resolve com.linkedin.openhouse:common:0.5.4.
```
To resolve this dependency publishing the subproject dependencies as well.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [X] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

Resolve sub-project dependencies.

## Testing
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [X] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Plan to check if resolution from linkedin.jfrog.io artifactory works after this publishing.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.