### PR TITLE
Return CommitStateUnknownException in case of an internal server error to prevent commit abort leading to data loss.

### DIFF
--- a/integrations/java/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
+++ b/integrations/java/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
@@ -100,6 +100,10 @@ public class OpenHouseTableOperationsTest {
     Assertions.assertThrows(
         NoSuchTableException.class, () -> openHouseTableOperations.doCommit(base, metadata));
     when(mockTableApi.updateTableV1(anyString(), anyString(), any()))
+        .thenReturn(Mono.error(mock(WebClientResponseException.InternalServerError.class)));
+    Assertions.assertThrows(
+        CommitStateUnknownException.class, () -> openHouseTableOperations.doCommit(base, metadata));
+    when(mockTableApi.updateTableV1(anyString(), anyString(), any()))
         .thenReturn(Mono.error(mock(WebClientRequestException.class)));
     Assertions.assertThrows(
         CommitStateUnknownException.class, () -> openHouseTableOperations.doCommit(base, metadata));

--- a/integrations/java/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
+++ b/integrations/java/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
@@ -87,6 +87,7 @@ public class OpenHouseTableOperationsTest {
     when(base.snapshots()).thenReturn(snapshotList);
 
     // Ensure tableApi throw expected exception
+
     when(mockTableApi.updateTableV1(anyString(), anyString(), any()))
         .thenReturn(Mono.error(mock(WebClientResponseException.ServiceUnavailable.class)));
     Assertions.assertThrows(

--- a/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -276,21 +276,21 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
       return Mono.error(
           new CommitFailedException(
               casted, casted.getStatusCode().value() + " , " + casted.getResponseBodyAsString()));
-    } else if (e instanceof WebClientResponseException.GatewayTimeout
-        | e instanceof WebClientResponseException.ServiceUnavailable) {
-      return Mono.error(new CommitStateUnknownException(e));
     } else if (e instanceof WebClientResponseException.BadRequest) {
       WebClientResponseException casted = (WebClientResponseException) e;
       return Mono.error(
           new BadRequestException(
               casted, casted.getStatusCode().value() + " , " + casted.getResponseBodyAsString()));
-    } else if (e instanceof WebClientResponseException) {
+    } else if (e instanceof WebClientResponseException.Forbidden
+        || e instanceof WebClientResponseException.Unauthorized) {
       return Mono.error(new WebClientResponseWithMessageException((WebClientResponseException) e));
     } else {
       /**
-       * This serves as a catch-all for any other exceptions that are not
-       * WebClientResponseException. It helps in skipping any unexpected cleanup that could occur
-       * when a commit aborts at the caller, thus avoiding any potential data loss.
+       * This serves as a catch-all for any other WebClientResponseException exceptions including
+       * gateway timeout, service being unavailable and internal server errors and also for any
+       * other exceptions that are not WebClientResponseException. This is a conservative approach
+       * to skip any unexpected cleanup that could occur when a commit aborts at the caller, thus
+       * avoiding any potential data loss.
        */
       return Mono.error(new CommitStateUnknownException(e));
     }

--- a/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -282,7 +282,7 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
         || e instanceof WebClientResponseException.InternalServerError) {
       /**
        * This is done to avoid any data loss that could occur when a commit aborts at the caller
-       * leads to deletion of iceberg metadat files.
+       * leads to deletion of iceberg metadata files.
        */
       WebClientResponseException casted = (WebClientResponseException) e;
       return Mono.error(new CommitStateUnknownException(casted.getResponseBodyAsString(), casted));

--- a/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/mock/DoCommitTest.java
+++ b/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/mock/DoCommitTest.java
@@ -4,7 +4,6 @@ import static com.linkedin.openhouse.spark.MockHelpers.*;
 import static com.linkedin.openhouse.spark.SparkTestBase.*;
 
 import com.linkedin.openhouse.javaclient.OpenHouseTableOperations;
-import com.linkedin.openhouse.relocated.org.springframework.web.reactive.function.client.WebClientResponseException;
 import com.linkedin.openhouse.spark.SparkTestBase;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -133,7 +132,7 @@ public class DoCommitTest {
   @Test
   public void testSurfaceRestExceptions() {
     mockTableService.enqueue(mockResponse(500, "{\"message\":\"Internal Server Error\"}"));
-    Assertions.assertThrows(WebClientResponseException.class, () -> ops.doCommit(null, base));
+    Assertions.assertThrows(CommitStateUnknownException.class, () -> ops.doCommit(null, base));
   }
 
   @Test


### PR DESCRIPTION
## Summary
Any error happening post HTS update needs to be treated as CommitStateUnknownException so that iceberg client side does not trigger the cleanup logic to clear out the metadata files leading to table corruption.
The errors post HTS update could happen due to any server issues like OOM, or other framework issues that could manifest as internal server error (500). In this PR we are converting internal server errors to commit state unknown exception similar to gateway and service unavailable errors. 

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [X] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [X] Added new tests for the changes made.
- [X] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
