### PR TITLE
Checkin a CNAME file

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+www.openhousedb.org


### PR DESCRIPTION
## Summary

We need to merge CNAME file so that it does not get lost on each deploy of gh pages. Today, when we add a new domain, from GH pages UI, it generates this file. As shown [here](https://github.com/linkedin/openhouse/blob/gh-pages/CNAME)

But when a new deploy happens this file is deleted as found [here](https://github.com/linkedin/openhouse/tree/dd9fc2644abe57dee77ddf78d231ec5ef7df12e9) from the latest docsite deploy.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [X] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

## Testing
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [X] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Merge of this PR will manually validate if the custom domain does not get unmapped.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.