### PR TITLE
Update the base image for docker containers from jdk11 to jdk23-ea-11

### DIFF
--- a/housetables-service.Dockerfile
+++ b/housetables-service.Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:23-ea-11-slim
 
 
 ARG USER=openhouse

--- a/jobs-scheduler.Dockerfile
+++ b/jobs-scheduler.Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:23-ea-11-slim
 
 ARG USER=openhouse
 ARG USER_ID=1000

--- a/jobs-service.Dockerfile
+++ b/jobs-service.Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:23-ea-11-slim
 
 ARG USER=openhouse
 ARG USER_ID=1000

--- a/tables-service.Dockerfile
+++ b/tables-service.Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:23-ea-11-slim
 
 
 ARG USER=openhouse


### PR DESCRIPTION
## Summary

Based on some inputs gathered around kind of vulnerabilities we have, it is recommended we change the base image.

Current: https://hub.docker.com/layers/library/openjdk/11.0-jre/images/sha256-762d8d035c3b1c98d30c5385f394f4d762302ba9ee8e0da8c93344c688d160b2?context=explore

New: https://hub.docker.com/layers/library/openjdk/23-ea-11-slim/images/sha256-db301ac83f97fd5dbfd8befdc0a10a19113d480c15fc17d5085c1cfe175d82e6?context=explore

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [X] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [X] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
