### PR TITLE
Add builder.default annotations to fields in CreateUpdateTableRequestBody with default values defined

### DIFF
--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/CreateUpdateTableRequestBody.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/CreateUpdateTableRequestBody.java
@@ -95,6 +95,7 @@ public class CreateUpdateTableRequestBody {
       defaultValue = "false",
       description = "Boolean that determines creating a staged table",
       example = "false")
+  @Builder.Default
   private boolean stageCreate = false;
 
   @Schema(description = "The version of table that the current update is based upon")
@@ -103,6 +104,7 @@ public class CreateUpdateTableRequestBody {
 
   @Schema(description = "The type of a table")
   @Valid
+  @Builder.Default
   private TableType tableType = TableType.PRIMARY_TABLE;
 
   public String toJson() {


### PR DESCRIPTION
## Summary

stageCreate and tableType fields have defaults defined in CreateUpdateTableRequestBody, but they are missing the @Builder.Default annotation. This means that when doing CreateUpdateTableRequestBody.builder().build() it will not have the default values populated in the returned instance. This pull request adds the annotations to ensure the builder is consistent with the default values specified.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

See summary.

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [x] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

I ran existing unit tests and all passed. There should be no behavior change here, just preventing potential issues in the future.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

N/A
