### PR TITLE
[PR1/N] Oauth: Run keycloak container for use in local docker 

### DIFF
--- a/infra/recipes/docker-compose/common/oauth-services.yml
+++ b/infra/recipes/docker-compose/common/oauth-services.yml
@@ -1,0 +1,13 @@
+version: "3.3"
+services:
+  oauth:
+    image: quay.io/keycloak/keycloak:23.0.7
+    ports:
+      - 8085:8080
+    environment:
+      - KEYCLOAK_ADMIN=admin
+      - KEYCLOAK_ADMIN_PASSWORD=admin
+      - DB_VENDOR=h2
+    volumes:
+      - ./oauth/openhouse-realm.json:/opt/keycloak/data/import/openhouse-realm.json:ro
+    command: ["start-dev", "--import-realm"]

--- a/infra/recipes/docker-compose/common/oauth/fetch_token.sh
+++ b/infra/recipes/docker-compose/common/oauth/fetch_token.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Check if username is provided
+if [ -z "$1" ]; then
+    echo "Error: Username not provided."
+    echo "Usage: $0 <username>"
+    exit 1
+fi
+
+KEYCLOAK_URL="http://localhost:8085"
+REALM="openhouse"
+CLIENT_ID="openhouse-services"
+USERNAME="$1"
+PASSWORD="$1"
+
+TOKEN=$(curl -X POST \
+  -d "client_id=$CLIENT_ID" \
+  -d "username=$USERNAME" \
+  -d "password=$PASSWORD" \
+  -d "grant_type=password" \
+  "$KEYCLOAK_URL/realms/$REALM/protocol/openid-connect/token" | jq -r '.access_token')
+
+echo "$TOKEN"

--- a/infra/recipes/docker-compose/common/oauth/openhouse-realm.json
+++ b/infra/recipes/docker-compose/common/oauth/openhouse-realm.json
@@ -75,7 +75,7 @@
               "user.attribute": "username",
               "id.token.claim": "true",
               "access.token.claim": "true",
-              "claim.name": "username",
+              "claim.name": "preferred_username",
               "jsonType.label": "String"
             }
           }

--- a/infra/recipes/docker-compose/common/oauth/openhouse-realm.json
+++ b/infra/recipes/docker-compose/common/oauth/openhouse-realm.json
@@ -1,0 +1,85 @@
+{
+  "realm": "openhouse",
+  "enabled": true,
+  "users": [
+    {
+      "username": "openhouse",
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "openhouse"
+        }
+      ],
+      "realmRoles": [
+        "admin"
+      ]
+    }, {
+        "username": "u_tableowner",
+        "enabled": true,
+        "credentials": [
+            {
+            "type": "password",
+            "value": "u_tableowner"
+            }
+        ],
+        "realmRoles": [
+            "user"
+        ]
+    }
+  ],
+  "roles": {
+    "realm": [
+      {
+        "name": "admin",
+        "description": "Admin role"
+      },
+      {
+        "name": "user",
+        "description": "User role"
+      }
+    ]
+  },
+  "clients": [
+    {
+      "clientId": "openhouse-services",
+      "defaultClientScopes": [
+        "openid"
+      ],
+      "directAccessGrantsEnabled": true,
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "redirectUris": [
+        "*"
+      ],
+      "serviceAccountsEnabled": true
+    }
+  ],
+  "clientScopes": [
+    {
+      "name": "openid",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.id.token": "true",
+        "include.in.access.token": "true",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+          {
+            "name": "username",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-usermodel-attribute-mapper",
+            "config": {
+              "userinfo.token.claim": "true",
+              "user.attribute": "username",
+              "id.token.claim": "true",
+              "access.token.claim": "true",
+              "claim.name": "username",
+              "jsonType.label": "String"
+            }
+          }
+      ]
+    }
+  ]
+}

--- a/infra/recipes/docker-compose/common/oauth/validate_token.sh
+++ b/infra/recipes/docker-compose/common/oauth/validate_token.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Check if token is provided
+if [ -z "$1" ]; then
+    echo "Error: Token not provided."
+    echo "Usage: $0 <token>"
+    exit 1
+fi
+
+KEYCLOAK_URL="http://localhost:8085"
+REALM="openhouse"
+TOKEN="$1"
+
+USERNAME=$(curl -X GET \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -H "Authorization: Bearer $TOKEN" \
+  "$KEYCLOAK_URL/realms/$REALM/protocol/openid-connect/userinfo" | jq -r '.username')
+
+echo "$USERNAME"

--- a/infra/recipes/docker-compose/common/oauth/validate_token.sh
+++ b/infra/recipes/docker-compose/common/oauth/validate_token.sh
@@ -14,6 +14,6 @@ TOKEN="$1"
 USERNAME=$(curl -X GET \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -H "Authorization: Bearer $TOKEN" \
-  "$KEYCLOAK_URL/realms/$REALM/protocol/openid-connect/userinfo" | jq -r '.username')
+  "$KEYCLOAK_URL/realms/$REALM/protocol/openid-connect/userinfo" | jq -r '.preferred_username')
 
 echo "$USERNAME"

--- a/infra/recipes/docker-compose/oh-only/docker-compose.yml
+++ b/infra/recipes/docker-compose/oh-only/docker-compose.yml
@@ -30,3 +30,9 @@ services:
     extends:
       file: ../common/opa-services.yml
       service: opa
+
+  oauth:
+    container_name: local.oauth
+    extends:
+      file: ../common/oauth-services.yml
+      service: oauth


### PR DESCRIPTION
## Summary

Today, we deal with hardcoded tokens in local docker. Even though it works, there are following issues:
- User needs to manage dummy tokens file.
- Not a standard authorization protocol like oauth.

This is first in the series of PRs that would bootstrap integration with OAuth providers. In this PR, we run keycloak server in local docker to authenticate. Following PR will introduce a `KeycloakOAuthTokenInterceptor` that would get userinfo and set it as principal in the Springboot's SecurityContext. Further PRs in the series should incrementally add capabilities with popular OAuth providers.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [X] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests


## Testing
<!--- Check any relevant boxes with "x" -->

- [X] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

```
❯ infra/recipes/docker-compose/common/oauth/validate_token.sh $(infra/recipes/docker-compose/common/oauth/fetch_token.sh openhouse)
openhouse

❯ infra/recipes/docker-compose/common/oauth/validate_token.sh $(infra/recipes/docker-compose/common/oauth/fetch_token.sh u_tableowner)
u_tableowner
```

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.