### PR TITLE
Bump springdoc-openapi to the newest

### DIFF
--- a/buildSrc/src/main/groovy/openhouse.springboot-conventions.gradle
+++ b/buildSrc/src/main/groovy/openhouse.springboot-conventions.gradle
@@ -33,8 +33,8 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa:' + springVersion
   implementation 'com.h2database:h2:' + '2.1.210'
 
-  implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
-  implementation 'org.springdoc:springdoc-openapi-data-rest:1.6.9'
+  implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
+  implementation 'org.springdoc:springdoc-openapi-data-rest:1.7.0'
   implementation 'io.swagger.core.v3:swagger-annotations:2.1.11'
 
   implementation("javax.servlet:javax.servlet-api:4.0.1")


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

This is again trying to resolve the ELR issues when OpenHouse is pulled back to LinkedIn internal. The previous attempt was not successful as its transitive dependencies still are identified as security vulnerable: 
- org.springframework.data:spring-data-rest-core:3.7.0
-  org.springframework.hateoas:spring-hateoas:1.5.0

Both of them came from `org.springdoc:springdoc-openapi-ui` 

`1.7.0` is the newest release for `springdoc-openapi-ui` (reference: https://github.com/springdoc/springdoc-openapi) 
And it is still pulling `spring-hateoas:1.5.4`. Will give this a try and if failed, we will need to find workaround to allow this to happen. 

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [x] Some other form of testing like staging or soak time in production. Please explain.

Verified the Build Scan and at least `spring-data-rest-core` is in the right security range.  

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.