### PR TITLE
Remove unused fields

### DIFF
--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/SnapshotInspector.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/SnapshotInspector.java
@@ -1,6 +1,5 @@
 package com.linkedin.openhouse.internal.catalog;
 
-import com.linkedin.openhouse.cluster.storage.filesystem.FsStorageProvider;
 import com.linkedin.openhouse.internal.catalog.exception.InvalidIcebergSnapshotException;
 import java.io.UncheckedIOException;
 import java.util.List;
@@ -28,8 +27,6 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class SnapshotInspector {
-  @Autowired private FsStorageProvider fsStorageProvider;
-
   @Autowired private Consumer<Supplier<Path>> fileSecurer;
   /**
    * TODO: ADD Validation for snapshot: Sequence-number based, schema-id based, see iceberg spec for

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -49,7 +49,6 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
-import org.apache.iceberg.io.FileIO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -73,8 +72,6 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
   @Autowired TableTypeMapper tableTypeMapper;
 
   @Autowired FsStorageProvider fsStorageProvider;
-
-  @Autowired FileIO fileIO;
 
   @Autowired MeterRegistry meterRegistry;
 


### PR DESCRIPTION
## Summary
Remove unused fields: fileIO and fsStorageProvider where applicable.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
Not adding any new code. 
Tested that existing tests continue to pass with the code removed.
Manually tested on local docker setup using oh-hadoop-spark recipe.

Commands tested on docker:
1. Create a table:
$ curl "${curlArgs[@]}" -XPOST http://localhost:8000/v1/databases/d3/tables/ \
> --data-raw '{
>   "tableId": "t1",
>   "databaseId": "d3",
>   "baseTableVersion": "INITIAL_VERSION",
>   "clusterId": "LocalHadoopCluster",
>   "schema": "{\"type\": \"struct\", \"fields\": [{\"id\": 1,\"required\": true,\"name\": \"id\",\"type\": \"string\"},{\"id\": 2,\"required\": true,\"name\": \"name\",\"type\": \"string\"},{\"id\": 3,\"required\": true,\"name\": \"ts\",\"type\": \"timestamp\"}]}",
>   "timePartitioning": {
>     "columnName": "ts",
>     "granularity": "HOUR"
>   },
>   "clustering": [
>     {
>       "columnName": "name"
>     }
>   ],
>   "tableProperties": {
>     "key": "value"
>   }
> }' | json_pp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2152    0  1578  100   574   1956    711 --:--:-- --:--:-- --:--:--  2666
{
   "clusterId" : "LocalHadoopCluster",
   "clustering" : [
      {
         "columnName" : "name",
         "transform" : null
      }
   ],
   "creationTime" : 1713551227382,
   "databaseId" : "d3",
   "lastModifiedTime" : 1713551227382,
   "policies" : null,
   "schema" : "{\"type\":\"struct\",\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"string\"},{\"id\":2,\"name\":\"name\",\"required\":true,\"type\":\"string\"},{\"id\":3,\"name\":\"ts\",\"required\":true,\"type\":\"timestamp\"}]}",
   "tableCreator" : "openhouse",
   "tableId" : "t1",
   "tableLocation" : "hdfs://namenode:9000/data/openhouse/d3/t1-cfc1b0cd-507c-4bed-8845-5aedbb88ab8b/00000-8f795899-ae32-4e82-b51a-f2908fb4e9b6.metadata.json",
   "tableProperties" : {
      "key" : "value",
      "openhouse.clusterId" : "LocalHadoopCluster",
      "openhouse.creationTime" : "1713551227382",
      "openhouse.databaseId" : "d3",
      "openhouse.lastModifiedTime" : "1713551227382",
      "openhouse.tableCreator" : "openhouse",
      "openhouse.tableId" : "t1",
      "openhouse.tableLocation" : "/data/openhouse/d3/t1-cfc1b0cd-507c-4bed-8845-5aedbb88ab8b/00000-8f795899-ae32-4e82-b51a-f2908fb4e9b6.metadata.json",
      "openhouse.tableType" : "PRIMARY_TABLE",
      "openhouse.tableUUID" : "cfc1b0cd-507c-4bed-8845-5aedbb88ab8b",
      "openhouse.tableUri" : "LocalHadoopCluster.d3.t1",
      "openhouse.tableVersion" : "INITIAL_VERSION",
      "policies" : "",
      "write.format.default" : "orc",
      "write.metadata.delete-after-commit.enabled" : "true",
      "write.metadata.previous-versions-max" : "28"
   },
   "tableType" : "PRIMARY_TABLE",
   "tableUUID" : "cfc1b0cd-507c-4bed-8845-5aedbb88ab8b",
   "tableUri" : "LocalHadoopCluster.d3.t1",
   "tableVersion" : "INITIAL_VERSION",
   "timePartitioning" : {
      "columnName" : "ts",
      "granularity" : "HOUR"
   }
}

2. Read a table:
$ curl "${curlArgs[@]}" -XGET http://localhost:8000/v1/databases/d3/tables/t1 | json_pp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1578    0  1578    0     0   9883      0 --:--:-- --:--:-- --:--:--  9924
{
   "clusterId" : "LocalHadoopCluster",
   "clustering" : [
      {
         "columnName" : "name",
         "transform" : null
      }
   ],
   "creationTime" : 1713551227382,
   "databaseId" : "d3",
   "lastModifiedTime" : 1713551227382,
   "policies" : null,
   "schema" : "{\"type\":\"struct\",\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"string\"},{\"id\":2,\"name\":\"name\",\"required\":true,\"type\":\"string\"},{\"id\":3,\"name\":\"ts\",\"required\":true,\"type\":\"timestamp\"}]}",
   "tableCreator" : "openhouse",
   "tableId" : "t1",
   "tableLocation" : "hdfs://namenode:9000/data/openhouse/d3/t1-cfc1b0cd-507c-4bed-8845-5aedbb88ab8b/00000-8f795899-ae32-4e82-b51a-f2908fb4e9b6.metadata.json",
   "tableProperties" : {
      "key" : "value",
      "openhouse.clusterId" : "LocalHadoopCluster",
      "openhouse.creationTime" : "1713551227382",
      "openhouse.databaseId" : "d3",
      "openhouse.lastModifiedTime" : "1713551227382",
      "openhouse.tableCreator" : "openhouse",
      "openhouse.tableId" : "t1",
      "openhouse.tableLocation" : "/data/openhouse/d3/t1-cfc1b0cd-507c-4bed-8845-5aedbb88ab8b/00000-8f795899-ae32-4e82-b51a-f2908fb4e9b6.metadata.json",
      "openhouse.tableType" : "PRIMARY_TABLE",
      "openhouse.tableUUID" : "cfc1b0cd-507c-4bed-8845-5aedbb88ab8b",
      "openhouse.tableUri" : "LocalHadoopCluster.d3.t1",
      "openhouse.tableVersion" : "INITIAL_VERSION",
      "policies" : "",
      "write.format.default" : "orc",
      "write.metadata.delete-after-commit.enabled" : "true",
      "write.metadata.previous-versions-max" : "28"
   },
   "tableType" : "PRIMARY_TABLE",
   "tableUUID" : "cfc1b0cd-507c-4bed-8845-5aedbb88ab8b",
   "tableUri" : "LocalHadoopCluster.d3.t1",
   "tableVersion" : "INITIAL_VERSION",
   "timePartitioning" : {
      "columnName" : "ts",
      "granularity" : "HOUR"
   }
}

3. List tables in a database:
$ curl "${curlArgs[@]}" -XGET http://localhost:8000/v1/databases/d3/tables/ | json_pp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1592    0  1592    0     0  19951      0 --:--:-- --:--:-- --:--:-- 20151
{
   "results" : [
      {
         "clusterId" : "LocalHadoopCluster",
         "clustering" : [
            {
               "columnName" : "name",
               "transform" : null
            }
         ],
         "creationTime" : 1713551227382,
         "databaseId" : "d3",
         "lastModifiedTime" : 1713551227382,
         "policies" : null,
         "schema" : "{\"type\":\"struct\",\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"string\"},{\"id\":2,\"name\":\"name\",\"required\":true,\"type\":\"string\"},{\"id\":3,\"name\":\"ts\",\"required\":true,\"type\":\"timestamp\"}]}",
         "tableCreator" : "openhouse",
         "tableId" : "t1",
         "tableLocation" : "hdfs://namenode:9000/data/openhouse/d3/t1-cfc1b0cd-507c-4bed-8845-5aedbb88ab8b/00000-8f795899-ae32-4e82-b51a-f2908fb4e9b6.metadata.json",
         "tableProperties" : {
            "key" : "value",
            "openhouse.clusterId" : "LocalHadoopCluster",
            "openhouse.creationTime" : "1713551227382",
            "openhouse.databaseId" : "d3",
            "openhouse.lastModifiedTime" : "1713551227382",
            "openhouse.tableCreator" : "openhouse",
            "openhouse.tableId" : "t1",
            "openhouse.tableLocation" : "/data/openhouse/d3/t1-cfc1b0cd-507c-4bed-8845-5aedbb88ab8b/00000-8f795899-ae32-4e82-b51a-f2908fb4e9b6.metadata.json",
            "openhouse.tableType" : "PRIMARY_TABLE",
            "openhouse.tableUUID" : "cfc1b0cd-507c-4bed-8845-5aedbb88ab8b",
            "openhouse.tableUri" : "LocalHadoopCluster.d3.t1",
            "openhouse.tableVersion" : "INITIAL_VERSION",
            "policies" : "",
            "write.format.default" : "orc",
            "write.metadata.delete-after-commit.enabled" : "true",
            "write.metadata.previous-versions-max" : "28"
         },
         "tableType" : "PRIMARY_TABLE",
         "tableUUID" : "cfc1b0cd-507c-4bed-8845-5aedbb88ab8b",
         "tableUri" : "LocalHadoopCluster.d3.t1",
         "tableVersion" : "INITIAL_VERSION",
         "timePartitioning" : {
            "columnName" : "ts",
            "granularity" : "HOUR"
         }
      }
   ]
}

Tested via spark:
scala> spark.sql("CREATE TABLE openhouse.db.tb (ts timestamp, col1 string, col2 string) PARTITIONED BY (days(ts))").show()
++
||
++
++


scala> spark.sql("DESCRIBE TABLE openhouse.db.tb").show()
+--------------+---------+-------+
|      col_name|data_type|comment|
+--------------+---------+-------+
|            ts|timestamp|       |
|          col1|   string|       |
|          col2|   string|       |
|              |         |       |
|# Partitioning|         |       |
|        Part 0| days(ts)|       |
+--------------+---------+-------+


scala> spark.sql("INSERT INTO TABLE openhouse.db.tb VALUES (current_timestamp(), 'val1', 'val2')")
res2: org.apache.spark.sql.DataFrame = []                                       

scala> spark.sql("INSERT INTO TABLE openhouse.db.tb VALUES (date_sub(CAST(current_timestamp() as DATE), 30), 'val1', 'val2')")
res3: org.apache.spark.sql.DataFrame = []                                       

scala> spark.sql("INSERT INTO TABLE openhouse.db.tb VALUES (date_sub(CAST(current_timestamp() as DATE), 60), 'val1', 'val2')")
res4: org.apache.spark.sql.DataFrame = []                                       

scala> spark.sql("SELECT * FROM openhouse.db.tb").show()
+--------------------+----+----+                                                
|                  ts|col1|col2|
+--------------------+----+----+
| 2024-02-19 00:00:00|val1|val2|
| 2024-03-20 00:00:00|val1|val2|
|2024-04-19 18:35:...|val1|val2|
+--------------------+----+----+


scala> spark.sql("SHOW TABLES IN openhouse.db").show()
+---------+---------+
|namespace|tableName|
+---------+---------+
|       db|       tb|
+---------+---------+



- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [x] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
