### PR TITLE
[PR 2/5] Add validation for storage properties to BaseStorageClient

### DIFF
--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/BaseStorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/BaseStorageClient.java
@@ -17,6 +17,26 @@ public abstract class BaseStorageClient<T> implements StorageClient<T> {
   // Holds storage properties for all configured storage types.
   @Autowired private StorageProperties storageProperties;
 
+  /**
+   * Returns the endpoint for the given storage type.
+   *
+   * @return endpoint for the given storage type.
+   */
+  @Override
+  public String getEndpoint() {
+    return storageProperties.getTypes().get(getStorageType().getValue()).getEndpoint();
+  }
+
+  /**
+   * Returns the root prefix for the given storage type.
+   *
+   * @return root prefix for the given storage type.
+   */
+  @Override
+  public String getRootPrefix() {
+    return storageProperties.getTypes().get(getStorageType().getValue()).getRootPath();
+  }
+
   // Validates the configuration for the given storage type.
   // The storage type is determined based on the derived class implementation of getStorageType().
   // Validates that:

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/BaseStorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/BaseStorageClient.java
@@ -5,17 +5,17 @@ import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
 import org.springframework.util.CollectionUtils;
 
 /**
- * BaseStorageClient is the interface that holds common functionality for all storage clients like
- * validating the configuration and storage properties for a given storage type.
+ * BaseStorageClient is the abstract class that holds common functionality for all storage clients
+ * like validating the configuration and storage properties for a given storage type.
  *
  * @param <T> native client type for the storage backend.
  */
-public interface BaseStorageClient<T> {
+public abstract class BaseStorageClient<T> implements StorageClient<T> {
   // Validates the configuration for the given storage type. Validates that:
   // 1. The storageProperties contain the entry for the given storage type.
   // 2. The storageProperties value for the given storage type is not null and has the endpoint and
   // root path configured.
-  static void validateProperties(
+  protected void validateProperties(
       StorageProperties storageProperties, StorageType.Type storageType) {
     Preconditions.checkArgument(
         !CollectionUtils.isEmpty(storageProperties.getTypes())

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/BaseStorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/BaseStorageClient.java
@@ -1,0 +1,36 @@
+package com.linkedin.openhouse.cluster.storage;
+
+import com.google.common.base.Preconditions;
+import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * BaseStorageClient is the interface that holds common functionality for all storage clients like
+ * validating the configuration and storage properties for a given storage type.
+ *
+ * @param <T> native client type for the storage backend.
+ */
+public interface BaseStorageClient<T> {
+  // Validates the configuration for the given storage type. Validates that:
+  // 1. The storageProperties contain the entry for the given storage type.
+  // 2. The storageProperties value for the given storage type is not null and has the endpoint and
+  // root path configured.
+  static void validateProperties(
+      StorageProperties storageProperties, StorageType.Type storageType) {
+    Preconditions.checkArgument(
+        !CollectionUtils.isEmpty(storageProperties.getTypes())
+            && storageProperties.getTypes().containsKey(storageType.getValue()),
+        "Storage properties doesn't contain type: " + storageType.getValue());
+    StorageProperties.StorageTypeProperties hdfsStorageProperties =
+        storageProperties.getTypes().get(storageType.getValue());
+    Preconditions.checkArgument(
+        hdfsStorageProperties != null,
+        "Storage properties doesn't contain type: " + storageType.getValue());
+    Preconditions.checkArgument(
+        hdfsStorageProperties.getEndpoint() != null,
+        "Storage properties doesn't contain endpoint for: " + storageType.getValue());
+    Preconditions.checkArgument(
+        hdfsStorageProperties.getRootPath() != null,
+        "Storage properties doesn't contain rootpath for: " + storageType.getValue());
+  }
+}

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/StorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/StorageClient.java
@@ -11,7 +11,7 @@ package com.linkedin.openhouse.cluster.storage;
  *
  * @param <T> the type of the native client of the storage system
  */
-public interface StorageClient<T> extends BaseStorageClient<T> {
+public interface StorageClient<T> {
 
   /**
    * Get the native client of the storage system.

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/StorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/StorageClient.java
@@ -11,7 +11,7 @@ package com.linkedin.openhouse.cluster.storage;
  *
  * @param <T> the type of the native client of the storage system
  */
-public interface StorageClient<T> {
+public interface StorageClient<T> extends BaseStorageClient<T> {
 
   /**
    * Get the native client of the storage system.

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/StorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/StorageClient.java
@@ -21,6 +21,13 @@ public interface StorageClient<T> {
   T getNativeClient();
 
   /**
+   * Get the storage type for the storage system.
+   *
+   * @return the storage type. Examples include "HDFS", "S3" etc.
+   */
+  StorageType.Type getStorageType();
+
+  /**
    * Get the endpoint of the storage system.
    *
    * <p>Example: For HDFS, the endpoint could be "hdfs://localhost:9000". For local file system, the

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/hdfs/HdfsStorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/hdfs/HdfsStorageClient.java
@@ -1,7 +1,6 @@
 package com.linkedin.openhouse.cluster.storage.hdfs;
 
 import com.linkedin.openhouse.cluster.storage.BaseStorageClient;
-import com.linkedin.openhouse.cluster.storage.StorageClient;
 import com.linkedin.openhouse.cluster.storage.StorageType;
 import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
 import java.io.IOException;
@@ -19,7 +18,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Lazy
 @Component
-public class HdfsStorageClient implements StorageClient<FileSystem> {
+public class HdfsStorageClient extends BaseStorageClient<FileSystem> {
 
   private FileSystem fs;
 
@@ -31,7 +30,7 @@ public class HdfsStorageClient implements StorageClient<FileSystem> {
   @PostConstruct
   public synchronized void init() throws IOException {
     log.info("Initializing storage client for type: " + HDFS_TYPE);
-    BaseStorageClient.validateProperties(storageProperties, HDFS_TYPE);
+    validateProperties(storageProperties, HDFS_TYPE);
     StorageProperties.StorageTypeProperties hdfsStorageProperties =
         storageProperties.getTypes().get(HDFS_TYPE.getValue());
     org.apache.hadoop.conf.Configuration configuration = new org.apache.hadoop.conf.Configuration();

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/hdfs/HdfsStorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/hdfs/HdfsStorageClient.java
@@ -22,6 +22,7 @@ public class HdfsStorageClient extends BaseStorageClient<FileSystem> {
 
   private FileSystem fs;
 
+  // Holds storage properties for all configured storage types.
   @Autowired private StorageProperties storageProperties;
 
   private static final StorageType.Type HDFS_TYPE = StorageType.HDFS;
@@ -30,7 +31,7 @@ public class HdfsStorageClient extends BaseStorageClient<FileSystem> {
   @PostConstruct
   public synchronized void init() throws IOException {
     log.info("Initializing storage client for type: " + HDFS_TYPE);
-    validateProperties(storageProperties, HDFS_TYPE);
+    validateProperties();
     StorageProperties.StorageTypeProperties hdfsStorageProperties =
         storageProperties.getTypes().get(HDFS_TYPE.getValue());
     org.apache.hadoop.conf.Configuration configuration = new org.apache.hadoop.conf.Configuration();
@@ -44,12 +45,27 @@ public class HdfsStorageClient extends BaseStorageClient<FileSystem> {
   }
 
   @Override
-  public String getEndpoint() {
-    return storageProperties.getTypes().get(HDFS_TYPE.getValue()).getEndpoint();
+  public StorageType.Type getStorageType() {
+    return HDFS_TYPE;
   }
 
+  /**
+   * Returns the endpoint for the given storage type.
+   *
+   * @return endpoint for the given storage type.
+   */
+  @Override
+  public String getEndpoint() {
+    return storageProperties.getTypes().get(getStorageType().getValue()).getEndpoint();
+  }
+
+  /**
+   * Returns the root prefix for the given storage type.
+   *
+   * @return root prefix for the given storage type.
+   */
   @Override
   public String getRootPrefix() {
-    return storageProperties.getTypes().get(HDFS_TYPE.getValue()).getRootPath();
+    return storageProperties.getTypes().get(getStorageType().getValue()).getRootPath();
   }
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/hdfs/HdfsStorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/hdfs/HdfsStorageClient.java
@@ -1,6 +1,6 @@
 package com.linkedin.openhouse.cluster.storage.hdfs;
 
-import com.google.common.base.Preconditions;
+import com.linkedin.openhouse.cluster.storage.BaseStorageClient;
 import com.linkedin.openhouse.cluster.storage.StorageClient;
 import com.linkedin.openhouse.cluster.storage.StorageType;
 import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
@@ -11,7 +11,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
-import org.springframework.util.CollectionUtils;
 
 /**
  * The HdfsStorageClient class is an implementation of the StorageClient interface for HDFS Storage.
@@ -31,32 +30,13 @@ public class HdfsStorageClient implements StorageClient<FileSystem> {
   /** Initialize the HdfsStorageClient when the bean is accessed for the first time. */
   @PostConstruct
   public synchronized void init() throws IOException {
-    validateProperties();
+    log.info("Initializing storage client for type: " + HDFS_TYPE);
+    BaseStorageClient.validateProperties(storageProperties, HDFS_TYPE);
     StorageProperties.StorageTypeProperties hdfsStorageProperties =
         storageProperties.getTypes().get(HDFS_TYPE.getValue());
     org.apache.hadoop.conf.Configuration configuration = new org.apache.hadoop.conf.Configuration();
     configuration.set("fs.defaultFS", hdfsStorageProperties.getEndpoint());
     fs = FileSystem.get(configuration);
-  }
-
-  /** Validate the storage properties. */
-  private void validateProperties() {
-    log.info("Initializing storage client for type: " + HDFS_TYPE);
-    Preconditions.checkArgument(
-        !CollectionUtils.isEmpty(storageProperties.getTypes())
-            && storageProperties.getTypes().containsKey(HDFS_TYPE.getValue()),
-        "Storage properties doesn't contain type: " + HDFS_TYPE.getValue());
-    StorageProperties.StorageTypeProperties hdfsStorageProperties =
-        storageProperties.getTypes().get(HDFS_TYPE.getValue());
-    Preconditions.checkArgument(
-        hdfsStorageProperties != null,
-        "Storage properties doesn't contain type: " + HDFS_TYPE.getValue());
-    Preconditions.checkArgument(
-        hdfsStorageProperties.getEndpoint() != null,
-        "Storage properties doesn't contain endpoint for: " + HDFS_TYPE.getValue());
-    Preconditions.checkArgument(
-        hdfsStorageProperties.getRootPath() != null,
-        "Storage properties doesn't contain rootpath for: " + HDFS_TYPE.getValue());
   }
 
   @Override

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/hdfs/HdfsStorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/hdfs/HdfsStorageClient.java
@@ -48,24 +48,4 @@ public class HdfsStorageClient extends BaseStorageClient<FileSystem> {
   public StorageType.Type getStorageType() {
     return HDFS_TYPE;
   }
-
-  /**
-   * Returns the endpoint for the given storage type.
-   *
-   * @return endpoint for the given storage type.
-   */
-  @Override
-  public String getEndpoint() {
-    return storageProperties.getTypes().get(getStorageType().getValue()).getEndpoint();
-  }
-
-  /**
-   * Returns the root prefix for the given storage type.
-   *
-   * @return root prefix for the given storage type.
-   */
-  @Override
-  public String getRootPrefix() {
-    return storageProperties.getTypes().get(getStorageType().getValue()).getRootPath();
-  }
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorageClient.java
@@ -45,7 +45,15 @@ public class LocalStorageClient extends BaseStorageClient<FileSystem> {
 
     URI uri;
     if (storageProperties.getTypes() != null && !storageProperties.getTypes().isEmpty()) {
-      validateProperties(storageProperties, LOCAL_TYPE);
+      Preconditions.checkArgument(
+          storageProperties.getTypes().containsKey(LOCAL_TYPE.getValue()),
+          "Storage properties doesn't contain type: " + LOCAL_TYPE.getValue());
+      Preconditions.checkArgument(
+          storageProperties.getTypes().get(LOCAL_TYPE.getValue()).getEndpoint() != null,
+          "Storage properties doesn't contain endpoint for: " + LOCAL_TYPE.getValue());
+      Preconditions.checkArgument(
+          storageProperties.getTypes().get(LOCAL_TYPE.getValue()).getRootPath() != null,
+          "Storage properties doesn't contain rootpath for: " + LOCAL_TYPE.getValue());
       Preconditions.checkArgument(
           storageProperties
               .getTypes()
@@ -76,6 +84,11 @@ public class LocalStorageClient extends BaseStorageClient<FileSystem> {
   @Override
   public FileSystem getNativeClient() {
     return fs;
+  }
+
+  @Override
+  public StorageType.Type getStorageType() {
+    return LOCAL_TYPE;
   }
 
   @Override

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorageClient.java
@@ -1,7 +1,7 @@
 package com.linkedin.openhouse.cluster.storage.local;
 
 import com.google.common.base.Preconditions;
-import com.linkedin.openhouse.cluster.storage.StorageClient;
+import com.linkedin.openhouse.cluster.storage.BaseStorageClient;
 import com.linkedin.openhouse.cluster.storage.StorageType;
 import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
 import java.io.IOException;
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Lazy
 @Component
-public class LocalStorageClient implements StorageClient<FileSystem> {
+public class LocalStorageClient extends BaseStorageClient<FileSystem> {
 
   private FileSystem fs;
 
@@ -45,15 +45,7 @@ public class LocalStorageClient implements StorageClient<FileSystem> {
 
     URI uri;
     if (storageProperties.getTypes() != null && !storageProperties.getTypes().isEmpty()) {
-      Preconditions.checkArgument(
-          storageProperties.getTypes().containsKey(LOCAL_TYPE.getValue()),
-          "Storage properties doesn't contain type: " + LOCAL_TYPE.getValue());
-      Preconditions.checkArgument(
-          storageProperties.getTypes().get(LOCAL_TYPE.getValue()).getEndpoint() != null,
-          "Storage properties doesn't contain endpoint for: " + LOCAL_TYPE.getValue());
-      Preconditions.checkArgument(
-          storageProperties.getTypes().get(LOCAL_TYPE.getValue()).getRootPath() != null,
-          "Storage properties doesn't contain rootpath for: " + LOCAL_TYPE.getValue());
+      validateProperties(storageProperties, LOCAL_TYPE);
       Preconditions.checkArgument(
           storageProperties
               .getTypes()

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/s3/S3StorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/s3/S3StorageClient.java
@@ -1,7 +1,6 @@
 package com.linkedin.openhouse.cluster.storage.s3;
 
 import com.linkedin.openhouse.cluster.storage.BaseStorageClient;
-import com.linkedin.openhouse.cluster.storage.StorageClient;
 import com.linkedin.openhouse.cluster.storage.StorageType;
 import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
 import java.util.HashMap;
@@ -25,7 +24,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 @Slf4j
 @Lazy
 @Component
-public class S3StorageClient implements StorageClient<S3Client> {
+public class S3StorageClient extends BaseStorageClient<S3Client> {
   // Storage type.
   private static final StorageType.Type S3_TYPE = StorageType.S3;
 
@@ -42,7 +41,7 @@ public class S3StorageClient implements StorageClient<S3Client> {
   @PostConstruct
   public synchronized void init() {
     log.info("Initializing storage client for type: " + S3_TYPE);
-    BaseStorageClient.validateProperties(storageProperties, S3_TYPE);
+    validateProperties(storageProperties, S3_TYPE);
     Map properties =
         new HashMap(storageProperties.getTypes().get(S3_TYPE.getValue()).getParameters());
 

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/s3/S3StorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/s3/S3StorageClient.java
@@ -25,23 +25,23 @@ import software.amazon.awssdk.services.s3.S3Client;
 @Lazy
 @Component
 public class S3StorageClient extends BaseStorageClient<S3Client> {
-  // Storage type.
-  private static final StorageType.Type S3_TYPE = StorageType.S3;
-
   // Storage properties.
   @Autowired private StorageProperties storageProperties;
+
+  // Storage type.
+  private static final StorageType.Type S3_TYPE = StorageType.S3;
 
   // S3 client.
   private S3Client s3;
 
   /**
    * Initialize the S3 client when the bean is accessed the first time. AWS_REGION must be set in
-   * the evironment variable or in the storage properties.
+   * the environment variable or in the storage properties.
    */
   @PostConstruct
   public synchronized void init() {
     log.info("Initializing storage client for type: " + S3_TYPE);
-    validateProperties(storageProperties, S3_TYPE);
+    validateProperties();
     Map properties =
         new HashMap(storageProperties.getTypes().get(S3_TYPE.getValue()).getParameters());
 
@@ -65,12 +65,27 @@ public class S3StorageClient extends BaseStorageClient<S3Client> {
   }
 
   @Override
-  public String getEndpoint() {
-    return storageProperties.getTypes().get(S3_TYPE.getValue()).getEndpoint();
+  public StorageType.Type getStorageType() {
+    return S3_TYPE;
   }
 
+  /**
+   * Returns the endpoint for the given storage type.
+   *
+   * @return endpoint for the given storage type.
+   */
+  @Override
+  public String getEndpoint() {
+    return storageProperties.getTypes().get(getStorageType().getValue()).getEndpoint();
+  }
+
+  /**
+   * Returns the root prefix for the given storage type.
+   *
+   * @return root prefix for the given storage type.
+   */
   @Override
   public String getRootPrefix() {
-    return storageProperties.getTypes().get(S3_TYPE.getValue()).getRootPath();
+    return storageProperties.getTypes().get(getStorageType().getValue()).getRootPath();
   }
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/s3/S3StorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/s3/S3StorageClient.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.cluster.storage.s3;
 
+import com.linkedin.openhouse.cluster.storage.BaseStorageClient;
 import com.linkedin.openhouse.cluster.storage.StorageClient;
 import com.linkedin.openhouse.cluster.storage.StorageType;
 import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
@@ -40,7 +41,8 @@ public class S3StorageClient implements StorageClient<S3Client> {
    */
   @PostConstruct
   public synchronized void init() {
-    // TODO: Validate properties.
+    log.info("Initializing storage client for type: " + S3_TYPE);
+    BaseStorageClient.validateProperties(storageProperties, S3_TYPE);
     Map properties =
         new HashMap(storageProperties.getTypes().get(S3_TYPE.getValue()).getParameters());
 

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/s3/S3StorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/s3/S3StorageClient.java
@@ -68,24 +68,4 @@ public class S3StorageClient extends BaseStorageClient<S3Client> {
   public StorageType.Type getStorageType() {
     return S3_TYPE;
   }
-
-  /**
-   * Returns the endpoint for the given storage type.
-   *
-   * @return endpoint for the given storage type.
-   */
-  @Override
-  public String getEndpoint() {
-    return storageProperties.getTypes().get(getStorageType().getValue()).getEndpoint();
-  }
-
-  /**
-   * Returns the root prefix for the given storage type.
-   *
-   * @return root prefix for the given storage type.
-   */
-  @Override
-  public String getRootPrefix() {
-    return storageProperties.getTypes().get(getStorageType().getValue()).getRootPath();
-  }
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/s3/S3StorageClientTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/s3/S3StorageClientTest.java
@@ -32,6 +32,32 @@ public class S3StorageClientTest {
   }
 
   @Test
+  public void testS3StorageClientInvalidProperties() {
+    when(storageProperties.getTypes())
+        .thenReturn(
+            new HashMap<>(
+                ImmutableMap.of(
+                    StorageType.S3.getValue(), new StorageProperties.StorageTypeProperties())));
+    assertThrows(IllegalArgumentException.class, () -> s3StorageClient.init());
+  }
+
+  @Test
+  public void testS3StorageClientNullOrEmptyProperties() {
+    when(storageProperties.getTypes()).thenReturn(null);
+    assertThrows(IllegalArgumentException.class, () -> s3StorageClient.init());
+    when(storageProperties.getTypes()).thenReturn(new HashMap<>());
+    assertThrows(IllegalArgumentException.class, () -> s3StorageClient.init());
+    when(storageProperties.getTypes())
+        .thenReturn(
+            new HashMap<String, StorageProperties.StorageTypeProperties>() {
+              {
+                put(StorageType.S3.getValue(), null);
+              }
+            });
+    assertThrows(IllegalArgumentException.class, () -> s3StorageClient.init());
+  }
+
+  @Test
   public void testS3StorageClientValidProperties() {
     when(storageProperties.getTypes())
         .thenReturn(


### PR DESCRIPTION
## Summary
This is the second PR in a sequence of PRs to add support for S3 storage.

Openhouse catalog currently supports HDFS as the storage backend. The end goal of this effort is to add the integration with S3 so that the storage backend can be configured to be S3 vs HDFS based on storage type.
The entire work will be done via a series of PRs:

1. Add S3 Storage type and S3StorageClient.
2. Add base class for StorageClient and move common logic like validation of properties there to avoid code duplication.
3. Add S3Storage implementation that uses S3StorageClient.
4. Add support for using S3FileIO for S3 storage type.
5. Add a recipe for end-to-end testing in docker.

This PR addresses 2 by adding BaseStorageClient and common logic to validate storage properties for a given storage type.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
Added more unot tests for S3 storage properties validation.
Manually tested oh-hadoop-spark recipe in docker.

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Docker testing:

lajain-mn2:oh-hadoop-spark lajain$ curl "${curlArgs[@]}" -XPOST http://localhost:8000/v1/databases/d3/tables/ \
> --data-raw '{
>   "tableId": "t1",
>   "databaseId": "d3",
>   "baseTableVersion": "INITIAL_VERSION",
>   "clusterId": "LocalHadoopCluster",
>   "schema": "{\"type\": \"struct\", \"fields\": [{\"id\": 1,\"required\": true,\"name\": \"id\",\"type\": \"string\"},{\"id\": 2,\"required\": true,\"name\": \"name\",\"type\": \"string\"},{\"id\": 3,\"required\": true,\"name\": \"ts\",\"type\": \"timestamp\"}]}",
>   "timePartitioning": {
>     "columnName": "ts",
>     "granularity": "HOUR"
>   },
>   "clustering": [
>     {
>       "columnName": "name"
>     }
>   ],
>   "tableProperties": {
>     "key": "value"
>   }
> }' | json_pp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2174    0  1600  100   574    614    220  0:00:02  0:00:02 --:--:--   835
{
   "clusterId" : "LocalHadoopCluster",
   "clustering" : [
      {
         "columnName" : "name",
         "transform" : null
      }
   ],
   "creationTime" : 1717110226250,
   "databaseId" : "d3",
   "lastModifiedTime" : 1717110226250,
   "policies" : null,
   "schema" : "{\"type\":\"struct\",\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"string\"},{\"id\":2,\"name\":\"name\",\"required\":true,\"type\":\"string\"},{\"id\":3,\"name\":\"ts\",\"required\":true,\"type\":\"timestamp\"}]}",
   "tableCreator" : "DUMMY_ANONYMOUS_USER",
   "tableId" : "t1",
   "tableLocation" : "hdfs://namenode:9000/data/openhouse/d3/t1-3b602ebe-562b-4dcf-8f5e-0713ded56a2b/00000-e605bcfc-0aea-4066-a608-7d45c88ecfbb.metadata.json",
   "tableProperties" : {
      "key" : "value",
      "openhouse.clusterId" : "LocalHadoopCluster",
      "openhouse.creationTime" : "1717110226250",
      "openhouse.databaseId" : "d3",
      "openhouse.lastModifiedTime" : "1717110226250",
      "openhouse.tableCreator" : "DUMMY_ANONYMOUS_USER",
      "openhouse.tableId" : "t1",
      "openhouse.tableLocation" : "/data/openhouse/d3/t1-3b602ebe-562b-4dcf-8f5e-0713ded56a2b/00000-e605bcfc-0aea-4066-a608-7d45c88ecfbb.metadata.json",
      "openhouse.tableType" : "PRIMARY_TABLE",
      "openhouse.tableUUID" : "3b602ebe-562b-4dcf-8f5e-0713ded56a2b",
      "openhouse.tableUri" : "LocalHadoopCluster.d3.t1",
      "openhouse.tableVersion" : "INITIAL_VERSION",
      "policies" : "",
      "write.format.default" : "orc",
      "write.metadata.delete-after-commit.enabled" : "true",
      "write.metadata.previous-versions-max" : "28"
   },
   "tableType" : "PRIMARY_TABLE",
   "tableUUID" : "3b602ebe-562b-4dcf-8f5e-0713ded56a2b",
   "tableUri" : "LocalHadoopCluster.d3.t1",
   "tableVersion" : "INITIAL_VERSION",
   "timePartitioning" : {
      "columnName" : "ts",
      "granularity" : "HOUR"
   }
}
lajain-mn2:oh-hadoop-spark lajain$ curl "${curlArgs[@]}" -XGET http://localhost:8000/v1/databases/d3/tables/t1
{"tableId":"t1","databaseId":"d3","clusterId":"LocalHadoopCluster","tableUri":"LocalHadoopCluster.d3.t1","tableUUID":"3b602ebe-562b-4dcf-8f5e-0713ded56a2b","tableLocation":"hdfs://namenode:9000/data/openhouse/d3/t1-3b602ebe-562b-4dcf-8f5e-0713ded56a2b/00000-e605bcfc-0aea-4066-a608-7d45c88ecfbb.metadata.json","tableVersion":"INITIAL_VERSION","tableCreator":"DUMMY_ANONYMOUS_USER","schema":"{\"type\":\"struct\",\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"string\"},{\"id\":2,\"name\":\"name\",\"required\":true,\"type\":\"string\"},{\"id\":3,\"name\":\"ts\",\"required\":true,\"type\":\"timestamp\"}]}","lastModifiedTime":1717110226250,"creationTime":1717110226250,"tableProperties":{"policies":"","write.metadata.delete-after-commit.enabled":"true","openhouse.tableId":"t1","openhouse.clusterId":"LocalHadoopCluster","openhouse.lastModifiedTime":"1717110226250","openhouse.tableVersion":"INITIAL_VERSION","openhouse.creationTime":"1717110226250","openhouse.tableUri":"LocalHadoopCluster.d3.t1","write.format.default":"orc","write.metadata.previous-versions-max":"28","openhouse.databaseId":"d3","openhouse.tableType":"PRIMARY_TABLE","openhouse.tableLocation":"/data/openhouse/d3/t1-3b602ebe-562b-4dcf-8f5e-0713ded56a2b/00000-e605bcfc-0aea-4066-a608-7d45c88ecfbb.metadata.json","openhouse.tableUUID":"3b602ebe-562b-4dcf-8f5e-0713ded56a2b","key":"value","openhouse.tableCreator":"DUMMY_ANONYMOUS_USER"},"timePartitioning":{"columnName":"ts","granularity":"HOUR"},"clustering":[{"columnName":"name","transform":null}],"policies":null,"tableType":"PRIMARY_TABLE"}lajain-mn2:oh-hadoop-spark lajacurl "${curlArgs[@]}" -XGET http://localhost:8000/v1/databases/d3/tables/ | json_pp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1614    0  1614    0     0   6673      0 --:--:-- --:--:-- --:--:--  6669
{
   "results" : [
      {
         "clusterId" : "LocalHadoopCluster",
         "clustering" : [
            {
               "columnName" : "name",
               "transform" : null
            }
         ],
         "creationTime" : 1717110226250,
         "databaseId" : "d3",
         "lastModifiedTime" : 1717110226250,
         "policies" : null,
         "schema" : "{\"type\":\"struct\",\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"string\"},{\"id\":2,\"name\":\"name\",\"required\":true,\"type\":\"string\"},{\"id\":3,\"name\":\"ts\",\"required\":true,\"type\":\"timestamp\"}]}",
         "tableCreator" : "DUMMY_ANONYMOUS_USER",
         "tableId" : "t1",
         "tableLocation" : "hdfs://namenode:9000/data/openhouse/d3/t1-3b602ebe-562b-4dcf-8f5e-0713ded56a2b/00000-e605bcfc-0aea-4066-a608-7d45c88ecfbb.metadata.json",
         "tableProperties" : {
            "key" : "value",
            "openhouse.clusterId" : "LocalHadoopCluster",
            "openhouse.creationTime" : "1717110226250",
            "openhouse.databaseId" : "d3",
            "openhouse.lastModifiedTime" : "1717110226250",
            "openhouse.tableCreator" : "DUMMY_ANONYMOUS_USER",
            "openhouse.tableId" : "t1",
            "openhouse.tableLocation" : "/data/openhouse/d3/t1-3b602ebe-562b-4dcf-8f5e-0713ded56a2b/00000-e605bcfc-0aea-4066-a608-7d45c88ecfbb.metadata.json",
            "openhouse.tableType" : "PRIMARY_TABLE",
            "openhouse.tableUUID" : "3b602ebe-562b-4dcf-8f5e-0713ded56a2b",
            "openhouse.tableUri" : "LocalHadoopCluster.d3.t1",
            "openhouse.tableVersion" : "INITIAL_VERSION",
            "policies" : "",
            "write.format.default" : "orc",
            "write.metadata.delete-after-commit.enabled" : "true",
            "write.metadata.previous-versions-max" : "28"
         },
         "tableType" : "PRIMARY_TABLE",
         "tableUUID" : "3b602ebe-562b-4dcf-8f5e-0713ded56a2b",
         "tableUri" : "LocalHadoopCluster.d3.t1",
         "tableVersion" : "INITIAL_VERSION",
         "timePartitioning" : {
            "columnName" : "ts",
            "granularity" : "HOUR"
         }
      }
   ]
}
lajain-mn2:oh-hadoop-spark lajain$ curl "${curlArgs[@]}" -XGET http://localhost:8000/v1/databases/d3/tables/ | json_pp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1614    0  1614    0     0  14629      0 --:--:-- --:--:-- --:--:-- 14672
{
   "results" : [
      {
         "clusterId" : "LocalHadoopCluster",
         "clustering" : [
            {
               "columnName" : "name",
               "transform" : null
            }
         ],
         "creationTime" : 1717110226250,
         "databaseId" : "d3",
         "lastModifiedTime" : 1717110226250,
         "policies" : null,
         "schema" : "{\"type\":\"struct\",\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"string\"},{\"id\":2,\"name\":\"name\",\"required\":true,\"type\":\"string\"},{\"id\":3,\"name\":\"ts\",\"required\":true,\"type\":\"timestamp\"}]}",
         "tableCreator" : "DUMMY_ANONYMOUS_USER",
         "tableId" : "t1",
         "tableLocation" : "hdfs://namenode:9000/data/openhouse/d3/t1-3b602ebe-562b-4dcf-8f5e-0713ded56a2b/00000-e605bcfc-0aea-4066-a608-7d45c88ecfbb.metadata.json",
         "tableProperties" : {
            "key" : "value",
            "openhouse.clusterId" : "LocalHadoopCluster",
            "openhouse.creationTime" : "1717110226250",
            "openhouse.databaseId" : "d3",
            "openhouse.lastModifiedTime" : "1717110226250",
            "openhouse.tableCreator" : "DUMMY_ANONYMOUS_USER",
            "openhouse.tableId" : "t1",
            "openhouse.tableLocation" : "/data/openhouse/d3/t1-3b602ebe-562b-4dcf-8f5e-0713ded56a2b/00000-e605bcfc-0aea-4066-a608-7d45c88ecfbb.metadata.json",
            "openhouse.tableType" : "PRIMARY_TABLE",
            "openhouse.tableUUID" : "3b602ebe-562b-4dcf-8f5e-0713ded56a2b",
            "openhouse.tableUri" : "LocalHadoopCluster.d3.t1",
            "openhouse.tableVersion" : "INITIAL_VERSION",
            "policies" : "",
            "write.format.default" : "orc",
            "write.metadata.delete-after-commit.enabled" : "true",
            "write.metadata.previous-versions-max" : "28"
         },
         "tableType" : "PRIMARY_TABLE",
         "tableUUID" : "3b602ebe-562b-4dcf-8f5e-0713ded56a2b",
         "tableUri" : "LocalHadoopCluster.d3.t1",
         "tableVersion" : "INITIAL_VERSION",
         "timePartitioning" : {
            "columnName" : "ts",
            "granularity" : "HOUR"
         }
      }
   ]
}
lajain-mn2:oh-hadoop-spark lajain$ curl "${curlArgs[@]}" -XDELETE http://localhost:8000/v1/databases/d3/tables/t1
lajain-mn2:oh-hadoop-spark lajain$ curl "${curlArgs[@]}" -XGET http://localhost:8000/v1/databases/d3/tables/ | json_pp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    14    0    14    0     0    593      0 --:--:-- --:--:-- --:--:--   608
{
   "results" : []
}
For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [x] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
