### PR TITLE
Adding Delta Table Format to OpenHouse, a proof-of-concept

### DIFF
--- a/infra/recipes/docker-compose/common/spark/spark-base-hadoop3.2.dockerfile
+++ b/infra/recipes/docker-compose/common/spark/spark-base-hadoop3.2.dockerfile
@@ -82,6 +82,7 @@ RUN mkdir -p "${LIVY_HOME}/logs"
 COPY /infra/recipes/docker-compose/common/spark/start-spark.sh /
 COPY /build/openhouse-spark-runtime_2.12/libs/*[^sources][^javadoc].jar $SPARK_HOME/openhouse-spark-runtime_2.12-latest-all.jar
 COPY /build/openhouse-spark-apps_2.12/libs/openhouse-spark-apps_2.12-*-all.jar $SPARK_HOME/openhouse-spark-apps_2.12-latest-all.jar
+COPY /build/spark-delta-client/libs/spark-delta-client-*-all.jar $SPARK_HOME/spark-delta-client-latest-all.jar
 COPY /build/dummytokens/libs/dummytokens*.jar /dummytokens.jar
 RUN java -jar /dummytokens.jar -d /var/config/
 

--- a/integrations/spark-delta-client/build.gradle
+++ b/integrations/spark-delta-client/build.gradle
@@ -1,0 +1,66 @@
+plugins {
+  id 'openhouse.java-minimal-conventions'
+  id 'com.github.johnrengelman.shadow' version '6.0.0'
+}
+
+repositories {
+  mavenCentral()
+}
+
+
+dependencies {
+
+  compileOnly("org.apache.spark:spark-sql_2.12:3.1.1")
+
+  implementation("io.delta:delta-core_2.12:1.0.+")
+  implementation("io.delta:delta-standalone_2.12:0.5.0")
+  implementation("io.delta:delta-storage:1.+")
+  implementation("org.apache.iceberg:iceberg-spark-runtime-3.1_2.12:1.2.0")
+
+  implementation(project(':client:secureclient')){
+    exclude group: 'org.slf4j'
+    exclude group: 'ch.qos.logback'
+    exclude group: 'org.apache.logging.slf4j'
+    exclude group: 'org.apache.logging.log4j'
+    exclude group: 'io.netty'
+  }
+  implementation(project(':client:tableclient')){
+    exclude group: 'org.slf4j'
+    exclude group: 'ch.qos.logback'
+    exclude group: 'org.apache.logging.slf4j'
+    exclude group: 'org.apache.logging.log4j'
+    exclude group: 'io.netty'
+  }
+  compileOnly("org.springframework.boot:spring-boot-starter-webflux:2.6.1"){
+    exclude group: 'org.slf4j'
+    exclude group: 'ch.qos.logback'
+    exclude group: 'org.apache.logging.slf4j'
+    exclude group: 'org.apache.logging.log4j'
+    exclude group: 'io.netty'
+  }
+
+
+
+  // Libraries required for spark
+  testImplementation("org.apache.spark:spark-sql_2.12:3.1.1"){
+    exclude group: "io.netty"
+  }
+  testImplementation("org.apache.spark:spark-core_2.12:3.1.1") {
+    exclude group: "io.netty"
+  }
+  // Libraries required for tables-test-fixtures
+  // TODO: [BDP-18150] This is a temp workaround for jasper-oh integration
+  testImplementation(project(path: ':tables-test-fixtures_2.12')){
+    exclude group: 'org.slf4j'
+    exclude group: 'ch.qos.logback'
+    exclude group: 'org.apache.logging.slf4j'
+    exclude group: 'org.apache.logging.log4j'
+    exclude group: 'io.netty'
+  }
+  testRuntime("org.eclipse.jetty:jetty-server:11.0.2")
+  testImplementation "com.fasterxml.jackson.module:jackson-module-scala_2.12:2.13.1"
+  testRuntimeOnly 'io.netty:netty-resolver-dns-native-macos:4.1.70.Final:osx-x86_64'
+  testImplementation 'io.netty:netty-codec-http:4.1.75.Final'
+  testImplementation 'io.netty:netty-codec-http2:4.1.75.Final'
+
+}

--- a/integrations/spark-delta-client/src/main/java/com/linkedin/openhouse/delta/OHCatalog.java
+++ b/integrations/spark-delta-client/src/main/java/com/linkedin/openhouse/delta/OHCatalog.java
@@ -1,0 +1,170 @@
+package com.linkedin.openhouse.delta;
+
+import com.linkedin.openhouse.client.ssl.HttpConnectionStrategy;
+import com.linkedin.openhouse.client.ssl.TablesApiClientFactory;
+import com.linkedin.openhouse.tables.client.api.DeltaSnapshotApi;
+import com.linkedin.openhouse.tables.client.api.TableApi;
+import com.linkedin.openhouse.tables.client.invoker.ApiClient;
+import com.linkedin.openhouse.tables.client.model.CreateUpdateTableRequestBody;
+import com.linkedin.openhouse.tables.client.model.GetAllTablesResponseBody;
+import com.linkedin.openhouse.tables.client.model.GetTableResponseBody;
+import java.net.MalformedURLException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.net.ssl.SSLException;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.catalog.TableChange;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.delta.catalog.DeltaTableV2;
+import org.apache.spark.sql.delta.storage.OHLogStore;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import scala.Option;
+
+public class OHCatalog implements TableCatalog {
+  private static final String INITIAL_TABLE_VERSION = "-1";
+  private static final String AUTH_TOKEN = "auth-token";
+  private static final String TRUST_STORE = "trust-store";
+  private static final String HTTP_CONNECTION_STRATEGY = "http-connection-strategy";
+  public TableApi tableApi;
+
+  public DeltaSnapshotApi deltaSnapshotApi;
+  private String clusterName;
+
+  @Override
+  public Identifier[] listTables(String[] namespace) throws NoSuchNamespaceException {
+    if (namespace.length > 1) {
+      throw new ValidationException(
+          "Input namespace has more than one levels " + String.join(".", namespace));
+    } else if (namespace.length == 0) {
+      throw new ValidationException(
+          "DatabaseId was not provided, for SQL please run \"SHOW TABLES IN <databaseId>\" instead");
+    }
+    List<Identifier> tables =
+        tableApi
+            .searchTablesV1(namespace[0])
+            .map(GetAllTablesResponseBody::getResults)
+            .flatMapMany(Flux::fromIterable)
+            .map(
+                x -> {
+                  assert x.getTableId() != null;
+                  return Identifier.of(new String[] {x.getDatabaseId()}, x.getTableId());
+                })
+            .collectList()
+            .block();
+    assert tables != null;
+    return tables.toArray(new Identifier[0]);
+  }
+
+  @Override
+  public Table loadTable(Identifier ident) throws NoSuchTableException {
+    Optional<GetTableResponseBody> a =
+        tableApi
+            .getTableV1(ident.namespace()[0], ident.name())
+            .onErrorResume(WebClientResponseException.NotFound.class, e -> Mono.empty())
+            .blockOptional();
+    if (!a.isPresent()) {
+      throw new NoSuchTableException(ident);
+    }
+
+    assert a.get().getTableLocation() != null;
+    assert a.get().getTableProperties() != null;
+
+    OHLogStore.TABLE_CACHE.put(ident, a.get());
+    return new DeltaTableV2(
+        SparkSession.active(),
+        new Path(a.get().getTableLocation()),
+        Option.empty(),
+        Option.apply(ident.toString()),
+        Option.empty(),
+        new CaseInsensitiveStringMap(a.get().getTableProperties()));
+  }
+
+  @Override
+  public Table createTable(
+      Identifier ident, StructType schema, Transform[] partitions, Map<String, String> properties)
+      throws TableAlreadyExistsException, NoSuchNamespaceException {
+    CreateUpdateTableRequestBody createUpdateTableRequestBody = new CreateUpdateTableRequestBody();
+    createUpdateTableRequestBody.setTableId(ident.name());
+    createUpdateTableRequestBody.setDatabaseId(ident.namespace()[0]);
+    createUpdateTableRequestBody.setClusterId(clusterName);
+    createUpdateTableRequestBody.setBaseTableVersion(INITIAL_TABLE_VERSION);
+    createUpdateTableRequestBody.setSchema(schema.json());
+    createUpdateTableRequestBody.setTableProperties(properties);
+    GetTableResponseBody a =
+        tableApi.createTableV1(ident.namespace()[0], createUpdateTableRequestBody).block();
+    assert a != null;
+    assert a.getTableLocation() != null;
+    assert a.getTableProperties() != null;
+    return new DeltaTableV2(
+        SparkSession.active(),
+        new Path(a.getTableLocation()),
+        Option.empty(),
+        Option.apply(ident.toString()),
+        Option.empty(),
+        new CaseInsensitiveStringMap(a.getTableProperties()));
+  }
+
+  @Override
+  public Table alterTable(Identifier ident, TableChange... changes) throws NoSuchTableException {
+    return null;
+  }
+
+  @Override
+  public boolean dropTable(Identifier ident) {
+    if (!tableExists(ident)) {
+      return false;
+    }
+    tableApi.deleteTableV1(ident.namespace()[0], ident.name()).block();
+    return true;
+  }
+
+  @Override
+  public void renameTable(Identifier oldIdent, Identifier newIdent)
+      throws NoSuchTableException, TableAlreadyExistsException {}
+
+  @Override
+  public void initialize(String name, CaseInsensitiveStringMap options) {
+    try {
+      String uri = options.get(CatalogProperties.URI);
+      Preconditions.checkNotNull(uri, "OpenHouse Table Service URI is required");
+      String truststore = options.getOrDefault(TRUST_STORE, "");
+      String token = options.getOrDefault(AUTH_TOKEN, null);
+      String httpConnectionStrategy = options.getOrDefault(HTTP_CONNECTION_STRATEGY, null);
+      clusterName = options.get("cluster");
+      ApiClient apiClient = null;
+      try {
+        TablesApiClientFactory tablesApiClientFactory = TablesApiClientFactory.getInstance();
+        tablesApiClientFactory.setStrategy(
+            HttpConnectionStrategy.fromString(httpConnectionStrategy));
+        apiClient = TablesApiClientFactory.getInstance().createApiClient(uri, token, truststore);
+      } catch (MalformedURLException | SSLException e) {
+        throw new RuntimeException(
+            "OpenHouse Catalog initialization failed: Failure while initializing ApiClient", e);
+      }
+      tableApi = new TableApi(apiClient);
+      deltaSnapshotApi = new DeltaSnapshotApi(apiClient);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Override
+  public String name() {
+    return "openhouse";
+  }
+}

--- a/integrations/spark-delta-client/src/main/java/org/apache/spark/sql/delta/storage/OHLogStore.java
+++ b/integrations/spark-delta-client/src/main/java/org/apache/spark/sql/delta/storage/OHLogStore.java
@@ -1,0 +1,70 @@
+package org.apache.spark.sql.delta.storage;
+
+import com.linkedin.openhouse.delta.OHCatalog;
+import com.linkedin.openhouse.tables.client.api.DeltaSnapshotApi;
+import com.linkedin.openhouse.tables.client.api.TableApi;
+import com.linkedin.openhouse.tables.client.model.DeltaActionsRequestBody;
+import com.linkedin.openhouse.tables.client.model.GetTableResponseBody;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.SparkConf;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.delta.actions.Action;
+import org.apache.spark.sql.delta.actions.CommitInfo;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import scala.collection.Iterator;
+
+public class OHLogStore extends HDFSLogStore {
+
+  TableApi _tableApi;
+  DeltaSnapshotApi _deltaSnapshotApi;
+
+  public static final ConcurrentHashMap<Identifier, GetTableResponseBody> TABLE_CACHE =
+      new ConcurrentHashMap<>();
+
+  public OHLogStore(SparkConf sparkConf, Configuration defaultHadoopConf) {
+    super(sparkConf, defaultHadoopConf);
+    String prefix = "spark.sql.catalog.openhouse.";
+    Map<String, String> stringStringMap = new HashMap();
+    Arrays.stream(sparkConf.getAllWithPrefix(prefix)).forEach(x -> stringStringMap.put(x._1, x._2));
+    OHCatalog ohCatalog = new OHCatalog();
+    ohCatalog.initialize("openhouse", new CaseInsensitiveStringMap(stringStringMap));
+    _tableApi = ohCatalog.tableApi;
+    _deltaSnapshotApi = ohCatalog.deltaSnapshotApi;
+  }
+
+  @Override
+  public void write(Path path, Iterator<String> actions, boolean overwrite) {
+    // Hack to get tableMetadata
+    // solving it the right way can be done via
+    // TableApi.searchApi(location=path.toString()) and then get the dbId and tableId
+    GetTableResponseBody lastLoadedTable =
+        TABLE_CACHE.entrySet().stream()
+            .filter(x -> path.toString().contains(x.getValue().getTableLocation()))
+            .collect(Collectors.toList())
+            .get(0)
+            .getValue();
+
+    DeltaActionsRequestBody deltaActionsRequestBody = new DeltaActionsRequestBody();
+
+    List<String> actionsList = new ArrayList<>();
+    actions.toStream().foreach(x -> actionsList.add(x));
+    deltaActionsRequestBody.setJsonActions(actionsList);
+
+    Integer baseVersion =
+        ((Long) ((CommitInfo) Action.fromJson(actionsList.get(0))).readVersion().get()).intValue();
+
+    deltaActionsRequestBody.setBaseTableVersion(baseVersion.toString());
+    _deltaSnapshotApi
+        .patchDeltaActionsV1(
+            lastLoadedTable.getDatabaseId(), lastLoadedTable.getTableId(), deltaActionsRequestBody)
+        .block();
+  }
+}

--- a/integrations/spark-delta-client/src/test/java/com/linkedin/openhouse/delta/BaseLiOHTest.java
+++ b/integrations/spark-delta-client/src/test/java/com/linkedin/openhouse/delta/BaseLiOHTest.java
@@ -1,0 +1,30 @@
+package com.linkedin.openhouse.delta;
+
+import com.linkedin.openhouse.tablestest.OpenHouseLocalServer;
+import com.linkedin.openhouse.tablestest.OpenHouseSparkITest;
+import java.net.URI;
+import org.apache.spark.sql.SparkSession;
+
+public class BaseLiOHTest extends OpenHouseSparkITest {
+
+  private static OpenHouseLocalServer openHouseLocalServer = null;
+
+  @Override
+  protected synchronized SparkSession getSparkSession() throws Exception {
+    if (openHouseLocalServer == null) {
+      openHouseLocalServer = new OpenHouseLocalServer();
+      openHouseLocalServer.start();
+    }
+    return SparkSession.builder()
+        .master("local[1]")
+        .config(
+            "spark.sql.catalog.openhouse.uri",
+            URI.create("http://localhost:" + openHouseLocalServer.getPort()).toString())
+        .config("spark.sql.catalog.openhouse.cluster", "local-cluster")
+        .config("spark.sql.sources.partitionOverwriteMode", "dynamic")
+        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        .config("spark.sql.catalog.openhouse", "com.linkedin.openhouse.delta.OHCatalog")
+        .config("spark.delta.logStore.class", "org.apache.spark.sql.delta.storage.OHLogStore")
+        .getOrCreate();
+  }
+}

--- a/integrations/spark-delta-client/src/test/java/com/linkedin/openhouse/delta/tests/SimpleTest.java
+++ b/integrations/spark-delta-client/src/test/java/com/linkedin/openhouse/delta/tests/SimpleTest.java
@@ -1,0 +1,18 @@
+package com.linkedin.openhouse.delta.tests;
+
+import com.linkedin.openhouse.delta.BaseLiOHTest;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.Test;
+
+public class SimpleTest extends BaseLiOHTest {
+
+  @Test
+  public void basicSQLCatalog() throws Exception {
+    SparkSession sparkSession = getSparkSession();
+    sparkSession.sql("CREATE TABLE openhouse.db.t3 (col1 string, col2 string, col3 string)").show();
+    sparkSession.sql("INSERT INTO openhouse.db.t3 VALUES ('a', 'b', 'c')").show();
+    sparkSession.sql("INSERT INTO openhouse.db.t3 VALUES ('c', 'd', 'd')").show();
+    sparkSession.sql("SELECT * FROM openhouse.db.t3").show();
+    sparkSession.sql("DROP TABLE openhouse.db.t3").show();
+  }
+}

--- a/services/tables/build.gradle
+++ b/services/tables/build.gradle
@@ -20,6 +20,10 @@ plugins {
   id 'openhouse.service-specgen-convention'
 }
 
+repositories {
+  mavenCentral()
+}
+
 dependencies {
   implementation project(':services:common')
   implementation project(':iceberg:openhouse:internalcatalog')
@@ -27,6 +31,7 @@ dependencies {
   implementation project(':cluster:configs')
   implementation project(':cluster:storage')
   implementation project(':cluster:metrics')
+  implementation("io.delta:delta-standalone_2.12:0.5.0")
   implementation 'org.springframework.security:spring-security-config:' + '5.7.2'
   implementation 'org.springframework.boot:spring-boot-starter-webflux:2.6.6'
   testCompile 'org.junit.jupiter:junit-jupiter-engine:5.8.1'

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v1/request/DeltaActionsRequestBody.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v1/request/DeltaActionsRequestBody.java
@@ -1,0 +1,31 @@
+package com.linkedin.openhouse.tables.api.spec.v1.request;
+
+import com.google.gson.Gson;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import javax.validation.constraints.NotEmpty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@EqualsAndHashCode
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeltaActionsRequestBody {
+
+  @Schema(description = "Base Table Version", example = "Base table version to apply the change to")
+  @NotEmpty(message = "baseTableVersion cannot be empty")
+  private String baseTableVersion;
+
+  @Schema(description = "List of json serialized snapshots to put")
+  private List<String> jsonActions;
+
+  public String toJson() {
+    return new Gson().toJson(this);
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/OpenHouseTablesApiValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/OpenHouseTablesApiValidator.java
@@ -79,8 +79,7 @@ public class OpenHouseTablesApiValidator implements TablesApiValidator {
               "databaseId : provided %s, doesn't match with the RequestBody %s",
               databaseId, createUpdateTableRequestBody.getDatabaseId()));
     }
-    if (createUpdateTableRequestBody.getSchema() != null
-        && getSchemaFromSchemaJson(createUpdateTableRequestBody.getSchema()).columns().isEmpty()) {
+    if (createUpdateTableRequestBody.getSchema() == null) {
       validationFailures.add(
           String.format(
               "schema : provided %s, should contain at least one column",
@@ -192,8 +191,7 @@ public class OpenHouseTablesApiValidator implements TablesApiValidator {
               "tableId : provided %s, doesn't match with the RequestBody %s",
               tableId, createUpdateTableRequestBody.getTableId()));
     }
-    if (createUpdateTableRequestBody.getSchema() != null
-        && getSchemaFromSchemaJson(createUpdateTableRequestBody.getSchema()).columns().isEmpty()) {
+    if (createUpdateTableRequestBody.getSchema() != null) {
       validationFailures.add(
           String.format(
               "schema : provided %s, should contain at least one column",

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/DeltaActionsController.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/DeltaActionsController.java
@@ -1,0 +1,68 @@
+package com.linkedin.openhouse.tables.controller;
+
+import static com.linkedin.openhouse.common.security.AuthenticationUtils.*;
+
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
+import com.linkedin.openhouse.tables.api.spec.v1.request.DeltaActionsRequestBody;
+import com.linkedin.openhouse.tables.dto.mapper.TablesMapper;
+import com.linkedin.openhouse.tables.model.TableDto;
+import com.linkedin.openhouse.tables.services.DeltaActionsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class DeltaActionsController {
+
+  @Autowired private DeltaActionsService deltaActionsService;
+
+  @Autowired private TablesMapper tablesMapper;
+
+  @Operation(
+      summary = "Puts Delta snapshots to Table",
+      description = "Puts Delta snapshots to Table",
+      tags = {"DeltaSnapshot"})
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "201", description = "Delta snapshot PATCH: CREATED"),
+        @ApiResponse(responseCode = "200", description = "Delta snapshot PATCH: UPDATED"),
+        @ApiResponse(responseCode = "400", description = "Delta snapshot PATCH: BAD_REQUEST"),
+        @ApiResponse(responseCode = "409", description = "Delta snapshot PATCH: CONFLICT")
+      })
+  @PatchMapping(
+      value = {"/v1/databases/{databaseId}/tables/{tableId}/delta/v1/actions"},
+      produces = {"application/json"},
+      consumes = {"application/json"})
+  public ResponseEntity<GetTableResponseBody> patchDeltaActions(
+      @Parameter(description = "Database ID", required = true) @PathVariable String databaseId,
+      @Parameter(description = "Table ID", required = true) @PathVariable String tableId,
+      @Parameter(
+              description =
+                  "Request containing a list of JSON serialized Iceberg Snapshots to be put",
+              required = true,
+              schema = @Schema(implementation = DeltaActionsRequestBody.class))
+          @RequestBody
+          DeltaActionsRequestBody deltaActionsRequestBody) {
+    TableDto tableDto =
+        deltaActionsService.appendDeltaActions(
+            databaseId, tableId, deltaActionsRequestBody, extractAuthenticatedUserPrincipal());
+
+    com.linkedin.openhouse.common.api.spec.ApiResponse<GetTableResponseBody> apiResponse =
+        com.linkedin.openhouse.common.api.spec.ApiResponse.<GetTableResponseBody>builder()
+            .httpStatus(HttpStatus.OK)
+            .responseBody(tablesMapper.toGetTableResponseBody(tableDto))
+            .build();
+
+    return new ResponseEntity<>(
+        apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseDeltaInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseDeltaInternalRepositoryImpl.java
@@ -1,0 +1,269 @@
+package com.linkedin.openhouse.tables.repository.impl;
+
+import static com.linkedin.openhouse.internal.catalog.mapper.HouseTableSerdeUtils.*;
+import static com.linkedin.openhouse.tables.repository.impl.InternalRepositoryUtils.*;
+
+import com.google.common.collect.ImmutableMap;
+import com.linkedin.openhouse.cluster.storage.filesystem.FsStorageProvider;
+import com.linkedin.openhouse.cluster.storage.filesystem.HdfsStorageProvider;
+import com.linkedin.openhouse.internal.catalog.model.HouseTable;
+import com.linkedin.openhouse.internal.catalog.model.HouseTablePrimaryKey;
+import com.linkedin.openhouse.internal.catalog.repository.HouseTableRepository;
+import com.linkedin.openhouse.internal.catalog.repository.exception.HouseTableNotFoundException;
+import com.linkedin.openhouse.tables.common.TableType;
+import com.linkedin.openhouse.tables.dto.mapper.iceberg.PartitionSpecMapper;
+import com.linkedin.openhouse.tables.dto.mapper.iceberg.PoliciesSpecMapper;
+import com.linkedin.openhouse.tables.dto.mapper.iceberg.TableTypeMapper;
+import com.linkedin.openhouse.tables.model.TableDto;
+import com.linkedin.openhouse.tables.model.TableDtoPrimaryKey;
+import com.linkedin.openhouse.tables.repository.OpenHouseInternalRepository;
+import io.delta.standalone.DeltaLog;
+import io.delta.standalone.Operation;
+import io.delta.standalone.OptimisticTransaction;
+import io.delta.standalone.actions.Action;
+import io.delta.standalone.actions.CommitInfo;
+import io.delta.standalone.actions.Metadata;
+import io.delta.standalone.internal.util.ConversionUtils;
+import io.delta.standalone.types.StructType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+/**
+ * Delta implementation for internal repository. In the future, we can layer it so that Iceberg and
+ * Delta are served through a common layer.
+ */
+@Primary
+@Component
+@Slf4j
+public class OpenHouseDeltaInternalRepositoryImpl implements OpenHouseInternalRepository {
+
+  @Autowired HdfsStorageProvider hdfsStorageProvider;
+
+  @Autowired FsStorageProvider fsStorageProvider;
+
+  @Autowired OpenHouseInternalRepositoryImpl openHouseInternalRepository; // TODO: clean this up
+
+  @Autowired HouseTableRepository houseTableRepository;
+
+  @Autowired PoliciesSpecMapper policiesMapper;
+
+  @Autowired PartitionSpecMapper partitionSpecMapper;
+
+  @Autowired TableTypeMapper tableTypeMapper;
+
+  @Override
+  public List<TableDto> findAllByDatabaseId(String databaseId) {
+    return houseTableRepository.findAllByDatabaseId(databaseId).stream()
+        .map(x -> TableDto.builder().databaseId(x.getDatabaseId()).tableId(x.getTableId()).build())
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<TableDtoPrimaryKey> findAllIds() {
+    return null;
+  }
+
+  @Override
+  public List<TableDto> searchTables(String databaseId) {
+    return houseTableRepository.findAllByDatabaseId(databaseId).stream()
+        .map(x -> TableDto.builder().databaseId(x.getDatabaseId()).tableId(x.getTableId()).build())
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public TableDto save(TableDto tableDto) {
+    Optional<TableDto> existed =
+        findById(
+            TableDtoPrimaryKey.builder()
+                .tableId(tableDto.getTableId())
+                .databaseId(tableDto.getDatabaseId())
+                .build());
+
+    Path tablePath;
+
+    Operation.Name operationType;
+
+    if (!existed.isPresent()) {
+      tablePath =
+          new Path(
+              constructTablePath(
+                      fsStorageProvider,
+                      tableDto.getDatabaseId(),
+                      tableDto.getTableId(),
+                      tableDto.getTableUUID())
+                  .toString());
+      operationType = Operation.Name.CREATE_TABLE;
+    } else {
+      tablePath = new Path(existed.get().getTableLocation());
+      operationType = Operation.Name.UPDATE;
+    }
+
+    DeltaLog log = DeltaLog.forTable(hdfsStorageProvider.storageClient().getConf(), tablePath);
+
+    OptimisticTransaction txn = log.startTransaction();
+
+    Metadata metaData =
+        txn.metadata()
+            .copyBuilder()
+            .configuration(openHouseInternalRepository.computePropsForTableCreation(tableDto))
+            .partitionColumns(new ArrayList())
+            .schema((StructType) StructType.fromJson(tableDto.getSchema()))
+            .build();
+    txn.updateMetadata(metaData);
+    List<Action> totalCommitFiles = new ArrayList<>();
+    CommitInfo commitInfo = null;
+    for (String actionString :
+        Optional.ofNullable(tableDto.getJsonSnapshots()).orElse(new ArrayList<>())) {
+      Action action =
+          ConversionUtils.convertAction(
+              io.delta.standalone.internal.actions.Action.fromJson(actionString));
+      if (!(action instanceof CommitInfo)) {
+        totalCommitFiles.add(action);
+      } else {
+        commitInfo = (CommitInfo) action;
+      }
+    }
+    if (commitInfo != null && log.snapshot().getVersion() != commitInfo.getReadVersion().get()) {
+      throw new CommitFailedException(
+          String.format(
+              "Conflict detected for databaseId: %s, tableId: %s, expected version: %s actual version %s: %s",
+              tableDto.getDatabaseId(),
+              tableDto.getTableId(),
+              commitInfo.getVersion().get(),
+              log.snapshot().getVersion(),
+              "The requested user table has been modified/created by other processes."));
+    }
+
+    txn.commit(
+        totalCommitFiles,
+        new Operation(operationType, ImmutableMap.of("ohVersion", tableDto.getTableVersion())),
+        "Zippy/1.0.0");
+
+    houseTableRepository.save(
+        HouseTable.builder()
+            .databaseId(tableDto.getDatabaseId())
+            .tableId(tableDto.getTableId())
+            .tableUUID(tableDto.getTableUUID())
+            .clusterId(tableDto.getClusterId())
+            .tableUri(tableDto.getTableUri())
+            .tableLocation(tablePath.toString())
+            .tableCreator(tableDto.getTableCreator())
+            .tableVersion(tableDto.getTableVersion())
+            .build());
+
+    // return committed metadata, can be optimized
+    return findById(
+            TableDtoPrimaryKey.builder()
+                .databaseId(tableDto.getDatabaseId())
+                .tableId(tableDto.getTableId())
+                .build())
+        .get();
+  }
+
+  @Override
+  public <S extends TableDto> Iterable<S> saveAll(Iterable<S> entities) {
+    return null;
+  }
+
+  @Override
+  public Optional<TableDto> findById(TableDtoPrimaryKey pk) {
+    Optional<HouseTable> houseTable;
+    try {
+      houseTable =
+          houseTableRepository.findById(
+              HouseTablePrimaryKey.builder()
+                  .databaseId(pk.getDatabaseId())
+                  .tableId(pk.getTableId())
+                  .build());
+    } catch (HouseTableNotFoundException houseTableNotFoundException) {
+      return Optional.empty();
+    }
+    if (houseTable.isPresent()) {
+      DeltaLog table =
+          DeltaLog.forTable(
+              hdfsStorageProvider.storageClient().getConf(), houseTable.get().getTableLocation());
+      Map<String, String> props = table.snapshot().getMetadata().getConfiguration();
+      return Optional.of(
+          convertToTableDto(
+              table,
+              props,
+              fsStorageProvider,
+              partitionSpecMapper,
+              policiesMapper,
+              tableTypeMapper));
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public boolean existsById(TableDtoPrimaryKey tableDtoPrimaryKey) {
+    return findById(tableDtoPrimaryKey).isPresent();
+  }
+
+  @Override
+  public Iterable<TableDto> findAll() {
+    return null;
+  }
+
+  @Override
+  public Iterable<TableDto> findAllById(Iterable<TableDtoPrimaryKey> tableDtoPrimaryKeys) {
+    return null;
+  }
+
+  @Override
+  public long count() {
+    return 0;
+  }
+
+  @Override
+  public void deleteById(TableDtoPrimaryKey tableDtoPrimaryKey) {}
+
+  @Override
+  public void delete(TableDto entity) {}
+
+  @Override
+  public void deleteAllById(Iterable<? extends TableDtoPrimaryKey> tableDtoPrimaryKeys) {}
+
+  @Override
+  public void deleteAll(Iterable<? extends TableDto> entities) {}
+
+  @Override
+  public void deleteAll() {}
+
+  static TableDto convertToTableDto(
+      DeltaLog table,
+      Map<String, String> megaProps,
+      FsStorageProvider fsStorageProvider,
+      PartitionSpecMapper partitionSpecMapper,
+      PoliciesSpecMapper policiesMapper,
+      TableTypeMapper tableTypeMapper) {
+    /* Contains everything needed to populate dto */
+    TableDto tableDto =
+        TableDto.builder()
+            .tableId(megaProps.get(getCanonicalFieldName("tableId")))
+            .databaseId(megaProps.get(getCanonicalFieldName("databaseId")))
+            .clusterId(megaProps.get(getCanonicalFieldName("clusterId")))
+            .tableUri(megaProps.get(getCanonicalFieldName("tableUri")))
+            .tableUUID(megaProps.get(getCanonicalFieldName("tableUUID")))
+            .tableLocation(table.getPath().toString())
+            .tableVersion(megaProps.get(getCanonicalFieldName("tableVersion")))
+            .tableCreator(megaProps.get(getCanonicalFieldName("tableCreator")))
+            .policies(policiesMapper.toPoliciesObject(megaProps.get("policies")))
+            .schema(table.snapshot().getMetadata().getSchema().toPrettyJson())
+            .tableType(TableType.PRIMARY_TABLE)
+            .jsonSnapshots(null)
+            .tableProperties(megaProps)
+            .build();
+
+    return tableDto;
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -236,7 +236,7 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
    * @param tableDto
    * @return
    */
-  private Map<String, String> computePropsForTableCreation(TableDto tableDto) {
+  public Map<String, String> computePropsForTableCreation(TableDto tableDto) {
     // Populate non-preserved keys, mainly user defined properties.
     Map<String, String> propertiesMap =
         tableDto.getTableProperties().entrySet().stream()

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/DeltaActionsService.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/DeltaActionsService.java
@@ -1,0 +1,13 @@
+package com.linkedin.openhouse.tables.services;
+
+import com.linkedin.openhouse.tables.api.spec.v1.request.DeltaActionsRequestBody;
+import com.linkedin.openhouse.tables.model.TableDto;
+
+public interface DeltaActionsService {
+
+  TableDto appendDeltaActions(
+      String databaseId,
+      String tableId,
+      DeltaActionsRequestBody deltaActionsRequestBody,
+      String tableCreator);
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/DeltaActionsServiceImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/DeltaActionsServiceImpl.java
@@ -1,0 +1,39 @@
+package com.linkedin.openhouse.tables.services;
+
+import com.linkedin.openhouse.common.exception.NoSuchUserTableException;
+import com.linkedin.openhouse.tables.api.spec.v1.request.DeltaActionsRequestBody;
+import com.linkedin.openhouse.tables.model.TableDto;
+import com.linkedin.openhouse.tables.model.TableDtoPrimaryKey;
+import com.linkedin.openhouse.tables.repository.OpenHouseInternalRepository;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DeltaActionsServiceImpl implements DeltaActionsService {
+
+  @Autowired OpenHouseInternalRepository openHouseInternalRepository;
+
+  @Override
+  public TableDto appendDeltaActions(
+      String databaseId,
+      String tableId,
+      DeltaActionsRequestBody deltaActionsRequestBody,
+      String tableCreator) {
+
+    Optional<TableDto> tableDto =
+        openHouseInternalRepository.findById(
+            TableDtoPrimaryKey.builder().databaseId(databaseId).tableId(tableId).build());
+    if (!tableDto.isPresent()) {
+      throw new NoSuchUserTableException(databaseId, tableId);
+    }
+    TableDto tableDtoToSave =
+        tableDto
+            .get()
+            .toBuilder()
+            .tableVersion(deltaActionsRequestBody.getBaseTableVersion())
+            .jsonSnapshots(deltaActionsRequestBody.getJsonActions())
+            .build();
+    return openHouseInternalRepository.save(tableDtoToSave);
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -37,6 +37,7 @@ include ':integrations:spark:openhouse-spark-itest'
 include ':integrations:spark-extensions'
 include ':integrations:java:openhouse-java-runtime'
 include ':integrations:java:openhouse-java-itest'
+include ':integrations:spark-delta-client'
 
 include ':iceberg:openhouse:htscatalog'
 include ':iceberg:openhouse:internalcatalog'


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->
Delta is an open-source table format that brings enterprise-grade capabilities to data lakes. It manages large datasets in data lakes efficiently and ensures data integrity through ACID transactions and enables historical data exploration with time travel features.

In this PR we replace OH's current Iceberg Table Format with Delta Format.

Guiding principles for coding this PR:
- Avoiding changing Delta Commit Protocol
- Use Delta's API plugs/ extensions (avoid changing Delta Source code)
- Avoid changing OpenHouse's architecture/design/feature set.

## Details
Overall architecture is the same as before for Iceberg, except for three crucial pieces:
- OH Client will use LogStore Plug for commits: Delta protocol doesn't provide doRefresh(), doCommit() plugs like Iceberg. This is because of fundamental difference in [Delta vs Iceberg](https://docs.google.com/document/d/15R_f9rTL3GU6FpW2ebTs6aTBOYaWn5e4VV9mR_4jGvU/edit#bookmark=id.hp73yi3j4tz8). Instead the client will use [LogStore plug](https://docs.google.com/document/d/15R_f9rTL3GU6FpW2ebTs6aTBOYaWn5e4VV9mR_4jGvU/edit#bookmark=id.4ndlzi81swhb) for any kind of writes.
- OH Server will use FileSystem as source of truth (not HTS): Again, because of protocol difference in Delta vs Iceberg. Now, the OH server commits using `DeltaLog.forTable(/tablePath).getTransaction().commit()` and keeps a record in HTS just for record keeping.
- Directory layout is bit different than Iceberg: [But protecting namespace should still be supported](https://docs.google.com/document/d/15R_f9rTL3GU6FpW2ebTs6aTBOYaWn5e4VV9mR_4jGvU/edit#heading=h.xu8zwim6xnh3).

- [X] New Features

## Testing
### Easy way: Just run the unit test
1. build the project first, `./gradlew build`
2. Open project in intellij, `open > ROOT/build.gradle`
3. Go the module: `:spark-delta-client`
4. Run the unit test: `com.linkedin.openhouse.delta.tests.SimpleTest#basicSQLCatalog()`
This will run the E2E flow in form of unit test, place debugger anywhere and have a fun time!

### Production way: Run the docker setup
1. build the project first, `./gradlew build`
2. `cd /infra/recipe/docker-compose/oh-hadoop-spark`
3. `docker compose up -d`
4. `docker exec -it local.spark-master /bin/bash`
5.  run following spark-shell command
```
bin/spark-shell --jars spark-delta-client-latest-all.jar    \
--conf spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension     \
--conf spark.sql.catalog.openhouse=com.linkedin.openhouse.delta.OHCatalog     \
--conf spark.sql.catalog.openhouse.uri=http://openhouse-tables:8080     \
--conf spark.sql.catalog.openhouse.auth-token=$(cat /var/config/openhouse.token)   \
--conf spark.sql.catalog.openhouse.cluster=LocalHadoopCluster   \
--conf spark.sql.catalogImplementation=in-memory
```
6: 
```
CREATE TABLE openhouse.db.t3 (col1 string, col2 string, col3 string)
```
7:
```
INSERT INTO openhouse.db.t3 VALUES ('c', 'd', 'd')
```
8:
```
SELECT * FROM openhouse.db.t3
```

See following demo for in-depth production test [![DeltaLake OH Demo](https://img.youtube.com/vi/24gsbgVDFC8/0.jpg)](https://www.youtube.com/watch?v=24gsbgVDFC8)
