### PR TITLE
Add schema to table location

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -235,7 +235,8 @@ public final class Operations implements AutoCloseable {
   }
 
   private Path getTrashPath(String path, String filePath, String trashDir) {
-    return new Path(filePath.replace(path, new Path(path, trashDir).toString()));
+    return new Path(
+        filePath.replace(new Path(path).toString(), new Path(path, trashDir).toString()));
   }
 
   /**

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/BaseStorage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/BaseStorage.java
@@ -60,10 +60,6 @@ public abstract class BaseStorage implements Storage {
       String databaseId, String tableId, String tableUUID, String tableCreator) {
     Preconditions.checkArgument(databaseId != null, "Database ID cannot be null");
     Preconditions.checkArgument(tableId != null, "Table ID cannot be null");
-    Preconditions.checkArgument(tableUUID != null, "Table UUID cannot be null");
-    Preconditions.checkState(
-        storageProperties.getTypes().containsKey(getType().getValue()),
-        "Storage properties doesn't contain type: " + getType().getValue());
     return URI.create(
             getClient().getEndpoint()
                 + getClient().getRootPrefix()

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/hdfs/HdfsStorage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/hdfs/HdfsStorage.java
@@ -3,7 +3,6 @@ package com.linkedin.openhouse.cluster.storage.hdfs;
 import com.linkedin.openhouse.cluster.storage.BaseStorage;
 import com.linkedin.openhouse.cluster.storage.StorageClient;
 import com.linkedin.openhouse.cluster.storage.StorageType;
-import java.nio.file.Paths;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
@@ -36,20 +35,5 @@ public class HdfsStorage extends BaseStorage {
   @Override
   public StorageClient<?> getClient() {
     return hdfsStorageClient;
-  }
-
-  /**
-   * Allocates Table Space for the HDFS storage.
-   *
-   * <p>tableLocation looks like: /{rootPrefix}/{databaseId}/{tableId}-{tableUUID} We strip the
-   * endpoint to ensure backward-compatibility. This override should be removed after resolving <a
-   * href="https://github.com/linkedin/openhouse/issues/121">
-   *
-   * @return the table location
-   */
-  @Override
-  public String allocateTableLocation(
-      String databaseId, String tableId, String tableUUID, String tableCreator) {
-    return Paths.get(getClient().getRootPrefix(), databaseId, tableId + "-" + tableUUID).toString();
   }
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorage.java
@@ -4,7 +4,6 @@ import com.linkedin.openhouse.cluster.storage.BaseStorage;
 import com.linkedin.openhouse.cluster.storage.StorageClient;
 import com.linkedin.openhouse.cluster.storage.StorageType;
 import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
-import java.nio.file.Paths;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
@@ -51,18 +50,5 @@ public class LocalStorage extends BaseStorage {
   @Override
   public StorageClient<?> getClient() {
     return localStorageClient;
-  }
-
-  /**
-   * Allocates Table Space for the Local Storage.
-   *
-   * <p>tableLocation looks like: /{rootPrefix}/{databaseId}/{tableId}-{tableUUID} We strip the
-   * endpoint to ensure backward-compatibility. This override should be removed after resolving <a
-   * href="https://github.com/linkedin/openhouse/issues/121">
-   */
-  @Override
-  public String allocateTableLocation(
-      String databaseId, String tableId, String tableUUID, String tableCreator) {
-    return Paths.get(getClient().getRootPrefix(), databaseId, tableId + "-" + tableUUID).toString();
   }
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorageClient.java
@@ -28,7 +28,7 @@ public class LocalStorageClient extends BaseStorageClient<FileSystem> {
 
   private static final StorageType.Type LOCAL_TYPE = StorageType.LOCAL;
 
-  private static final String DEFAULT_ENDPOINT = "file:/";
+  private static final String DEFAULT_ENDPOINT = "file://";
 
   private static final String DEFAULT_ROOTPATH = "/tmp";
 

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorageClient.java
@@ -28,7 +28,7 @@ public class LocalStorageClient extends BaseStorageClient<FileSystem> {
 
   private static final StorageType.Type LOCAL_TYPE = StorageType.LOCAL;
 
-  private static final String DEFAULT_ENDPOINT = "file:";
+  private static final String DEFAULT_ENDPOINT = "file:/";
 
   private static final String DEFAULT_ROOTPATH = "/tmp";
 

--- a/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/datasource/TableFileStatsTest.java
+++ b/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/datasource/TableFileStatsTest.java
@@ -39,8 +39,7 @@ public class TableFileStatsTest extends OpenHouseSparkITest {
               .getParent();
       Map<String, Long> expectedStats = new HashMap<>();
       for (FileStatus fileStatus : fs.listStatus(new Path(tableDirectory, "data"))) {
-        expectedStats.put(
-            fileStatus.getPath().toString().substring("file:".length()), fileStatus.getLen());
+        expectedStats.put(fileStatus.getPath().toString(), fileStatus.getLen());
       }
       Assertions.assertEquals(expectedStats, stats);
     }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/InternalRepositoryUtils.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/InternalRepositoryUtils.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.UpdateProperties;
 
@@ -35,14 +34,19 @@ public final class InternalRepositoryUtils {
     // Utils' class constructor, noop
   }
 
-  public static java.nio.file.Path constructTablePath(
+  public static URI constructTablePath(
       StorageManager storageManager, String databaseID, String tableId, String tableUUID) {
     // TODO: Default storage is used here. Support for non-default storage type per table needs to
     // be added.
-    return Paths.get(
-        storageManager.getDefaultStorage().getClient().getRootPrefix(),
-        databaseID,
-        tableId + "-" + tableUUID);
+    String endpoint = storageManager.getDefaultStorage().getClient().getEndpoint();
+    String path =
+        Paths.get(
+                storageManager.getDefaultStorage().getClient().getRootPrefix(),
+                databaseID,
+                tableId + "-" + tableUUID)
+            .toString();
+
+    return URI.create(endpoint + '/' + path).normalize();
   }
 
   /**
@@ -142,11 +146,7 @@ public final class InternalRepositoryUtils {
             .tableUri(megaProps.get(getCanonicalFieldName("tableUri")))
             .tableUUID(megaProps.get(getCanonicalFieldName("tableUUID")))
             .tableLocation(
-                URI.create(
-                        StringUtils.prependIfMissing( // remove after resolving
-                            // https://github.com/linkedin/openhouse/issues/121
-                            megaProps.get(getCanonicalFieldName("tableLocation")),
-                            storage.getClient().getEndpoint()))
+                URI.create(megaProps.get(getCanonicalFieldName("tableLocation")))
                     .normalize()
                     .toString())
             .tableVersion(megaProps.get(getCanonicalFieldName("tableVersion")))
@@ -161,7 +161,6 @@ public final class InternalRepositoryUtils {
             .jsonSnapshots(null)
             .tableProperties(megaProps)
             .build();
-
     return tableDto;
   }
 

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/TableUUIDGenerator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/TableUUIDGenerator.java
@@ -144,8 +144,10 @@ public class TableUUIDGenerator {
         extractFromTblPropsIfExists(databaseId + "." + tableId, tableProperties, TBL_RAW_KEY);
 
     java.nio.file.Path previousPath =
-        InternalRepositoryUtils.constructTablePath(
-            storageManager, dbIdFromProps, tblIdFromProps, tableUUIDProperty);
+        Paths.get(
+            InternalRepositoryUtils.constructTablePath(
+                    storageManager, dbIdFromProps, tblIdFromProps, tableUUIDProperty)
+                .getPath());
     if (TableType.REPLICA_TABLE != tableType && !doesPathExist(previousPath)) {
       log.error("Previous tableLocation: {} doesn't exist", previousPath);
       throw new RequestValidationFailureException(

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/TableUUIDGenerator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/TableUUIDGenerator.java
@@ -244,7 +244,7 @@ public class TableUUIDGenerator {
             .next();
     /* check if tableDirectory is of the form "tablename-<UUID>", if it is, extract UUID */
     String tableIdDash = String.format("%s-", tableId);
-    if (!tableDirectoryPath.startsWith(tableIdDash)) {
+    if (!tableDirectoryPath.toString().startsWith(tableIdDash.toString())) {
       log.error(
           "Provided Snapshot location is incorrect, should have table name: {}_, but provided {}",
           tableId,

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/TableUUIDGenerator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/TableUUIDGenerator.java
@@ -13,6 +13,7 @@ import com.linkedin.openhouse.tables.common.TableType;
 import com.linkedin.openhouse.tables.repository.impl.InternalRepositoryUtils;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URI;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
@@ -223,9 +224,11 @@ public class TableUUIDGenerator {
   @VisibleForTesting
   private UUID extractUUIDFromExistingManifestListPath(
       java.nio.file.Path manifestListPath, java.nio.file.Path databaseDirPath, String tableId) {
+    java.nio.file.Path manifestListSchemelessPath =
+        Paths.get(URI.create(manifestListPath.toString()).getPath());
     boolean isProperPathPrefix =
-        manifestListPath.startsWith(databaseDirPath)
-            && databaseDirPath.getNameCount() < manifestListPath.getNameCount();
+        manifestListSchemelessPath.startsWith(databaseDirPath)
+            && databaseDirPath.getNameCount() < manifestListSchemelessPath.getNameCount();
     if (!isProperPathPrefix) {
       log.error(
           "Provided Snapshot location is incorrect, should be in: {}, but provided {}",
@@ -235,13 +238,13 @@ public class TableUUIDGenerator {
           String.format("Provided snapshot is invalid for %s", tableId));
     }
     java.nio.file.Path tableDirectoryPath =
-        manifestListPath
-            .subpath(databaseDirPath.getNameCount(), manifestListPath.getNameCount())
+        manifestListSchemelessPath
+            .subpath(databaseDirPath.getNameCount(), manifestListSchemelessPath.getNameCount())
             .iterator()
             .next();
     /* check if tableDirectory is of the form "tablename-<UUID>", if it is, extract UUID */
     String tableIdDash = String.format("%s-", tableId);
-    if (!tableDirectoryPath.toString().startsWith(tableIdDash)) {
+    if (!tableDirectoryPath.startsWith(tableIdDash)) {
       log.error(
           "Provided Snapshot location is incorrect, should have table name: {}_, but provided {}",
           tableId,

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
@@ -646,7 +646,7 @@ public class RepositoryTest {
             table.getTableId() + "-" + table.getTableUUID());
     Assertions.assertEquals(TABLE_DTO.getTimePartitioning(), table.getTimePartitioning());
     Assertions.assertEquals(TABLE_DTO.getClustering(), table.getClustering());
-    Assertions.assertTrue(table.getTableLocation().startsWith(path.toString()));
+    Assertions.assertTrue(Paths.get(table.getTableLocation()).startsWith(path.toString()));
   }
 
   private void verifyTable(HouseTable table) {
@@ -656,9 +656,10 @@ public class RepositoryTest {
     Assertions.assertEquals(TABLE_DTO.getTableUri(), table.getTableUri());
     Path path =
         Paths.get(
+            "file:",
             storageManager.getDefaultStorage().getClient().getRootPrefix(),
             table.getDatabaseId(),
             table.getTableId() + "-" + table.getTableUUID());
-    Assertions.assertTrue(table.getTableLocation().startsWith(path.toString()));
+    Assertions.assertTrue(Paths.get(table.getTableLocation()).startsWith(path.toString()));
   }
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RequestAndValidateHelper.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RequestAndValidateHelper.java
@@ -84,10 +84,7 @@ public class RequestAndValidateHelper {
             .andExpect(jsonPath("$.databaseId", is(equalTo(getTableResponseBody.getDatabaseId()))))
             .andExpect(jsonPath("$.clusterId", is(equalTo(getTableResponseBody.getClusterId()))))
             .andExpect(jsonPath("$.tableUri", is(equalTo(getTableResponseBody.getTableUri()))))
-            .andExpect(
-                jsonPath(
-                    "$.tableVersion",
-                    is(equalTo(TablesServiceTest.stripPathScheme(previousTableLocation)))))
+            .andExpect(jsonPath("$.tableVersion", is(equalTo(previousTableLocation))))
             .andReturn();
     ValidationUtilities.validateUUID(mvcResult, getTableResponseBody.getTableUUID());
     ValidationUtilities.validateSchema(mvcResult, getTableResponseBody.getSchema());
@@ -358,10 +355,7 @@ public class RequestAndValidateHelper {
             .andExpect(
                 jsonPath(
                     "$.tableVersion",
-                    is(
-                        equalTo(
-                            TablesServiceTest.stripPathScheme(
-                                icebergSnapshotsRequestBody.getBaseTableVersion())))))
+                    is(equalTo(icebergSnapshotsRequestBody.getBaseTableVersion()))))
             .andReturn();
 
     validateSnapshots(catalog, result, icebergSnapshotsRequestBody);

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
@@ -82,10 +82,9 @@ public class TablesServiceTest {
             storageManager.getDefaultStorage().getClient().getRootPrefix(),
             actual.getDatabaseId(),
             actual.getTableId() + "-" + actual.getTableUUID());
-    Assertions.assertTrue(actual.getTableLocation().startsWith(expectedPath.toString()));
+    Assertions.assertTrue(Paths.get(actual.getTableLocation()).startsWith(expectedPath.toString()));
     if (previousVersion != null) {
-      Assertions.assertEquals(
-          stripPathScheme(previousVersion.getTableLocation()), actual.getTableVersion());
+      Assertions.assertEquals(previousVersion.getTableLocation(), actual.getTableVersion());
     } else {
       Assertions.assertEquals(INITIAL_TABLE_VERSION, actual.getTableVersion());
     }
@@ -149,20 +148,17 @@ public class TablesServiceTest {
     TableDto updatedPutResultCreate =
         verifyPutTableRequest(evolveDummySchema(putResultCreate), putResultCreate, false);
     Assertions.assertEquals(
-        updatedPutResultCreate.getTableVersion(),
-        stripPathScheme(putResultCreate.getTableLocation()));
+        updatedPutResultCreate.getTableVersion(), putResultCreate.getTableLocation());
     TableDto updatedPutResultCreateSameDB =
         verifyPutTableRequest(
             evolveDummySchema(putResultCreateSameDB), putResultCreateSameDB, false);
     Assertions.assertEquals(
-        updatedPutResultCreateSameDB.getTableVersion(),
-        stripPathScheme(putResultCreateSameDB.getTableLocation()));
+        updatedPutResultCreateSameDB.getTableVersion(), putResultCreateSameDB.getTableLocation());
     TableDto updatedPutResultCreateDiffDB =
         verifyPutTableRequest(
             evolveDummySchema(putResultCreateDiffDB), putResultCreateDiffDB, false);
     Assertions.assertEquals(
-        updatedPutResultCreateDiffDB.getTableVersion(),
-        stripPathScheme(putResultCreateDiffDB.getTableLocation()));
+        updatedPutResultCreateDiffDB.getTableVersion(), putResultCreateDiffDB.getTableLocation());
 
     // Delete Table
     tablesService.deleteTable(TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER);
@@ -212,8 +208,7 @@ public class TablesServiceTest {
         verifyPutTableRequest(decorateSchemaEvolution(baseResult, baseInt2Long), baseResult, false);
 
     // Verify version
-    Assertions.assertEquals(
-        stripPathScheme(baseResult.getTableLocation()), updatedResult.getTableVersion());
+    Assertions.assertEquals(baseResult.getTableLocation(), updatedResult.getTableVersion());
 
     // Verify schema updated
     // Again schema's namespace might be not matching so only compare fields.

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/ValidationUtilities.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/ValidationUtilities.java
@@ -97,7 +97,7 @@ public final class ValidationUtilities {
     String tableLocation =
         JsonPath.read(result.getResponse().getContentAsString(), "$.tableLocation");
     Path expectedPath = Paths.get("file:", rootPath, databaseId, tableId + "-" + tableUUID);
-    Assertions.assertTrue(Paths.get(tableLocation).toString().startsWith(expectedPath.toString()));
+    Assertions.assertTrue(Paths.get(tableLocation).startsWith(expectedPath.toString()));
   }
 
   static void validateTimestamp(

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/ValidationUtilities.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/ValidationUtilities.java
@@ -97,7 +97,7 @@ public final class ValidationUtilities {
     String tableLocation =
         JsonPath.read(result.getResponse().getContentAsString(), "$.tableLocation");
     Path expectedPath = Paths.get("file:", rootPath, databaseId, tableId + "-" + tableUUID);
-    Assertions.assertTrue(tableLocation.startsWith(expectedPath.toString()));
+    Assertions.assertTrue(Paths.get(tableLocation).toString().startsWith(expectedPath.toString()));
   }
 
   static void validateTimestamp(

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/hdfs/HdfsStorageTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/hdfs/HdfsStorageTest.java
@@ -65,7 +65,8 @@ public class HdfsStorageTest {
     String tableCreator = "creator1";
     boolean skipProvisioning = false;
     when(hdfsStorageClient.getRootPrefix()).thenReturn("/data/openhouse");
-    String expected = "/data/openhouse/db1/table1-uuid1";
+    when(hdfsStorageClient.getEndpoint()).thenReturn("hdfs://");
+    String expected = "hdfs:///data/openhouse/db1/table1-uuid1";
     assertEquals(
         expected, hdfsStorage.allocateTableLocation(databaseId, tableId, tableUUID, tableCreator));
   }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/local/LocalStorageTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/local/LocalStorageTest.java
@@ -93,7 +93,8 @@ public class LocalStorageTest {
     String tableCreator = "creator1";
     boolean skipProvisioning = false;
     when(localStorageClient.getRootPrefix()).thenReturn("/tmp");
-    String expected = "/tmp/db1/table1-uuid1";
+    when(localStorageClient.getEndpoint()).thenReturn("file://");
+    String expected = "file:///tmp/db1/table1-uuid1";
     assertEquals(
         expected, localStorage.allocateTableLocation(databaseId, tableId, tableUUID, tableCreator));
   }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/uuid/TableUUIDGeneratorTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/uuid/TableUUIDGeneratorTest.java
@@ -71,6 +71,7 @@ public class TableUUIDGeneratorTest {
         new Path(
             InternalRepositoryUtils.constructTablePath(
                     storageManager, "db", "t", expectedUUID.toString())
+                .getPath()
                 .toString()));
     UUID existingUUID =
         tableUUIDGenerator.generateUUID(
@@ -105,6 +106,7 @@ public class TableUUIDGeneratorTest {
         new Path(
             InternalRepositoryUtils.constructTablePath(
                     storageManager, "db", "t", expectedUUID.toString())
+                .getPath()
                 .toString()));
     UUID existingUUID =
         tableUUIDGenerator.generateUUID(

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/repository/impl/InternalRepositoryUtilsTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/repository/impl/InternalRepositoryUtilsTest.java
@@ -197,7 +197,7 @@
 //    String uuid = UUID.randomUUID().toString();
 //    Mockito.when(fsStorageProvider.rootPath()).thenReturn(someRoot);
 //    Assertions.assertEquals(
-//        InternalRepositoryUtils.constructTablePath(fsStorageProvider, dbId, tbId, uuid),
+//        InternalRepositoryUtils.constructTablePath(fsStorageProvider, dbId, tbId, uuid).getPath(),
 //        Paths.get(someRoot, dbId, tbId + "-" + uuid));
 //  }
 //


### PR DESCRIPTION
## Summary

[Issue](https://github.com/linkedin/openhouse/issues/121) Changed table locations to include the scheme.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [x] Tests

Changed both the implementation of creating the table location (and dealing with its ramifications) and the tests that test the table location. Allows all table locations to include the schema (eg. `hdfs://tmp/...` instead of `tmp/...`). Furthermore, added this fix for the old `constructTablePath` method and the new `allocateTableStorage` method. Removed outdated overriding methods for Local and HDFS storage that don't include the scheme.

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Changed tests to reflect the table locations now containing the schema.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
