### PR TITLE
Skip IcebergCatalogMapperTest to avoid conflicting catalogs

### DIFF
--- a/.github/workflows/build-tag-publish.yml
+++ b/.github/workflows/build-tag-publish.yml
@@ -28,7 +28,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1
 
       - name: Build with Gradle
-        run: ./gradlew clean build
+        run: ./gradlew clean build --debug
 
       - name: Start Docker Containers
         run: docker compose -f infra/recipes/docker-compose/oh-only/docker-compose.yml up -d --build

--- a/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/mock/mapper/IcebergCatalogMapperTest.java
+++ b/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/mock/mapper/IcebergCatalogMapperTest.java
@@ -11,6 +11,7 @@ import org.apache.iceberg.spark.SparkSessionCatalog;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.junit.Ignore;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -22,6 +23,7 @@ public class IcebergCatalogMapperTest {
   private static SparkSession spark = null;
 
   @Test
+  @Ignore
   public void testSparkCatalog() {
     SparkCatalog sparkCatalog = new SparkCatalog();
     sparkCatalog.initialize(
@@ -34,6 +36,7 @@ public class IcebergCatalogMapperTest {
   }
 
   @Test
+  @Ignore
   public void testSparkCatalogCacheDisabled() {
     SparkCatalog sparkCatalog = new SparkCatalog();
     sparkCatalog.initialize(
@@ -52,6 +55,7 @@ public class IcebergCatalogMapperTest {
   }
 
   @Test
+  @Ignore
   public void testSparkSessionCatalog() {
     SparkSessionCatalog sparkCatalog = new SparkSessionCatalog();
     sparkCatalog.initialize(
@@ -64,6 +68,7 @@ public class IcebergCatalogMapperTest {
   }
 
   @Test
+  @Ignore
   public void testSparkSessionCatalogCacheDisabled() {
     SparkSessionCatalog sparkCatalog = new SparkSessionCatalog();
     sparkCatalog.initialize(
@@ -82,6 +87,7 @@ public class IcebergCatalogMapperTest {
   }
 
   @Test
+  @Ignore
   public void testNonIcebergCatalog() {
     TableCatalog fakeTableCatalog = Mockito.mock(TableCatalog.class);
     assert IcebergCatalogMapper.toIcebergCatalog(fakeTableCatalog) == null;

--- a/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/mock/mapper/IcebergCatalogMapperTest.java
+++ b/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/mock/mapper/IcebergCatalogMapperTest.java
@@ -11,10 +11,8 @@ import org.apache.iceberg.spark.SparkSessionCatalog;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
-import org.junit.Ignore;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mockito;
 
@@ -22,8 +20,6 @@ import org.mockito.Mockito;
 public class IcebergCatalogMapperTest {
   private static SparkSession spark = null;
 
-  @Test
-  @Ignore
   public void testSparkCatalog() {
     SparkCatalog sparkCatalog = new SparkCatalog();
     sparkCatalog.initialize(
@@ -35,8 +31,6 @@ public class IcebergCatalogMapperTest {
     assert icebergCatalog != null;
   }
 
-  @Test
-  @Ignore
   public void testSparkCatalogCacheDisabled() {
     SparkCatalog sparkCatalog = new SparkCatalog();
     sparkCatalog.initialize(
@@ -54,8 +48,6 @@ public class IcebergCatalogMapperTest {
     assert icebergCatalog != null;
   }
 
-  @Test
-  @Ignore
   public void testSparkSessionCatalog() {
     SparkSessionCatalog sparkCatalog = new SparkSessionCatalog();
     sparkCatalog.initialize(
@@ -67,8 +59,6 @@ public class IcebergCatalogMapperTest {
     assert icebergCatalog != null;
   }
 
-  @Test
-  @Ignore
   public void testSparkSessionCatalogCacheDisabled() {
     SparkSessionCatalog sparkCatalog = new SparkSessionCatalog();
     sparkCatalog.initialize(
@@ -86,8 +76,6 @@ public class IcebergCatalogMapperTest {
     assert icebergCatalog != null;
   }
 
-  @Test
-  @Ignore
   public void testNonIcebergCatalog() {
     TableCatalog fakeTableCatalog = Mockito.mock(TableCatalog.class);
     assert IcebergCatalogMapper.toIcebergCatalog(fakeTableCatalog) == null;


### PR DESCRIPTION
## Summary

The IcebergCatalogMapperTest uses a custom catalog that interferes with the other tests in spark-itests that uses SparkCatalog as the sparkcontext are being reused. To avoid false postive build failure happening due to these conflicts, this PR disables the IcebergCatalogMapperTest.

`IcebergCatalogMapperTest` verifies if `SparkCatalog` and `SparkSessionCatalog` can be converted to iceberg `Catalog` as expected including cases where cache is disabled. 

In the subsequent PR, will try separating this test similar to `statementtest` to re-enable this without test failures.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [X] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [X] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
