### PR TITLE
publish gradle module metadata

### DIFF
--- a/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
+++ b/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
@@ -56,6 +56,9 @@ publishing {
 
         configurePom(pom)
       }
+      mavenJava(MavenPublication) {
+        from components.java
+      }
     } else if(tasks.findByName('bootJar')) {
       mavenJava(MavenPublication) {
         from components.java


### PR DESCRIPTION
## Summary

maven-publish is missing gradle module metadata, try publishing the file.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [X] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

Before 
```
❯ ls -alt ~/.m2/repository/com/linkedin/openhouse/tables-test-fixtures_2.12/0.200.31
total 520648
   128 Apr 24 02:44 ..
  9325 Apr 24 02:44 tables-test-fixtures_2.12-0.200.31-sources.jar
    224 Apr 24 02:44 .
1288 Apr 24 02:44 tables-test-fixtures_2.12-0.200.31-javadoc.jar
 260818406 Apr 24 02:44 tables-test-fixtures_2.12-0.200.31-all.jar
   2596 Apr 24 02:44 tables-test-fixtures_2.12-0.200.31.pom
    12046 Apr 24 02:44 tables-test-fixtures_2.12-0.200.31.jar
```

After
```
❯ ls ~/.m2/repository/com/linkedin/openhouse/tables-test-fixtures_2.12/0.200.31
tables-test-fixtures_2.12-0.200.31-all.jar     tables-test-fixtures_2.12-0.200.31-sources.jar tables-test-fixtures_2.12-0.200.31.module
tables-test-fixtures_2.12-0.200.31-javadoc.jar tables-test-fixtures_2.12-0.200.31.jar         tables-test-fixtures_2.12-0.200.31.pom
```

works fine with local maven publication, will need to test with jfrog publication, after merging 🤞 

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
