### PR TITLE
Files in trash should not be considered as orphan

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -152,7 +152,11 @@ public final class Operations implements AutoCloseable {
   public boolean deleteOrphanDirectory(
       Path tableDirectoryPath, String trashDir, long olderThanTimestampMillis) {
     List<Path> matchingFiles = Lists.newArrayList();
-    listFiles(tableDirectoryPath, file -> true, true, matchingFiles);
+    listFiles(
+        tableDirectoryPath,
+        file -> !file.getPath().toString().contains(trashDir),
+        true,
+        matchingFiles);
 
     boolean anyMatched = false;
     // if there is one file that satisfy predicate, all files should go into trash
@@ -174,15 +178,12 @@ public final class Operations implements AutoCloseable {
     }
 
     for (Path matchingFile : matchingFiles) {
-      if (!matchingFile.toString().contains(trashDir)) {
-        Path trashPath =
-            getTrashPath(tableDirectoryPath.toString(), matchingFile.toString(), trashDir);
-        try {
-          rename(matchingFile, trashPath);
-        } catch (IOException e) {
-          log.error(
-              String.format("Move operation failed for file path: %s", tableDirectoryPath), e);
-        }
+      Path trashPath =
+          getTrashPath(tableDirectoryPath.toString(), matchingFile.toString(), trashDir);
+      try {
+        rename(matchingFile, trashPath);
+      } catch (IOException e) {
+        log.error(String.format("Move operation failed for file path: %s", tableDirectoryPath), e);
       }
     }
     return true;

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -472,6 +472,8 @@ public class OperationsTest extends OpenHouseSparkITest {
       ops.listFiles(tbLoc, file -> true, true, matchingFilesBefore);
       boolean orphaned = ops.deleteOrphanDirectory(tbLoc, ".trash", timeThreshold);
       Assertions.assertTrue(orphaned);
+      // All files should have been moved to trash dir
+      // Making sure nothing needs to be orphaned again
       orphaned = ops.deleteOrphanDirectory(tbLoc, ".trash", timeThreshold);
       Assertions.assertFalse(orphaned);
       List<Path> matchingFilesAfter = new ArrayList<>();

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -472,6 +472,8 @@ public class OperationsTest extends OpenHouseSparkITest {
       ops.listFiles(tbLoc, file -> true, true, matchingFilesBefore);
       boolean orphaned = ops.deleteOrphanDirectory(tbLoc, ".trash", timeThreshold);
       Assertions.assertTrue(orphaned);
+      orphaned = ops.deleteOrphanDirectory(tbLoc, ".trash", timeThreshold);
+      Assertions.assertFalse(orphaned);
       List<Path> matchingFilesAfter = new ArrayList<>();
       ops.listFiles(tbLoc, file -> true, true, matchingFilesAfter);
       Assertions.assertEquals(matchingFilesBefore.size(), matchingFilesAfter.size());


### PR DESCRIPTION
## Summary

Right now, ODD lists all files in the table directory and the filter for non trashed files happen later. This is problematic because by the time it happens, orphan will return true and the code won't enter staged deletion stage. 

By moving the predicate up, if no other files outside of the trash folder, we should directory enter staged files deletion and see if we need to empty the trash folder

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [] Some other form of testing like staging or soak time in production. Please explain.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
