### PR TITLE
[PR 3/5]: Add S3 storage

### DIFF
--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/s3/S3Storage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/s3/S3Storage.java
@@ -1,0 +1,37 @@
+package com.linkedin.openhouse.cluster.storage.s3;
+
+import com.linkedin.openhouse.cluster.storage.BaseStorage;
+import com.linkedin.openhouse.cluster.storage.StorageClient;
+import com.linkedin.openhouse.cluster.storage.StorageType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * The S3Storage class is an implementation of the Storage interface for S3 storage. It uses a
+ * S3StorageClient which in turn uses the native S3Client to interact with the S3 storage system.
+ */
+@Component
+public class S3Storage extends BaseStorage {
+  @Autowired @Lazy private S3StorageClient s3StorageClient;
+
+  /**
+   * Get the storage type for the S3 storage.
+   *
+   * @return the "S3" storage type
+   */
+  @Override
+  public StorageType.Type getType() {
+    return StorageType.S3;
+  }
+
+  /**
+   * Get the S3 storage client.
+   *
+   * @return the S3 storage client
+   */
+  @Override
+  public StorageClient<?> getClient() {
+    return s3StorageClient;
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/s3/S3StorageTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/s3/S3StorageTest.java
@@ -71,11 +71,10 @@ public class S3StorageTest {
         .thenReturn(
             ImmutableMap.of(
                 StorageType.S3.getValue(),
-                new StorageProperties.StorageTypeProperties(
-                    "/mybucket", "http://S3:9000", testMap)));
-    when(s3StorageClient.getEndpoint()).thenReturn("http://S3:9000");
-    when(s3StorageClient.getRootPrefix()).thenReturn("/mybucket");
-    String expected = "http://S3:9000/mybucket/db1/table1-uuid1";
+                new StorageProperties.StorageTypeProperties("mybucket", "S3://", testMap)));
+    when(s3StorageClient.getEndpoint()).thenReturn("S3://");
+    when(s3StorageClient.getRootPrefix()).thenReturn("mybucket");
+    String expected = "S3://mybucket/db1/table1-uuid1";
     assertEquals(
         expected, s3Storage.allocateTableLocation(databaseId, tableId, tableUUID, tableCreator));
   }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/s3/S3StorageTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/s3/S3StorageTest.java
@@ -1,0 +1,61 @@
+package com.linkedin.openhouse.tables.mock.storage.s3;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.google.common.collect.ImmutableMap;
+import com.linkedin.openhouse.cluster.storage.StorageType;
+import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
+import com.linkedin.openhouse.cluster.storage.s3.S3Storage;
+import com.linkedin.openhouse.cluster.storage.s3.S3StorageClient;
+import java.util.Map;
+import org.apache.iceberg.aws.AwsClientProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest
+public class S3StorageTest {
+  @Autowired private S3Storage s3Storage;
+
+  @MockBean private StorageProperties storageProperties;
+
+  @MockBean private S3StorageClient s3StorageClient;
+
+  @Test
+  public void testS3StorageIsConfiguredWhenTypeIsProvided() {
+    when(storageProperties.getTypes())
+        .thenReturn(
+            ImmutableMap.of(
+                StorageType.S3.getValue(), new StorageProperties.StorageTypeProperties()));
+    assertTrue(s3Storage.isConfigured());
+  }
+
+  @Test
+  public void testS3StorageTypeIsCorrect() {
+    assertEquals(StorageType.S3, s3Storage.getType());
+  }
+
+  @Test
+  public void testS3StorageClientIsNotNull() {
+    when(storageProperties.getTypes())
+        .thenReturn(
+            ImmutableMap.of(
+                StorageType.S3.getValue(), new StorageProperties.StorageTypeProperties()));
+    assertNotNull(s3StorageClient);
+  }
+
+  @Test
+  public void testS3StoragePropertiesReturned() {
+    Map<String, String> testMap =
+        ImmutableMap.of("k1", "v1", "k2", "v2", AwsClientProperties.CLIENT_REGION, "us-east-1");
+    when(storageProperties.getTypes())
+        .thenReturn(
+            ImmutableMap.of(
+                StorageType.S3.getValue(),
+                new StorageProperties.StorageTypeProperties(
+                    "/mybucket", "hdfs://S3:9000", testMap)));
+    assertEquals(testMap, s3Storage.getProperties());
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/s3/S3StorageTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/s3/S3StorageTest.java
@@ -55,7 +55,28 @@ public class S3StorageTest {
             ImmutableMap.of(
                 StorageType.S3.getValue(),
                 new StorageProperties.StorageTypeProperties(
-                    "/mybucket", "hdfs://S3:9000", testMap)));
+                    "/mybucket", "http://S3:9000", testMap)));
     assertEquals(testMap, s3Storage.getProperties());
+  }
+
+  @Test
+  public void testAllocateTableSpace() {
+    String databaseId = "db1";
+    String tableId = "table1";
+    String tableUUID = "uuid1";
+    String tableCreator = "creator1";
+    boolean skipProvisioning = false;
+    Map<String, String> testMap = ImmutableMap.of(AwsClientProperties.CLIENT_REGION, "us-east-1");
+    when(storageProperties.getTypes())
+        .thenReturn(
+            ImmutableMap.of(
+                StorageType.S3.getValue(),
+                new StorageProperties.StorageTypeProperties(
+                    "/mybucket", "http://S3:9000", testMap)));
+    when(s3StorageClient.getEndpoint()).thenReturn("http://S3:9000");
+    when(s3StorageClient.getRootPrefix()).thenReturn("/mybucket");
+    String expected = "http://S3:9000/mybucket/db1/table1-uuid1";
+    assertEquals(
+        expected, s3Storage.allocateTableLocation(databaseId, tableId, tableUUID, tableCreator));
   }
 }


### PR DESCRIPTION
## Summary
This is the third PR in a sequence of PRs to add support for S3 storage.

Openhouse catalog currently supports HDFS as the storage backend. The end goal of this effort is to add the integration with S3 so that the storage backend can be configured to be S3 vs HDFS based on storage type.
The entire work will be done via a series of PRs:

1. Add S3 Storage type and S3StorageClient.
2. Add base class for StorageClient and move common logic like validation of properties there to avoid code duplication.
3. Add S3Storage implementation that uses S3StorageClient.
4. Add support for using S3FileIO for S3 storage type.
5. Add a recipe for end-to-end testing in docker.

This PR addresses 3 by adding S3Storage class. 

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
Tested oh-hadoop-spark recipe. New recipe for S3 testing will be added in successive PRs.
Added unit tests.

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [x] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
