### PR TITLE
JobScheduler switch using getAllTables to searchTables api

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
@@ -84,7 +84,7 @@ public class TablesClient {
         (RetryCallback<GetTableResponseBody, Exception>)
             context ->
                 tableApi
-                    .getTableV0(tableMetadata.getDbName(), tableMetadata.getTableName())
+                    .getTableV1(tableMetadata.getDbName(), tableMetadata.getTableName())
                     .block(Duration.ofSeconds(REQUEST_TIMEOUT_SECONDS)),
         null);
   }
@@ -145,12 +145,12 @@ public class TablesClient {
                     context -> {
                       GetAllTablesResponseBody response =
                           tableApi
-                              .getAllTablesV0(dbName)
+                              .searchTablesV1(dbName)
                               .block(Duration.ofSeconds(REQUEST_TIMEOUT_SECONDS));
                       return Optional.ofNullable(response.getResults())
                           .map(Collection::stream)
                           .orElseGet(Stream::empty)
-                          .map(this::parseGetTableResponse)
+                          .map(this::mapTableResponseToTableMetadata)
                           .filter(databaseFilter::apply)
                           .collect(Collectors.toList());
                     },
@@ -181,7 +181,7 @@ public class TablesClient {
                     return Optional.ofNullable(response.getResults())
                         .map(Collection::stream)
                         .orElseGet(Stream::empty)
-                        .map(this::parseGetTableResponseToTableDirectoryName)
+                        .map(this::mapTableResponseToTableDirectoryName)
                         .filter(databaseFilter::applyTableDirectoryPath)
                         .collect(Collectors.toSet());
                   },
@@ -233,7 +233,7 @@ public class TablesClient {
             context -> {
               GetAllDatabasesResponseBody response =
                   databaseApi
-                      .getAllDatabasesV0()
+                      .getAllDatabasesV1()
                       .block(Duration.ofSeconds(REQUEST_TIMEOUT_SECONDS));
               return Optional.ofNullable(response == null ? null : response.getResults())
                   .map(Collection::stream)
@@ -244,15 +244,23 @@ public class TablesClient {
         Collections.emptyList());
   }
 
-  protected TableMetadata parseGetTableResponse(GetTableResponseBody responseBody) {
-    return TableMetadata.builder()
-        .dbName(responseBody.getDatabaseId())
-        .tableName(responseBody.getTableId())
-        .creator(responseBody.getTableCreator())
-        .build();
+  protected TableMetadata mapTableResponseToTableMetadata(GetTableResponseBody responseBody) {
+    TableMetadata metadata =
+        TableMetadata.builder()
+            .dbName(responseBody.getDatabaseId())
+            .tableName(responseBody.getTableId())
+            .build();
+    String creator = getTable(metadata).getTableCreator();
+    return new TableMetadata(creator, responseBody.getDatabaseId(), responseBody.getTableId());
   }
 
-  private String parseGetTableResponseToTableDirectoryName(GetTableResponseBody responseBody) {
-    return new Path(responseBody.getTableLocation()).getParent().getName();
+  private String mapTableResponseToTableDirectoryName(GetTableResponseBody responseBody) {
+    TableMetadata metadata =
+        TableMetadata.builder()
+            .dbName(responseBody.getDatabaseId())
+            .tableName(responseBody.getTableId())
+            .build();
+    String location = getTable(metadata).getTableLocation();
+    return new Path(location).getParent().getName();
   }
 }

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
@@ -251,7 +251,11 @@ public class TablesClient {
             .tableName(responseBody.getTableId())
             .build();
     String creator = getTable(metadata).getTableCreator();
-    return new TableMetadata(creator, responseBody.getDatabaseId(), responseBody.getTableId());
+    return TableMetadata.builder()
+        .creator(creator)
+        .dbName(responseBody.getDatabaseId())
+        .tableName(responseBody.getTableId())
+        .build();
   }
 
   private String mapTableResponseToTableDirectoryName(GetTableResponseBody responseBody) {

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
@@ -244,7 +244,7 @@ public class TablesClient {
         Collections.emptyList());
   }
 
-  protected TableMetadata mapTableResponseToTableMetadata(GetTableResponseBody responseBody) {
+  private TableMetadata mapTableResponseToTableMetadata(GetTableResponseBody responseBody) {
     TableMetadata metadata =
         TableMetadata.builder()
             .dbName(responseBody.getDatabaseId())

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
@@ -176,7 +176,7 @@ public class TablesClient {
                   context -> {
                     GetAllTablesResponseBody response =
                         tableApi
-                            .getAllTablesV1(dbName)
+                            .searchTablesV1(dbName)
                             .block(Duration.ofSeconds(REQUEST_TIMEOUT_SECONDS));
                     return Optional.ofNullable(response.getResults())
                         .map(Collection::stream)

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/clients/TablesClientTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/clients/TablesClientTest.java
@@ -109,8 +109,8 @@ public class TablesClientTest {
     Mockito.when(responseMock.block(any(Duration.class))).thenReturn(allTablesResponseBodyMock);
     Mockito.when(dbResponseMock.block(any(Duration.class)))
         .thenReturn(allDatabasesResponseBodyMock);
-    Mockito.when(dbApiMock.getAllDatabasesV0()).thenReturn(dbResponseMock);
-    Mockito.when(apiMock.getAllTablesV0("db")).thenReturn(responseMock);
+    Mockito.when(dbApiMock.getAllDatabasesV1()).thenReturn(dbResponseMock);
+    Mockito.when(apiMock.searchTablesV1("db")).thenReturn(responseMock);
     Assertions.assertEquals(
         Arrays.asList(
             TableMetadata.builder().dbName(testDbName).tableName(testTableNamePartitioned).build(),
@@ -182,7 +182,7 @@ public class TablesClientTest {
     Mono<GetTableResponseBody> responseMock = (Mono<GetTableResponseBody>) Mockito.mock(Mono.class);
     Mockito.when(responseMock.block(any(Duration.class)))
         .thenReturn(partitionedTableResponseBodyMock);
-    Mockito.when(apiMock.getTableV0(testDbName, testTableNamePartitioned)).thenReturn(responseMock);
+    Mockito.when(apiMock.getTableV1(testDbName, testTableNamePartitioned)).thenReturn(responseMock);
     Optional<RetentionConfig> result =
         client.getTableRetention(
             TableMetadata.builder().dbName(testDbName).tableName(testTableNamePartitioned).build());
@@ -197,7 +197,7 @@ public class TablesClientTest {
             .build(),
         result.orElse(null));
     Mockito.verify(responseMock, Mockito.times(1)).block(any(Duration.class));
-    Mockito.verify(apiMock, Mockito.times(1)).getTableV0(testDbName, testTableNamePartitioned);
+    Mockito.verify(apiMock, Mockito.times(1)).getTableV1(testDbName, testTableNamePartitioned);
   }
 
   @Test
@@ -208,13 +208,13 @@ public class TablesClientTest {
     Mono<GetTableResponseBody> responseMock = (Mono<GetTableResponseBody>) Mockito.mock(Mono.class);
     Mockito.when(responseMock.block(any(Duration.class)))
         .thenReturn(partitionedTableResponseBodyMock);
-    Mockito.when(apiMock.getTableV0(testDbName, testTableNamePartitioned)).thenReturn(responseMock);
+    Mockito.when(apiMock.getTableV1(testDbName, testTableNamePartitioned)).thenReturn(responseMock);
     Optional<RetentionConfig> result =
         client.getTableRetention(
             TableMetadata.builder().dbName(testDbName).tableName(testTableNamePartitioned).build());
     Assertions.assertFalse(result.isPresent());
     Mockito.verify(responseMock, Mockito.times(1)).block(any(Duration.class));
-    Mockito.verify(apiMock, Mockito.times(1)).getTableV0(testDbName, testTableNamePartitioned);
+    Mockito.verify(apiMock, Mockito.times(1)).getTableV1(testDbName, testTableNamePartitioned);
   }
 
   @Test
@@ -223,7 +223,7 @@ public class TablesClientTest {
         createUnpartitionedTableResponseBodyMock(testDbName, testTableName);
     Mono<GetTableResponseBody> responseMock = (Mono<GetTableResponseBody>) Mockito.mock(Mono.class);
     Mockito.when(responseMock.block(any(Duration.class))).thenReturn(primaryTableResponseBodyMock);
-    Mockito.when(apiMock.getTableV0(testDbName, testTableName)).thenReturn(responseMock);
+    Mockito.when(apiMock.getTableV1(testDbName, testTableName)).thenReturn(responseMock);
 
     GetTableResponseBody replicaTableResponseBodyMock =
         createReplicaTableResponseBodyMock(testDbName, testReplicaTableName);
@@ -231,7 +231,7 @@ public class TablesClientTest {
         (Mono<GetTableResponseBody>) Mockito.mock(Mono.class);
     Mockito.when(replicaResponseMock.block(any(Duration.class)))
         .thenReturn(replicaTableResponseBodyMock);
-    Mockito.when(apiMock.getTableV0(testDbName, testReplicaTableName))
+    Mockito.when(apiMock.getTableV1(testDbName, testReplicaTableName))
         .thenReturn(replicaResponseMock);
 
     Assertions.assertTrue(
@@ -251,7 +251,7 @@ public class TablesClientTest {
         (Mono<GetTableResponseBody>) Mockito.mock(Mono.class);
     Mockito.when(partitionedTableResponseMock.block(any(Duration.class)))
         .thenReturn(partitionedTableResponseBodyMock);
-    Mockito.when(apiMock.getTableV0(testDbName, testTableNamePartitioned))
+    Mockito.when(apiMock.getTableV1(testDbName, testTableNamePartitioned))
         .thenReturn(partitionedTableResponseMock);
     // Retention should be executed for a primary  table that has retention config
     Assertions.assertTrue(
@@ -265,7 +265,7 @@ public class TablesClientTest {
         createUnpartitionedTableResponseBodyMock(testDbName, testTableName);
     Mono<GetTableResponseBody> responseMock = (Mono<GetTableResponseBody>) Mockito.mock(Mono.class);
     Mockito.when(responseMock.block(any(Duration.class))).thenReturn(primaryTableResponseBodyMock);
-    Mockito.when(apiMock.getTableV0(testDbName, testTableName)).thenReturn(responseMock);
+    Mockito.when(apiMock.getTableV1(testDbName, testTableName)).thenReturn(responseMock);
     // Retention skipped for a replica table that is un-partitioned.
     Assertions.assertFalse(
         client.canRunRetention(
@@ -278,7 +278,7 @@ public class TablesClientTest {
         (Mono<GetTableResponseBody>) Mockito.mock(Mono.class);
     Mockito.when(responseMock.block(any(Duration.class)))
         .thenReturn(partitionedReplicaTableResponseBodyMock);
-    Mockito.when(apiMock.getTableV0(testDbName, testTableNamePartitioned))
+    Mockito.when(apiMock.getTableV1(testDbName, testTableNamePartitioned))
         .thenReturn(partitionedReplicaTableResponseMock);
     // Retention skipped for a replica table despite retention config being set.
     Assertions.assertFalse(
@@ -295,7 +295,7 @@ public class TablesClientTest {
         createUnpartitionedTableResponseBodyMock(testDbName, testTableName);
     Mono<GetTableResponseBody> responseMock = (Mono<GetTableResponseBody>) Mockito.mock(Mono.class);
     Mockito.when(responseMock.block(any(Duration.class))).thenReturn(primaryTableResponseBodyMock);
-    Mockito.when(apiMock.getTableV0(testDbName, testTableName)).thenReturn(responseMock);
+    Mockito.when(apiMock.getTableV1(testDbName, testTableName)).thenReturn(responseMock);
 
     GetTableResponseBody replicaTableResponseBodyMock =
         createReplicaTableResponseBodyMock(testDbName, testReplicaTableName);
@@ -303,7 +303,7 @@ public class TablesClientTest {
         (Mono<GetTableResponseBody>) Mockito.mock(Mono.class);
     Mockito.when(replicaResponseMock.block(any(Duration.class)))
         .thenReturn(replicaTableResponseBodyMock);
-    Mockito.when(apiMock.getTableV0(testDbName, testReplicaTableName))
+    Mockito.when(apiMock.getTableV1(testDbName, testReplicaTableName))
         .thenReturn(replicaResponseMock);
 
     Assertions.assertTrue(
@@ -323,7 +323,7 @@ public class TablesClientTest {
     Mockito.when(responseMock.block(any(Duration.class)))
         .thenReturn(partitionedTableResponseBodyMock);
 
-    Mockito.when(apiMock.getTableV0(testDbName, testTableName)).thenReturn(responseMock);
+    Mockito.when(apiMock.getTableV1(testDbName, testTableName)).thenReturn(responseMock);
     Optional<RetentionConfig> result =
         client.getTableRetention(
             TableMetadata.builder().dbName(testDbName).tableName(testTableName).build());
@@ -332,7 +332,7 @@ public class TablesClientTest {
         "Retention config must not be present for a test partitioned "
             + "table with null policies");
     Mockito.verify(responseMock, Mockito.times(1)).block(any(Duration.class));
-    Mockito.verify(apiMock, Mockito.times(1)).getTableV0(testDbName, testTableName);
+    Mockito.verify(apiMock, Mockito.times(1)).getTableV1(testDbName, testTableName);
   }
 
   @Test
@@ -341,14 +341,14 @@ public class TablesClientTest {
         createUnpartitionedTableResponseBodyMock(testDbName, testTableName);
     Mono<GetTableResponseBody> responseMock = (Mono<GetTableResponseBody>) Mockito.mock(Mono.class);
     Mockito.when(responseMock.block(any(Duration.class))).thenReturn(tableResponseBodyMock);
-    Mockito.when(apiMock.getTableV0(testDbName, testTableName)).thenReturn(responseMock);
+    Mockito.when(apiMock.getTableV1(testDbName, testTableName)).thenReturn(responseMock);
     Optional<RetentionConfig> result =
         client.getTableRetention(
             TableMetadata.builder().dbName(testDbName).tableName(testTableName).build());
     Assertions.assertFalse(
         result.isPresent(), "Retention config must not be present for a test unpartitioned table");
     Mockito.verify(responseMock, Mockito.times(1)).block(any(Duration.class));
-    Mockito.verify(apiMock, Mockito.times(1)).getTableV0(testDbName, testTableName);
+    Mockito.verify(apiMock, Mockito.times(1)).getTableV1(testDbName, testTableName);
   }
 
   @Test
@@ -358,7 +358,7 @@ public class TablesClientTest {
             testDbName, testTableName, testRetentionTTLDays);
     Mono<GetTableResponseBody> responseMock = (Mono<GetTableResponseBody>) Mockito.mock(Mono.class);
     Mockito.when(responseMock.block(any(Duration.class))).thenReturn(tableResponseBodyMock);
-    Mockito.when(apiMock.getTableV0(testDbName, testTableName)).thenReturn(responseMock);
+    Mockito.when(apiMock.getTableV1(testDbName, testTableName)).thenReturn(responseMock);
     Optional<RetentionConfig> result =
         client.getTableRetention(
             TableMetadata.builder().dbName(testDbName).tableName(testTableName).build());
@@ -367,7 +367,7 @@ public class TablesClientTest {
         "Retention config must not be present for a test unpartitioned table without "
             + "retention columnPattern");
     Mockito.verify(responseMock, Mockito.times(1)).block(any(Duration.class));
-    Mockito.verify(apiMock, Mockito.times(1)).getTableV0(testDbName, testTableName);
+    Mockito.verify(apiMock, Mockito.times(1)).getTableV1(testDbName, testTableName);
   }
 
   @Test
@@ -383,7 +383,7 @@ public class TablesClientTest {
     Mono<GetTableResponseBody> responseMock = (Mono<GetTableResponseBody>) Mockito.mock(Mono.class);
     Mockito.when(responseMock.block(any(Duration.class)))
         .thenReturn(partitionedTableResponseBodyMock);
-    Mockito.when(apiMock.getTableV0(testDbName, testTableNamePartitioned)).thenReturn(responseMock);
+    Mockito.when(apiMock.getTableV1(testDbName, testTableNamePartitioned)).thenReturn(responseMock);
     Optional<RetentionConfig> result =
         client.getTableRetention(
             TableMetadata.builder().dbName(testDbName).tableName(testTableNamePartitioned).build());
@@ -401,7 +401,7 @@ public class TablesClientTest {
             .build(),
         result.orElse(null));
     Mockito.verify(responseMock, Mockito.times(1)).block(any(Duration.class));
-    Mockito.verify(apiMock, Mockito.times(1)).getTableV0(testDbName, testTableNamePartitioned);
+    Mockito.verify(apiMock, Mockito.times(1)).getTableV1(testDbName, testTableNamePartitioned);
   }
 
   @Test
@@ -412,7 +412,7 @@ public class TablesClientTest {
     Mono<GetTableResponseBody> responseMock = (Mono<GetTableResponseBody>) Mockito.mock(Mono.class);
     Mockito.when(responseMock.block(any(Duration.class)))
         .thenReturn(partitionedTableResponseBodyMock);
-    Mockito.when(apiMock.getTableV0(testDbName, testTableNamePartitioned)).thenReturn(responseMock);
+    Mockito.when(apiMock.getTableV1(testDbName, testTableNamePartitioned)).thenReturn(responseMock);
     Optional<RetentionConfig> result =
         client.getTableRetention(
             TableMetadata.builder().dbName(testDbName).tableName(testTableNamePartitioned).build());
@@ -427,7 +427,7 @@ public class TablesClientTest {
             .build(),
         result.orElse(null));
     Mockito.verify(responseMock, Mockito.times(1)).block(any(Duration.class));
-    Mockito.verify(apiMock, Mockito.times(1)).getTableV0(testDbName, testTableNamePartitioned);
+    Mockito.verify(apiMock, Mockito.times(1)).getTableV1(testDbName, testTableNamePartitioned);
   }
 
   @Test
@@ -441,7 +441,7 @@ public class TablesClientTest {
         (Mono<GetAllDatabasesResponseBody>) Mockito.mock(Mono.class);
     Mockito.when(dbResponseMock.block(any(Duration.class)))
         .thenReturn(allDatabasesResponseBodyMock);
-    Mockito.when(dbApiMock.getAllDatabasesV0()).thenReturn(dbResponseMock);
+    Mockito.when(dbApiMock.getAllDatabasesV1()).thenReturn(dbResponseMock);
     Assertions.assertEquals(Arrays.asList("db"), client.getDatabases());
     Mockito.verify(dbResponseMock, Mockito.times(1)).block(any(Duration.class));
   }
@@ -455,7 +455,7 @@ public class TablesClientTest {
         (Mono<GetAllDatabasesResponseBody>) Mockito.mock(Mono.class);
     Mockito.when(dbResponseMock.block(any(Duration.class)))
         .thenReturn(allDatabasesResponseBodyMock);
-    Mockito.when(dbApiMock.getAllDatabasesV0()).thenReturn(dbResponseMock);
+    Mockito.when(dbApiMock.getAllDatabasesV1()).thenReturn(dbResponseMock);
     Assertions.assertEquals(client.getDatabases().size(), 0);
     Mockito.verify(dbResponseMock, Mockito.times(1)).block(any(Duration.class));
   }

--- a/integrations/java/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/SmokeTest.java
+++ b/integrations/java/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/SmokeTest.java
@@ -81,7 +81,7 @@ public class SmokeTest {
     Assertions.assertDoesNotThrow(
         () ->
             snapshotApi
-                .putSnapshotsV0("database", "table", new IcebergSnapshotsRequestBody())
+                .putSnapshotsV1("database", "table", new IcebergSnapshotsRequestBody())
                 .block());
   }
 


### PR DESCRIPTION
## Summary
JobScheduler is using getAllTables api which can bottlenecks the system and fails the jobs. This PR moves JobScheduler to use searchTables api.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [x] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [ ] Tests

Move all usage of getAllTables api inside TablesClient to searchTables api combined with getTable call.

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Updated TablesClientTest to reflect the api change.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
