### PR TITLE
Introduce FileIOManager and FileIO implementations for HDFS and Local Storage

### DIFF
--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -21,6 +21,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.SupportsPrefixOperations;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 /**
@@ -34,7 +35,9 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
 
   @Autowired HouseTableRepository houseTableRepository;
 
-  @Autowired FileIO fileIO;
+  @Autowired
+  @Qualifier("LegacyFileIO")
+  FileIO fileIO;
 
   @Autowired SnapshotInspector snapshotInspector;
 

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/fileio/ConfigureFileIO.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/fileio/ConfigureFileIO.java
@@ -1,0 +1,66 @@
+package com.linkedin.openhouse.internal.catalog.fileio;
+
+import com.linkedin.openhouse.cluster.storage.StorageManager;
+import com.linkedin.openhouse.cluster.storage.StorageType;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.io.FileIO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configures the FileIO beans for storages configured in {@link StorageManager}
+ *
+ * <p>Each storage type should have a corresponding FileIO bean defined in this class. The return
+ * value of the bean is null if the storage type is not configured. The return class of the bean is
+ * the FileIO implementation for the respective storage type. If conflicting class could be returned
+ * for the same storage type, the bean name should be annotated with Qualifier to distinguish
+ * between them.
+ */
+@Slf4j
+@Configuration
+public class ConfigureFileIO {
+
+  @Autowired StorageManager storageManager;
+
+  /**
+   * Provides the HadoopFileIO bean for HDFS storage type
+   *
+   * @return HadoopFileIO bean for HDFS storage type, or null if HDFS storage type is not configured
+   */
+  @Bean
+  HadoopFileIO provideHadoopFileIO() {
+    try {
+      FileSystem fs =
+          (FileSystem) storageManager.getStorage(StorageType.HDFS).getClient().getNativeClient();
+      return new HadoopFileIO(fs.getConf());
+    } catch (IllegalArgumentException e) {
+      // If the HDFS storage type is not configured, return null
+      // Spring doesn't define the bean if the return value is null
+      log.debug("HDFS storage type is not configured");
+      return null;
+    }
+  }
+
+  /**
+   * Provides the HadoopFileIO bean for Local storage type
+   *
+   * @return HadoopFileIO bean for Local storage type, or null if Local storage type is not
+   *     configured
+   */
+  @Bean("LocalFileIO")
+  FileIO provideLocalFileIO() {
+    try {
+      FileSystem fs =
+          (FileSystem) storageManager.getStorage(StorageType.LOCAL).getClient().getNativeClient();
+      return new HadoopFileIO(fs.getConf());
+    } catch (IllegalArgumentException e) {
+      // If the Local storage type is not configured, return null
+      // Spring doesn't define the bean if the return value is null
+      log.debug("Local storage type is not configured");
+      return null;
+    }
+  }
+}

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/fileio/ConfigureFileIO.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/fileio/ConfigureFileIO.java
@@ -30,7 +30,7 @@ public class ConfigureFileIO {
    *
    * @return HadoopFileIO bean for HDFS storage type, or null if HDFS storage type is not configured
    */
-  @Bean
+  @Bean("HadoopFileIO")
   HadoopFileIO provideHadoopFileIO() {
     try {
       FileSystem fs =

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/fileio/ConfigureFileIO.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/fileio/ConfigureFileIO.java
@@ -39,7 +39,7 @@ public class ConfigureFileIO {
     } catch (IllegalArgumentException e) {
       // If the HDFS storage type is not configured, return null
       // Spring doesn't define the bean if the return value is null
-      log.debug("HDFS storage type is not configured");
+      log.debug("HDFS storage type is not configured", e);
       return null;
     }
   }
@@ -59,7 +59,7 @@ public class ConfigureFileIO {
     } catch (IllegalArgumentException e) {
       // If the Local storage type is not configured, return null
       // Spring doesn't define the bean if the return value is null
-      log.debug("Local storage type is not configured");
+      log.debug("Local storage type is not configured", e);
       return null;
     }
   }

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/fileio/FileIOConfig.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/fileio/FileIOConfig.java
@@ -21,17 +21,17 @@ import org.springframework.context.annotation.Configuration;
  */
 @Slf4j
 @Configuration
-public class ConfigureFileIO {
+public class FileIOConfig {
 
   @Autowired StorageManager storageManager;
 
   /**
-   * Provides the HadoopFileIO bean for HDFS storage type
+   * Provides the HdfsFileIO bean for HDFS storage type
    *
-   * @return HadoopFileIO bean for HDFS storage type, or null if HDFS storage type is not configured
+   * @return HdfsFileIO bean for HDFS storage type, or null if HDFS storage type is not configured
    */
-  @Bean("HadoopFileIO")
-  HadoopFileIO provideHadoopFileIO() {
+  @Bean("HdfsFileIO")
+  HadoopFileIO provideHdfsFileIO() {
     try {
       FileSystem fs =
           (FileSystem) storageManager.getStorage(StorageType.HDFS).getClient().getNativeClient();
@@ -45,10 +45,9 @@ public class ConfigureFileIO {
   }
 
   /**
-   * Provides the HadoopFileIO bean for Local storage type
+   * Provides the HdfsFileIO bean for Local storage type
    *
-   * @return HadoopFileIO bean for Local storage type, or null if Local storage type is not
-   *     configured
+   * @return HdfsFileIO bean for Local storage type, or null if Local storage type is not configured
    */
   @Bean("LocalFileIO")
   FileIO provideLocalFileIO() {

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/fileio/FileIOManager.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/fileio/FileIOManager.java
@@ -1,0 +1,50 @@
+package com.linkedin.openhouse.internal.catalog.fileio;
+
+import static com.linkedin.openhouse.cluster.storage.StorageType.HDFS;
+import static com.linkedin.openhouse.cluster.storage.StorageType.LOCAL;
+
+import com.linkedin.openhouse.cluster.storage.StorageType;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.io.FileIO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+/**
+ * This is the main class that provides the FileIO implementation based on the storage type. Each
+ * storage type should have a corresponding FileIO bean field defined in this class and the
+ * corresponding FileIO bean should be returned for appropriate storage type in the method {@link
+ * #getFileIO(StorageType.Type)}. If the storage type is not configured, the method should throw an
+ * IllegalArgumentException.
+ */
+@Component
+public class FileIOManager {
+
+  @Autowired(required = false)
+  HadoopFileIO hadoopFileIO;
+
+  @Autowired(required = false)
+  @Qualifier("LocalFileIO")
+  FileIO localFileIO;
+
+  /**
+   * Returns the FileIO implementation for the given storage type.
+   *
+   * @param storageType, the storage type for which the FileIO implementation is required
+   * @return FileIO implementation for the given storage type
+   * @throws IllegalArgumentException if the storage type is not configured
+   */
+  public FileIO getFileIO(StorageType.Type storageType) throws IllegalArgumentException {
+    Supplier<? extends RuntimeException> exceptionSupplier =
+        () -> new IllegalArgumentException(storageType.getValue() + " is not configured");
+    if (HDFS.equals(storageType)) {
+      return Optional.ofNullable(hadoopFileIO).orElseThrow(exceptionSupplier);
+    } else if (LOCAL.equals(storageType)) {
+      return Optional.ofNullable(localFileIO).orElseThrow(exceptionSupplier);
+    } else {
+      throw new IllegalArgumentException("FileIO not supported for storage type: " + storageType);
+    }
+  }
+}

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/fileio/FileIOManager.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/fileio/FileIOManager.java
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Component;
 public class FileIOManager {
 
   @Autowired(required = false)
+  @Qualifier("HadoopFileIO")
   HadoopFileIO hadoopFileIO;
 
   @Autowired(required = false)

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/fileio/FileIOManager.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/fileio/FileIOManager.java
@@ -23,8 +23,8 @@ import org.springframework.stereotype.Component;
 public class FileIOManager {
 
   @Autowired(required = false)
-  @Qualifier("HadoopFileIO")
-  HadoopFileIO hadoopFileIO;
+  @Qualifier("HdfsFileIO")
+  HadoopFileIO hdfsFileIO;
 
   @Autowired(required = false)
   @Qualifier("LocalFileIO")
@@ -41,7 +41,7 @@ public class FileIOManager {
     Supplier<? extends RuntimeException> exceptionSupplier =
         () -> new IllegalArgumentException(storageType.getValue() + " is not configured");
     if (HDFS.equals(storageType)) {
-      return Optional.ofNullable(hadoopFileIO).orElseThrow(exceptionSupplier);
+      return Optional.ofNullable(hdfsFileIO).orElseThrow(exceptionSupplier);
     } else if (LOCAL.equals(storageType)) {
       return Optional.ofNullable(localFileIO).orElseThrow(exceptionSupplier);
     } else {

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/SnapshotInspectorTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/SnapshotInspectorTest.java
@@ -1,6 +1,9 @@
 package com.linkedin.openhouse.internal.catalog;
 
+import com.linkedin.openhouse.cluster.storage.StorageManager;
 import com.linkedin.openhouse.internal.catalog.exception.InvalidIcebergSnapshotException;
+import com.linkedin.openhouse.internal.catalog.fileio.FileIOConfig;
+import com.linkedin.openhouse.internal.catalog.fileio.FileIOManager;
 import com.linkedin.openhouse.internal.catalog.mapper.HouseTableMapperTest;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -37,6 +40,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 
 @SpringBootTest
@@ -47,6 +51,11 @@ class SnapshotInspectorTest {
 
   @TempDir static Path tempDir;
 
+  @MockBean StorageManager storageManager;
+
+  @MockBean FileIOManager fileIOManager;
+
+  @MockBean FileIOConfig fileIOConfig;
   private static final TableMetadata noSnapshotsMetadata =
       TableMetadata.newTableMetadata(
           new Schema(

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/fileio/FileIOManagerTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/fileio/FileIOManagerTest.java
@@ -1,0 +1,37 @@
+package com.linkedin.openhouse.internal.catalog.fileio;
+
+import com.linkedin.openhouse.cluster.storage.StorageType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@SpringBootTest(classes = FileIOManagerTest.FileIOManagerTestConfig.class)
+public class FileIOManagerTest {
+
+  @Autowired FileIOManager fileIOManager;
+
+  @Test
+  public void testGetLocalFileIO() {
+    // local storage is configured
+    Assertions.assertNotNull(fileIOManager.getFileIO(StorageType.LOCAL));
+  }
+
+  @Test
+  public void testGetUndefinedFileIOThrowsException() {
+    // hdfs storage is not configured
+    Assertions.assertThrows(
+        IllegalArgumentException.class, () -> fileIOManager.getFileIO(StorageType.HDFS));
+  }
+
+  @Configuration
+  @ComponentScan(
+      basePackages = {
+        "com.linkedin.openhouse.internal.catalog.fileio",
+        "com.linkedin.openhouse.cluster.storage",
+        "com.linkedin.openhouse.cluster.configs"
+      })
+  public static class FileIOManagerTestConfig {}
+}

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/mapper/HouseTableMapperTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/mapper/HouseTableMapperTest.java
@@ -4,10 +4,14 @@ import com.linkedin.openhouse.housetables.client.api.UserTableApi;
 import com.linkedin.openhouse.housetables.client.invoker.ApiClient;
 import com.linkedin.openhouse.internal.catalog.repository.HouseTableRepository;
 import com.linkedin.openhouse.internal.catalog.repository.HouseTableRepositoryImpl;
+import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.io.FileIO;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
 
 @SpringBootTest
 public class HouseTableMapperTest {
@@ -30,6 +34,13 @@ public class HouseTableMapperTest {
     @Bean
     public HouseTableRepository provideRealHtsRepository() {
       return new HouseTableRepositoryImpl();
+    }
+
+    @Primary
+    @Bean
+    @Qualifier("LegacyFileIO")
+    public FileIO provideFileIO() {
+      return new HadoopFileIO();
     }
   }
 

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepositoryImplTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepositoryImplTest.java
@@ -4,11 +4,14 @@ import static com.linkedin.openhouse.internal.catalog.HouseTableModelConstants.*
 import static org.assertj.core.api.Assertions.*;
 
 import com.google.gson.Gson;
+import com.linkedin.openhouse.cluster.storage.StorageManager;
 import com.linkedin.openhouse.housetables.client.api.UserTableApi;
 import com.linkedin.openhouse.housetables.client.invoker.ApiClient;
 import com.linkedin.openhouse.housetables.client.model.EntityResponseBodyUserTable;
 import com.linkedin.openhouse.housetables.client.model.GetAllEntityResponseBodyUserTable;
 import com.linkedin.openhouse.housetables.client.model.UserTable;
+import com.linkedin.openhouse.internal.catalog.fileio.FileIOConfig;
+import com.linkedin.openhouse.internal.catalog.fileio.FileIOManager;
 import com.linkedin.openhouse.internal.catalog.mapper.HouseTableMapper;
 import com.linkedin.openhouse.internal.catalog.model.HouseTable;
 import com.linkedin.openhouse.internal.catalog.model.HouseTablePrimaryKey;
@@ -21,6 +24,8 @@ import java.util.HashMap;
 import java.util.List;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.io.FileIO;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -29,7 +34,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.util.ReflectionUtils;
 
@@ -43,6 +50,12 @@ public class HouseTableRepositoryImplTest {
   HouseTableRepository htsRepo;
 
   @Autowired HouseTableMapper houseTableMapper;
+
+  @MockBean StorageManager storageManager;
+
+  @MockBean FileIOManager fileIOManager;
+
+  @MockBean FileIOConfig fileIOConfig;
 
   @TestConfiguration
   public static class MockWebServerConfiguration {
@@ -71,6 +84,13 @@ public class HouseTableRepositoryImplTest {
     @Qualifier("repoTest")
     public HouseTableRepository provideRealHtsRepository() {
       return new HouseTableRepositoryImpl();
+    }
+
+    @Primary
+    @Bean
+    @Qualifier("LegacyFileIO")
+    public FileIO provideFileIO() {
+      return new HadoopFileIO();
     }
   }
 

--- a/infra/recipes/docker-compose/oh-hadoop-spark/cluster.yaml
+++ b/infra/recipes/docker-compose/oh-hadoop-spark/cluster.yaml
@@ -4,6 +4,12 @@ cluster:
     type: "hadoop"
     uri: "hdfs://namenode:9000/"
     root-path: "/data/openhouse"
+  storages:
+    default-type: "hdfs"
+    types:
+      hdfs:
+        rootpath: "/data/openhouse"
+        endpoint: "hdfs://namenode:9000/"
   iceberg:
     write:
       format:

--- a/infra/recipes/docker-compose/oh-hadoop/cluster.yaml
+++ b/infra/recipes/docker-compose/oh-hadoop/cluster.yaml
@@ -4,6 +4,12 @@ cluster:
     type: "hadoop"
     uri: "hdfs://namenode:9000/"
     root-path: "/data/openhouse"
+  storages:
+    default-type: "hdfs"
+    types:
+      hdfs:
+        rootpath: "/data/openhouse"
+        endpoint: "hdfs://namenode:9000/"
   iceberg:
     write:
       format:

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/config/MainApplicationConfig.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/config/MainApplicationConfig.java
@@ -25,6 +25,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.springdoc.core.customizers.OpenApiCustomiser;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -48,6 +49,7 @@ public class MainApplicationConfig extends BaseApplicationConfig {
    *
    * @return Iceberg's File abstraction {@link FileIO}.
    */
+  @Qualifier("LegacyFileIO")
   @Bean
   public FileIO provideIcebergFileIO() {
     if ("hadoop".equals(fsStorageProvider.storageType())) {

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTestWithSettableComponents.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTestWithSettableComponents.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Import;
@@ -56,7 +57,9 @@ public class RepositoryTestWithSettableComponents {
 
   @Autowired Catalog catalog;
 
-  @Autowired FileIO fileIO;
+  @Autowired
+  @Qualifier("LegacyFileIO")
+  FileIO fileIO;
 
   @Autowired SnapshotInspector snapshotInspector;
 

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/SnapshotsControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/SnapshotsControllerTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -64,7 +65,9 @@ public class SnapshotsControllerTest {
 
   @Autowired FsStorageProvider fsStorageProvider;
 
-  @Autowired FileIO fileIo;
+  @Autowired
+  @Qualifier("LegacyFileIO")
+  FileIO fileIo;
 
   /** For now starting with a naive object feeder. */
   private static Stream<GetTableResponseBody> responseBodyFeeder() {


### PR DESCRIPTION
## Summary
Laying foundations for storage part 4: `FileIOManager` and FileIO implementations for `HDFS` and `Local`

FileIOManager interface looks like:

```
FileIOManager {
   FileIO getFileIO(Type)
}
```

This interface is accompanied by `ConfigureFileIO` which sets up FileIOs for all "configured" storages.

We do not replace the existing FileIO instances to ensure production systems do not break.

To learn the motivation behind these changes please [see this doc](https://docs.google.com/document/d/1iPKol1jPzR6fq2YaoWbHHCYzBciCwfhqZqGyYhzZfoQ/edit?usp=sharing) 

## What's the next plan

1) Deploy new services with new + old cluster yaml (along with new fileIOs and old fileIOs)
```
- storages
    - newconfs
- storage
    - oldconfs  
```
2) Make refactors/remove old usage safely (remove old fileIOs and use new fileIOs)
3) Switch to new cluster yaml completely. 
```
- storages
    - newconfs
```

## Changes
- [X] New Features
Other related PRs:
https://github.com/linkedin/openhouse/pull/90
https://github.com/linkedin/openhouse/pull/82
https://github.com/linkedin/openhouse/pull/76

## Testing Done
- [X] Added new tests for the changes made.
- [X] docker tests, we change cluster.yaml in docker setup and tested the server boot with old and new config
```
/infra/recipes/docker-compose/oh-hadoop-spark> docker compose up -d
/infra/recipes/docker-compose/oh-hadoop-spark> docker exec -it local.spark-master /bin/bash

scala> spark.sql("CREATE TABLE openhouse.db.tb (ts timestamp, col1 string, col2 string) PARTITIONED BY (days(ts))").show()
++
||
++
++


scala> spark.sql("INSERT INTO TABLE openhouse.db.tb VALUES (date_sub(CAST(current_timestamp() as DATE), 30), 'val1', 'val2')")
res2: org.apache.spark.sql.DataFrame = []

scala> spark.sql("SELECT * FROM openhouse.db.tb").show()
+-------------------+----+----+
|                 ts|col1|col2|
+-------------------+----+----+
|2024-04-02 00:00:00|val1|val2|
+-------------------+----+----+
```
we can observe logs like:
```
INFO 9 --- [           main] c.l.o.c.s.h.HdfsStorageClient            : Initializing storage client for type:..
```


