### PR TITLE
Adding memory config param in JobConf for spark applications

### DIFF
--- a/services/common/src/main/java/com/linkedin/openhouse/common/api/validator/ValidatorConstants.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/api/validator/ValidatorConstants.java
@@ -9,6 +9,8 @@ public final class ValidatorConstants {
       "Only alphanumerics and underscore supported";
 
   public static final String ALPHA_NUM_UNDERSCORE_REGEX_HYPHEN_ALLOW = "^[a-zA-Z0-9-_]+$";
+  // supported memory format: Integer values ending with G or M
+  public static final String SPARK_MEMORY_FORMAT = "^(?!0[MG])(\\d+[MG])$";
   public static final String ALPHA_NUM_UNDERSCORE_ERROR_MSG_HYPHEN_ALLOW =
       "Only alphanumerics, hyphen and underscore supported";
   public static final int MAX_ALLOWED_CLUSTERING_COLUMNS = 4;

--- a/services/common/src/main/java/com/linkedin/openhouse/common/api/validator/ValidatorConstants.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/api/validator/ValidatorConstants.java
@@ -15,4 +15,5 @@ public final class ValidatorConstants {
       "Only alphanumerics, hyphen and underscore supported";
   public static final int MAX_ALLOWED_CLUSTERING_COLUMNS = 4;
   public static final String INITIAL_TABLE_VERSION = "INITIAL_VERSION";
+  public static final String JOB_MEMORY_CONFIG = "memory";
 }

--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/api/validator/impl/OpenHouseJobsApiValidator.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/api/validator/impl/OpenHouseJobsApiValidator.java
@@ -8,6 +8,7 @@ import com.linkedin.openhouse.jobs.api.spec.request.CreateJobRequestBody;
 import com.linkedin.openhouse.jobs.api.validator.JobsApiValidator;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
@@ -39,15 +40,25 @@ public class OpenHouseJobsApiValidator implements JobsApiValidator {
               "clusterId : provided %s, %s",
               createJobRequestBody.getClusterId(), ALPHA_NUM_UNDERSCORE_ERROR_MSG_HYPHEN_ALLOW));
     }
-    if (!createJobRequestBody.getJobConf().getMemory().isEmpty()
-        && !createJobRequestBody.getJobConf().getMemory().matches(SPARK_MEMORY_FORMAT)) {
+    if (!createJobRequestBody.getJobConf().getExecutionConf().isEmpty()
+        && !JobConfValidator.executionConfigValidator(
+            createJobRequestBody.getJobConf().getExecutionConf())) {
       validationFailures.add(
           String.format(
               "memory : provided %s, %s",
-              createJobRequestBody.getClusterId(), SPARK_MEMORY_FORMAT));
+              createJobRequestBody.getJobConf().getExecutionConf().get(JOB_MEMORY_CONFIG),
+              SPARK_MEMORY_FORMAT));
     }
     if (!validationFailures.isEmpty()) {
       throw new RequestValidationFailureException(validationFailures);
+    }
+  }
+
+  // inner class to validate jobConf fields.
+  private static class JobConfValidator {
+    public static boolean executionConfigValidator(Map<String, String> executionConf) {
+      String memoryConfig = executionConf.getOrDefault(JOB_MEMORY_CONFIG, "");
+      return memoryConfig.matches(SPARK_MEMORY_FORMAT);
     }
   }
 }

--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/api/validator/impl/OpenHouseJobsApiValidator.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/api/validator/impl/OpenHouseJobsApiValidator.java
@@ -39,7 +39,8 @@ public class OpenHouseJobsApiValidator implements JobsApiValidator {
               "clusterId : provided %s, %s",
               createJobRequestBody.getClusterId(), ALPHA_NUM_UNDERSCORE_ERROR_MSG_HYPHEN_ALLOW));
     }
-    if (!createJobRequestBody.getJobConf().getMemory().matches(SPARK_MEMORY_FORMAT)) {
+    if (!createJobRequestBody.getJobConf().getMemory().isEmpty()
+        && !createJobRequestBody.getJobConf().getMemory().matches(SPARK_MEMORY_FORMAT)) {
       validationFailures.add(
           String.format(
               "memory : provided %s, %s",

--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/api/validator/impl/OpenHouseJobsApiValidator.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/api/validator/impl/OpenHouseJobsApiValidator.java
@@ -1,7 +1,6 @@
 package com.linkedin.openhouse.jobs.api.validator.impl;
 
-import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.ALPHA_NUM_UNDERSCORE_ERROR_MSG_HYPHEN_ALLOW;
-import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.ALPHA_NUM_UNDERSCORE_REGEX_HYPHEN_ALLOW;
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.*;
 
 import com.linkedin.openhouse.common.api.validator.ApiValidatorUtil;
 import com.linkedin.openhouse.common.exception.RequestValidationFailureException;
@@ -39,6 +38,12 @@ public class OpenHouseJobsApiValidator implements JobsApiValidator {
           String.format(
               "clusterId : provided %s, %s",
               createJobRequestBody.getClusterId(), ALPHA_NUM_UNDERSCORE_ERROR_MSG_HYPHEN_ALLOW));
+    }
+    if (!createJobRequestBody.getJobConf().getMemory().matches(SPARK_MEMORY_FORMAT)) {
+      validationFailures.add(
+          String.format(
+              "memory : provided %s, %s",
+              createJobRequestBody.getClusterId(), SPARK_MEMORY_FORMAT));
     }
     if (!validationFailures.isEmpty()) {
       throw new RequestValidationFailureException(validationFailures);

--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/model/JobConf.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/model/JobConf.java
@@ -17,6 +17,7 @@ import lombok.NoArgsConstructor;
 public class JobConf {
   private JobType jobType;
   private String proxyUser;
+  private String memory;
   @Builder.Default private List<String> args = new ArrayList<>();
 
   public enum JobType {

--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/model/JobConf.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/model/JobConf.java
@@ -1,7 +1,9 @@
 package com.linkedin.openhouse.jobs.model;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,7 +19,7 @@ import lombok.NoArgsConstructor;
 public class JobConf {
   private JobType jobType;
   private String proxyUser;
-  private String memory;
+  @Builder.Default private Map<String, String> executionConf = new HashMap<>();
   @Builder.Default private List<String> args = new ArrayList<>();
 
   public enum JobType {

--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/services/JobsRegistry.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/services/JobsRegistry.java
@@ -40,7 +40,7 @@ public class JobsRegistry {
     if (authTokenPath != null) {
       propsMap.put("spark.sql.catalog.openhouse.auth-token", getToken(authTokenPath));
     }
-    populateJobMemory(conf.getMemory(), propsMap);
+    populateSparkProps(conf.getExecutionConf(), propsMap);
     defaultConf.setSparkProperties(propsMap);
     JobLaunchConf.JobLaunchConfBuilder builder = defaultConf.toBuilder();
 
@@ -54,7 +54,9 @@ public class JobsRegistry {
     return builder.proxyUser(conf.getProxyUser()).args(extendedArgs).build();
   }
 
-  private void populateJobMemory(String memory, Map<String, String> sparkPropsMap) {
+  private void populateSparkProps(
+      Map<String, String> executionConf, Map<String, String> sparkPropsMap) {
+    String memory = executionConf.getOrDefault("memory", null);
     if (!Strings.isNullOrEmpty(memory)) {
       sparkPropsMap.put("spark.driver.memory", memory);
       sparkPropsMap.put("spark.executor.memory", memory);

--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/services/JobsRegistry.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/services/JobsRegistry.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.jobs.services;
 
+import com.google.common.base.Strings;
 import com.linkedin.openhouse.common.exception.JobEngineException;
 import com.linkedin.openhouse.jobs.config.JobLaunchConf;
 import com.linkedin.openhouse.jobs.config.JobsProperties;
@@ -39,8 +40,7 @@ public class JobsRegistry {
     if (authTokenPath != null) {
       propsMap.put("spark.sql.catalog.openhouse.auth-token", getToken(authTokenPath));
     }
-    // handle job properties defined in iceberg table.properties
-    populateTableProperties(conf.getMemory(), propsMap);
+    populateJobMemory(conf.getMemory(), propsMap);
     defaultConf.setSparkProperties(propsMap);
     JobLaunchConf.JobLaunchConfBuilder builder = defaultConf.toBuilder();
 
@@ -54,9 +54,11 @@ public class JobsRegistry {
     return builder.proxyUser(conf.getProxyUser()).args(extendedArgs).build();
   }
 
-  private void populateTableProperties(String memory, Map<String, String> sparkPropsMap) {
-    sparkPropsMap.put("spark.driver.memory", memory);
-    sparkPropsMap.put("spark.executor.memory", memory);
+  private void populateJobMemory(String memory, Map<String, String> sparkPropsMap) {
+    if (!Strings.isNullOrEmpty(memory)) {
+      sparkPropsMap.put("spark.driver.memory", memory);
+      sparkPropsMap.put("spark.executor.memory", memory);
+    }
   }
 
   public static JobsRegistry from(JobsProperties properties, Map<String, String> storageProps) {

--- a/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobModelConstants.java
+++ b/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobModelConstants.java
@@ -23,7 +23,7 @@ public class JobModelConstants {
     return getPartialJobDtoBuilder()
         .jobName("my_job")
         .clusterId("my_cluster")
-        .jobConf(JobConf.builder().jobType(JobConf.JobType.RETENTION).memory("4G").build())
+        .jobConf(JobConf.builder().jobType(JobConf.JobType.RETENTION).build())
         .executionId("1")
         .build();
   }

--- a/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobModelConstants.java
+++ b/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobModelConstants.java
@@ -23,7 +23,7 @@ public class JobModelConstants {
     return getPartialJobDtoBuilder()
         .jobName("my_job")
         .clusterId("my_cluster")
-        .jobConf(JobConf.builder().jobType(JobConf.JobType.RETENTION).build())
+        .jobConf(JobConf.builder().jobType(JobConf.JobType.RETENTION).memory("4G").build())
         .executionId("1")
         .build();
   }

--- a/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobModelConstants.java
+++ b/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobModelConstants.java
@@ -3,6 +3,8 @@ package com.linkedin.openhouse.jobs.mock;
 import com.linkedin.openhouse.common.JobState;
 import com.linkedin.openhouse.jobs.model.JobConf;
 import com.linkedin.openhouse.jobs.model.JobDto;
+import java.util.HashMap;
+import java.util.Map;
 
 public class JobModelConstants {
   static final JobDto JOB_DTO = getFullJobDto();
@@ -24,6 +26,21 @@ public class JobModelConstants {
         .jobName("my_job")
         .clusterId("my_cluster")
         .jobConf(JobConf.builder().jobType(JobConf.JobType.RETENTION).build())
+        .executionId("1")
+        .build();
+  }
+
+  static JobDto getFullJobDtoWithExecutionConf() {
+    Map<String, String> executionConf = new HashMap<>();
+    executionConf.put("memory", "4G");
+    return getPartialJobDtoBuilder()
+        .jobName("my_job")
+        .clusterId("my_cluster")
+        .jobConf(
+            JobConf.builder()
+                .jobType(JobConf.JobType.RETENTION)
+                .executionConf(executionConf)
+                .build())
         .executionId("1")
         .build();
   }

--- a/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsApiValidatorTest.java
+++ b/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsApiValidatorTest.java
@@ -87,12 +87,6 @@ class JobsApiValidatorTest {
         RequestValidationFailureException.class,
         () ->
             jobsApiValidator.validateCreateJob(
-                makeJobRequestBodyFromJobNameJobConf("job-name", "10MG")));
-
-    assertThrows(
-        RequestValidationFailureException.class,
-        () ->
-            jobsApiValidator.validateCreateJob(
                 makeJobRequestBodyFromJobNameJobConf("job-name", "-10G")));
 
     assertThrows(

--- a/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsApiValidatorTest.java
+++ b/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsApiValidatorTest.java
@@ -77,7 +77,18 @@ class JobsApiValidatorTest {
 
   @Test
   public void testInValidMemoryFormatInJobRequestBody() {
-    // Ensure hyphen is fine in clusterId and JobName
+    assertThrows(
+        RequestValidationFailureException.class,
+        () ->
+            jobsApiValidator.validateCreateJob(
+                makeJobRequestBodyFromJobNameJobConf("job-name", "10MG")));
+
+    assertThrows(
+        RequestValidationFailureException.class,
+        () ->
+            jobsApiValidator.validateCreateJob(
+                makeJobRequestBodyFromJobNameJobConf("job-name", "10MG")));
+
     assertThrows(
         RequestValidationFailureException.class,
         () ->

--- a/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsApiValidatorTest.java
+++ b/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsApiValidatorTest.java
@@ -6,6 +6,8 @@ import com.linkedin.openhouse.common.exception.RequestValidationFailureException
 import com.linkedin.openhouse.jobs.api.spec.request.CreateJobRequestBody;
 import com.linkedin.openhouse.jobs.api.validator.JobsApiValidator;
 import com.linkedin.openhouse.jobs.model.JobConf;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,7 +23,7 @@ class JobsApiValidatorTest {
   private CreateJobRequestBody makeJobRequestBodyFromJobNameClusterId(
       String jobName, String clusterId) {
     JobConf mockJobConf = Mockito.mock(JobConf.class);
-    Mockito.when(mockJobConf.getMemory()).thenReturn("2G");
+    Mockito.when(mockJobConf.getExecutionConf()).thenReturn(new HashMap<>());
     return CreateJobRequestBody.builder()
         .jobName(jobName)
         .clusterId(clusterId)
@@ -30,10 +32,12 @@ class JobsApiValidatorTest {
   }
 
   private CreateJobRequestBody makeJobRequestBodyFromJobNameJobConf(String jobName, String memory) {
+    Map<String, String> executionConf = new HashMap<>();
+    executionConf.put("memory", memory);
     return CreateJobRequestBody.builder()
         .jobName(jobName)
         .clusterId("clusterId")
-        .jobConf(JobConf.builder().memory(memory).build())
+        .jobConf(JobConf.builder().executionConf(executionConf).build())
         .build();
   }
 
@@ -58,7 +62,6 @@ class JobsApiValidatorTest {
 
   @Test
   public void testValidMemoryFormatInJobRequestBody() {
-    // Ensure hyphen is fine in clusterId and JobName
     assertDoesNotThrow(
         () ->
             jobsApiValidator.validateCreateJob(
@@ -77,6 +80,12 @@ class JobsApiValidatorTest {
 
   @Test
   public void testInValidMemoryFormatInJobRequestBody() {
+    assertThrows(
+        RequestValidationFailureException.class,
+        () ->
+            jobsApiValidator.validateCreateJob(
+                makeJobRequestBodyFromJobNameJobConf("job-name", "")));
+
     assertThrows(
         RequestValidationFailureException.class,
         () ->

--- a/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsMapperTest.java
+++ b/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsMapperTest.java
@@ -14,7 +14,11 @@ public class JobsMapperTest {
   protected JobsMapper mapper = new JobsMapperImpl();
 
   private static final JobDto JOB_DTO = JobModelConstants.getFullJobDto();
+  private static final JobDto JOB_DTO_WITH_EXECUTION_CONF =
+      JobModelConstants.getFullJobDtoWithExecutionConf();
   private static final JobResponseBody GET_JOB_RESPONSE_BODY = toGetResponseBody(JOB_DTO);
+  private static final JobResponseBody GET_JOB_RESPONSE_BODY_WITH_CONF =
+      toGetResponseBody(JOB_DTO_WITH_EXECUTION_CONF);
   private static final CreateJobRequestBody CREATE_JOB_REQUEST_BODY =
       toCreateJobRequestBody(JOB_DTO);
   private static final Job JOB = toJob(JOB_DTO);
@@ -22,6 +26,8 @@ public class JobsMapperTest {
   @Test
   public void testToGetJobResponseBody() {
     Assertions.assertEquals(GET_JOB_RESPONSE_BODY, mapper.toGetJobResponseBody(JOB_DTO));
+    Assertions.assertEquals(
+        GET_JOB_RESPONSE_BODY_WITH_CONF, mapper.toGetJobResponseBody(JOB_DTO_WITH_EXECUTION_CONF));
   }
 
   @Test
@@ -30,6 +36,11 @@ public class JobsMapperTest {
         JOB_DTO,
         mapper.toJobDto(
             JobModelConstants.getPartialJobDtoBuilder().build(), CREATE_JOB_REQUEST_BODY));
+    Assertions.assertEquals(
+        JOB_DTO_WITH_EXECUTION_CONF,
+        mapper.toJobDto(
+            JobModelConstants.getPartialJobDtoBuilder().build(),
+            toCreateJobRequestBody(JOB_DTO_WITH_EXECUTION_CONF)));
   }
 
   @Test

--- a/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsRegistryTest.java
+++ b/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsRegistryTest.java
@@ -32,6 +32,7 @@ public class JobsRegistryTest {
     JobsRegistry jr = JobsRegistry.from(properties, propertyMap);
     Mockito.when(jobConf.getJobType()).thenReturn(JobConf.JobType.RETENTION);
     Mockito.when(jobConf.getArgs()).thenReturn(new ArrayList<>());
+    Mockito.when(jobConf.getMemory()).thenReturn("5G");
     JobLaunchConf launchConf = jr.createLaunchConf("jobId", jobConf);
     Assertions.assertEquals(launchConf.getJarPath(), "default-jar-path");
     Assertions.assertTrue(launchConf.getExecutionTags().keySet().contains("pool"));
@@ -41,6 +42,9 @@ public class JobsRegistryTest {
             .getSparkProperties()
             .keySet()
             .contains("spark.sql.catalog.openhouse.auth-token"));
+    Assertions.assertTrue(launchConf.getSparkProperties().keySet().contains("spark.driver.memory"));
+    Assertions.assertTrue(
+        launchConf.getSparkProperties().keySet().contains("spark.executor.memory"));
     Assertions.assertTrue(launchConf.getSparkProperties().containsKey("fs.defaultFS"));
     Assertions.assertEquals(launchConf.getArgs().size(), 4);
   }

--- a/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsRegistryTest.java
+++ b/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsRegistryTest.java
@@ -8,6 +8,7 @@ import com.linkedin.openhouse.jobs.config.JobsProperties;
 import com.linkedin.openhouse.jobs.model.JobConf;
 import com.linkedin.openhouse.jobs.services.JobsRegistry;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -32,7 +33,9 @@ public class JobsRegistryTest {
     JobsRegistry jr = JobsRegistry.from(properties, propertyMap);
     Mockito.when(jobConf.getJobType()).thenReturn(JobConf.JobType.RETENTION);
     Mockito.when(jobConf.getArgs()).thenReturn(new ArrayList<>());
-    Mockito.when(jobConf.getMemory()).thenReturn("5G");
+    Map<String, String> executionConf = new HashMap<>();
+    executionConf.put("memory", "5G");
+    Mockito.when(jobConf.getExecutionConf()).thenReturn(executionConf);
     JobLaunchConf launchConf = jr.createLaunchConf("jobId", jobConf);
     Assertions.assertEquals(launchConf.getJarPath(), "default-jar-path");
     Assertions.assertTrue(launchConf.getExecutionTags().keySet().contains("pool"));

--- a/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsServiceTest.java
+++ b/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsServiceTest.java
@@ -2,6 +2,7 @@ package com.linkedin.openhouse.jobs.mock;
 
 import com.linkedin.openhouse.jobs.api.spec.request.CreateJobRequestBody;
 import com.linkedin.openhouse.jobs.config.JobLaunchConf;
+import com.linkedin.openhouse.jobs.model.JobConf;
 import com.linkedin.openhouse.jobs.model.JobDto;
 import com.linkedin.openhouse.jobs.model.JobDtoPrimaryKey;
 import com.linkedin.openhouse.jobs.repository.JobsInternalRepository;
@@ -48,6 +49,30 @@ public class JobsServiceTest {
     Mockito.when(jobHandle.getInfo()).thenReturn(jobInfo);
     Mockito.when(jobInfo.getExecutionId()).thenReturn(job.getExecutionId());
     Assertions.assertEquals(job, service.create(requestBody));
+  }
+
+  @Test
+  void testCreateWithSparkMemory() {
+    JobDto job =
+        JobModelConstants.JOB_DTO
+            .toBuilder()
+            .jobConf(JobConf.builder().memory("4G").jobType(JobConf.JobType.RETENTION).build())
+            .build();
+    CreateJobRequestBody requestBody =
+        CreateJobRequestBody.builder()
+            .jobName(job.getJobName())
+            .clusterId(job.getClusterId())
+            .jobConf(job.getJobConf())
+            .build();
+    Mockito.when(repository.save(Mockito.any())).thenReturn(job);
+    Mockito.when(jobsRegistry.createLaunchConf(Mockito.any(), Mockito.any()))
+        .thenReturn(JobLaunchConf.builder().build());
+    Mockito.when(jobsCoordinator.submit(Mockito.any())).thenReturn(jobHandle);
+    Mockito.when(jobHandle.getInfo()).thenReturn(jobInfo);
+    Mockito.when(jobInfo.getExecutionId()).thenReturn(job.getExecutionId());
+    JobDto actualJobDto = service.create(requestBody);
+    Assertions.assertEquals("4G", actualJobDto.getJobConf().getMemory());
+    Assertions.assertEquals(job, actualJobDto);
   }
 
   @Test

--- a/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsServiceTest.java
+++ b/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsServiceTest.java
@@ -11,6 +11,8 @@ import com.linkedin.openhouse.jobs.services.HouseJobsCoordinator;
 import com.linkedin.openhouse.jobs.services.JobInfo;
 import com.linkedin.openhouse.jobs.services.JobsRegistry;
 import com.linkedin.openhouse.jobs.services.JobsService;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -53,10 +55,16 @@ public class JobsServiceTest {
 
   @Test
   void testCreateWithSparkMemory() {
+    Map<String, String> executionConf = new HashMap<>();
+    executionConf.put("memory", "4G");
     JobDto job =
         JobModelConstants.JOB_DTO
             .toBuilder()
-            .jobConf(JobConf.builder().memory("4G").jobType(JobConf.JobType.RETENTION).build())
+            .jobConf(
+                JobConf.builder()
+                    .executionConf(executionConf)
+                    .jobType(JobConf.JobType.RETENTION)
+                    .build())
             .build();
     CreateJobRequestBody requestBody =
         CreateJobRequestBody.builder()
@@ -71,7 +79,7 @@ public class JobsServiceTest {
     Mockito.when(jobHandle.getInfo()).thenReturn(jobInfo);
     Mockito.when(jobInfo.getExecutionId()).thenReturn(job.getExecutionId());
     JobDto actualJobDto = service.create(requestBody);
-    Assertions.assertEquals("4G", actualJobDto.getJobConf().getMemory());
+    Assertions.assertEquals("4G", actualJobDto.getJobConf().getExecutionConf().get("memory"));
     Assertions.assertEquals(job, actualJobDto);
   }
 


### PR DESCRIPTION
## Summary

By default, spark applications run with 1G memory. OH maintenance jobs for tables with large size require larger memory in order to avoid OOM failures. 
The PR allows to set memory param in jobs POST request to set spark memory config.
Memory param only allows format:  <PositiveInteger><G or M>
e.g: 4G, 10G, 250M

Sample POST request:
` {
    "jobName": "test_job",
    "clusterId": "local",
    "jobConf": {
      "jobType": "ORPHAN_FILES_DELETION",
      "proxyUser": "openhouse",
      "executionConf": {"memory": "4G"},
      "args": [
        "--tableName", "$table",
        "--trashDir", ".trash" 
      ]
    }
  }`


## Changes

- [ ] Client-facing API Changes
- [x] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->
- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [x] Some other form of testing like staging or soak time in production. Please explain.

Build tests
Ran Setu jobs with memory config set in spark properties. ref: Image
<img width="674" alt="Screenshot 2024-05-12 at 6 33 04 PM" src="https://github.com/linkedin/openhouse/assets/1126602/6ccc2648-7d21-4693-93b5-b586f1e2cf1c">

Docker tests:
Post with execution conf:
<img width="1501" alt="Screenshot 2024-05-17 at 5 39 59 PM" src="https://github.com/linkedin/openhouse/assets/1126602/d8de983b-f1cf-44fd-9a9d-b2ff71a4e964">

Post/Get without execution conf
<img width="1520" alt="Screenshot 2024-05-17 at 5 40 14 PM" src="https://github.com/linkedin/openhouse/assets/1126602/11552926-b3fa-4ef8-abeb-77b56038660c">
<img width="1428" alt="Screenshot 2024-05-17 at 5 41 03 PM" src="https://github.com/linkedin/openhouse/assets/1126602/c42deff7-a0df-43ff-bd56-28ea588317bc">

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
