### PR TITLE
Publish bootJar and libJar artifacts for Springboot services

### DIFF
--- a/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
+++ b/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
@@ -12,6 +12,11 @@ task javadocJar(type: Jar) {
   from javadoc.destinationDir
 }
 
+task libJar(type: Jar) {
+  classifier = "lib"
+  from sourceSets.main.output
+}
+
 [jar, sourcesJar, javadocJar].each { task ->
   task.from(rootDir) {
     include 'LICENSE'
@@ -51,6 +56,16 @@ publishing {
 
         configurePom(pom)
       }
+    } else if(tasks.findByName('bootJar')) {
+      mavenJava(MavenPublication) {
+        from components.java
+
+        artifact sourcesJar
+        artifact javadocJar
+        artifact libJar
+
+        configurePom(pom)
+      }
     } else {
       mavenJava(MavenPublication) {
         from components.java
@@ -73,10 +88,4 @@ publishing {
       }
     }
   }
-}
-
-artifacts {
-  archives jar
-  archives sourcesJar
-  archives javadocJar
 }


### PR DESCRIPTION
## Summary

For the springboot services, tables, jobs, and hts, we were only publishing the bootJar to the maven repository. We also produce a regular jar with a classifier `lib`.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [X] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

PR adds publishing of regular jar with lib classifier, in addition to bootJar. 
Also added configurePom for shadowJar publication logic to not miss maven metadata for shadowJar.

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [X] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

```
./gradlew -Pversion=0.200.25 publishToMavenLocal

❯ ls ~/.m2/repository/com/linkedin/openhouse/tables/0.200.15
tables-0.200.15-javadoc.jar tables-0.200.15-sources.jar tables-0.200.15.jar         tables-0.200.15.module      tables-0.200.15.pom

❯ ls ~/.m2/repository/com/linkedin/openhouse/tables/0.200.20
tables-0.200.20-javadoc.jar *tables-0.200.20-lib.jar*     tables-0.200.20-sources.jar tables-0.200.20.jar         tables-0.200.20.module      tables-0.200.20.pom
```

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.
