### PR TITLE
Fix tables service tests due to removal of getAllTables api

### DIFF
--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RequestAndValidateHelper.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RequestAndValidateHelper.java
@@ -4,9 +4,7 @@ import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.INI
 import static com.linkedin.openhouse.tables.e2e.h2.ValidationUtilities.*;
 import static com.linkedin.openhouse.tables.model.TableModelConstants.buildCreateUpdateTableRequestBody;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.oneOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -21,9 +19,7 @@ import com.linkedin.openhouse.tables.api.spec.v0.request.IcebergSnapshotsRequest
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
 import com.linkedin.openhouse.tables.common.TableType;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.apache.directory.api.util.Strings;
 import org.apache.iceberg.catalog.Catalog;
 import org.junit.jupiter.api.Assertions;
@@ -267,48 +263,6 @@ public class RequestAndValidateHelper {
           ((JsonObject) (mapDiff.get("onlyOnRight"))).has(badKey)
               || ((JsonObject) (mapDiff.get("onlyOnLeft"))).has(badKey));
     }
-  }
-
-  static void listAllAndValidateResponse(
-      MockMvc mvc, String databaseId, List<GetTableResponseBody> inputTableList) throws Exception {
-    mvc.perform(
-            MockMvcRequestBuilders.get(
-                    String.format(
-                        ValidationUtilities.CURRENT_MAJOR_VERSION_PREFIX + "/databases/%s/tables/",
-                        databaseId))
-                .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())
-        .andDo(MockMvcResultHandlers.print())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.results", hasSize(inputTableList.size())))
-        .andExpect(
-            jsonPath(
-                "$.results[*].tableId",
-                oneOf(
-                    inputTableList.stream()
-                        .map(GetTableResponseBody::getTableId)
-                        .collect(Collectors.toList()))))
-        .andExpect(
-            jsonPath(
-                "$.results[*].databaseId",
-                oneOf(
-                    inputTableList.stream()
-                        .map(GetTableResponseBody::getDatabaseId)
-                        .collect(Collectors.toList()))))
-        .andExpect(
-            jsonPath(
-                "$.results[*].clusterId",
-                oneOf(
-                    inputTableList.stream()
-                        .map(GetTableResponseBody::getClusterId)
-                        .collect(Collectors.toList()))))
-        .andExpect(
-            jsonPath(
-                "$.results[*].tableUri",
-                oneOf(
-                    inputTableList.stream()
-                        .map(GetTableResponseBody::getTableUri)
-                        .collect(Collectors.toList()))));
   }
 
   static void deleteTableAndValidateResponse(MockMvc mvc, GetTableResponseBody getTableResponseBody)

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesControllerTest.java
@@ -136,15 +136,6 @@ public class TablesControllerTest {
     RequestAndValidateHelper.updateTableAndValidateResponse(
         mvc, storageManager, evolveDummySchema(mvcResultT1d2), tableDiffDbLocation);
 
-    RequestAndValidateHelper.listAllAndValidateResponse(
-        mvc,
-        GET_TABLE_RESPONSE_BODY.getDatabaseId(),
-        Arrays.asList(GET_TABLE_RESPONSE_BODY, GET_TABLE_RESPONSE_BODY_SAME_DB));
-    RequestAndValidateHelper.listAllAndValidateResponse(
-        mvc,
-        GET_TABLE_RESPONSE_BODY_DIFF_DB.getDatabaseId(),
-        Arrays.asList(GET_TABLE_RESPONSE_BODY_DIFF_DB));
-
     RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, GET_TABLE_RESPONSE_BODY);
     RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, GET_TABLE_RESPONSE_BODY_SAME_DB);
     RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, GET_TABLE_RESPONSE_BODY_DIFF_DB);


### PR DESCRIPTION
## Summary

The [PR](https://github.com/linkedin/openhouse/pull/127) has not cleaned all the tests related to the getAllTables api (not sure why the build succeeded). This PR is to remove the tests to make github build succeed.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
