### PR TITLE
Fix 'io-impl' relocation in `openhouse-java-runtime` and `openhouse-spark-runtime`

### DIFF
--- a/integrations/java/openhouse-java-runtime/build.gradle
+++ b/integrations/java/openhouse-java-runtime/build.gradle
@@ -48,7 +48,7 @@ shadowJar {
     exclude("org/springframework/http/codec/CodecConfigurer.properties")
     exclude("javax/**")
 
-    relocate ('io', 'com.linkedin.openhouse.relocated.io')
+    relocate ('io.', 'com.linkedin.openhouse.relocated.io.')
     relocate('org','com.linkedin.openhouse.relocated.org') {
       exclude 'org.xml.sax.**'
       exclude 'org.apache.hadoop.**'


### PR DESCRIPTION
## Summary
This bug was discovered in the PR: https://github.com/linkedin/openhouse/pull/106

As a result of this bug, we need to specify the spark config as:
```
--conf spark.sql.catalog.openhouse.com.linkedin.openhouse.relocated.io-impl=XYZ
```
instead of the right way:
```
--conf spark.sql.catalog.openhouse.io-impl=XYZ
```
This bug was introduced because of incorrect relocation.
The jar before the change contains following code:
![image](https://github.com/linkedin/openhouse/assets/6441597/9b95ab75-3174-4d1c-bd15-1ba06795f0ec)

## Changes

- [X] Bug Fixes

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
✅ build will succeed
✅ new jar and code looks good:
![image](https://github.com/linkedin/openhouse/assets/6441597/25257b3d-5fd1-4efc-9746-89205b1f0902)
✅ older relocation looks good:
![image](https://github.com/linkedin/openhouse/assets/6441597/166263c1-8890-447a-8b1c-a0215c90ce9c)

- [X] Some other form of testing.
