### PR TITLE
Log task counts per status in JobScheduler

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
@@ -180,8 +180,9 @@ public class JobsScheduler {
       }
     }
     log.info(
-        "Finishing scheduler, tasks stats: {} created, {} succeeded,"
+        "Finishing scheduler for job type {}, tasks stats: {} created, {} succeeded,"
             + " {} cancelled (timeout), {} failed, {} skipped (no state)",
+        jobType,
         taskList.size(),
         jobStateCountMap.get(JobState.SUCCEEDED),
         jobStateCountMap.get(JobState.CANCELLED),

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTask.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTask.java
@@ -128,14 +128,13 @@ public abstract class OperationTask<T extends Metadata> implements Callable<Opti
         }
       }
     }
-    Optional<JobResponseBody> response = jobsClient.getJob(jobId);
-    if (response.isPresent()) {
-      reportJobState(response.get(), typeAttributes, startTime);
-      return Optional.of(Enum.valueOf(JobState.class, response.get().getState().getValue()));
+    Optional<JobResponseBody> ret = jobsClient.getJob(jobId);
+    if (ret.isPresent()) {
+      reportJobState(ret.get(), typeAttributes, startTime);
     } else {
-      log.warn("Job {} for {} has empty state", jobId, metadata);
-      return Optional.empty();
+      log.warn("Job: {} for {} has empty state", jobId, metadata);
     }
+    return Optional.of(Enum.valueOf(JobState.class, ret.get().getState().getValue()));
   }
 
   private void reportJobState(

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTask.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTask.java
@@ -128,13 +128,14 @@ public abstract class OperationTask<T extends Metadata> implements Callable<Opti
         }
       }
     }
-    Optional<JobResponseBody> ret = jobsClient.getJob(jobId);
-    if (ret.isPresent()) {
-      reportJobState(ret.get(), typeAttributes, startTime);
+    Optional<JobResponseBody> response = jobsClient.getJob(jobId);
+    if (response.isPresent()) {
+      reportJobState(response.get(), typeAttributes, startTime);
+      return Optional.of(Enum.valueOf(JobState.class, response.get().getState().getValue()));
     } else {
-      log.warn("Job: {} for {} has empty state", jobId, metadata);
+      log.warn("Job {} for {} has empty state", jobId, metadata);
+      return Optional.empty();
     }
-    return Optional.of(Enum.valueOf(JobState.class, ret.get().getState().getValue()));
   }
 
   private void reportJobState(


### PR DESCRIPTION
## Summary

Currently only success, cancel count and total count are logged. This incomplete information can mislead to think that success rate is slow. We need to also show skipped count since many tasks will be skipped for some tables, e.g. missing retention policy, replica, etc.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [x] Code Style
- [x] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
