### PR TITLE
Part I: Enable feature toggle skeleton

### DIFF
--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/TablesSpringApplication.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/TablesSpringApplication.java
@@ -22,11 +22,16 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @EntityScan(
     basePackages = {
       "com.linkedin.openhouse.tables.model",
-      "com.linkedin.openhouse.internal.catalog.model"
+      "com.linkedin.openhouse.internal.catalog.model",
+      "com.linkedin.openhouse.tables.toggle.model"
     })
 @EnableAutoConfiguration(
     exclude = {SecurityAutoConfiguration.class, ManagementWebSecurityAutoConfiguration.class})
-@EnableJpaRepositories(basePackages = {"com.linkedin.openhouse.internal.catalog.repository"})
+@EnableJpaRepositories(
+    basePackages = {
+      "com.linkedin.openhouse.internal.catalog.repository",
+      "com.linkedin.openhouse.tables.toggle.repository"
+    })
 public class TablesSpringApplication {
 
   public static void main(String[] args) {

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -149,8 +149,8 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
 
   /**
    * Check the eligibility of table creation. Throw exceptions when invalidate behaviors detected
-   * for * {@link com.linkedin.openhouse.common.exception.handler.OpenHouseExceptionHandler} to deal
-   * with
+   * for {@link com.linkedin.openhouse.common.exception.handler.OpenHouseExceptionHandler} to deal
+   * with.
    */
   protected void creationEligibilityCheck(TableDto tableDto) {
     versionCheck(null, tableDto);

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/toggle/BaseTableFeatureToggle.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/toggle/BaseTableFeatureToggle.java
@@ -1,0 +1,35 @@
+package com.linkedin.openhouse.tables.toggle;
+
+import com.linkedin.openhouse.tables.toggle.model.TableToggleStatus;
+import com.linkedin.openhouse.tables.toggle.model.ToggleStatusKey;
+import com.linkedin.openhouse.tables.toggle.repository.ToggleStatusesRepository;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BaseTableFeatureToggle implements TableFeatureToggle {
+  @Autowired ToggleStatusesRepository toggleStatusesRepository;
+
+  /**
+   * A naive implementation that omits the necessity of rule engine and assumes every {@link
+   * TableToggleStatus} is written explicitly without specifying patterns.
+   *
+   * @param databaseId databaseId
+   * @param tableId tableId
+   * @return True if the provided pair of databaseId and tableId has the feature "dummy" activated.
+   */
+  @Override
+  public boolean isFeatureActivated(String databaseId, String tableId, String featureId) {
+    ToggleStatusKey toggleStatusKey =
+        ToggleStatusKey.builder()
+            .databaseId(databaseId)
+            .tableId(tableId)
+            .featureId(featureId)
+            .build();
+    Optional<TableToggleStatus> toggleStatus = toggleStatusesRepository.findById(toggleStatusKey);
+    // TODO: Change this once HTS PR is in
+    return toggleStatus.isPresent()
+        && toggleStatus.get().getToggleStatusEnum().equalsIgnoreCase("active");
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/toggle/TableFeatureToggle.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/toggle/TableFeatureToggle.java
@@ -1,0 +1,14 @@
+package com.linkedin.openhouse.tables.toggle;
+
+/** Interface to check if a feature is toggled-on for a table */
+public interface TableFeatureToggle {
+  /**
+   * Determine if given feature is activated for the table.
+   *
+   * @param databaseId databaseId
+   * @param tableId tableId
+   * @param featureId featureId
+   * @return True if the feature is activated for the table.
+   */
+  boolean isFeatureActivated(String databaseId, String tableId, String featureId);
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/toggle/model/TableToggleStatus.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/toggle/model/TableToggleStatus.java
@@ -1,0 +1,31 @@
+package com.linkedin.openhouse.tables.toggle.model;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** Data Model for persisting Feature-Toggle Rule in the HTS-Repository. */
+@Entity
+@IdClass(ToggleStatusKey.class)
+@Builder(toBuilder = true)
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class TableToggleStatus {
+
+  @Id private String featureId;
+
+  @Id private String tableId;
+
+  @Id private String databaseId;
+
+  // TODO: Need to change it to the shared Enum class once HTS PR is in
+  private String toggleStatusEnum;
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/toggle/model/ToggleStatusKey.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/toggle/model/ToggleStatusKey.java
@@ -1,0 +1,22 @@
+package com.linkedin.openhouse.tables.toggle.model;
+
+import java.io.Serializable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ToggleStatusKey implements Serializable {
+  private String featureId;
+
+  private String tableId;
+
+  private String databaseId;
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/toggle/repository/BaseToggleStatusesRepository.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/toggle/repository/BaseToggleStatusesRepository.java
@@ -1,0 +1,61 @@
+package com.linkedin.openhouse.tables.toggle.repository;
+
+import com.linkedin.openhouse.tables.toggle.model.TableToggleStatus;
+import com.linkedin.openhouse.tables.toggle.model.ToggleStatusKey;
+import java.util.Optional;
+
+/**
+ * THIS IS A TEMPORARY PLACEHOLDER, without this the whole springboot application is failed to start
+ * given missing injection entity for {@link ToggleStatusesRepository}.
+ */
+public class BaseToggleStatusesRepository implements ToggleStatusesRepository {
+  @Override
+  public <S extends TableToggleStatus> S save(S entity) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public <S extends TableToggleStatus> Iterable<S> saveAll(Iterable<S> entities) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public Optional<TableToggleStatus> findById(ToggleStatusKey toggleStatusKey) {
+    return Optional.empty();
+  }
+
+  @Override
+  public boolean existsById(ToggleStatusKey toggleStatusKey) {
+    return false;
+  }
+
+  @Override
+  public Iterable<TableToggleStatus> findAll() {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public Iterable<TableToggleStatus> findAllById(Iterable<ToggleStatusKey> ruleKeys) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public long count() {
+    return 0;
+  }
+
+  @Override
+  public void deleteById(ToggleStatusKey toggleStatusKey) {}
+
+  @Override
+  public void delete(TableToggleStatus entity) {}
+
+  @Override
+  public void deleteAllById(Iterable<? extends ToggleStatusKey> ruleKeys) {}
+
+  @Override
+  public void deleteAll(Iterable<? extends TableToggleStatus> entities) {}
+
+  @Override
+  public void deleteAll() {}
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/toggle/repository/ToggleStatusesRepository.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/toggle/repository/ToggleStatusesRepository.java
@@ -1,0 +1,10 @@
+package com.linkedin.openhouse.tables.toggle.repository;
+
+import com.linkedin.openhouse.tables.toggle.model.TableToggleStatus;
+import com.linkedin.openhouse.tables.toggle.model.ToggleStatusKey;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ToggleStatusesRepository
+    extends CrudRepository<TableToggleStatus, ToggleStatusKey> {}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/BaseTableFeatureToggleTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/BaseTableFeatureToggleTest.java
@@ -1,0 +1,52 @@
+package com.linkedin.openhouse.tables.e2e.h2;
+
+import com.linkedin.openhouse.tables.toggle.BaseTableFeatureToggle;
+import com.linkedin.openhouse.tables.toggle.model.TableToggleStatus;
+import com.linkedin.openhouse.tables.toggle.repository.ToggleStatusesRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class BaseTableFeatureToggleTest {
+  @Autowired BaseTableFeatureToggle baseFeatureToggle;
+
+  @Autowired ToggleStatusesRepository toggleStatusesRepository;
+
+  @Test
+  public void testDummyToggle() {
+    TableToggleStatus rule1 =
+        TableToggleStatus.builder()
+            .featureId("dummy")
+            .databaseId("db1")
+            .tableId("tbl1")
+            .toggleStatusEnum("ACTIVE")
+            .build();
+    TableToggleStatus rule2 =
+        TableToggleStatus.builder()
+            .featureId("dummy")
+            .databaseId("db2")
+            .tableId("tbl2")
+            .toggleStatusEnum("ACTIVE")
+            .build();
+    TableToggleStatus rule3 =
+        TableToggleStatus.builder()
+            .featureId("random")
+            .databaseId("db1")
+            .tableId("tbl3")
+            .toggleStatusEnum("ACTIVE")
+            .build();
+    toggleStatusesRepository.save(rule1);
+    toggleStatusesRepository.save(rule2);
+    toggleStatusesRepository.save(rule3);
+
+    Assertions.assertTrue(baseFeatureToggle.isFeatureActivated("db1", "tbl1", "dummy"));
+    Assertions.assertTrue(baseFeatureToggle.isFeatureActivated("db2", "tbl2", "dummy"));
+    Assertions.assertTrue(baseFeatureToggle.isFeatureActivated("db1", "tbl3", "random"));
+    /* This is a rule of random, using dummyFeatureToggle should see this deactivated. */
+    Assertions.assertFalse(baseFeatureToggle.isFeatureActivated("db1", "tbl3", "dummy"));
+
+    toggleStatusesRepository.deleteAll();
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/SpringH2Application.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/SpringH2Application.java
@@ -34,6 +34,7 @@ import org.springframework.context.annotation.Primary;
       "com.linkedin.openhouse.tables.controller",
       "com.linkedin.openhouse.tables.services",
       "com.linkedin.openhouse.tables.config",
+      "com.linkedin.openhouse.tables.toggle",
       "com.linkedin.openhouse.internal.catalog",
       "com.linkedin.openhouse.cluster.configs",
       "com.linkedin.openhouse.cluster.storage",
@@ -46,7 +47,8 @@ import org.springframework.context.annotation.Primary;
 @EntityScan(
     basePackages = {
       "com.linkedin.openhouse.tables.model",
-      "com.linkedin.openhouse.internal.catalog.model"
+      "com.linkedin.openhouse.internal.catalog.model",
+      "com.linkedin.openhouse.tables.toggle.model"
     })
 @EnableAutoConfiguration(
     exclude = {SecurityAutoConfiguration.class, ManagementWebSecurityAutoConfiguration.class})

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/ToggleH2StatusesRepository.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/ToggleH2StatusesRepository.java
@@ -1,0 +1,14 @@
+package com.linkedin.openhouse.tables.e2e.h2;
+
+import com.linkedin.openhouse.tables.toggle.repository.ToggleStatusesRepository;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The {@link org.springframework.context.annotation.Bean} injected into /tables e2e tests when
+ * communication to the implementation of {@link ToggleStatusesRepository} is not needed. With
+ * {@link Primary} annotation, this repository will be the default injection.
+ */
+@Repository
+@Primary
+public interface ToggleH2StatusesRepository extends ToggleStatusesRepository {}


### PR DESCRIPTION
## Summary

This is the first part of feature toggle for OpenHouse. 
Feature toggle provides OH developers a way to slowly ramp a feature by enabling it for a limited set of table entities. 
For example, for features like `wap`, it will be great to limit the offering to testing tracking tables only, instead of having it widely open for all tables to try out.

Functional requirement for this includes: 
- Configuration driven: Enabling a ramp itself shouldn't require redeployment/restart of a service. 
- Configuration storage semantics: Having the configuration sitting somewhere with versioned semantic which is important for production use case.
- It will be great to go through regular PR and deployment process whenever the hotfix requirement is not urgent to enable or disable. 

The proposal here: 
- Having a new HTS table storing these configuration. HTS remains publicaly unavailable and only dev teams will have access directly towards mysql instance if there's config-change needs to be deployed without going through normal deployment process. Interface of this HTS table remains the same (put/get). Table-service will abstract this properly for generalization among all features that we would like to control the range of tables that are impacted.
- This new HTS table is re-populated whenever there's a restart of the HTS server. Data being populated is controlled by `.sql` file checked in the code repo. Every change of this initial table population file will be reviewed. 
In normal scenario, changes in this file will be deployed like other features and take a day or two given the soaking cycles. 
In cases where users cannot wait, dev could raising the PR and meanwhile use SQL stmt to hit MySQL backend directly. 


## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

This PR contains the part I, that outlines the data model for `FeatureToggle` within tables-service. 
Part II we will focus on plumbing with HTS. 
Part III will introduce rule engines to allow specifying patterns of tables and databases instead of allowing to explicitly specify the full Id of database and table. 

After finishing all three parts we will be able to make li-openhouse changes for disallowing table-creation with certain properties present, while preserving a backdoor for some users in case they cannot find the alternative API working.

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
