### PR TITLE
Revert "publish gradle module metadata"

### DIFF
--- a/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
+++ b/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
@@ -56,9 +56,6 @@ publishing {
 
         configurePom(pom)
       }
-      mavenJava(MavenPublication) {
-        from components.java
-      }
     } else if(tasks.findByName('bootJar')) {
       mavenJava(MavenPublication) {
         from components.java


### PR DESCRIPTION
Reverts linkedin/openhouse#86 fails with Jfrog
https://github.com/linkedin/openhouse/actions/runs/8815067684/job/24196243848

```
> Task :tables-test-fixtures_2.12:publishShadowPublicationToLinkedInJFrogRepository FAILED
Multiple publications with coordinates 'com.linkedin.openhouse:tables-test-fixtures_2.12:0.5.47' are published to repository 'LinkedInJFrog'. The publications will overwrite each other!
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':tables-test-fixtures_2.12:publishShadowPublicationToLinkedInJFrogRepository'.
> Failed to publish publication 'shadow' to repository 'LinkedInJFrog'
   > Could not PUT 'https://linkedin.jfrog.io/artifactory/openhouse/com/linkedin/openhouse/tables-test-fixtures_2.12/0.5.47/tables-test-fixtures_2.12-0.5.47.jar'. Received status code 403 from server: 
```