### PR TITLE
Fix build issues after classifier change

### DIFF
--- a/infra/recipes/docker-compose/common/spark/spark-base-hadoop3.2.dockerfile
+++ b/infra/recipes/docker-compose/common/spark/spark-base-hadoop3.2.dockerfile
@@ -81,7 +81,7 @@ RUN mkdir -p "${LIVY_HOME}/logs"
 
 COPY /infra/recipes/docker-compose/common/spark/start-spark.sh /
 COPY /build/openhouse-spark-runtime_2.12/libs/*[^sources][^javadoc].jar $SPARK_HOME/openhouse-spark-runtime_2.12-latest-all.jar
-COPY /build/openhouse-spark-apps_2.12/libs/openhouse-spark-apps_2.12-all.jar $SPARK_HOME/openhouse-spark-apps_2.12-latest-all.jar
+COPY /build/openhouse-spark-apps_2.12/libs/openhouse-spark-apps_2.12-uber.jar $SPARK_HOME/openhouse-spark-apps_2.12-latest-all.jar
 COPY /build/dummytokens/libs/dummytokens*.jar /dummytokens.jar
 RUN java -jar /dummytokens.jar -d /var/config/
 

--- a/jobs-scheduler.Dockerfile
+++ b/jobs-scheduler.Dockerfile
@@ -15,7 +15,7 @@ WORKDIR $USER_HOME
 ENV PATH=$PATH:/export/apps/jdk/JDK-1_8_0_172/bin/:$USER_HOME
 
 ARG BUILD_DIR="build/$APP_NAME/libs"
-ARG JAR_FILES=$BUILD_DIR/*-all.jar
+ARG JAR_FILES=$BUILD_DIR/*-uber.jar
 
 COPY $JAR_FILES ./
 


### PR DESCRIPTION
## Summary
We changed the classifier from "-all" -> "-uber". 

This works fine for `./gradlew build` but fails when building docker images.
In this PR we fix the build issue:

## Testing Done
Docker compose up succeeds 🟢 
```
/infra/recipes/docker-compose/oh-hadoop-spark> docker compose up -d
```