### PR TITLE
Adding OpenSourcing OH Blog link

### DIFF
--- a/blog/2024-03-04-opensourcing-oh.mdx
+++ b/blog/2024-03-04-opensourcing-oh.mdx
@@ -1,0 +1,18 @@
+---
+slug: opensourcing-oh
+title: Open Sourcing OpenHouse, A Control Plane for Managing Tables in a Data Lakehouse
+authors:
+  name: Sumedh Sakdeo
+  url: https://www.linkedin.com/in/sumedhsakdeo/
+  image_url: https://github.com/sumedhsakdeo.png
+tags: [openhouse, big data, opensource]
+hide_reading_time: true
+---
+
+import Link from '@docusaurus/Link';
+
+<Link
+    className='button button--primary button--small'
+    to="https://www.linkedin.com/blog/engineering/open-source/open-sourcing-openhouse">
+    <small> Read More </small>
+</Link>


### PR DESCRIPTION
## Summary
Adds Blog link for [Open Sourcing OpenHouse](https://www.linkedin.com/blog/engineering/open-source/open-sourcing-openhouse)

## Changes
- [X] Documentation

## Testing
- [X] Manually Tested on local docker setup. Please include commands ran, and their output.

<img width="1596" alt="image" src="https://github.com/linkedin/openhouse/assets/6441597/6860ae37-31ba-402c-92ba-d666c9157af8">
