### PR TITLE
Stop returning shallow copy of catalog properties by public api

### DIFF
--- a/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
+++ b/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
@@ -84,7 +84,7 @@ public class OpenHouseCatalog extends BaseMetastoreCatalog
 
   private String name;
 
-  private Map<String, String> properties;
+  protected Map<String, String> properties;
 
   private static final String DEFAULT_CLUSTER = "local";
 
@@ -143,9 +143,14 @@ public class OpenHouseCatalog extends BaseMetastoreCatalog
     }
   }
 
+  /**
+   * returns an unmodifiableMap of catalog properties preserving original properties
+   *
+   * @return
+   */
   @Override
   public Map<String, String> properties() {
-    return properties;
+    return Collections.unmodifiableMap(properties);
   }
 
   @Override


### PR DESCRIPTION
## Summary

A shallow copy of Catalog properties were exposed via a public API making them vulnerable to modifications. This could be mistakenly updated by consumers affecting Catalog operations.

With this change, public API now returns a **unmodifiableMap** of properties which should allow to read only but writes will throw exception. Also, and changes to original catalog properties will also be reflected in the copy returned keeping it in sync.

Also updated the TokenRefetch consumer to ensure it works on original properties object.
## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->
Mint tests.
Ran AZ job with token refetch process with snapshot version - [AZ Job Link](https://ltx1-holdemaz05.grid.linkedin.com:8443/executor?execid=103825809)

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [x] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
