### PR TITLE
Made Retention Operation Lightweight by removing/fixing non-metadata ops

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -31,7 +31,6 @@ import org.apache.iceberg.actions.RewriteDataFiles;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.spark.actions.SparkActions;
-import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import scala.collection.JavaConverters;
@@ -237,8 +236,8 @@ public final class Operations implements AutoCloseable {
       String fqtn, String columnName, String columnPattern, String granularity, int count) {
     final String statement =
         SparkJobUtil.createDeleteStatement(fqtn, columnName, columnPattern, granularity, count);
-    Dataset<Row> dsWithExpiredRows = spark.sql(statement);
-    log.info("Retention Job deleted records: {} from table: {}", dsWithExpiredRows.count(), fqtn);
+    List<Row> dsWithExpiredRows = spark.sql(statement).collectAsList();
+    log.info("Retention Job deleted records: {} from table: {}", dsWithExpiredRows.size(), fqtn);
   }
 
   private Path getTrashPath(String path, String filePath, String trashDir) {

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -31,7 +31,6 @@ import org.apache.iceberg.actions.RewriteDataFiles;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.spark.actions.SparkActions;
-import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import scala.collection.JavaConverters;
 
@@ -236,8 +235,8 @@ public final class Operations implements AutoCloseable {
       String fqtn, String columnName, String columnPattern, String granularity, int count) {
     final String statement =
         SparkJobUtil.createDeleteStatement(fqtn, columnName, columnPattern, granularity, count);
-    List<Row> dsWithExpiredRows = spark.sql(statement).collectAsList();
-    log.info("Retention Job deleted records: {} from table: {}", dsWithExpiredRows.size(), fqtn);
+    log.info("deleting records from table: {}", fqtn);
+    spark.sql(statement);
   }
 
   private Path getTrashPath(String path, String filePath, String trashDir) {

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/SparkJobUtil.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/SparkJobUtil.java
@@ -87,45 +87,6 @@ public final class SparkJobUtil {
     }
   }
 
-  public static String createSelectLimitStatement(
-      String fqtn,
-      String columnName,
-      String columnPattern,
-      String granularity,
-      int count,
-      int limit) {
-    if (!StringUtils.isBlank(columnPattern)) {
-      String query =
-          String.format(
-              "SELECT * FROM %s WHERE %s limit %d",
-              getQuotedFqtn(fqtn),
-              String.format(
-                  RETENTION_CONDITION_WITH_PATTERN_TEMPLATE,
-                  columnName,
-                  count,
-                  granularity,
-                  columnPattern),
-              limit);
-      log.info("Table: {} column pattern provided: {} selectQuery: {}", fqtn, columnPattern, query);
-      return query;
-    } else {
-      String query =
-          String.format(
-              "SELECT * FROM %s WHERE %s limit %d",
-              getQuotedFqtn(fqtn),
-              String.format(
-                  RETENTION_CONDITION_TEMPLATE,
-                  granularity,
-                  columnName,
-                  granularity,
-                  count,
-                  granularity),
-              limit);
-      log.info("Table: {} No column pattern provided: selectQuery: {}", fqtn, query);
-      return query;
-    }
-  }
-
   public static String getQuotedFqtn(String fqtn) {
     String[] fqtnTokens = fqtn.split("\\.");
     // adding single quotes around fqtn for cases when db and/or tableName has special character(s),

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/SparkJobUtil.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/SparkJobUtil.java
@@ -47,7 +47,7 @@ public final class SparkJobUtil {
       result: records will be filtered from deletion
   */
   private static final String RETENTION_CONDITION_WITH_PATTERN_TEMPLATE =
-      "to_date(substring(%s, 0, CHAR_LENGTH('%s')), '%s') < date_trunc('%s', current_timestamp() - INTERVAL %s %ss)";
+      "%s < cast(date_format(current_timestamp() - INTERVAL %s %ss, '%s') as string)";
 
   public static String createDeleteStatement(
       String fqtn, String columnName, String columnPattern, String granularity, int count) {
@@ -59,11 +59,9 @@ public final class SparkJobUtil {
               String.format(
                   RETENTION_CONDITION_WITH_PATTERN_TEMPLATE,
                   columnName,
-                  columnPattern,
-                  columnPattern,
-                  granularity,
                   count,
-                  granularity));
+                  granularity,
+                  columnPattern));
       log.info(
           "Table: {}. Column pattern: {}, columnName {}, granularity {}s, " + "retention query: {}",
           fqtn,
@@ -104,11 +102,9 @@ public final class SparkJobUtil {
               String.format(
                   RETENTION_CONDITION_WITH_PATTERN_TEMPLATE,
                   columnName,
-                  columnPattern,
-                  columnPattern,
-                  granularity,
                   count,
-                  granularity),
+                  granularity,
+                  columnPattern),
               limit);
       log.info("Table: {} column pattern provided: {} selectQuery: {}", fqtn, columnPattern, query);
       return query;

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -129,7 +129,7 @@ public class OperationsTest extends OpenHouseSparkITest {
           ops, tableName6, rowValue, "datePartition", "yyyy-MM-dd-HH", "day");
       verifyRowCount(ops, tableName6, 0);
       rowValue.clear();
-      List<String> operations = getSnapshotOperations(ops, tableName6);
+      List<String> operations = getSnapshotOperationTypes(ops, tableName6);
       Assertions.assertEquals(operations.get(0), "delete");
     }
   }
@@ -693,7 +693,7 @@ public class OperationsTest extends OpenHouseSparkITest {
         .collect(Collectors.toList());
   }
 
-  private static List<String> getSnapshotOperations(Operations ops, String tableName) {
+  private static List<String> getSnapshotOperationTypes(Operations ops, String tableName) {
     log.info("Getting snapshot Operations");
     List<Row> ordered_snapshots =
         ops.spark()

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/util/SparkJobUtilTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/util/SparkJobUtilTest.java
@@ -21,31 +21,12 @@ public class SparkJobUtilTest {
   }
 
   @Test
-  void testCreateSelectLimitStatement() {
-    String statement =
-        SparkJobUtil.createSelectLimitStatement("table.name", "attribute", "", "day", 3, 1);
-    Assertions.assertEquals(
-        statement,
-        "SELECT * FROM `table`.`name` WHERE date_trunc('day', attribute) < date_trunc('day', current_timestamp() - INTERVAL 3 days) limit 1");
-  }
-
-  @Test
-  void testCreateSelectLimitStatementWithStringColumnPartition() {
-    String expected =
-        "SELECT * FROM `table`.`name` WHERE to_date(substring(attribute, 0, CHAR_LENGTH('yyyy-MM-dd')), 'yyyy-MM-dd') < date_trunc('day', current_timestamp() - INTERVAL 3 days) limit 1";
-    String actual =
-        SparkJobUtil.createSelectLimitStatement(
-            "table.name", "attribute", "yyyy-MM-dd", "day", 3, 1);
-    Assertions.assertEquals(expected, actual);
-  }
-
-  @Test
   void testCreateDeleteStatementWithStringColumnPartition() {
     String expected =
-        "DELETE FROM `db`.`table-name` WHERE to_date(substring(string_partition, 0, CHAR_LENGTH('yyyy-MM-dd-HH')), 'yyyy-MM-dd-HH') < date_trunc('day', current_timestamp() - INTERVAL 2 days)";
+        "DELETE FROM `db`.`table-name` WHERE string_partition < cast(date_format(current_timestamp() - INTERVAL 2 DAYs, 'yyyy-MM-dd-HH') as string)";
     Assertions.assertEquals(
         expected,
         SparkJobUtil.createDeleteStatement(
-            "db.table-name", "string_partition", "yyyy-MM-dd-HH", "day", 2));
+            "db.table-name", "string_partition", "yyyy-MM-dd-HH", "DAY", 2));
   }
 }


### PR DESCRIPTION
## Summary

Deletion Logic in Retention Job had complex predicate to filter rows based on partitionColumns for String partitioned table. This leads to problems with delete ops:
1. Adding snapshots with `overwrite` type
2. Scanning data files as well since predicate pushdown was not happening, evident from Query plans. Filter in BatchScan is empty and line above BatchScan has filter with SQL function.

```
spark.sql("explain extended select count(*) from `u_pageai`.`pages_representatives_v1` WHERE to_date(substring(datepartition, 0, CHAR_LENGTH('yyyy-MM-dd')), 'yyyy-MM-dd') < date_trunc('DAY', current_timestamp() - INTERVAL 3 DAYs)").show(200, false)

== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- HashAggregate(keys=[], functions=[count(1)], output=[count(1)#190L])
   +- Exchange SinglePartition, ENSURE_REQUIREMENTS, [id=#224]
      +- HashAggregate(keys=[], functions=[partial_count(1)], output=[count#193L])
         +- Project
            +- Filter (cast(cast(gettimestamp(substring(datepartition#184, 0, 10), yyyy-MM-dd, Some(UTC), false) as date) as timestamp) < 1711670400000000)
               +- BatchScan openhouse.u_pageai.pages_representatives_v1[datepartition#184] openhouse.u_pageai.pages_representatives_v1 [filters=]
``` 


The change:
1. Updates the delete query to use string comparison which makes delete ops metadata only query
2. Remove other optimizations in Retention Job which scan datasets preventing Retention delete Ops from being a Pure metadata OPS.

Query Plan with new Query:

```
|plan                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
|== Parsed Logical Plan ==
'Project [*]
+- 'Filter ('datePartition < cast('date_format(('current_timestamp() - 3 days), yyyy-MM-dd) as string))
   +- 'UnresolvedRelation [openhouse, oh_playground, retentionNewTest], [], false

== Analyzed Logical Plan ==
id: bigint, datePartition: string
Project [id#160L, datePartition#161]
+- Filter (datePartition#161 < cast(date_format(cast(current_timestamp() - 3 days as timestamp), yyyy-MM-dd, Some(UTC)) as string))
   +- SubqueryAlias openhouse.oh_playground.retentionNewTest
      +- RelationV2[id#160L, datePartition#161] openhouse.oh_playground.retentionNewTest

== Optimized Logical Plan ==
Filter (isnotnull(datePartition#161) AND (datePartition#161 < 2024-04-21))
+- RelationV2[id#160L, datePartition#161] openhouse.oh_playground.retentionNewTest

== Physical Plan ==
*(1) Project [id#160L, datePartition#161]
+- *(1) Filter (isnotnull(datePartition#161) AND (datePartition#161 < 2024-04-21))
   +- BatchScan openhouse.oh_playground.retentionNewTest[id#160L, datePartition#161] openhouse.oh_playground.retentionNewTest [filters=datePartition IS NOT NULL, datePartition < '2024-04-21']
``` 
BatchScan shows that partitions with a specific value in filter

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [x] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [x] Some other form of testing like staging or soak time in production. Please explain.

Mint Tests
Fixed Unit tests to account for updated Query
Ran tests with Local dataset to validate the Delete query deletes records as intended

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
