### PR TITLE
Pass the right ODD implementation class in jobs.yaml 

### DIFF
--- a/docs/specs/jobs.md
+++ b/docs/specs/jobs.md
@@ -206,6 +206,7 @@ Job config
 |jobType|ORPHAN_FILES_DELETION|
 |jobType|SNAPSHOTS_EXPIRATION|
 |jobType|STAGED_FILES_DELETION|
+|jobType|ORPHAN_DIRECTORY_DELETION| 
 
 <h2 id="tocS_JobResponseBody">JobResponseBody</h2>
 <!-- backwards compatibility -->

--- a/infra/recipes/docker-compose/oh-hadoop-spark/jobs.yaml
+++ b/infra/recipes/docker-compose/oh-hadoop-spark/jobs.yaml
@@ -50,7 +50,7 @@ jobs:
         args: ["--trashDir", ".trash", "--daysOld", "10", "--recursive", "true"]
         <<: *apps-defaults
       - type: ORPHAN_DIRECTORY_DELETION
-        class-name: com.linkedin.openhouse.jobs.spark.OrphanDirectoryDeletionSparkApp
+        class-name: com.linkedin.openhouse.jobs.spark.OrphanTableDirectoryDeletionSparkApp
         args: [ "--trashDir", ".trash" ]
         <<: *apps-defaults
       - type: TABLE_STATS_COLLECTION


### PR DESCRIPTION
## Summary

Implementation class name is wrong in jobs.yaml. Added new job type in documentation

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [x] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

No class is named the old name. 

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
