### PR TITLE
Make mapTableResponseToTableMetadata protected in TablesClient

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
@@ -244,7 +244,7 @@ public class TablesClient {
         Collections.emptyList());
   }
 
-  private TableMetadata mapTableResponseToTableMetadata(GetTableResponseBody responseBody) {
+  protected TableMetadata mapTableResponseToTableMetadata(GetTableResponseBody responseBody) {
     TableMetadata metadata =
         TableMetadata.builder()
             .dbName(responseBody.getDatabaseId())


### PR DESCRIPTION
## Summary
This change allows to override mapTableResponseToTableMetadata method in a subclass.

## Changes

- [ ] Client-facing API Changes
- [x] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [x] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

No tests added/changed since the change relaxes method visibility only.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
