### PR TITLE
[PR4/5]: Add S3FileIO

### DIFF
--- a/buildSrc/src/main/groovy/openhouse.iceberg-aws-conventions.gradle
+++ b/buildSrc/src/main/groovy/openhouse.iceberg-aws-conventions.gradle
@@ -1,12 +1,10 @@
 ext {
-  icebergAwsVersion = '1.5.2'
+  icebergAwsVersion = '1.2.0'
 }
 
 dependencies {
-  implementation('org.apache.iceberg:iceberg-aws:' + icebergAwsVersion) {
-    exclude group: 'org.apache.iceberg'
-  }
-  implementation('org.apache.iceberg:iceberg-aws-bundle:' + icebergAwsVersion) {
-    exclude group: 'org.apache.iceberg'
-  }
+  implementation('org.apache.iceberg:iceberg-aws:' + icebergAwsVersion)
+  implementation('software.amazon.awssdk:s3:2.20.18')
+  implementation('software.amazon.awssdk:sts:2.20.18')
+  implementation('software.amazon.awssdk:url-connection-client:2.20.18')
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/s3/S3StorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/s3/S3StorageClient.java
@@ -7,10 +7,8 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.iceberg.aws.AwsClientFactories;
 import org.apache.iceberg.aws.AwsClientFactory;
-import org.apache.iceberg.aws.S3FileIOAwsClientFactories;
-import org.apache.iceberg.aws.s3.S3FileIOAwsClientFactory;
-import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
@@ -44,19 +42,8 @@ public class S3StorageClient extends BaseStorageClient<S3Client> {
     validateProperties();
     Map properties =
         new HashMap(storageProperties.getTypes().get(S3_TYPE.getValue()).getParameters());
-
-    S3FileIOProperties s3FileIOProperties =
-        new S3FileIOProperties(
-            storageProperties.getTypes().get(S3_TYPE.getValue()).getParameters());
-    if (s3 == null) {
-      Object clientFactory = S3FileIOAwsClientFactories.initialize(properties);
-      if (clientFactory instanceof S3FileIOAwsClientFactory) {
-        this.s3 = ((S3FileIOAwsClientFactory) clientFactory).s3();
-      }
-      if (clientFactory instanceof AwsClientFactory) {
-        this.s3 = ((AwsClientFactory) clientFactory).s3();
-      }
-    }
+    AwsClientFactory clientFactory = AwsClientFactories.from(properties);
+    this.s3 = clientFactory.s3();
   }
 
   @Override

--- a/iceberg/openhouse/internalcatalog/build.gradle
+++ b/iceberg/openhouse/internalcatalog/build.gradle
@@ -3,6 +3,7 @@ plugins {
   id 'openhouse.client-codegen-convention'
   id 'openhouse.iceberg-conventions'
   id 'openhouse.hadoop-conventions'
+  id 'openhouse.iceberg-aws-conventions'
   id 'openhouse.maven-publish'
   id 'java-test-fixtures'
 }

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/fileio/FileIOConfig.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/fileio/FileIOConfig.java
@@ -4,11 +4,13 @@ import com.linkedin.openhouse.cluster.storage.StorageManager;
 import com.linkedin.openhouse.cluster.storage.StorageType;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.iceberg.aws.s3.S3FileIO;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.io.FileIO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.services.s3.S3Client;
 
 /**
  * Configures the FileIO beans for storages configured in {@link StorageManager}
@@ -59,6 +61,25 @@ public class FileIOConfig {
       // If the Local storage type is not configured, return null
       // Spring doesn't define the bean if the return value is null
       log.debug("Local storage type is not configured", e);
+      return null;
+    }
+  }
+
+  /**
+   * Provides the S3FileIO bean for S3 storage type
+   *
+   * @return S3FileIO bean for S3 storage type, or null if S3 storage type is not configured
+   */
+  @Bean("S3FileIO")
+  S3FileIO provideS3FileIO() {
+    try {
+      S3Client s3 =
+          (S3Client) storageManager.getStorage(StorageType.S3).getClient().getNativeClient();
+      return new S3FileIO(() -> s3);
+    } catch (IllegalArgumentException e) {
+      // If the S3 storage type is not configured, return null
+      // Spring doesn't define the bean if the return value is null
+      log.debug("S3 storage type is not configured", e);
       return null;
     }
   }

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/fileio/FileIOConfig.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/fileio/FileIOConfig.java
@@ -77,10 +77,18 @@ public class FileIOConfig {
           (S3Client) storageManager.getStorage(StorageType.S3).getClient().getNativeClient();
       return new S3FileIO(() -> s3);
     } catch (IllegalArgumentException e) {
-      // If the S3 storage type is not configured, return null
-      // Spring doesn't define the bean if the return value is null
-      log.debug("S3 storage type is not configured", e);
-      return null;
+      // If S3 storage is not configured then return null, otherwise throw an exception.
+      try {
+        storageManager.getStorage(StorageType.S3);
+      } catch (IllegalArgumentException err) {
+        // S3 storage type is not configured. Return null.
+        // Spring doesn't define the bean if the return value is null
+        log.debug("S3 storage type is not configured", err);
+        return null;
+      }
+      // S3 storage configured but could not instantiate S3FileIO.
+      throw new IllegalArgumentException(
+          "S3 storage configured but could not initialize S3FileIO" + e.getMessage());
     }
   }
 }

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/fileio/FileIOManager.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/fileio/FileIOManager.java
@@ -9,6 +9,7 @@ import com.linkedin.openhouse.cluster.storage.local.LocalStorage;
 import com.linkedin.openhouse.cluster.storage.s3.S3Storage;
 import java.util.Optional;
 import java.util.function.Supplier;
+import org.apache.iceberg.aws.s3.S3FileIO;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.io.FileIO;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,8 +35,7 @@ public class FileIOManager {
   FileIO localFileIO;
 
   @Autowired(required = false)
-  @Qualifier("S3FileIO")
-  FileIO s3FileIO;
+  S3FileIO s3FileIO;
 
   @Autowired HdfsStorage hdfsStorage;
 

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/fileio/FileIOManager.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/fileio/FileIOManager.java
@@ -1,12 +1,12 @@
 package com.linkedin.openhouse.internal.catalog.fileio;
 
-import static com.linkedin.openhouse.cluster.storage.StorageType.HDFS;
-import static com.linkedin.openhouse.cluster.storage.StorageType.LOCAL;
+import static com.linkedin.openhouse.cluster.storage.StorageType.*;
 
 import com.linkedin.openhouse.cluster.storage.Storage;
 import com.linkedin.openhouse.cluster.storage.StorageType;
 import com.linkedin.openhouse.cluster.storage.hdfs.HdfsStorage;
 import com.linkedin.openhouse.cluster.storage.local.LocalStorage;
+import com.linkedin.openhouse.cluster.storage.s3.S3Storage;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.iceberg.hadoop.HadoopFileIO;
@@ -33,9 +33,16 @@ public class FileIOManager {
   @Qualifier("LocalFileIO")
   FileIO localFileIO;
 
+  @Autowired(required = false)
+  @Qualifier("S3FileIO")
+  FileIO s3FileIO;
+
   @Autowired HdfsStorage hdfsStorage;
 
   @Autowired LocalStorage localStorage;
+
+  @Autowired S3Storage s3Storage;
+
   /**
    * Returns the FileIO implementation for the given storage type.
    *
@@ -50,6 +57,8 @@ public class FileIOManager {
       return Optional.ofNullable(hdfsFileIO).orElseThrow(exceptionSupplier);
     } else if (LOCAL.equals(storageType)) {
       return Optional.ofNullable(localFileIO).orElseThrow(exceptionSupplier);
+    } else if (S3.equals(storageType)) {
+      return Optional.ofNullable(s3FileIO).orElseThrow(exceptionSupplier);
     } else {
       throw new IllegalArgumentException("FileIO not supported for storage type: " + storageType);
     }
@@ -67,6 +76,8 @@ public class FileIOManager {
       return hdfsStorage;
     } else if (fileIO.equals(localFileIO)) {
       return localStorage;
+    } else if (fileIO.equals(s3FileIO)) {
+      return s3Storage;
     } else {
       throw new IllegalArgumentException("Storage not supported for fileIO: " + fileIO);
     }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/s3/S3StorageClientTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/s3/S3StorageClientTest.java
@@ -10,7 +10,6 @@ import com.linkedin.openhouse.cluster.storage.s3.S3StorageClient;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.PostConstruct;
-import org.apache.iceberg.aws.AwsClientProperties;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -74,7 +73,7 @@ public class S3StorageClientTest {
     storageTypeProperties.setEndpoint("http://S3:9000");
     storageTypeProperties.setRootPath("/mybucket");
     Map<String, String> parameters = new HashMap<>();
-    parameters.put(AwsClientProperties.CLIENT_REGION, "us-east-1");
+    System.setProperty("aws.region", "us-east-1");
     storageTypeProperties.setParameters(parameters);
     return storageTypeProperties;
   }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/s3/S3StorageTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/s3/S3StorageTest.java
@@ -9,7 +9,6 @@ import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
 import com.linkedin.openhouse.cluster.storage.s3.S3Storage;
 import com.linkedin.openhouse.cluster.storage.s3.S3StorageClient;
 import java.util.Map;
-import org.apache.iceberg.aws.AwsClientProperties;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -48,8 +47,8 @@ public class S3StorageTest {
 
   @Test
   public void testS3StoragePropertiesReturned() {
-    Map<String, String> testMap =
-        ImmutableMap.of("k1", "v1", "k2", "v2", AwsClientProperties.CLIENT_REGION, "us-east-1");
+    Map<String, String> testMap = ImmutableMap.of("k1", "v1", "k2", "v2");
+    System.setProperty("aws.region", "us-east-1");
     when(storageProperties.getTypes())
         .thenReturn(
             ImmutableMap.of(
@@ -66,7 +65,8 @@ public class S3StorageTest {
     String tableUUID = "uuid1";
     String tableCreator = "creator1";
     boolean skipProvisioning = false;
-    Map<String, String> testMap = ImmutableMap.of(AwsClientProperties.CLIENT_REGION, "us-east-1");
+    Map<String, String> testMap = ImmutableMap.of("k1", "v1", "k2", "v2");
+    System.setProperty("aws.region", "us-east-1");
     when(storageProperties.getTypes())
         .thenReturn(
             ImmutableMap.of(


### PR DESCRIPTION
## Summary
This is the fourth PR in a sequence of PRs to add support for S3 storage.

Openhouse catalog currently supports HDFS as the storage backend. The end goal of this effort is to add the integration with S3 so that the storage backend can be configured to be S3 vs HDFS based on storage type.

The entire work is done via a series of PRs:
1. Add S3 Storage type and S3StorageClient.
2. Add base class for StorageClient and move common logic like validation of properties there to avoid code duplication.
3. Add S3Storage implementation that uses S3StorageClient.
4. Add support for using S3FileIO for S3 storage type.
5. Add a recipe for end-to-end testing in docker.

This PR addresses 4 by adding S3FileIO.

Sushant has already done 5. So, this marks the completion of S3 integration.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
Testing by running the oh-s3-spark recipe in docker.

1. Run docker:

$ docker compose up -d
[+] Building 0.0s (0/0)                                                                                                                                                               docker:desktop-linux
[+] Running 16/16
 ✔ Network oh-s3-spark_default                                                                                                                                   Cre...                               0.0s 
 ✔ Container local.spark-master                                                                                                                                  St...                                0.2s 
 ✔ Container oh-s3-spark-prometheus-1                                                                                                                            Started                              0.2s 
 ✔ Container local.mysql                                                                                                                                         Started                              0.2s 
 ✔ Container local.minioS3                                                                                                                                       Started                              0.2s 
 ✔ Container local.opa                                                                                                                                           Started                              0.2s 
 ! opa The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested                                                 0.0s 
 ! spark-master The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested                                        0.0s 
 ✔ Container local.spark-livy                                                                                                                                    Star...                              0.1s 
 ✔ Container local.spark-worker-a                                                                                                                                Started                              0.1s 
 ✔ Container local.minioClient                                                                                                                                   Sta...                               0.0s 
 ✔ Container local.openhouse-housetables                                                                                                                         Started                              0.0s 
 ! spark-worker-a The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested                                      0.0s 
 ! spark-livy The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested                                          0.0s 
 ✔ Container local.openhouse-jobs                                                                                                                                Started                              0.0s 
 ✔ Container local.openhouse-tables                                                                                                                              Started                              0.0s 
lajain-mn2:oh-s3-spark lajain$ docker exec -it local.spark-master /bin/bash

<img width="1120" alt="Screenshot 2024-06-13 at 3 47 32 PM" src="https://github.com/linkedin/openhouse/assets/114708561/6e827de9-19ac-46a6-9786-cf2b5403ace7">

2. Login to MinIO.
<img width="1402" alt="Screenshot 2024-06-13 at 3 48 36 PM" src="https://github.com/linkedin/openhouse/assets/114708561/4c49ad7d-82b7-45c2-b444-b2548ddfb43f">

<img width="1466" alt="Screenshot 2024-06-13 at 3 48 59 PM" src="https://github.com/linkedin/openhouse/assets/114708561/aafb55dc-d49e-45f9-9c31-60b6d88bbc4f">

3. Run spark shell:
openhouse@cff3c38358c5:/opt/spark$ export AWS_REGION=us-east-1
openhouse@cff3c38358c5:/opt/spark$ bin/spark-shell --packages org.apache.iceberg:iceberg-spark-runtime-3.1_2.12:1.2.0,software.amazon.awssdk:bundle:2.20.18,software.amazon.awssdk:url-connection-client:2.20.18   \
>   --jars openhouse-spark-runtime_2.12-*-all.jar  \
>   --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,com.linkedin.openhouse.spark.extensions.OpenhouseSparkSessionExtensions   \
>   --conf spark.sql.catalog.openhouse=org.apache.iceberg.spark.SparkCatalog   \
>   --conf spark.sql.catalog.openhouse.catalog-impl=com.linkedin.openhouse.spark.OpenHouseCatalog     \
>   --conf spark.sql.catalog.openhouse.metrics-reporter-impl=com.linkedin.openhouse.javaclient.OpenHouseMetricsReporter    \
>   --conf spark.sql.catalog.openhouse.uri=http://openhouse-tables:8080   \
>   --conf spark.sql.catalog.openhouse.auth-token=$(cat /var/config/$(whoami).token) \
>   --conf spark.sql.catalog.openhouse.cluster=LocalS3Cluster  \
>   --conf spark.sql.catalog.openhouse.io-impl=org.apache.iceberg.aws.s3.S3FileIO  \
>   --conf spark.sql.catalog.openhouse.s3.endpoint=http://minioS3:9000 \
>   --conf spark.sql.catalog.openhouse.s3.access-key-id=admin \
>   --conf spark.sql.catalog.openhouse.s3.secret-access-key=password \
>   --conf spark.sql.catalog.openhouse.s3.path-style-access=true
:: loading settings :: url = jar:file:/opt/spark/jars/ivy-2.4.0.jar!/org/apache/ivy/core/settings/ivysettings.xml
Ivy Default Cache set to: /home/openhouse/.ivy2/cache
The jars for the packages stored in: /home/openhouse/.ivy2/jars
org.apache.iceberg#iceberg-spark-runtime-3.1_2.12 added as a dependency
software.amazon.awssdk#bundle added as a dependency
software.amazon.awssdk#url-connection-client added as a dependency
:: resolving dependencies :: org.apache.spark#spark-submit-parent-9d1e3e8a-c713-44f0-93b3-bd5029daa8e2;1.0
	confs: [default]
	found org.apache.iceberg#iceberg-spark-runtime-3.1_2.12;1.2.0 in central

	found software.amazon.awssdk#bundle;2.20.18 in central
	found software.amazon.eventstream#eventstream;1.0.1 in central
	found software.amazon.awssdk#url-connection-client;2.20.18 in central
	found software.amazon.awssdk#utils;2.20.18 in central
	found org.reactivestreams#reactive-streams;1.0.3 in central
	found software.amazon.awssdk#annotations;2.20.18 in central
	found org.slf4j#slf4j-api;1.7.30 in central
	found software.amazon.awssdk#http-client-spi;2.20.18 in central
	found software.amazon.awssdk#metrics-spi;2.20.18 in central
downloading https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.1_2.12/1.2.0/iceberg-spark-runtime-3.1_2.12-1.2.0.jar ...
	[SUCCESSFUL ] org.apache.iceberg#iceberg-spark-runtime-3.1_2.12;1.2.0!iceberg-spark-runtime-3.1_2.12.jar (966ms)
downloading https://repo1.maven.org/maven2/software/amazon/awssdk/bundle/2.20.18/bundle-2.20.18.jar ...
	[SUCCESSFUL ] software.amazon.awssdk#bundle;2.20.18!bundle.jar (8889ms)
downloading https://repo1.maven.org/maven2/software/amazon/awssdk/url-connection-client/2.20.18/url-connection-client-2.20.18.jar ...
	[SUCCESSFUL ] software.amazon.awssdk#url-connection-client;2.20.18!url-connection-client.jar (66ms)
downloading https://repo1.maven.org/maven2/software/amazon/eventstream/eventstream/1.0.1/eventstream-1.0.1.jar ...
	[SUCCESSFUL ] software.amazon.eventstream#eventstream;1.0.1!eventstream.jar (59ms)
downloading https://repo1.maven.org/maven2/software/amazon/awssdk/utils/2.20.18/utils-2.20.18.jar ...
	[SUCCESSFUL ] software.amazon.awssdk#utils;2.20.18!utils.jar (66ms)
downloading https://repo1.maven.org/maven2/software/amazon/awssdk/annotations/2.20.18/annotations-2.20.18.jar ...
	[SUCCESSFUL ] software.amazon.awssdk#annotations;2.20.18!annotations.jar (62ms)
downloading https://repo1.maven.org/maven2/software/amazon/awssdk/http-client-spi/2.20.18/http-client-spi-2.20.18.jar ...
	[SUCCESSFUL ] software.amazon.awssdk#http-client-spi;2.20.18!http-client-spi.jar (61ms)
downloading https://repo1.maven.org/maven2/org/reactivestreams/reactive-streams/1.0.3/reactive-streams-1.0.3.jar ...
	[SUCCESSFUL ] org.reactivestreams#reactive-streams;1.0.3!reactive-streams.jar (58ms)
downloading https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.jar ...
	[SUCCESSFUL ] org.slf4j#slf4j-api;1.7.30!slf4j-api.jar (59ms)
downloading https://repo1.maven.org/maven2/software/amazon/awssdk/metrics-spi/2.20.18/metrics-spi-2.20.18.jar ...
	[SUCCESSFUL ] software.amazon.awssdk#metrics-spi;2.20.18!metrics-spi.jar (56ms)
:: resolution report :: resolve 153033ms :: artifacts dl 10382ms
	:: modules in use:
	org.apache.iceberg#iceberg-spark-runtime-3.1_2.12;1.2.0 from central in [default]
	org.reactivestreams#reactive-streams;1.0.3 from central in [default]
	org.slf4j#slf4j-api;1.7.30 from central in [default]
	software.amazon.awssdk#annotations;2.20.18 from central in [default]
	software.amazon.awssdk#bundle;2.20.18 from central in [default]
	software.amazon.awssdk#http-client-spi;2.20.18 from central in [default]
	software.amazon.awssdk#metrics-spi;2.20.18 from central in [default]
	software.amazon.awssdk#url-connection-client;2.20.18 from central in [default]
	software.amazon.awssdk#utils;2.20.18 from central in [default]
	software.amazon.eventstream#eventstream;1.0.1 from central in [default]
	---------------------------------------------------------------------
	|                  |            modules            ||   artifacts   |
	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
	---------------------------------------------------------------------
	|      default     |   10  |   10  |   10  |   0   ||   10  |   10  |
	---------------------------------------------------------------------
:: retrieving :: org.apache.spark#spark-submit-parent-9d1e3e8a-c713-44f0-93b3-bd5029daa8e2
	confs: [default]
	10 artifacts copied, 0 already retrieved (480145kB/974ms)
2024-06-14 00:51:50,318 WARN util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
Spark context Web UI available at http://cff3c38358c5:4040
Spark context available as 'sc' (master = local[*], app id = local-1718326322630).
Spark session available as 'spark'.
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 3.1.1
      /_/
         
Using Scala version 2.12.10 (OpenJDK 64-Bit Server VM, Java 1.8.0_232)
Type in expressions to have them evaluated.
Type :help for more information.

scala> 

The bucket right now is empty:
<img width="1467" alt="Screenshot 2024-06-13 at 5 50 19 PM" src="https://github.com/linkedin/openhouse/assets/114708561/8c4f2576-f867-4561-b680-9d340b9237a3">

4. Create table:
scala> spark.sql("CREATE TABLE openhouse.db.tb (ts timestamp, col1 string, col2 string) PARTITIONED BY (days(ts))").show()
++
||
++
++


scala> spark.sql("DESCRIBE TABLE openhouse.db.tb").show()
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
+--------------+---------+-------+
|      col_name|data_type|comment|
+--------------+---------+-------+
|            ts|timestamp|       |
|          col1|   string|       |
|          col2|   string|       |
|              |         |       |
|# Partitioning|         |       |
|        Part 0| days(ts)|       |
+--------------+---------+-------+

<img width="1463" alt="Screenshot 2024-06-13 at 5 53 55 PM" src="https://github.com/linkedin/openhouse/assets/114708561/a7cc8882-5099-43c5-b73b-6f779620a7fc">

<img width="1463" alt="Screenshot 2024-06-13 at 5 54 11 PM" src="https://github.com/linkedin/openhouse/assets/114708561/9f1d8665-1f9b-49a3-be3b-495561ecf3ce">

<img width="1452" alt="Screenshot 2024-06-13 at 5 54 22 PM" src="https://github.com/linkedin/openhouse/assets/114708561/efeea33e-f27a-44e7-ab95-a390e86e6893">

5. Add data

scala> spark.sql("INSERT INTO TABLE openhouse.db.tb VALUES (current_timestamp(), 'val1', 'val2')")
res2: org.apache.spark.sql.DataFrame = []                                       

scala> spark.sql("INSERT INTO TABLE openhouse.db.tb VALUES (date_sub(CAST(current_timestamp() as DATE), 30), 'val1', 'val2')")
res3: org.apache.spark.sql.DataFrame = []

scala> spark.sql("INSERT INTO TABLE openhouse.db.tb VALUES (date_sub(CAST(current_timestamp() as DATE), 60), 'val1', 'val2')")
res4: org.apache.spark.sql.DataFrame = []

scala> spark.sql("SELECT * FROM openhouse.db.tb").show()
+--------------------+----+----+                                                
|                  ts|col1|col2|
+--------------------+----+----+
| 2024-05-15 00:00:00|val1|val2|
| 2024-04-15 00:00:00|val1|val2|
|2024-06-14 00:55:...|val1|val2|
+--------------------+----+----+


scala> spark.sql("SHOW TABLES IN openhouse.db").show()
+---------+---------+
|namespace|tableName|
+---------+---------+
|       db|       tb|
+---------+---------+

<img width="1460" alt="Screenshot 2024-06-13 at 5 56 15 PM" src="https://github.com/linkedin/openhouse/assets/114708561/593f731a-fda8-49d1-86fd-f34d40e4cab8">

Test using table service:
$ curl "${curlArgs[@]}" -XPOST http://localhost:8000/v1/databases/d3/tables/ \
> --data-raw '{
>   "tableId": "t1",
>   "databaseId": "d3",
>   "baseTableVersion": "INITIAL_VERSION",
>   "clusterId": "LocalS3Cluster",
>   "schema": "{\"type\": \"struct\", \"fields\": [{\"id\": 1,\"required\": true,\"name\": \"id\",\"type\": \"string\"},{\"id\": 2,\"required\": true,\"name\": \"name\",\"type\": \"string\"},{\"id\": 3,\"required\": true,\"name\": \"ts\",\"type\": \"timestamp\"}]}",
>   "timePartitioning": {
>     "columnName": "ts",
>     "granularity": "HOUR"
>   },
>   "clustering": [
>     {
>       "columnName": "name"
>     }
>   ],
>   "tableProperties": {
>     "key": "value"
>   }
> }' | json_pp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2146    0  1576  100   570   4184   1513 --:--:-- --:--:-- --:--:--  5692
{
   "clusterId" : "LocalS3Cluster",
   "clustering" : [
      {
         "columnName" : "name",
         "transform" : null
      }
   ],
   "creationTime" : 1718327830198,
   "databaseId" : "d3",
   "lastModifiedTime" : 1718327830198,
   "policies" : null,
   "schema" : "{\"type\":\"struct\",\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"string\"},{\"id\":2,\"name\":\"name\",\"required\":true,\"type\":\"string\"},{\"id\":3,\"name\":\"ts\",\"required\":true,\"type\":\"timestamp\"}]}",
   "tableCreator" : "DUMMY_ANONYMOUS_USER",
   "tableId" : "t1",
   "tableLocation" : "s3://openhouse-bucket/d3/t1-394d8186-143f-482a-b5e5-e6aa6e382556/00000-8e498f9d-153e-412f-bb0e-476cfcab926d.metadata.json",
   "tableProperties" : {
      "key" : "value",
      "openhouse.clusterId" : "LocalS3Cluster",
      "openhouse.creationTime" : "1718327830198",
      "openhouse.databaseId" : "d3",
      "openhouse.lastModifiedTime" : "1718327830198",
      "openhouse.tableCreator" : "DUMMY_ANONYMOUS_USER",
      "openhouse.tableId" : "t1",
      "openhouse.tableLocation" : "s3://openhouse-bucket/d3/t1-394d8186-143f-482a-b5e5-e6aa6e382556/00000-8e498f9d-153e-412f-bb0e-476cfcab926d.metadata.json",
      "openhouse.tableType" : "PRIMARY_TABLE",
      "openhouse.tableUUID" : "394d8186-143f-482a-b5e5-e6aa6e382556",
      "openhouse.tableUri" : "LocalS3Cluster.d3.t1",
      "openhouse.tableVersion" : "INITIAL_VERSION",
      "policies" : "",
      "write.format.default" : "orc",
      "write.metadata.delete-after-commit.enabled" : "true",
      "write.metadata.previous-versions-max" : "28"
   },
   "tableType" : "PRIMARY_TABLE",
   "tableUUID" : "394d8186-143f-482a-b5e5-e6aa6e382556",
   "tableUri" : "LocalS3Cluster.d3.t1",
   "tableVersion" : "INITIAL_VERSION",
   "timePartitioning" : {
      "columnName" : "ts",
      "granularity" : "HOUR"
   }
}

<img width="1465" alt="Screenshot 2024-06-13 at 6 17 46 PM" src="https://github.com/linkedin/openhouse/assets/114708561/7f0f2e8a-dfb0-405e-a42c-9936ff6ed2bc">

$ curl "${curlArgs[@]}" -XGET http://localhost:8000/v1/databases/d3/tables/t1 | json_pp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1576    0  1576    0     0   9477      0 --:--:-- --:--:-- --:--:--  9493
{
   "clusterId" : "LocalS3Cluster",
   "clustering" : [
      {
         "columnName" : "name",
         "transform" : null
      }
   ],
   "creationTime" : 1718327830198,
   "databaseId" : "d3",
   "lastModifiedTime" : 1718327830198,
   "policies" : null,
   "schema" : "{\"type\":\"struct\",\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"string\"},{\"id\":2,\"name\":\"name\",\"required\":true,\"type\":\"string\"},{\"id\":3,\"name\":\"ts\",\"required\":true,\"type\":\"timestamp\"}]}",
   "tableCreator" : "DUMMY_ANONYMOUS_USER",
   "tableId" : "t1",
   "tableLocation" : "s3://openhouse-bucket/d3/t1-394d8186-143f-482a-b5e5-e6aa6e382556/00000-8e498f9d-153e-412f-bb0e-476cfcab926d.metadata.json",
   "tableProperties" : {
      "key" : "value",
      "openhouse.clusterId" : "LocalS3Cluster",
      "openhouse.creationTime" : "1718327830198",
      "openhouse.databaseId" : "d3",
      "openhouse.lastModifiedTime" : "1718327830198",
      "openhouse.tableCreator" : "DUMMY_ANONYMOUS_USER",
      "openhouse.tableId" : "t1",
      "openhouse.tableLocation" : "s3://openhouse-bucket/d3/t1-394d8186-143f-482a-b5e5-e6aa6e382556/00000-8e498f9d-153e-412f-bb0e-476cfcab926d.metadata.json",
      "openhouse.tableType" : "PRIMARY_TABLE",
      "openhouse.tableUUID" : "394d8186-143f-482a-b5e5-e6aa6e382556",
      "openhouse.tableUri" : "LocalS3Cluster.d3.t1",
      "openhouse.tableVersion" : "INITIAL_VERSION",
      "policies" : "",
      "write.format.default" : "orc",
      "write.metadata.delete-after-commit.enabled" : "true",
      "write.metadata.previous-versions-max" : "28"
   },
   "tableType" : "PRIMARY_TABLE",
   "tableUUID" : "394d8186-143f-482a-b5e5-e6aa6e382556",
   "tableUri" : "LocalS3Cluster.d3.t1",
   "tableVersion" : "INITIAL_VERSION",
   "timePartitioning" : {
      "columnName" : "ts",
      "granularity" : "HOUR"
   }
}

$ curl "${curlArgs[@]}" -XGET http://localhost:8000/v1/databases/d3/tables/ | json_pp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1590    0  1590    0     0  22490      0 --:--:-- --:--:-- --:--:-- 22714
{
   "results" : [
      {
         "clusterId" : "LocalS3Cluster",
         "clustering" : [
            {
               "columnName" : "name",
               "transform" : null
            }
         ],
         "creationTime" : 1718327830198,
         "databaseId" : "d3",
         "lastModifiedTime" : 1718327830198,
         "policies" : null,
         "schema" : "{\"type\":\"struct\",\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"string\"},{\"id\":2,\"name\":\"name\",\"required\":true,\"type\":\"string\"},{\"id\":3,\"name\":\"ts\",\"required\":true,\"type\":\"timestamp\"}]}",
         "tableCreator" : "DUMMY_ANONYMOUS_USER",
         "tableId" : "t1",
         "tableLocation" : "s3://openhouse-bucket/d3/t1-394d8186-143f-482a-b5e5-e6aa6e382556/00000-8e498f9d-153e-412f-bb0e-476cfcab926d.metadata.json",
         "tableProperties" : {
            "key" : "value",
            "openhouse.clusterId" : "LocalS3Cluster",
            "openhouse.creationTime" : "1718327830198",
            "openhouse.databaseId" : "d3",
            "openhouse.lastModifiedTime" : "1718327830198",
            "openhouse.tableCreator" : "DUMMY_ANONYMOUS_USER",
            "openhouse.tableId" : "t1",
            "openhouse.tableLocation" : "s3://openhouse-bucket/d3/t1-394d8186-143f-482a-b5e5-e6aa6e382556/00000-8e498f9d-153e-412f-bb0e-476cfcab926d.metadata.json",
            "openhouse.tableType" : "PRIMARY_TABLE",
            "openhouse.tableUUID" : "394d8186-143f-482a-b5e5-e6aa6e382556",
            "openhouse.tableUri" : "LocalS3Cluster.d3.t1",
            "openhouse.tableVersion" : "INITIAL_VERSION",
            "policies" : "",
            "write.format.default" : "orc",
            "write.metadata.delete-after-commit.enabled" : "true",
            "write.metadata.previous-versions-max" : "28"
         },
         "tableType" : "PRIMARY_TABLE",
         "tableUUID" : "394d8186-143f-482a-b5e5-e6aa6e382556",
         "tableUri" : "LocalS3Cluster.d3.t1",
         "tableVersion" : "INITIAL_VERSION",
         "timePartitioning" : {
            "columnName" : "ts",
            "granularity" : "HOUR"
         }
      }
   ]
}

Delete table:
$ curl "${curlArgs[@]}" -XDELETE http://localhost:8000/v1/databases/d3/tables/t1

Valid that the table is deleted:
![Uploading Screenshot 2024-06-13 at 6.21.03 PM.png…]()


- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [x] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
