### PR TITLE
Refactor publishing in TableStatsCollector Job to support custom downstream implementation

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -494,7 +494,7 @@ public final class Operations implements AutoCloseable {
       return null;
     }
 
-    IcebergTableStats tableStats = tableStatsCollector.collectAndPublishTableStats();
+    IcebergTableStats tableStats = tableStatsCollector.collectTableStats();
     return tableStats;
   }
 }

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/TableStatsCollectionSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/TableStatsCollectionSparkApp.java
@@ -1,5 +1,7 @@
 package com.linkedin.openhouse.jobs.spark;
 
+import com.google.gson.Gson;
+import com.linkedin.openhouse.common.stats.model.IcebergTableStats;
 import com.linkedin.openhouse.jobs.spark.state.StateManager;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,7 +26,18 @@ public class TableStatsCollectionSparkApp extends BaseTableSparkApp {
   protected void runInner(Operations ops) {
     log.info("Running TableStatsCollectorApp for table {}", fqtn);
 
-    ops.collectTableStats(fqtn);
+    IcebergTableStats icebergTableStats = ops.collectTableStats(fqtn);
+    publishStats(icebergTableStats);
+  }
+
+  /**
+   * Publish table stats.
+   *
+   * @param icebergTableStats
+   */
+  protected void publishStats(IcebergTableStats icebergTableStats) {
+    log.info("Publishing stats for table: {}", fqtn);
+    log.info(new Gson().toJson(icebergTableStats));
   }
 
   public static void main(String[] args) {

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableStatsCollector.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableStatsCollector.java
@@ -1,6 +1,5 @@
 package com.linkedin.openhouse.jobs.util;
 
-import com.google.gson.Gson;
 import com.linkedin.openhouse.common.stats.model.IcebergTableStats;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,8 +17,8 @@ public class TableStatsCollector {
   String fqtn;
   Table table;
 
-  /** Collect and publish table stats. */
-  public IcebergTableStats collectAndPublishTableStats() {
+  /** Collect table stats. */
+  public IcebergTableStats collectTableStats() {
     IcebergTableStats stats = IcebergTableStats.builder().build();
 
     IcebergTableStats statsWithMetadataData =
@@ -34,17 +33,6 @@ public class TableStatsCollector {
     IcebergTableStats tableStats =
         TableStatsCollectorUtil.populateStorageStats(fqtn, table, fs, statsWithCurrentSnapshot);
 
-    publishStats(tableStats);
     return tableStats;
-  }
-
-  /**
-   * Publish table stats.
-   *
-   * @param stats Table stats to publish
-   */
-  void publishStats(IcebergTableStats stats) {
-    log.info("Publishing stats for table: {}", fqtn);
-    log.info(new Gson().toJson(stats));
   }
 }


### PR DESCRIPTION
## Summary

This PR moves publishing of stats from TableStatsCollector to the spark app. This enables having a customized publishing mechanism for the stats. No functionality change introduced in this PR.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [X] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [X] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Executed the same tests as in PR #70 .  Spark app logs look like below.

The difference is the logs printing happens in TableStatsCollectionSparkApp instead of TableStatsCollector. 
`
INFO spark.TableStatsCollectionSparkApp: {\"totalReferencedDataFilesSizeInBytes\":459,\"numReferencedDataFiles\":1,\"totalDirectorySizeInBytes\":16954,\"numObjectsInDirectory\":5,\"currentSnapshotId\":569617771834801003,\"currentSnapshotTimestamp\":1712880334963,\"numCurrentSnapshotReferencedDataFiles\":1,\"totalCurrentSnapshotReferencedDataFilesSizeInBytes\":459,\"oldestSnapshotTimestamp\":1712880334963,\"numExistingMetadataJsonFiles\":2,\"numReferencedManifestFiles\":1,\"numReferencedManifestLists\":1,\"recordTimestamp\":1712880598869,\"clusterName\":\"LocalHadoopCluster\",\"databaseName\":\"db\",\"tableName\":\"tb\",\"tableUUID\":\"8dd7b973-65d4-4c69-953b-abfcb760cc49\",\"tableLocation\":\"/data/openhouse/db/tb-8dd7b973-65d4-4c69-953b-abfcb760cc49\",\"tableCreator\":\"openhouse\",\"tableCreationTimestamp\":0,\"tableLastUpdatedTimestamp\":0,\"tableType\":\"PRIMARY_TABLE\"}`

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
