### PR TITLE
HTS concurrent put and delete resolution

### DIFF
--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/spec/model/UserTable.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/spec/model/UserTable.java
@@ -37,7 +37,9 @@ public class UserTable {
   @Pattern(regexp = ALPHA_NUM_UNDERSCORE_REGEX, message = ALPHA_NUM_UNDERSCORE_ERROR_MSG)
   private String databaseId;
 
-  @Schema(description = "Current Version of the user table.", example = "")
+  @Schema(
+      description = "Current Version of the user table. New record should have 'INTITAL_VERISON'",
+      example = "")
   @JsonProperty(value = "tableVersion")
   private String tableVersion;
 

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/dto/mapper/UserTableVersionMapper.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/dto/mapper/UserTableVersionMapper.java
@@ -15,11 +15,21 @@ import org.mapstruct.Named;
  */
 @Mapper(componentModel = "spring")
 public class UserTableVersionMapper {
+  public static final String INITIAL_VERSION = "INITIAL_VERSION";
 
   @Named("toVersion")
   public Long toVersion(UserTable userTable, @Context Optional<UserTableRow> existingUserTableRow) {
     if (!existingUserTableRow.isPresent()) {
-      return 1L;
+      if (!userTable.getTableVersion().equals(INITIAL_VERSION)) {
+        throw new EntityConcurrentModificationException(
+            String.format(
+                "databaseId : %s, tableId : %s %s",
+                userTable.getDatabaseId(),
+                userTable.getTableId(),
+                "The requested user table has been deleted by other processes."),
+            new RuntimeException());
+      }
+      return null;
     } else {
       if (existingUserTableRow.get().getMetadataLocation().equals(userTable.getTableVersion())) {
         return existingUserTableRow.get().getVersion();

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/dto/mapper/UserTableVersionMapper.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/dto/mapper/UserTableVersionMapper.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.housetables.dto.mapper;
 
+import com.linkedin.openhouse.common.api.validator.ValidatorConstants;
 import com.linkedin.openhouse.common.exception.EntityConcurrentModificationException;
 import com.linkedin.openhouse.housetables.api.spec.model.UserTable;
 import com.linkedin.openhouse.housetables.model.UserTableRow;
@@ -15,12 +16,10 @@ import org.mapstruct.Named;
  */
 @Mapper(componentModel = "spring")
 public class UserTableVersionMapper {
-  public static final String INITIAL_VERSION = "INITIAL_VERSION";
-
   @Named("toVersion")
   public Long toVersion(UserTable userTable, @Context Optional<UserTableRow> existingUserTableRow) {
     if (!existingUserTableRow.isPresent()) {
-      if (!userTable.getTableVersion().equals(INITIAL_VERSION)) {
+      if (!userTable.getTableVersion().equals(ValidatorConstants.INITIAL_TABLE_VERSION)) {
         throw new EntityConcurrentModificationException(
             String.format(
                 "databaseId : %s, tableId : %s %s",

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesServiceImpl.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesServiceImpl.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.util.Pair;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Component;
@@ -68,7 +69,9 @@ public class UserTablesServiceImpl implements UserTablesService {
 
     try {
       returnedDto = userTablesMapper.toUserTableDto(htsJdbcRepository.save(targetUserTableRow));
-    } catch (CommitFailedException | ObjectOptimisticLockingFailureException ce) {
+    } catch (CommitFailedException
+        | ObjectOptimisticLockingFailureException
+        | DataIntegrityViolationException e) {
       throw new EntityConcurrentModificationException(
           String.format(
               "databaseId : %s, tableId : %s, version: %s %s",
@@ -77,7 +80,7 @@ public class UserTablesServiceImpl implements UserTablesService {
               targetUserTableRow.getVersion(),
               "The requested user table has been modified/created by other processes."),
           userTablesMapper.fromUserTableToRowKey(userTable).toString(),
-          ce);
+          e);
     }
 
     return Pair.of(returnedDto, existingUserTableRow.isPresent());

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/HtsRepositoryTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/HtsRepositoryTest.java
@@ -97,8 +97,4 @@ public class HtsRepositoryTest {
     htsRepository.deleteById(
         UserTableRowPrimaryKey.builder().databaseId(TEST_DB_ID).tableId(TEST_TABLE_ID).build());
   }
-
-  private Boolean isUserTableRowEqual(UserTableRow expected, UserTableRow actual) {
-    return expected.toBuilder().version(0L).build().equals(actual.toBuilder().version(0L).build());
-  }
 }

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/HtsRepositoryTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/HtsRepositoryTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.test.context.ContextConfiguration;
 
@@ -58,9 +59,15 @@ public class HtsRepositoryTest {
   @Test
   public void testSaveUserTableWithConflict() {
     Long currentVersion = htsRepository.save(TEST_USER_TABLE_ROW).getVersion();
+    // test create the table again
+    Exception exception =
+        Assertions.assertThrows(
+            Exception.class,
+            () -> htsRepository.save(TEST_USER_TABLE_ROW.toBuilder().version(null).build()));
+    Assertions.assertTrue(exception instanceof DataIntegrityViolationException);
 
     // test update at wrong version
-    Exception exception =
+    exception =
         Assertions.assertThrows(
             Exception.class,
             () -> htsRepository.save(TEST_USER_TABLE_ROW.toBuilder().version(100L).build()));

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/HtsRepositoryTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/HtsRepositoryTest.java
@@ -24,6 +24,14 @@ public class HtsRepositoryTest {
   @Autowired HtsRepository<UserTableRow, UserTableRowPrimaryKey> htsRepository;
 
   @Test
+  public void testSaveFirstRecord() {
+    // before insertion
+    Assertions.assertEquals(null, TEST_USER_TABLE_ROW.getVersion());
+    // after insertion
+    Assertions.assertEquals(0, htsRepository.save(TEST_USER_TABLE_ROW).getVersion());
+  }
+
+  @Test
   public void testHouseTable() {
     htsRepository.save(TEST_USER_TABLE_ROW);
     UserTableRow actual =

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/mock/mapper/UserTableVersionMapperTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/mock/mapper/UserTableVersionMapperTest.java
@@ -17,8 +17,8 @@ public class UserTableVersionMapperTest {
   @Test
   void testToVersionWithNoExistingRow() {
     Assertions.assertEquals(
-        versionMapper.toVersion(TestHouseTableModelConstants.TEST_USER_TABLE, Optional.empty()),
-        null);
+        null,
+        versionMapper.toVersion(TestHouseTableModelConstants.TEST_USER_TABLE, Optional.empty()));
   }
 
   @Test

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/mock/mapper/UserTableVersionMapperTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/mock/mapper/UserTableVersionMapperTest.java
@@ -18,7 +18,17 @@ public class UserTableVersionMapperTest {
   void testToVersionWithNoExistingRow() {
     Assertions.assertEquals(
         versionMapper.toVersion(TestHouseTableModelConstants.TEST_USER_TABLE, Optional.empty()),
-        1L);
+        null);
+  }
+
+  @Test
+  void testToVersionWithNoExistingRowAndIncorrectTableVersion() {
+    Assertions.assertThrows(
+        EntityConcurrentModificationException.class,
+        () ->
+            versionMapper.toVersion(
+                TestHouseTableModelConstants.TEST_USER_TABLE.toBuilder().tableVersion("v1").build(),
+                Optional.empty()));
   }
 
   @Test

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/mock/mapper/UserTablesMapperTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/mock/mapper/UserTablesMapperTest.java
@@ -1,5 +1,7 @@
 package com.linkedin.openhouse.housetables.mock.mapper;
 
+import static com.linkedin.openhouse.housetables.model.TestHouseTableModelConstants.*;
+
 import com.linkedin.openhouse.housetables.dto.mapper.UserTablesMapper;
 import com.linkedin.openhouse.housetables.dto.model.UserTableDto;
 import com.linkedin.openhouse.housetables.model.TestHouseTableModelConstants;
@@ -36,20 +38,28 @@ public class UserTablesMapperTest {
 
   @Test
   void toUserTableRowNullStorageType() {
-    Assertions.assertEquals(
-        TestHouseTableModelConstants.TEST_USER_TABLE_ROW,
-        userTablesMapper.toUserTableRow(
-            TestHouseTableModelConstants.TEST_USER_TABLE.toBuilder().storageType(null).build(),
-            Optional.empty()));
+    Assertions.assertTrue(
+        isUserTableRowEqual(
+            TestHouseTableModelConstants.TEST_USER_TABLE_ROW,
+            userTablesMapper.toUserTableRow(
+                TestHouseTableModelConstants.TEST_USER_TABLE.toBuilder().storageType(null).build(),
+                Optional.empty())));
   }
 
   @Test
   void toUserTableRowCustomStorageType() {
-    Assertions.assertEquals(
-        TestHouseTableModelConstants.TEST_USER_TABLE_ROW.toBuilder().storageType("blobfs").build(),
-        userTablesMapper.toUserTableRow(
-            TestHouseTableModelConstants.TEST_USER_TABLE.toBuilder().storageType("blobfs").build(),
-            Optional.empty()));
+    Assertions.assertTrue(
+        isUserTableRowEqual(
+            TestHouseTableModelConstants.TEST_USER_TABLE_ROW
+                .toBuilder()
+                .storageType("blobfs")
+                .build(),
+            userTablesMapper.toUserTableRow(
+                TestHouseTableModelConstants.TEST_USER_TABLE
+                    .toBuilder()
+                    .storageType("blobfs")
+                    .build(),
+                Optional.empty())));
   }
 
   @Test

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/model/TestHouseTableModelConstants.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/model/TestHouseTableModelConstants.java
@@ -87,4 +87,8 @@ public class TestHouseTableModelConstants {
               .build();
     }
   }
+
+  public static Boolean isUserTableRowEqual(UserTableRow expected, UserTableRow actual) {
+    return expected.toBuilder().version(0L).build().equals(actual.toBuilder().version(0L).build());
+  }
 }

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/model/TestHouseTableModelConstants.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/model/TestHouseTableModelConstants.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.housetables.model;
 
+import com.linkedin.openhouse.common.api.validator.ValidatorConstants;
 import com.linkedin.openhouse.housetables.api.spec.model.UserTable;
 import com.linkedin.openhouse.housetables.dto.model.UserTableDto;
 import lombok.Getter;
@@ -51,16 +52,12 @@ public class TestHouseTableModelConstants {
     public TestTuple(int tbSeq, int dbSeq) {
       this.tableId = "test_table" + tbSeq;
       this.databaseId = "test_db" + dbSeq;
-      this.ver =
-          LOC_TEMPLATE
-              .replace("$test_db", databaseId)
-              .replace("$test_table", tableId)
-              .replace("$version", "v0");
+      this.ver = ValidatorConstants.INITIAL_TABLE_VERSION;
       this.tableLoc =
           LOC_TEMPLATE
               .replace("$test_db", databaseId)
               .replace("$test_table", tableId)
-              .replace("$version", "v1");
+              .replace("$version", "v0");
       this.storageType = TEST_DEFAULT_STORAGE_TYPE;
       this._userTable =
           UserTable.builder()
@@ -84,7 +81,7 @@ public class TestHouseTableModelConstants {
           UserTableRow.builder()
               .tableId(tableId)
               .databaseId(databaseId)
-              .version(1L)
+              .version(null)
               .metadataLocation(tableLoc)
               .storageType(storageType)
               .build();


### PR DESCRIPTION
## Summary

This PR provides a resolution for the concurrent put and delete bug in HTS. It also fixes the concurrent posts issue.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

Added `INITIAL_VERSION` check to prevent a put request being blindly accepted when the entry has been deleted. Also changed the initial version of a row to be null so that it can be considered as a new entry to JPA.

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Added temporary code to facilitate tests: Put thread will sleep 5s before calling the save() method.

There are 4 sets of docker tests carried out before and after the change:
### Before change
**Ex1. concurrent posts**
Succeeded. Second post will be taken as a put.

**Ex2. concurrent puts**
Failed. Second put will conflict.

**Ex3. concurrent put and delete**
Failed. Delete goes before save(), and so put will conflict.
```
{"status":"CONFLICT","error":"Conflict","message":"Entity with key[databaseId : d1, tableId : t1, version: 1 The requested user table has been modified/created by other processes.] is modified by another process already, nested exception message: Batch update returned unexpected row count from update [0]; actual row count: 0; expected: 1; statement executed: update user_table_row set metadata_location=?, storage_type=?, version=? where database_id=? and table_id=? and version=?; nested exception is org.hibernate.StaleStateException: Batch update returned unexpected row count from update [0]; actual row count: 0; expected: 1; statement executed: update user_table_row set metadata_location=?, storage_type=?, version=? where database_id=? and table_id=? and version=?","stacktrace":null,"cause":"Batch update returned unexpected row count from update [0]; actual row count: 0; expected: 1; statement executed: update user_table_row set metadata_location=?, storage_type=?, version=? where database_id=? and table_id=?* Connection #0 to host localhost left intact
 and version=?; nested exception is org.hibernate.StaleStateException: Batch update returned unexpected row count from update [0]; actual row count: 0; expected: 1; statement executed: update user_table_row set metadata_location=?, storage_type=?, version=? where database_id=? and table_id=? and version=?"}
```

**Ex4. Put on a deleted entry**
Succeeded. Put will be blindly accepted.

**We can see that there are 2 problems:**
1. Concurrent post should fail, but not taken as a put.
2. Put on a deleted entry should also fail.

**We can also learn an important fact:**
Concurrent puts and concurrent put/delete can be taken care at the repository level. We don't need additional locks or transactions to make the save() method safe. So we only need to tackle the 2 problems at the service level, more specifically in the mapper.

As a matter of fact, in JPA implementation, the save() method will consider an entity as new only if the versioned column is null. If so, it will throw an error on the second post. Therefore, `UserTableVersionMapper` should return null as the version for the new entry instead of `1L`. With this knowledge in mind, we can also understand why concurrent puts or concurrent put/delete can be taken care. The JPA module takes the entry as being seen, but it can not find it as it has been modified or deleted, so it throws an error.

Source: https://docs.spring.io/spring-data/jpa/docs/2.6.1/reference/html/#jpa.entity-persistence

### After change
**Ex1. concurrent posts**
Failed. Second post causes internal server error.
```
{"status":"CONFLICT","error":"Conflict","message":"Entity with key[databaseId : d1, tableId : t1, version: 0 The requested user table has been modified/created by other processes.] is modified by another process already, nested exception message: could not execute statement; SQL [n/a]; constraint [user_table_row.PRIMARY]; nested exception is org.hibernate.exception.ConstraintViolationException: could not execute statement","stacktrace":null,"cause":"could not execute statement; SQL [n/a]; constraint [user_table_row.PRIMARY]; nested exception is org.hibernate.exception.ConstraintViolationException: could not execute statement"}
```

**Ex2. concurrent puts**
Failed. Second put will conflict.

**Ex3. concurrent put and delete**
Failed. Delete goes before save(), and so put will conflict.

**Ex4. Put on a deleted entry**
Failed. Put will be rejected as the entry is deleted.
```
{"status":"CONFLICT","error":"Conflict","message":"Entity with key[databaseId : d1, tableId : t1 The requested user table has been deleted by other processes.] is modified by another process already, nested exception message: null","stacktrace":null,"cause":null}
```

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.
