### PR TITLE
Introduce `AllocateTableStorage` in Storage interface 

### DIFF
--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/BaseStorage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/BaseStorage.java
@@ -53,17 +53,11 @@ public abstract class BaseStorage implements Storage {
    * @param tableId the table id of the table
    * @param tableUUID the UUID of the table
    * @param tableCreator the creator of the table
-   * @param skipProvisioning Set to true if heavy-lifting allocation work needs to be skipped and
-   *     only the table location needs to be returned
    * @return the table location where the table data should be stored
    */
   @Override
   public String allocateTableLocation(
-      String databaseId,
-      String tableId,
-      String tableUUID,
-      String tableCreator,
-      boolean skipProvisioning) {
+      String databaseId, String tableId, String tableUUID, String tableCreator) {
     Preconditions.checkArgument(databaseId != null, "Database ID cannot be null");
     Preconditions.checkArgument(tableId != null, "Table ID cannot be null");
     Preconditions.checkArgument(tableUUID != null, "Table UUID cannot be null");

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/BaseStorage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/BaseStorage.java
@@ -45,7 +45,7 @@ public abstract class BaseStorage implements Storage {
   }
 
   /**
-   * Allocates Table Space for the storage.
+   * Allocates Table Storage and return location.
    *
    * <p>Default tableLocation looks like: {endpoint}/{rootPrefix}/{databaseId}/{tableId}-{tableUUID}
    *

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/BaseStorage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/BaseStorage.java
@@ -49,10 +49,16 @@ public abstract class BaseStorage implements Storage {
    *
    * <p>Default tableLocation looks like: {endpoint}/{rootPrefix}/{databaseId}/{tableId}-{tableUUID}
    *
+   * @param databaseId the database id of the table
+   * @param tableId the table id of the table
+   * @param tableUUID the UUID of the table
+   * @param tableCreator the creator of the table
+   * @param skipProvisioning Set to true if heavy-lifting allocation work needs to be skipped and
+   *     only the table location needs to be returned
    * @return the table location where the table data should be stored
    */
   @Override
-  public String allocateTableSpace(
+  public String allocateTableLocation(
       String databaseId,
       String tableId,
       String tableUUID,

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/BaseStorage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/BaseStorage.java
@@ -1,6 +1,8 @@
 package com.linkedin.openhouse.cluster.storage;
 
+import com.google.common.base.Preconditions;
 import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -40,5 +42,38 @@ public abstract class BaseStorage implements Storage {
         .map(StorageProperties.StorageTypeProperties::getParameters)
         .map(HashMap::new)
         .orElseGet(HashMap::new);
+  }
+
+  /**
+   * Allocates Table Space for the storage.
+   *
+   * <p>Default tableLocation looks like: {endpoint}/{rootPrefix}/{databaseId}/{tableId}-{tableUUID}
+   *
+   * @return the table location where the table data should be stored
+   */
+  @Override
+  public String allocateTableSpace(
+      String databaseId,
+      String tableId,
+      String tableUUID,
+      String tableCreator,
+      boolean skipProvisioning) {
+    Preconditions.checkArgument(databaseId != null, "Database ID cannot be null");
+    Preconditions.checkArgument(tableId != null, "Table ID cannot be null");
+    Preconditions.checkArgument(tableUUID != null, "Table UUID cannot be null");
+    Preconditions.checkState(
+        storageProperties.getTypes().containsKey(getType().getValue()),
+        "Storage properties doesn't contain type: " + getType().getValue());
+    return URI.create(
+            getClient().getEndpoint()
+                + getClient().getRootPrefix()
+                + "/"
+                + databaseId
+                + "/"
+                + tableId
+                + "-"
+                + tableUUID)
+        .normalize()
+        .toString();
   }
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/Storage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/Storage.java
@@ -48,4 +48,32 @@ public interface Storage {
    * @return a client to interact with the storage
    */
   StorageClient<?> getClient();
+
+  /**
+   * Allocates Table Space for the storage.
+   *
+   * <p>Allocating involves creating directory structure/ creating bucket, and setting appropriate
+   * permissions etc. Please note that this method should avoid creating TableFormat specific
+   * directories (ex: /data, /metadata for Iceberg or _delta_log for DeltaLake). Such provisioning
+   * should be done by the TableFormat implementation.
+   *
+   * <p>After allocation is done, this method should return the table location where the table data
+   * should be stored. Example: /rootPrefix/databaseId/tableId-UUID for HDFS storage
+   * /tmp/databaseId/tableId-UUID for Local storage s3://bucket/databaseId/tableId-UUID for S3
+   * storage
+   *
+   * @param databaseId the database id of the table
+   * @param tableId the table id of the table
+   * @param tableUUID the UUID of the table
+   * @param tableCreator the creator of the table
+   * @param skipProvisioning Set to true if heavy-lifting allocation work needs to be skipped and
+   *     only the table location needs to be returned
+   * @return the table location after provisioning is done
+   */
+  String allocateTableSpace(
+      String databaseId,
+      String tableId,
+      String tableUUID,
+      String tableCreator,
+      boolean skipProvisioning);
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/Storage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/Storage.java
@@ -58,8 +58,8 @@ public interface Storage {
    * should be done by the TableFormat implementation.
    *
    * <p>After allocation is done, this method should return the table location where the table data
-   * should be stored. Example: /rootPrefix/databaseId/tableId-UUID for HDFS storage;
-   * /tmp/databaseId/tableId-UUID for Local storage; s3://bucket/databaseId/tableId-UUID for S3
+   * should be stored. Example: hdfs:///rootPrefix/databaseId/tableId-UUID for HDFS storage;
+   * file:/tmp/databaseId/tableId-UUID for Local storage; s3://bucket/databaseId/tableId-UUID for S3
    * storage
    *
    * @param databaseId the database id of the table

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/Storage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/Storage.java
@@ -50,7 +50,7 @@ public interface Storage {
   StorageClient<?> getClient();
 
   /**
-   * Allocates Table Space for the storage.
+   * Allocates Table Storage and return location.
    *
    * <p>Allocating involves creating directory structure/ creating bucket, and setting appropriate
    * permissions etc. Please note that this method should avoid creating TableFormat specific
@@ -70,7 +70,7 @@ public interface Storage {
    *     only the table location needs to be returned
    * @return the table location after provisioning is done
    */
-  String allocateTableSpace(
+  String allocateTableLocation(
       String databaseId,
       String tableId,
       String tableUUID,

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/Storage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/Storage.java
@@ -66,14 +66,8 @@ public interface Storage {
    * @param tableId the table id of the table
    * @param tableUUID the UUID of the table
    * @param tableCreator the creator of the table
-   * @param skipProvisioning Set to true if heavy-lifting allocation work needs to be skipped and
-   *     only the table location needs to be returned
    * @return the table location after provisioning is done
    */
   String allocateTableLocation(
-      String databaseId,
-      String tableId,
-      String tableUUID,
-      String tableCreator,
-      boolean skipProvisioning);
+      String databaseId, String tableId, String tableUUID, String tableCreator);
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/Storage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/Storage.java
@@ -58,8 +58,8 @@ public interface Storage {
    * should be done by the TableFormat implementation.
    *
    * <p>After allocation is done, this method should return the table location where the table data
-   * should be stored. Example: /rootPrefix/databaseId/tableId-UUID for HDFS storage
-   * /tmp/databaseId/tableId-UUID for Local storage s3://bucket/databaseId/tableId-UUID for S3
+   * should be stored. Example: /rootPrefix/databaseId/tableId-UUID for HDFS storage;
+   * /tmp/databaseId/tableId-UUID for Local storage; s3://bucket/databaseId/tableId-UUID for S3
    * storage
    *
    * @param databaseId the database id of the table

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/hdfs/HdfsStorage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/hdfs/HdfsStorage.java
@@ -49,11 +49,7 @@ public class HdfsStorage extends BaseStorage {
    */
   @Override
   public String allocateTableLocation(
-      String databaseId,
-      String tableId,
-      String tableUUID,
-      String tableCreator,
-      boolean skipProvisioning) {
+      String databaseId, String tableId, String tableUUID, String tableCreator) {
     return Paths.get(getClient().getRootPrefix(), databaseId, tableId + "-" + tableUUID).toString();
   }
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/hdfs/HdfsStorage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/hdfs/HdfsStorage.java
@@ -3,6 +3,7 @@ package com.linkedin.openhouse.cluster.storage.hdfs;
 import com.linkedin.openhouse.cluster.storage.BaseStorage;
 import com.linkedin.openhouse.cluster.storage.StorageClient;
 import com.linkedin.openhouse.cluster.storage.StorageType;
+import java.nio.file.Paths;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
@@ -35,5 +36,23 @@ public class HdfsStorage extends BaseStorage {
   @Override
   public StorageClient<?> getClient() {
     return hdfsStorageClient;
+  }
+
+  /**
+   * Allocates Table Space for the HDFS storage.
+   *
+   * <p>tableLocation looks like: /{rootPrefix}/{databaseId}/{tableId}-{tableUUID} We strip the
+   * endpoint as it's not needed for HDFS.
+   *
+   * @return the table location
+   */
+  @Override
+  public String allocateTableSpace(
+      String databaseId,
+      String tableId,
+      String tableUUID,
+      String tableCreator,
+      boolean skipProvisioning) {
+    return Paths.get(getClient().getRootPrefix(), databaseId, tableId + "-" + tableUUID).toString();
   }
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/hdfs/HdfsStorage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/hdfs/HdfsStorage.java
@@ -42,7 +42,8 @@ public class HdfsStorage extends BaseStorage {
    * Allocates Table Space for the HDFS storage.
    *
    * <p>tableLocation looks like: /{rootPrefix}/{databaseId}/{tableId}-{tableUUID} We strip the
-   * endpoint as it's not needed for HDFS.
+   * endpoint to ensure backward-compatibility. This override should be removed after resolving <a
+   * href="https://github.com/linkedin/openhouse/issues/121">
    *
    * @return the table location
    */

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/hdfs/HdfsStorage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/hdfs/HdfsStorage.java
@@ -47,7 +47,7 @@ public class HdfsStorage extends BaseStorage {
    * @return the table location
    */
   @Override
-  public String allocateTableSpace(
+  public String allocateTableLocation(
       String databaseId,
       String tableId,
       String tableUUID,

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorage.java
@@ -62,7 +62,7 @@ public class LocalStorage extends BaseStorage {
    * @return the table location
    */
   @Override
-  public String allocateTableSpace(
+  public String allocateTableLocation(
       String databaseId,
       String tableId,
       String tableUUID,

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorage.java
@@ -62,11 +62,7 @@ public class LocalStorage extends BaseStorage {
    */
   @Override
   public String allocateTableLocation(
-      String databaseId,
-      String tableId,
-      String tableUUID,
-      String tableCreator,
-      boolean skipProvisioning) {
+      String databaseId, String tableId, String tableUUID, String tableCreator) {
     return Paths.get(getClient().getRootPrefix(), databaseId, tableId + "-" + tableUUID).toString();
   }
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorage.java
@@ -4,6 +4,7 @@ import com.linkedin.openhouse.cluster.storage.BaseStorage;
 import com.linkedin.openhouse.cluster.storage.StorageClient;
 import com.linkedin.openhouse.cluster.storage.StorageType;
 import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
+import java.nio.file.Paths;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
@@ -50,5 +51,23 @@ public class LocalStorage extends BaseStorage {
   @Override
   public StorageClient<?> getClient() {
     return localStorageClient;
+  }
+
+  /**
+   * Allocates Table Space for the Local Storage.
+   *
+   * <p>tableLocation looks like: /{rootPrefix}/{databaseId}/{tableId}-{tableUUID} We strip the
+   * endpoint as it's not needed for Local Storage.
+   *
+   * @return the table location
+   */
+  @Override
+  public String allocateTableSpace(
+      String databaseId,
+      String tableId,
+      String tableUUID,
+      String tableCreator,
+      boolean skipProvisioning) {
+    return Paths.get(getClient().getRootPrefix(), databaseId, tableId + "-" + tableUUID).toString();
   }
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorage.java
@@ -57,9 +57,8 @@ public class LocalStorage extends BaseStorage {
    * Allocates Table Space for the Local Storage.
    *
    * <p>tableLocation looks like: /{rootPrefix}/{databaseId}/{tableId}-{tableUUID} We strip the
-   * endpoint as it's not needed for Local Storage.
-   *
-   * @return the table location
+   * endpoint to ensure backward-compatibility. This override should be removed after resolving <a
+   * href="https://github.com/linkedin/openhouse/issues/121">
    */
   @Override
   public String allocateTableLocation(

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/InternalRepositoryUtils.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/InternalRepositoryUtils.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.UpdateProperties;
 
@@ -142,8 +143,9 @@ public final class InternalRepositoryUtils {
             .tableUUID(megaProps.get(getCanonicalFieldName("tableUUID")))
             .tableLocation(
                 URI.create(
-                        storage.getClient().getEndpoint()
-                            + megaProps.get(getCanonicalFieldName("tableLocation")))
+                        StringUtils.prependIfMissing(
+                            megaProps.get(getCanonicalFieldName("tableLocation")),
+                            storage.getClient().getEndpoint()))
                     .normalize()
                     .toString())
             .tableVersion(megaProps.get(getCanonicalFieldName("tableVersion")))

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/InternalRepositoryUtils.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/InternalRepositoryUtils.java
@@ -143,7 +143,8 @@ public final class InternalRepositoryUtils {
             .tableUUID(megaProps.get(getCanonicalFieldName("tableUUID")))
             .tableLocation(
                 URI.create(
-                        StringUtils.prependIfMissing(
+                        StringUtils.prependIfMissing( // remove after resolving
+                            // https://github.com/linkedin/openhouse/issues/121
                             megaProps.get(getCanonicalFieldName("tableLocation")),
                             storage.getClient().getEndpoint()))
                     .normalize()

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -117,8 +117,7 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
                       tableDto.getDatabaseId(),
                       tableDto.getTableId(),
                       tableDto.getTableUUID(),
-                      tableDto.getTableCreator(),
-                      false),
+                      tableDto.getTableCreator()),
               computePropsForTableCreation(tableDto));
       meterRegistry.counter(MetricsConstant.REPO_TABLE_CREATED_CTR).increment();
       log.info(

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -113,7 +113,7 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
               partitionSpec,
               storageManager
                   .getDefaultStorage()
-                  .allocateTableSpace(
+                  .allocateTableLocation(
                       tableDto.getDatabaseId(),
                       tableDto.getTableId(),
                       tableDto.getTableUUID(),

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -111,12 +111,14 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
               tableIdentifier,
               writeSchema,
               partitionSpec,
-              constructTablePath(
-                      storageManager,
+              storageManager
+                  .getDefaultStorage()
+                  .allocateTableSpace(
                       tableDto.getDatabaseId(),
                       tableDto.getTableId(),
-                      tableDto.getTableUUID())
-                  .toString(),
+                      tableDto.getTableUUID(),
+                      tableDto.getTableCreator(),
+                      false),
               computePropsForTableCreation(tableDto));
       meterRegistry.counter(MetricsConstant.REPO_TABLE_CREATED_CTR).increment();
       log.info(

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/base/BaseStorageTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/base/BaseStorageTest.java
@@ -1,0 +1,105 @@
+package com.linkedin.openhouse.tables.mock.storage.base;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import com.linkedin.openhouse.cluster.storage.BaseStorage;
+import com.linkedin.openhouse.cluster.storage.StorageClient;
+import com.linkedin.openhouse.cluster.storage.StorageType;
+import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
+import com.linkedin.openhouse.cluster.storage.hdfs.HdfsStorageClient;
+import org.apache.hadoop.fs.FileSystem;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest
+public class BaseStorageTest {
+
+  @MockBean private StorageProperties storageProperties;
+
+  @MockBean private HdfsStorageClient hdfsStorageClient;
+
+  @TestComponent
+  public static class DummyBaseStorage extends BaseStorage {
+
+    @Autowired private HdfsStorageClient hdfsStorageClient;
+
+    @Override
+    public StorageType.Type getType() {
+      return StorageType.HDFS; // return a dummy type
+    }
+
+    @Override
+    public StorageClient<FileSystem> getClient() {
+      return hdfsStorageClient; // return a dummy client
+    }
+  }
+
+  @Autowired private DummyBaseStorage baseStorage;
+
+  private static final String databaseId = "db1";
+  private static final String tableId = "table1";
+  private static final String tableUUID = "uuid1";
+  private static final String tableCreator = "creator1";
+  private static final boolean skipProvisioning = false;
+
+  @Test
+  public void testAllocateTableLocationPattern1() {
+    mockStorageProperties("hdfs://localhost:9000", "/data/openhouse");
+    assertEquals(
+        "hdfs://localhost:9000/data/openhouse/db1/table1-uuid1",
+        baseStorage.allocateTableLocation(
+            databaseId, tableId, tableUUID, tableCreator, skipProvisioning));
+  }
+
+  @Test
+  public void testAllocateTableLocationPattern2() {
+    mockStorageProperties("hdfs://localhost:9000/", "/data/openhouse");
+    assertEquals(
+        "hdfs://localhost:9000/data/openhouse/db1/table1-uuid1",
+        baseStorage.allocateTableLocation(
+            databaseId, tableId, tableUUID, tableCreator, skipProvisioning));
+  }
+
+  @Test
+  public void testAllocateTableLocationPattern3() {
+    mockStorageProperties("hdfs://localhost:9000/", "data/openhouse");
+    assertEquals(
+        "hdfs://localhost:9000/data/openhouse/db1/table1-uuid1",
+        baseStorage.allocateTableLocation(
+            databaseId, tableId, tableUUID, tableCreator, skipProvisioning));
+  }
+
+  @Test
+  public void testAllocateTableLocationPattern4() {
+    mockStorageProperties("hdfs://localhost:9000/", "data");
+    assertEquals(
+        "hdfs://localhost:9000/data/db1/table1-uuid1",
+        baseStorage.allocateTableLocation(
+            databaseId, tableId, tableUUID, tableCreator, skipProvisioning));
+  }
+
+  @Test
+  public void testAllocateTableLocationPattern5() {
+    mockStorageProperties("hdfs:///", "data/openhouse");
+    assertEquals(
+        "hdfs:///data/openhouse/db1/table1-uuid1",
+        baseStorage.allocateTableLocation(
+            databaseId, tableId, tableUUID, tableCreator, skipProvisioning));
+  }
+
+  void mockStorageProperties(String endpoint, String rootPrefix) {
+    when(hdfsStorageClient.getEndpoint()).thenReturn(endpoint);
+    when(hdfsStorageClient.getRootPrefix()).thenReturn(rootPrefix);
+    when(storageProperties.getTypes())
+        .thenReturn(
+            ImmutableMap.of(
+                StorageType.HDFS.getValue(),
+                new StorageProperties.StorageTypeProperties(
+                    rootPrefix, endpoint, ImmutableMap.of())));
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/hdfs/HdfsStorageTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/hdfs/HdfsStorageTest.java
@@ -68,7 +68,7 @@ public class HdfsStorageTest {
     String expected = "/data/openhouse/db1/table1-uuid1";
     assertEquals(
         expected,
-        hdfsStorage.allocateTableSpace(
+        hdfsStorage.allocateTableLocation(
             databaseId, tableId, tableUUID, tableCreator, skipProvisioning));
   }
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/hdfs/HdfsStorageTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/hdfs/HdfsStorageTest.java
@@ -56,4 +56,19 @@ public class HdfsStorageTest {
                     "/data/openhouse", "hdfs://localhost:9000", testMap)));
     assertEquals(testMap, hdfsStorage.getProperties());
   }
+
+  @Test
+  public void testAllocateTableSpace() {
+    String databaseId = "db1";
+    String tableId = "table1";
+    String tableUUID = "uuid1";
+    String tableCreator = "creator1";
+    boolean skipProvisioning = false;
+    when(hdfsStorageClient.getRootPrefix()).thenReturn("/data/openhouse");
+    String expected = "/data/openhouse/db1/table1-uuid1";
+    assertEquals(
+        expected,
+        hdfsStorage.allocateTableSpace(
+            databaseId, tableId, tableUUID, tableCreator, skipProvisioning));
+  }
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/hdfs/HdfsStorageTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/hdfs/HdfsStorageTest.java
@@ -67,8 +67,6 @@ public class HdfsStorageTest {
     when(hdfsStorageClient.getRootPrefix()).thenReturn("/data/openhouse");
     String expected = "/data/openhouse/db1/table1-uuid1";
     assertEquals(
-        expected,
-        hdfsStorage.allocateTableLocation(
-            databaseId, tableId, tableUUID, tableCreator, skipProvisioning));
+        expected, hdfsStorage.allocateTableLocation(databaseId, tableId, tableUUID, tableCreator));
   }
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/local/LocalStorageTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/local/LocalStorageTest.java
@@ -96,7 +96,7 @@ public class LocalStorageTest {
     String expected = "/tmp/db1/table1-uuid1";
     assertEquals(
         expected,
-        localStorage.allocateTableSpace(
+        localStorage.allocateTableLocation(
             databaseId, tableId, tableUUID, tableCreator, skipProvisioning));
   }
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/local/LocalStorageTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/local/LocalStorageTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.tables.mock.storage.local;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -82,5 +83,20 @@ public class LocalStorageTest {
     LocalFileSystem localFileSystem = new LocalFileSystem();
     when(localStorageClient.getNativeClient()).thenReturn(localFileSystem);
     assertTrue(localStorage.getClient().getNativeClient().equals(localFileSystem));
+  }
+
+  @Test
+  public void testAllocateTableSpace() {
+    String databaseId = "db1";
+    String tableId = "table1";
+    String tableUUID = "uuid1";
+    String tableCreator = "creator1";
+    boolean skipProvisioning = false;
+    when(localStorageClient.getRootPrefix()).thenReturn("/tmp");
+    String expected = "/tmp/db1/table1-uuid1";
+    assertEquals(
+        expected,
+        localStorage.allocateTableSpace(
+            databaseId, tableId, tableUUID, tableCreator, skipProvisioning));
   }
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/local/LocalStorageTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/local/LocalStorageTest.java
@@ -95,8 +95,6 @@ public class LocalStorageTest {
     when(localStorageClient.getRootPrefix()).thenReturn("/tmp");
     String expected = "/tmp/db1/table1-uuid1";
     assertEquals(
-        expected,
-        localStorage.allocateTableLocation(
-            databaseId, tableId, tableUUID, tableCreator, skipProvisioning));
+        expected, localStorage.allocateTableLocation(databaseId, tableId, tableUUID, tableCreator));
   }
 }


### PR DESCRIPTION
## Summary
We introduce a new method in the storage interface as follows:
```
Storage {
  String allocateTableSpace(...)
}
```
which returns the tablelocation where table objects will be created. 

Implementations of this api should also execute one time operations such as creating buckets, assigning permissions etc. 

Please note the comment: 
`this method should avoid creating TableFormat specific directories (ex: /data, /metadata for Iceberg or _delta_log for DeltaLake)`,it describes what **shouldn't** be done as part of this implementation.

## Layering with internal implementations
Internal implementations such as `LiHdfsStorage` will now have flexibiliity to do one-time operations such as table provisioning.

## Changes
- [X] New Features
- [X] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->
- [X] Existing tests run ✅ 
- [X] Gradle build succeeds ✅ 
- [X] E2E local tests work as well ✅ 
