### PR TITLE
[PR1/5] Add S3 Storage type and S3StorageClient

### DIFF
--- a/.github/workflows/build-tag-publish.yml
+++ b/.github/workflows/build-tag-publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout project sources
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
 
       - name: Set up JDK 1.8

--- a/.github/workflows/build-tag-publish.yml
+++ b/.github/workflows/build-tag-publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout project sources
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Set up JDK 1.8

--- a/buildSrc/src/main/groovy/openhouse.iceberg-aws-conventions.gradle
+++ b/buildSrc/src/main/groovy/openhouse.iceberg-aws-conventions.gradle
@@ -1,0 +1,12 @@
+ext {
+  icebergAwsVersion = '1.5.2'
+}
+
+dependencies {
+  implementation('org.apache.iceberg:iceberg-aws:' + icebergAwsVersion) {
+    exclude group: 'org.apache.iceberg'
+  }
+  implementation('org.apache.iceberg:iceberg-aws-bundle:' + icebergAwsVersion) {
+    exclude group: 'org.apache.iceberg'
+  }
+}

--- a/cluster/storage/build.gradle
+++ b/cluster/storage/build.gradle
@@ -1,12 +1,12 @@
 plugins {
   id 'openhouse.java-conventions'
   id 'openhouse.hadoop-conventions'
+  id 'openhouse.iceberg-aws-conventions'
+  id 'openhouse.iceberg-conventions'
   id 'openhouse.maven-publish'
 }
 
 dependencies {
   implementation project(':cluster:configs')
   implementation 'org.springframework.boot:spring-boot-autoconfigure:' + spring_web_version
-  implementation 'org.apache.iceberg:iceberg-aws:1.5.2'
-  implementation 'org.apache.iceberg:iceberg-aws-bundle:1.5.2'
 }

--- a/cluster/storage/build.gradle
+++ b/cluster/storage/build.gradle
@@ -7,4 +7,6 @@ plugins {
 dependencies {
   implementation project(':cluster:configs')
   implementation 'org.springframework.boot:spring-boot-autoconfigure:' + spring_web_version
+  implementation 'org.apache.iceberg:iceberg-aws:1.5.2'
+  implementation 'org.apache.iceberg:iceberg-aws-bundle:1.5.2'
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/StorageType.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/StorageType.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 public class StorageType {
   public static final Type HDFS = new Type("hdfs");
   public static final Type LOCAL = new Type("local");
+  public static final Type S3 = new Type("s3");
 
   @AllArgsConstructor
   @EqualsAndHashCode
@@ -30,6 +31,8 @@ public class StorageType {
       return HDFS;
     } else if (LOCAL.getValue().equals(type)) {
       return LOCAL;
+    } else if (S3.getValue().equals(type)) {
+      return S3;
     } else {
       throw new IllegalArgumentException("Unknown storage type: " + type);
     }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/s3/S3StorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/s3/S3StorageClient.java
@@ -16,16 +16,28 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.s3.S3Client;
 
+/**
+ * S3StorageClient is an implementation of the StorageClient interface for S3. It uses the {@link
+ * S3Client} to interact with S3 storage. An AWS_REGION must be set either in the environment
+ * variable or in the storage properties for the client initialization.
+ */
 @Slf4j
 @Lazy
 @Component
 public class S3StorageClient implements StorageClient<S3Client> {
+  // Storage type.
   private static final StorageType.Type S3_TYPE = StorageType.S3;
 
+  // Storage properties.
   @Autowired private StorageProperties storageProperties;
 
+  // S3 client.
   private S3Client s3;
 
+  /**
+   * Initialize the S3 client when the bean is accessed the first time. AWS_REGION must be set in
+   * the evironment variable or in the storage properties.
+   */
   @PostConstruct
   public synchronized void init() {
     // TODO: Validate properties.

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/s3/S3StorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/s3/S3StorageClient.java
@@ -1,0 +1,57 @@
+package com.linkedin.openhouse.cluster.storage.s3;
+
+import com.linkedin.openhouse.cluster.storage.StorageClient;
+import com.linkedin.openhouse.cluster.storage.StorageType;
+import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.PostConstruct;
+import org.apache.iceberg.aws.AwsClientFactory;
+import org.apache.iceberg.aws.S3FileIOAwsClientFactories;
+import org.apache.iceberg.aws.s3.S3FileIOAwsClientFactory;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import software.amazon.awssdk.services.s3.S3Client;
+
+public class S3StorageClient implements StorageClient<S3Client> {
+  private static final StorageType.Type S3_TYPE = StorageType.S3;
+
+  @Autowired private StorageProperties storageProperties;
+
+  private S3Client s3;
+
+  @PostConstruct
+  public synchronized void init() {
+    // TODO: Validate properties.
+    Map properties =
+        new HashMap(storageProperties.getTypes().get(S3_TYPE.getValue()).getParameters());
+
+    S3FileIOProperties s3FileIOProperties =
+        new S3FileIOProperties(
+            storageProperties.getTypes().get(S3_TYPE.getValue()).getParameters());
+    if (s3 == null) {
+      Object clientFactory = S3FileIOAwsClientFactories.initialize(properties);
+      if (clientFactory instanceof S3FileIOAwsClientFactory) {
+        this.s3 = ((S3FileIOAwsClientFactory) clientFactory).s3();
+      }
+      if (clientFactory instanceof AwsClientFactory) {
+        this.s3 = ((AwsClientFactory) clientFactory).s3();
+      }
+    }
+  }
+
+  @Override
+  public S3Client getNativeClient() {
+    return s3;
+  }
+
+  @Override
+  public String getEndpoint() {
+    return storageProperties.getTypes().get(S3_TYPE.getValue()).getEndpoint();
+  }
+
+  @Override
+  public String getRootPrefix() {
+    return storageProperties.getTypes().get(S3_TYPE.getValue()).getRootPath();
+  }
+}

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/s3/S3StorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/s3/S3StorageClient.java
@@ -6,13 +6,19 @@ import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.iceberg.aws.AwsClientFactory;
 import org.apache.iceberg.aws.S3FileIOAwsClientFactories;
 import org.apache.iceberg.aws.s3.S3FileIOAwsClientFactory;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.s3.S3Client;
 
+@Slf4j
+@Lazy
+@Component
 public class S3StorageClient implements StorageClient<S3Client> {
   private static final StorageType.Type S3_TYPE = StorageType.S3;
 

--- a/scripts/java/tools/dummytokens/build.gradle
+++ b/scripts/java/tools/dummytokens/build.gradle
@@ -7,7 +7,9 @@ apply plugin: 'application'
 mainClassName = 'com.linkedin.openhouse.tools.dummytokens.DummyTokenGenerator'
 
 dependencies {
-    implementation project(':services:common')
+    implementation(project(':services:common')){
+        exclude group: 'org.apache.iceberg'
+    }
     implementation 'commons-cli:commons-cli:1.5.0'
     implementation 'org.codehaus.jettison:jettison:1.3.8'
 }

--- a/services/tables/build.gradle
+++ b/services/tables/build.gradle
@@ -1,6 +1,7 @@
 plugins {
   id 'openhouse.springboot-ext-conventions'
   id 'openhouse.hadoop-conventions'
+  id 'openhouse.iceberg-aws-conventions'
   id 'openhouse.iceberg-conventions'
   id 'openhouse.maven-publish'
   /**

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/s3/S3StorageClientTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/s3/S3StorageClientTest.java
@@ -8,7 +8,9 @@ import com.linkedin.openhouse.cluster.storage.StorageType;
 import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
 import com.linkedin.openhouse.cluster.storage.s3.S3StorageClient;
 import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.PostConstruct;
+import org.apache.iceberg.aws.AwsClientProperties;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -45,7 +47,9 @@ public class S3StorageClientTest {
         new StorageProperties.StorageTypeProperties();
     storageTypeProperties.setEndpoint("http://S3:9000");
     storageTypeProperties.setRootPath("/mybucket");
-    storageTypeProperties.setParameters(new HashMap<>());
+    Map<String, String> parameters = new HashMap<>();
+    parameters.put(AwsClientProperties.CLIENT_REGION, "us-east-1");
+    storageTypeProperties.setParameters(parameters);
     return storageTypeProperties;
   }
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/s3/S3StorageClientTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/s3/S3StorageClientTest.java
@@ -1,0 +1,51 @@
+package com.linkedin.openhouse.tables.mock.storage.s3;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.google.common.collect.ImmutableMap;
+import com.linkedin.openhouse.cluster.storage.StorageType;
+import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
+import com.linkedin.openhouse.cluster.storage.s3.S3StorageClient;
+import java.util.HashMap;
+import javax.annotation.PostConstruct;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationContext;
+
+@SpringBootTest
+public class S3StorageClientTest {
+  @MockBean private StorageProperties storageProperties;
+  @Autowired private ApplicationContext context;
+  private S3StorageClient s3StorageClient;
+
+  @PostConstruct
+  public void setupTest() {
+    when(storageProperties.getDefaultType()).thenReturn(StorageType.S3.getValue());
+    when(storageProperties.getTypes())
+        .thenReturn(ImmutableMap.of(StorageType.S3.getValue(), getStorageTypeProperties()));
+    s3StorageClient = context.getBean(S3StorageClient.class);
+  }
+
+  @Test
+  public void testS3StorageClientValidProperties() {
+    when(storageProperties.getTypes())
+        .thenReturn(
+            new HashMap<>(ImmutableMap.of(StorageType.S3.getValue(), getStorageTypeProperties())));
+    assertDoesNotThrow(() -> s3StorageClient.init());
+    assert s3StorageClient.getNativeClient() != null;
+    assertEquals("http://S3:9000", s3StorageClient.getEndpoint());
+    assertEquals("/mybucket", s3StorageClient.getRootPrefix());
+  }
+
+  private StorageProperties.StorageTypeProperties getStorageTypeProperties() {
+    StorageProperties.StorageTypeProperties storageTypeProperties =
+        new StorageProperties.StorageTypeProperties();
+    storageTypeProperties.setEndpoint("http://S3:9000");
+    storageTypeProperties.setRootPath("/mybucket");
+    storageTypeProperties.setParameters(new HashMap<>());
+    return storageTypeProperties;
+  }
+}


### PR DESCRIPTION
## Summary
Openhouse catalog currently supports HDFS as the storage backend. The end goal of this effort is to add the integration with S3 so that the storage backend can be configured to be S3 vs HDFS based on storage type.
The entire work will be done via a series of PRs:
1. Add S3 Storage type and S3StorageClient.
2. Add base class for StorageClient and move common logic like validation of properties there to avoid code duplication.
3. Add S3Storage implementation that uses S3StorageClient.
4. Add support for using S3FileIO for S3 storage type.
5. Add a recipe for end-to-end testing in docker.

This PR addresses 1 by adding S3 storage type and S3StorageClient.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
Added unit tests. This is one of the first few PRs to complete plugging in S3 storage. More test recipes to test with S3 storage will be added when S3 storage is completely plugged in. Currently tested oh-hadoop-spark recipe to ensure that  the HDFS integration is not broken by this change.

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

Docker testing oh-hadoop-spark recipe:

1. Create table:

$ curl "${curlArgs[@]}" -XPOST http://localhost:8000/v1/databases/d3/tables/ \
> --data-raw '{
>   "tableId": "t1",
>   "databaseId": "d3",
>   "baseTableVersion": "INITIAL_VERSION",
>   "clusterId": "LocalHadoopCluster",
>   "schema": "{\"type\": \"struct\", \"fields\": [{\"id\": 1,\"required\": true,\"name\": \"id\",\"type\": \"string\"},{\"id\": 2,\"required\": true,\"name\": \"name\",\"type\": \"string\"},{\"id\": 3,\"required\": true,\"name\": \"ts\",\"type\": \"timestamp\"}]}",
>   "timePartitioning": {
>     "columnName": "ts",
>     "granularity": "HOUR"
>   },
>   "clustering": [
>     {
>       "columnName": "name"
>     }
>   ],
>   "tableProperties": {
>     "key": "value"
>   }
> }' | json_pp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2174    0  1600  100   574    548    196  0:00:02  0:00:02 --:--:--   745
{
   "clusterId" : "LocalHadoopCluster",
   "clustering" : [
      {
         "columnName" : "name",
         "transform" : null
      }
   ],
   "creationTime" : 1717098450027,
   "databaseId" : "d3",
   "lastModifiedTime" : 1717098450027,
   "policies" : null,
   "schema" : "{\"type\":\"struct\",\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"string\"},{\"id\":2,\"name\":\"name\",\"required\":true,\"type\":\"string\"},{\"id\":3,\"name\":\"ts\",\"required\":true,\"type\":\"timestamp\"}]}",
   "tableCreator" : "DUMMY_ANONYMOUS_USER",
   "tableId" : "t1",
   "tableLocation" : "hdfs://namenode:9000/data/openhouse/d3/t1-30f90df6-4c45-47ee-916c-7cf0bdea5d4d/00000-5fec4fc6-4bf9-4bab-b6a9-112967a57497.metadata.json",
   "tableProperties" : {
      "key" : "value",
      "openhouse.clusterId" : "LocalHadoopCluster",
      "openhouse.creationTime" : "1717098450027",
      "openhouse.databaseId" : "d3",
      "openhouse.lastModifiedTime" : "1717098450027",
      "openhouse.tableCreator" : "DUMMY_ANONYMOUS_USER",
      "openhouse.tableId" : "t1",
      "openhouse.tableLocation" : "/data/openhouse/d3/t1-30f90df6-4c45-47ee-916c-7cf0bdea5d4d/00000-5fec4fc6-4bf9-4bab-b6a9-112967a57497.metadata.json",
      "openhouse.tableType" : "PRIMARY_TABLE",
      "openhouse.tableUUID" : "30f90df6-4c45-47ee-916c-7cf0bdea5d4d",
      "openhouse.tableUri" : "LocalHadoopCluster.d3.t1",
      "openhouse.tableVersion" : "INITIAL_VERSION",
      "policies" : "",
      "write.format.default" : "orc",
      "write.metadata.delete-after-commit.enabled" : "true",
      "write.metadata.previous-versions-max" : "28"
   },
   "tableType" : "PRIMARY_TABLE",
   "tableUUID" : "30f90df6-4c45-47ee-916c-7cf0bdea5d4d",
   "tableUri" : "LocalHadoopCluster.d3.t1",
   "tableVersion" : "INITIAL_VERSION",
   "timePartitioning" : {
      "columnName" : "ts",
      "granularity" : "HOUR"
   }
}

2. Read table:
$ curl "${curlArgs[@]}" -XGET http://localhost:8000/v1/databases/d3/tables/t1 | json_pp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1600    0  1600    0     0  22736      0 --:--:-- --:--:-- --:--:-- 22857
{
   "clusterId" : "LocalHadoopCluster",
   "clustering" : [
      {
         "columnName" : "name",
         "transform" : null
      }
   ],
   "creationTime" : 1717098450027,
   "databaseId" : "d3",
   "lastModifiedTime" : 1717098450027,
   "policies" : null,
   "schema" : "{\"type\":\"struct\",\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"string\"},{\"id\":2,\"name\":\"name\",\"required\":true,\"type\":\"string\"},{\"id\":3,\"name\":\"ts\",\"required\":true,\"type\":\"timestamp\"}]}",
   "tableCreator" : "DUMMY_ANONYMOUS_USER",
   "tableId" : "t1",
   "tableLocation" : "hdfs://namenode:9000/data/openhouse/d3/t1-30f90df6-4c45-47ee-916c-7cf0bdea5d4d/00000-5fec4fc6-4bf9-4bab-b6a9-112967a57497.metadata.json",
   "tableProperties" : {
      "key" : "value",
      "openhouse.clusterId" : "LocalHadoopCluster",
      "openhouse.creationTime" : "1717098450027",
      "openhouse.databaseId" : "d3",
      "openhouse.lastModifiedTime" : "1717098450027",
      "openhouse.tableCreator" : "DUMMY_ANONYMOUS_USER",
      "openhouse.tableId" : "t1",
      "openhouse.tableLocation" : "/data/openhouse/d3/t1-30f90df6-4c45-47ee-916c-7cf0bdea5d4d/00000-5fec4fc6-4bf9-4bab-b6a9-112967a57497.metadata.json",
      "openhouse.tableType" : "PRIMARY_TABLE",
      "openhouse.tableUUID" : "30f90df6-4c45-47ee-916c-7cf0bdea5d4d",
      "openhouse.tableUri" : "LocalHadoopCluster.d3.t1",
      "openhouse.tableVersion" : "INITIAL_VERSION",
      "policies" : "",
      "write.format.default" : "orc",
      "write.metadata.delete-after-commit.enabled" : "true",
      "write.metadata.previous-versions-max" : "28"
   },
   "tableType" : "PRIMARY_TABLE",
   "tableUUID" : "30f90df6-4c45-47ee-916c-7cf0bdea5d4d",
   "tableUri" : "LocalHadoopCluster.d3.t1",
   "tableVersion" : "INITIAL_VERSION",
   "timePartitioning" : {
      "columnName" : "ts",
      "granularity" : "HOUR"
   }
}

3. List tables:
$ curl "${curlArgs[@]}" -XGET http://localhost:8000/v1/databases/d3/tables/ | json_pp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1614    0  1614    0     0  30447      0 --:--:-- --:--:-- --:--:-- 31038
{
   "results" : [
      {
         "clusterId" : "LocalHadoopCluster",
         "clustering" : [
            {
               "columnName" : "name",
               "transform" : null
            }
         ],
         "creationTime" : 1717098450027,
         "databaseId" : "d3",
         "lastModifiedTime" : 1717098450027,
         "policies" : null,
         "schema" : "{\"type\":\"struct\",\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"string\"},{\"id\":2,\"name\":\"name\",\"required\":true,\"type\":\"string\"},{\"id\":3,\"name\":\"ts\",\"required\":true,\"type\":\"timestamp\"}]}",
         "tableCreator" : "DUMMY_ANONYMOUS_USER",
         "tableId" : "t1",
         "tableLocation" : "hdfs://namenode:9000/data/openhouse/d3/t1-30f90df6-4c45-47ee-916c-7cf0bdea5d4d/00000-5fec4fc6-4bf9-4bab-b6a9-112967a57497.metadata.json",
         "tableProperties" : {
            "key" : "value",
            "openhouse.clusterId" : "LocalHadoopCluster",
            "openhouse.creationTime" : "1717098450027",
            "openhouse.databaseId" : "d3",
            "openhouse.lastModifiedTime" : "1717098450027",
            "openhouse.tableCreator" : "DUMMY_ANONYMOUS_USER",
            "openhouse.tableId" : "t1",
            "openhouse.tableLocation" : "/data/openhouse/d3/t1-30f90df6-4c45-47ee-916c-7cf0bdea5d4d/00000-5fec4fc6-4bf9-4bab-b6a9-112967a57497.metadata.json",
            "openhouse.tableType" : "PRIMARY_TABLE",
            "openhouse.tableUUID" : "30f90df6-4c45-47ee-916c-7cf0bdea5d4d",
            "openhouse.tableUri" : "LocalHadoopCluster.d3.t1",
            "openhouse.tableVersion" : "INITIAL_VERSION",
            "policies" : "",
            "write.format.default" : "orc",
            "write.metadata.delete-after-commit.enabled" : "true",
            "write.metadata.previous-versions-max" : "28"
         },
         "tableType" : "PRIMARY_TABLE",
         "tableUUID" : "30f90df6-4c45-47ee-916c-7cf0bdea5d4d",
         "tableUri" : "LocalHadoopCluster.d3.t1",
         "tableVersion" : "INITIAL_VERSION",
         "timePartitioning" : {
            "columnName" : "ts",
            "granularity" : "HOUR"
         }
      }
   ]
}

4. Delete table:
$ curl "${curlArgs[@]}" -XDELETE http://localhost:8000/v1/databases/d3/tables/t1
lajain-mn2:oh-hadoop-spark lajain$ curl "${curlArgs[@]}" -XGET http://localhost:8000/v1/databases/d3/tables/ | json_pp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    14    0    14    0     0    331      0 --:--:-- --:--:-- --:--:--   333
{
   "results" : []
}

Testing via spark shell:
scala> spark.sql("CREATE TABLE openhouse.db.tb (ts timestamp, col1 string, col2 string) PARTITIONED BY (days(ts))").show()
++
||
++
++


scala> spark.sql("DESCRIBE TABLE openhouse.db.tb").show()
+--------------+---------+-------+
|      col_name|data_type|comment|
+--------------+---------+-------+
|            ts|timestamp|       |
|          col1|   string|       |
|          col2|   string|       |
|              |         |       |
|# Partitioning|         |       |
|        Part 0| days(ts)|       |
+--------------+---------+-------+


scala> spark.sql("INSERT INTO TABLE openhouse.db.tb VALUES (current_timestamp(), 'val1', 'val2')")
res2: org.apache.spark.sql.DataFrame = []                                       

scala> spark.sql("INSERT INTO TABLE openhouse.db.tb VALUES (date_sub(CAST(current_timestamp() as DATE), 30), 'val1', 'val2')")
res3: org.apache.spark.sql.DataFrame = []

scala> spark.sql("INSERT INTO TABLE openhouse.db.tb VALUES (date_sub(CAST(current_timestamp() as DATE), 60), 'val1', 'val2')")
res4: org.apache.spark.sql.DataFrame = []                                       

scala> spark.sql("SELECT * FROM openhouse.db.tb").show()
+--------------------+----+----+                                                
|                  ts|col1|col2|
+--------------------+----+----+
|2024-05-30 19:52:...|val1|val2|
| 2024-03-31 00:00:00|val1|val2|
| 2024-04-30 00:00:00|val1|val2|
+--------------------+----+----+


scala> spark.sql("SHOW TABLES IN openhouse.db").show()
+---------+---------+
|namespace|tableName|
+---------+---------+
|       db|       tb|
+---------+---------+


# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [x] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
