### PR TITLE
Enabling access to swagger-ui using client without auth

### DIFF
--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/config/TablesMvcConfigurer.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/config/TablesMvcConfigurer.java
@@ -35,7 +35,7 @@ public class TablesMvcConfigurer implements WebMvcConfigurer {
             registry
                 .addInterceptor((HandlerInterceptor) cons.get().newInstance())
                 .addPathPatterns("/**")
-                .excludePathPatterns("/actuator/**", "/**/api-docs/**");
+                .excludePathPatterns("/actuator/**", "/**/api-docs/**", "/**/swagger-ui/**");
           } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(
                 "Unable to install the configured Request Interception Handler", e);


### PR DESCRIPTION
## Summary
problem: swagger ui returns 401 when requesting api-docs via browser
<img width="989" alt="image" src="https://github.com/linkedin/openhouse/assets/25903091/7f0c2f35-676f-4999-b11d-c9601c0969a7">

solution: expose swagger ui to unauthenticated access (just like the existing, non-ui version `/v3/api-docs`)

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [x] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request. 

Swagger-ui is beneficial for browsing API configuration for features like, what are the required client headers for a given API endpoint. 

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [x] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

I manually ran tests by configuring  infra/recipes/docker-compose/oh-only/docker-compose.yml  to also start the jobs rest service, then
```bash
➜ JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_282-msft.jdk/Contents/Home ./gradlew clean build -x test -x javadoc
➜ docker compose -f infra/recipes/docker-compose/oh-only/docker-compose.yml down --rmi all
➜ docker compose -f infra/recipes/docker-compose/oh-only/docker-compose.yml up
```

then querying each endpoint:
tables
<img width="680" alt="image" src="https://github.com/linkedin/openhouse/assets/25903091/b5411c96-0f52-4010-96fc-ce4db8e34ac5">
housetables
<img width="680" alt="image" src="https://github.com/linkedin/openhouse/assets/25903091/6a2dda20-f501-4298-be5a-4919ed4a1075">
jobs
<img width="680" alt="image" src="https://github.com/linkedin/openhouse/assets/25903091/eb7a6cb8-1a28-4d23-b353-e2c6e0ca54a3">

> No tests added or updated. Please explain why. If unsure, please feel free to ask for help.

When atttempting to add unittests, using e.g. MockMvcBuilder, the swagger endpoint returns 404 for our services. I believe this is because the service unittests use a Mocked version of the controller, but none of our controllers specify swagger. Swagger is configured at spring application start, so would require a different method of testing than using a mocked controller. I tried to use a tomcat/h2 local server but still was getting issues of 404.

I would be open to continuing to try unittests with some pointers in the right direction for testing springboot application server with configured swagger.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
