### PR TITLE
Add S3 docker setup for OpenHouse

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -78,6 +78,7 @@ spark-master|9001
 livy-server|9003
 hdfs-namenode|9870
 minio-s3-ui|9871
+minio-s3-server|9870
 mysql|3306
 spark-livy|8998
 opa|8181

--- a/SETUP.md
+++ b/SETUP.md
@@ -77,6 +77,7 @@ prometheus|9090
 spark-master|9001
 livy-server|9003
 hdfs-namenode|9870
+minio-s3-ui|9871
 mysql|3306
 spark-livy|8998
 opa|8181

--- a/infra/recipes/docker-compose/common/aws-services.yml
+++ b/infra/recipes/docker-compose/common/aws-services.yml
@@ -1,0 +1,27 @@
+version: "3.3"
+services:
+  minioS3:
+    image: minio/minio
+    environment:
+      - MINIO_ROOT_USER=admin
+      - MINIO_ROOT_PASSWORD=password
+    ports:
+      - 9871:9001
+      - 9870:9000
+    command: [ "server", "/data", "--console-address", ":9001" ]
+  mc:
+    depends_on:
+      - minioS3
+    image: minio/mc
+    environment:
+      - AWS_ACCESS_KEY_ID=admin
+      - AWS_SECRET_ACCESS_KEY=password
+      - AWS_REGION=us-east-1
+    entrypoint: >
+      /bin/sh -c "
+      until (/usr/bin/mc config host add minio http://minioS3:9000 admin password) do echo '...waiting...' && sleep 1; done;
+      /usr/bin/mc rm -r --force minio/openhouse-bucket;
+      /usr/bin/mc mb minio/openhouse-bucket;
+      /usr/bin/mc policy set public minio/openhouse-bucket;
+      tail -f /dev/null
+      "

--- a/infra/recipes/docker-compose/common/s3-services.yml
+++ b/infra/recipes/docker-compose/common/s3-services.yml
@@ -7,7 +7,7 @@ services:
       - MINIO_ROOT_PASSWORD=password
     ports:
       - 9871:9001
-      - 9870:9000
+      - 9870:9000  # Minio Server will be available at this port
     command: [ "server", "/data", "--console-address", ":9001" ]
   minioClient:
     depends_on:

--- a/infra/recipes/docker-compose/common/s3-services.yml
+++ b/infra/recipes/docker-compose/common/s3-services.yml
@@ -9,10 +9,10 @@ services:
       - 9871:9001
       - 9870:9000
     command: [ "server", "/data", "--console-address", ":9001" ]
-  mc:
+  minioClient:
     depends_on:
       - minioS3
-    image: minio/mc
+    image: minio/mc # MinIO Client to pre-create bucket
     environment:
       - AWS_ACCESS_KEY_ID=admin
       - AWS_SECRET_ACCESS_KEY=password

--- a/infra/recipes/docker-compose/oh-s3-spark/cluster.yaml
+++ b/infra/recipes/docker-compose/oh-s3-spark/cluster.yaml
@@ -1,0 +1,35 @@
+cluster:
+  name: "LocalAwsCluster"
+  storages:
+    default-type: "s3"
+    types:
+      s3:
+        rootpath: "openhouse-bucket"
+        endpoint: "s3://"
+        parameters:
+          s3.endpoint: "http://minioS3:9000"
+          s3.access-key-id: "admin"
+          s3.secret-access-key: "password"
+          s3.path-style-access: true
+  iceberg:
+    write:
+      format:
+        default: "orc"
+      metadata:
+        previous-versions-max: 28
+        delete-after-commit:
+          enabled: true
+  housetables:
+    base-uri: "http://openhouse-housetables:8080"
+    database:
+      type: "MYSQL"
+      url: "jdbc:mysql://mysql:3306/oh_db?allowPublicKeyRetrieval=true&useSSL=false"
+  security:
+    token:
+      interceptor:
+        classname: "com.linkedin.openhouse.common.security.DummyTokenInterceptor"
+    tables:
+      authorization:
+        enabled: true
+        opa:
+          base-uri: "http://opa:8181"

--- a/infra/recipes/docker-compose/oh-s3-spark/cluster.yaml
+++ b/infra/recipes/docker-compose/oh-s3-spark/cluster.yaml
@@ -1,5 +1,5 @@
 cluster:
-  name: "LocalAwsCluster"
+  name: "LocalS3Cluster"
   storages:
     default-type: "s3"
     types:

--- a/infra/recipes/docker-compose/oh-s3-spark/docker-compose.yml
+++ b/infra/recipes/docker-compose/oh-s3-spark/docker-compose.yml
@@ -14,8 +14,6 @@ services:
       - prometheus
       - opa
     environment:
-      - AWS_ACCESS_KEY_ID=admin
-      - AWS_SECRET_ACCESS_KEY=password
       - AWS_REGION=us-east-1
 
   openhouse-jobs:

--- a/infra/recipes/docker-compose/oh-s3-spark/docker-compose.yml
+++ b/infra/recipes/docker-compose/oh-s3-spark/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     depends_on:
       - openhouse-housetables
       - minioS3
-      - mc
+      - minioClient
       - prometheus
       - opa
     environment:
@@ -65,14 +65,14 @@ services:
   minioS3:
     container_name: local.minioS3
     extends:
-      file: ../common/aws-services.yml
+      file: ../common/s3-services.yml
       service: minioS3
 
-  mc:
-    container_name: local.mc
+  minioClient:
+    container_name: local.minioClient
     extends:
-      file: ../common/aws-services.yml
-      service: mc
+      file: ../common/s3-services.yml
+      service: minioClient
 
   spark-master:
     container_name: local.spark-master

--- a/infra/recipes/docker-compose/oh-s3-spark/docker-compose.yml
+++ b/infra/recipes/docker-compose/oh-s3-spark/docker-compose.yml
@@ -1,0 +1,115 @@
+version: "3.3"
+services:
+  openhouse-tables:
+    container_name: local.openhouse-tables
+    extends:
+      file: ../common/oh-services.yml
+      service: openhouse-tables
+    volumes:
+      - ./:/var/config/
+    depends_on:
+      - openhouse-housetables
+      - minioS3
+      - mc
+      - prometheus
+      - opa
+    environment:
+      - AWS_ACCESS_KEY_ID=admin
+      - AWS_SECRET_ACCESS_KEY=password
+      - AWS_REGION=us-east-1
+
+  openhouse-jobs:
+    container_name: local.openhouse-jobs
+    extends:
+      file: ../common/oh-services.yml
+      service: openhouse-jobs
+    volumes:
+      - ./:/var/config/
+    depends_on:
+      - openhouse-housetables
+      - prometheus
+
+  openhouse-jobs-scheduler:
+    container_name: local.openhouse-jobs-scheduler
+    extends:
+      file: ../common/oh-services.yml
+      service: openhouse-jobs-scheduler
+    volumes:
+      - ./:/var/config/
+    depends_on:
+      - openhouse-tables
+      - openhouse-jobs
+      - prometheus
+      - minioS3
+
+    profiles:
+      - with_jobs_scheduler
+
+  openhouse-housetables:
+    container_name: local.openhouse-housetables
+    extends:
+      file: ../common/oh-services.yml
+      service: openhouse-housetables
+    volumes:
+      - ./:/var/config/
+    depends_on:
+      - prometheus
+      - mysql
+    environment:
+      - HTS_DB_USER=oh_user
+      - HTS_DB_PASSWORD=oh_password
+
+  prometheus:
+    extends:
+      file: ../common/oh-services.yml
+      service: prometheus
+
+  minioS3:
+    container_name: local.minioS3
+    extends:
+      file: ../common/aws-services.yml
+      service: minioS3
+
+  mc:
+    container_name: local.mc
+    extends:
+      file: ../common/aws-services.yml
+      service: mc
+
+  spark-master:
+    container_name: local.spark-master
+    extends:
+      file: ../common/spark-services.yml
+      service: spark-master
+    ports:
+      - "5005:5005"
+    environment:
+      - AWS_REGION=us-east-1
+
+  spark-worker-a:
+    container_name: local.spark-worker-a
+    extends:
+      file: ../common/spark-services.yml
+      service: spark-worker-a
+    depends_on:
+      - spark-master
+
+  spark-livy:
+    container_name: local.spark-livy
+    extends:
+      file: ../common/spark-services.yml
+      service: spark-livy
+    depends_on:
+      - spark-master
+
+  mysql:
+    container_name: local.mysql
+    extends:
+      file: ../common/mysql-services.yml
+      service: mysql
+
+  opa:
+    container_name: local.opa
+    extends:
+      file: ../common/opa-services.yml
+      service: opa


### PR DESCRIPTION
## Summary
In this PR we add docker-compose files for s3 setup
Following different files are added:

- **common/s3-services.yaml**: will contain scripts for all s3 docker containers 
- **docker-compose/oh-s3-spark/docker-compose.yml**: contains logic for all OH services
- **docker-compose/oh-s3-spark/cluster.yml**: contains `cluster.yaml` for OH-s3 setup

## To test these changes
```
./gradlew build
cd ~/openhouse/infra/recipes/docker-compose/oh-s3-spark
docker compose up -d
```
All services should spin up and minio webui should be enabled at `http://localhost:9871/` and looks like:
![image](https://github.com/linkedin/openhouse/assets/6441597/913ee9c0-e804-44ec-8f7a-99affa9da366)

you should be able to login with:
`admin`, `password`

## Changes
- [X] New Features

## Testing Done
- [X] Manually Tested on local docker setup. Please include commands ran, and their output.
Details of testing are explained in the PR:
https://github.com/linkedin/openhouse/pull/106

