### PR TITLE
Bump springdoc-openapi-webmvc-core version to ensure spring-webmvc exceeds v5.3.18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,6 @@ allprojects {
       force 'com.fasterxml.jackson:jackson-bom:2.13.4'
       force 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
       force 'org.apache.orc:orc-core:1.8.3'
-      force 'org.springframework:spring-webmvc:5.3.18'
     }
   }
 

--- a/buildSrc/src/main/groovy/openhouse.springboot-conventions.gradle
+++ b/buildSrc/src/main/groovy/openhouse.springboot-conventions.gradle
@@ -33,8 +33,8 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa:' + springVersion
   implementation 'com.h2database:h2:' + '2.1.210'
 
-  implementation 'org.springdoc:springdoc-openapi-ui:1.6.1'
-  implementation 'org.springdoc:springdoc-openapi-data-rest:1.6.1'
+  implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
+  implementation 'org.springdoc:springdoc-openapi-data-rest:1.6.9'
   implementation 'io.swagger.core.v3:swagger-annotations:2.1.11'
 
   implementation("javax.servlet:javax.servlet-api:4.0.1")


### PR DESCRIPTION
## Summary
It turns out that forcing is not necessary as Gradle is smart enough to pick the higher version when there are both `5.3.13`  and `5.3.18` of `org.springframework:spring-webmvc` appeared. However this doesn't prohibit the version `5.3.13` itself being present in the resolution tree. Thus when dependency tree is resolved, the version `5.3.13` will still cause security vulnerability. 

This change is eliminate the presence of `5.3.13` from the source. `org.springdoc:springdoc-openapi-ui:1.6.9` is depending on `5.3.20` of `org.springframework:spring-webmvc`

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

See the dependency tree updated below
```
|    +--- org.springdoc:springdoc-openapi-webmvc-core:1.6.9
|    |    +--- org.springdoc:springdoc-openapi-common:1.6.9
|    |    |    +--- org.springframework.boot:spring-boot-autoconfigure:2.7.0 -> 2.7.11 (*)
|    |    |    +--- org.springframework:spring-web:5.3.20 (*)
|    |    |    \--- io.swagger.core.v3:swagger-core:2.2.0
|    |    |         +--- jakarta.xml.bind:jakarta.xml.bind-api:2.3.2
|    |    |         |    \--- jakarta.activation:jakarta.activation-api:1.2.1
|    |    |         +--- org.apache.commons:commons-lang3:3.12.0
|    |    |         +--- org.slf4j:slf4j-api:1.7.35 -> 1.7.36
|    |    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.13.2 -> 2.13.4 (*)
|    |    |         +--- com.fasterxml.jackson.core:jackson-databind:2.13.2.2 -> 2.13.4 (*)
|    |    |         +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2 -> 2.13.4
|    |    |         |    +--- com.fasterxml.jackson.core:jackson-databind:2.13.4 (*)
|    |    |         |    +--- org.yaml:snakeyaml:1.31
|    |    |         |    +--- com.fasterxml.jackson.core:jackson-core:2.13.4 (*)
|    |    |         |    \--- com.fasterxml.jackson:jackson-bom:2.13.4 (*)
|    |    |         +--- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.2 -> 2.13.4 (*)
|    |    |         +--- io.swagger.core.v3:swagger-annotations:2.2.0
|    |    |         +--- io.swagger.core.v3:swagger-models:2.2.0
|    |    |         |    \--- com.fasterxml.jackson.core:jackson-annotations:2.13.2 -> 2.13.4 (*)
|    |    |         \--- jakarta.validation:jakarta.validation-api:2.0.2
|    |    \--- org.springframework:spring-webmvc:5.3.20 (*)
```

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.