### PR TITLE
Add cluster.yaml, StorageProperties, StorageType enum for supporting multiple storages

### DIFF
--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/StorageType.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/StorageType.java
@@ -1,0 +1,34 @@
+package com.linkedin.openhouse.cluster.storage;
+
+import lombok.*;
+
+/**
+ * Enum for supported storage types.
+ *
+ * <p>New types should be added here as public static final fields, and their corresponding
+ * implementations should be added to the fromString method.
+ */
+public class StorageType {
+  public static final Type HDFS = new Type("hdfs");
+  public static final Type LOCAL = new Type("local");
+
+  @AllArgsConstructor
+  @EqualsAndHashCode
+  @Getter
+  public static class Type {
+    private String value;
+  }
+
+  public Type fromString(String type) {
+    if (type == null) {
+      return null;
+    }
+    if (type.equals(HDFS.getValue())) {
+      return HDFS;
+    } else if (type.equals(LOCAL.getValue())) {
+      return LOCAL;
+    } else {
+      return null;
+    }
+  }
+}

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/StorageType.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/StorageType.java
@@ -20,15 +20,12 @@ public class StorageType {
   }
 
   public Type fromString(String type) {
-    if (type == null) {
-      return null;
-    }
-    if (type.equals(HDFS.getValue())) {
+    if (HDFS.getValue().equals(type)) {
       return HDFS;
-    } else if (type.equals(LOCAL.getValue())) {
+    } else if (LOCAL.getValue().equals(type)) {
       return LOCAL;
     } else {
-      return null;
+      throw new IllegalArgumentException("Unknown storage type: " + type);
     }
   }
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/configs/StorageProperties.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/configs/StorageProperties.java
@@ -1,0 +1,35 @@
+package com.linkedin.openhouse.cluster.storage.configs;
+
+import com.linkedin.openhouse.cluster.configs.YamlPropertySourceFactory;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.*;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+@Configuration
+@ConfigurationProperties(prefix = "cluster.storages")
+@PropertySource(
+    name = "clusterStorage",
+    value = "file:${OPENHOUSE_CLUSTER_CONFIG_PATH:/var/config/cluster.yaml}",
+    factory = YamlPropertySourceFactory.class,
+    ignoreResourceNotFound = true)
+@Getter
+@Setter
+public class StorageProperties {
+  private String defaultType;
+  private Map<String, StorageTypeProperties> types = new HashMap<>();
+
+  @Getter
+  @Setter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Builder(toBuilder = true)
+  public static class StorageTypeProperties {
+    private String scheme;
+    private String rootPath;
+    private String endpoint;
+    @Builder.Default private Map<String, String> parameters = new HashMap<>();
+  }
+}

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/configs/StorageProperties.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/configs/StorageProperties.java
@@ -19,7 +19,7 @@ import org.springframework.context.annotation.PropertySource;
 @Setter
 public class StorageProperties {
   private String defaultType;
-  private Map<String, StorageTypeProperties> types = new HashMap<>();
+  private Map<String, StorageTypeProperties> types;
 
   @Getter
   @Setter

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/configs/StorageProperties.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/configs/StorageProperties.java
@@ -10,8 +10,8 @@ import org.springframework.context.annotation.PropertySource;
 
 /**
  * This class represents the storage properties for the cluster. It includes the default storage
- * type and a map of different storage types. Each storage type has its own properties such as
- * scheme, root path, endpoint, and parameters. For list of supported storage types, see {@link
+ * type and a map of different storage types. Each storage type has its own properties such as root
+ * path, endpoint, and parameters. For list of supported storage types, see {@link
  * com.linkedin.openhouse.cluster.storage.StorageType}.
  */
 @Configuration
@@ -33,7 +33,6 @@ public class StorageProperties {
   @NoArgsConstructor
   @Builder(toBuilder = true)
   public static class StorageTypeProperties {
-    private String scheme;
     private String rootPath;
     private String endpoint;
     @Builder.Default private Map<String, String> parameters = new HashMap<>();

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/configs/StorageProperties.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/configs/StorageProperties.java
@@ -8,6 +8,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 
+/**
+ * This class represents the storage properties for the cluster. It includes the default storage
+ * type and a map of different storage types. Each storage type has its own properties such as
+ * scheme, root path, endpoint, and parameters. For list of supported storage types, see {@link
+ * com.linkedin.openhouse.cluster.storage.StorageType}.
+ */
 @Configuration
 @ConfigurationProperties(prefix = "cluster.storages")
 @PropertySource(

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/StoragePropertiesConfigTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/StoragePropertiesConfigTest.java
@@ -16,11 +16,11 @@ public class StoragePropertiesConfigTest {
 
   private static final String DEFAULT_TYPE = "hdfs";
 
-  private static final String DEFAULT_SCHEME = "hdfs";
+  private static final String DEFAULT_ENDPOINT = "hdfs://localhost:9000";
 
   private static final String ANOTHER_TYPE = "objectstore";
 
-  private static final String ANOTHER_SCHEME = "objectstorescheme";
+  private static final String ANOTHER_ENDPOINT = "http://localhost:9000";
   private static final String NON_EXISTING_TYPE = "non-existing-type";
 
   @Test
@@ -31,13 +31,13 @@ public class StoragePropertiesConfigTest {
   @Test
   public void testStorageTypeScheme() {
     Assertions.assertEquals(
-        DEFAULT_SCHEME, storageProperties.getTypes().get(DEFAULT_TYPE).getScheme());
+        DEFAULT_ENDPOINT, storageProperties.getTypes().get(DEFAULT_TYPE).getEndpoint());
   }
 
   @Test
   public void testStorageTypeLookup() {
     Assertions.assertEquals(
-        ANOTHER_SCHEME, storageProperties.getTypes().get(ANOTHER_TYPE).getScheme());
+        ANOTHER_ENDPOINT, storageProperties.getTypes().get(ANOTHER_TYPE).getEndpoint());
   }
 
   @Test

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/StoragePropertiesConfigTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/StoragePropertiesConfigTest.java
@@ -15,7 +15,12 @@ public class StoragePropertiesConfigTest {
   @Autowired private StorageProperties storageProperties;
 
   private static final String DEFAULT_TYPE = "hdfs";
-  private static final String ANOTHER_TYPE = "s3";
+
+  private static final String DEFAULT_SCHEME = "hdfs";
+
+  private static final String ANOTHER_TYPE = "objectstore";
+
+  private static final String ANOTHER_SCHEME = "objectstorescheme";
   private static final String NON_EXISTING_TYPE = "non-existing-type";
 
   @Test
@@ -26,13 +31,13 @@ public class StoragePropertiesConfigTest {
   @Test
   public void testStorageTypeScheme() {
     Assertions.assertEquals(
-        DEFAULT_TYPE, storageProperties.getTypes().get(DEFAULT_TYPE).getScheme());
+        DEFAULT_SCHEME, storageProperties.getTypes().get(DEFAULT_TYPE).getScheme());
   }
 
   @Test
   public void testStorageTypeLookup() {
     Assertions.assertEquals(
-        ANOTHER_TYPE, storageProperties.getTypes().get(ANOTHER_TYPE).getScheme());
+        ANOTHER_SCHEME, storageProperties.getTypes().get(ANOTHER_TYPE).getScheme());
   }
 
   @Test

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/StoragePropertiesConfigTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/StoragePropertiesConfigTest.java
@@ -1,0 +1,53 @@
+package com.linkedin.openhouse.tables.mock.storage;
+
+import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
+import com.linkedin.openhouse.tables.mock.properties.CustomClusterPropertiesInitializer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+
+@SpringBootTest
+@ContextConfiguration(initializers = CustomClusterPropertiesInitializer.class)
+public class StoragePropertiesConfigTest {
+  @Autowired private StorageProperties storageProperties;
+
+  private static final String DEFAULT_TYPE = "hdfs";
+  private static final String ANOTHER_TYPE = "s3";
+  private static final String NON_EXISTING_TYPE = "non-existing-type";
+
+  @Test
+  public void testDefaultType() {
+    Assertions.assertEquals(DEFAULT_TYPE, storageProperties.getDefaultType());
+  }
+
+  @Test
+  public void testStorageTypeScheme() {
+    Assertions.assertEquals(
+        DEFAULT_TYPE, storageProperties.getTypes().get(DEFAULT_TYPE).getScheme());
+  }
+
+  @Test
+  public void testStorageTypeLookup() {
+    Assertions.assertEquals(
+        ANOTHER_TYPE, storageProperties.getTypes().get(ANOTHER_TYPE).getScheme());
+  }
+
+  @Test
+  public void testStorageTypeVariableProperties() {
+    Assertions.assertFalse(
+        storageProperties.getTypes().get(DEFAULT_TYPE).getParameters().isEmpty());
+  }
+
+  @Test
+  public void testUnsetPropertiesAreNull() {
+    Assertions.assertNull(storageProperties.getTypes().get(NON_EXISTING_TYPE));
+  }
+
+  @AfterAll
+  static void unsetSysProp() {
+    System.clearProperty("OPENHOUSE_CLUSTER_CONFIG_PATH");
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/StoragePropertiesConfigTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/StoragePropertiesConfigTest.java
@@ -29,7 +29,7 @@ public class StoragePropertiesConfigTest {
   }
 
   @Test
-  public void testStorageTypeScheme() {
+  public void testStorageTypeEndpoint() {
     Assertions.assertEquals(
         DEFAULT_ENDPOINT, storageProperties.getTypes().get(DEFAULT_TYPE).getEndpoint());
   }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/StorageTypeEnumTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/StorageTypeEnumTest.java
@@ -1,0 +1,59 @@
+package com.linkedin.openhouse.tables.mock.storage;
+
+import com.linkedin.openhouse.cluster.storage.StorageType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class StorageTypeEnumTest {
+
+  /**
+   * This test demonstrates the ability to extends the StorageType class to add new storage types.
+   */
+  public static class ExtendedStorageType extends StorageType {
+    public static final Type GCS = new Type("gcs");
+    public static final Type S3 = new Type("s3");
+
+    @Override
+    public Type fromString(String type) {
+      if (type.equals(GCS.getValue())) {
+        return GCS;
+      } else if (type.equals(S3.getValue())) {
+        return S3;
+      }
+      return super.fromString(type);
+    }
+  }
+
+  @Test
+  public void testEnumEquality() {
+    Assertions.assertSame(StorageType.LOCAL, StorageType.LOCAL);
+    Assertions.assertNotSame(StorageType.HDFS, StorageType.LOCAL);
+    Assertions.assertNotSame(ExtendedStorageType.GCS, StorageType.HDFS);
+    Assertions.assertSame(ExtendedStorageType.HDFS, StorageType.HDFS);
+    Assertions.assertTrue(StorageType.LOCAL.equals(ExtendedStorageType.LOCAL));
+  }
+
+  @Test
+  public void testValueEquality() {
+    Assertions.assertEquals("local", StorageType.LOCAL.getValue());
+    Assertions.assertEquals("hdfs", StorageType.HDFS.getValue());
+    Assertions.assertEquals("gcs", ExtendedStorageType.GCS.getValue());
+    Assertions.assertEquals("s3", ExtendedStorageType.S3.getValue());
+    Assertions.assertEquals(StorageType.LOCAL.getValue(), ExtendedStorageType.LOCAL.getValue());
+  }
+
+  @Test
+  public void testTypeFromString() {
+    // Allows StorageType to be extended with new types. A primary bean can be provided.
+    StorageType storageType = new ExtendedStorageType();
+    Assertions.assertSame(StorageType.LOCAL, storageType.fromString("local"));
+    Assertions.assertSame(StorageType.HDFS, storageType.fromString("hdfs"));
+    Assertions.assertSame(ExtendedStorageType.GCS, storageType.fromString("gcs"));
+    Assertions.assertSame(ExtendedStorageType.S3, storageType.fromString("s3"));
+    Assertions.assertSame(StorageType.LOCAL, storageType.fromString("local"));
+    Assertions.assertSame(StorageType.HDFS, storageType.fromString("hdfs"));
+    Assertions.assertSame(ExtendedStorageType.GCS, storageType.fromString("gcs"));
+    Assertions.assertSame(ExtendedStorageType.S3, storageType.fromString("s3"));
+    Assertions.assertNull(storageType.fromString("non-existing-type"));
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/StorageTypeEnumTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/StorageTypeEnumTest.java
@@ -54,6 +54,13 @@ public class StorageTypeEnumTest {
     Assertions.assertSame(StorageType.HDFS, storageType.fromString("hdfs"));
     Assertions.assertSame(ExtendedStorageType.GCS, storageType.fromString("gcs"));
     Assertions.assertSame(ExtendedStorageType.S3, storageType.fromString("s3"));
-    Assertions.assertNull(storageType.fromString("non-existing-type"));
+  }
+
+  @Test
+  public void testExceptionForInvalidString() {
+    StorageType storageType = new StorageType();
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> storageType.fromString("non-existing-type"));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> storageType.fromString(null));
   }
 }

--- a/services/tables/src/test/resources/cluster-test-properties.yaml
+++ b/services/tables/src/test/resources/cluster-test-properties.yaml
@@ -2,6 +2,21 @@ cluster:
   name: "TestCluster"
   storage:
     root-path: "/tmp/unittest"
+  storages:
+    default-type: "hdfs"
+    types:
+      hdfs:
+        scheme: "hdfs"
+        rootpath: "/tmp/unittest"
+        endpoint: "hdfs://localhost:9000"
+        parameters:
+          key1: value1
+      s3:
+        scheme: "s3"
+        rootpath: "tmpbucket"
+        endpoint: "http://localhost:9000"
+        parameters:
+          key2: value2
   housetables:
     base-uri: "http://localhost:8080"
   security:

--- a/services/tables/src/test/resources/cluster-test-properties.yaml
+++ b/services/tables/src/test/resources/cluster-test-properties.yaml
@@ -6,17 +6,16 @@ cluster:
     default-type: "hdfs"
     types:
       hdfs:
-        scheme: "hdfs"
         rootpath: "/tmp/unittest"
         endpoint: "hdfs://localhost:9000"
         parameters:
           key1: value1
       objectstore:
-        scheme: "objectstorescheme"
         rootpath: "tmpbucket"
         endpoint: "http://localhost:9000"
         parameters:
           key2: value2
+          token: xyz
   housetables:
     base-uri: "http://localhost:8080"
   security:

--- a/services/tables/src/test/resources/cluster-test-properties.yaml
+++ b/services/tables/src/test/resources/cluster-test-properties.yaml
@@ -11,8 +11,8 @@ cluster:
         endpoint: "hdfs://localhost:9000"
         parameters:
           key1: value1
-      s3:
-        scheme: "s3"
+      objectstore:
+        scheme: "objectstorescheme"
         rootpath: "tmpbucket"
         endpoint: "http://localhost:9000"
         parameters:


### PR DESCRIPTION
## Summary
This PR along with series of future PR will lay a foundation for adding multiple storages.

- `cluster-test-properties.yaml` shows how the yaml would look like post multi-storage support
```
cluster:
storages:
  default-type: hdfs
  types:
    hdfs:                                       # <----- this StorageType will be stored in HTS
      scheme: hdfs
      root-path: /data/openhouse
      endpoint: hdfs://namenode:9000/
      parameters:
        stringK1: stringV1
        token-refresh-enabled: true

    s3:
      scheme: s3
      root-path: bucketName
      endpoint: http://minio:9000
      parameters:
        stringK2: stringV2

    blob:
      scheme: blobfs
      root-path:
      endpoint: 127.0.0.1:22814
      parameters:
        tenant-name: e2eTestTenant1

```
- `StorageType` imitates an enum and should contain all storages that are supported by OH.
```
StorageType {
  HDFS
  LOCAL
}
```

## Details
`StorageType` is designed in a way that allows it to be extended to add more Storages. Please see the test `StorageTypeEnumTest`

If cluster.yaml is not updated with new layout, `StorageProperties` will be null.

For more details see this doc: https://docs.google.com/document/d/1iPKol1jPzR6fq2YaoWbHHCYzBciCwfhqZqGyYhzZfoQ/edit?usp=sharing

## Changes

- [X] New Features
-- Mult-storage support

## Testing Done
✅ Added unit tests
✅ Build succeeds
✅ springboot service starts even if cluster.yaml is not updated. (Backward-compatible)
