### PR TITLE
Fix github build failure

### DIFF
--- a/docs/development/client-code-generation.md
+++ b/docs/development/client-code-generation.md
@@ -4,7 +4,7 @@ To enable a server to produce OpenApi spec, just include the following code bloc
 ```
 plugin {
   id 'com.github.johnrengelman.processes' version '0.5.0'
-  id 'org.springdoc.openapi-gradle-plugin' version '1.3.3'
+  id 'org.springdoc.openapi-gradle-plugin' version '1.6.0'
   id 'openhouse.service-specgen-convention'
 }
 ```

--- a/services/housetables/build.gradle
+++ b/services/housetables/build.gradle
@@ -33,6 +33,7 @@ dependencies {
   implementation "org.glassfish.jaxb:jaxb-runtime:2.3.2"
   implementation "mysql:mysql-connector-java:8.+"
   implementation "org.jetbrains:annotations:16.0.3"
+  implementation "khttp:khttp:1.0.0"
   testImplementation(testFixtures(project(':services:common')))
 }
 

--- a/services/housetables/build.gradle
+++ b/services/housetables/build.gradle
@@ -16,7 +16,7 @@ plugins {
    * These are the dependencies to enable client generation for the service.
    * */
   id 'com.github.johnrengelman.processes' version '0.5.0'
-  id 'org.springdoc.openapi-gradle-plugin' version '1.3.4'
+  id 'org.springdoc.openapi-gradle-plugin' version '1.6.0'
   id 'openhouse.service-specgen-convention'
 }
 
@@ -33,7 +33,6 @@ dependencies {
   implementation "org.glassfish.jaxb:jaxb-runtime:2.3.2"
   implementation "mysql:mysql-connector-java:8.+"
   implementation "org.jetbrains:annotations:16.0.3"
-  implementation "khttp:khttp:1.0.0"
   testImplementation(testFixtures(project(':services:common')))
 }
 

--- a/services/housetables/build.gradle
+++ b/services/housetables/build.gradle
@@ -16,7 +16,7 @@ plugins {
    * These are the dependencies to enable client generation for the service.
    * */
   id 'com.github.johnrengelman.processes' version '0.5.0'
-  id 'org.springdoc.openapi-gradle-plugin' version '1.3.3'
+  id 'org.springdoc.openapi-gradle-plugin' version '1.3.4'
   id 'openhouse.service-specgen-convention'
 }
 

--- a/services/jobs/build.gradle
+++ b/services/jobs/build.gradle
@@ -16,7 +16,7 @@ plugins {
    * These are the dependencies to enable client generation for the service.
    * */
   id 'com.github.johnrengelman.processes' version '0.5.0'
-  id 'org.springdoc.openapi-gradle-plugin' version '1.3.3'
+  id 'org.springdoc.openapi-gradle-plugin' version '1.6.0'
   id 'openhouse.service-specgen-convention'
 }
 

--- a/services/tables/build.gradle
+++ b/services/tables/build.gradle
@@ -17,7 +17,7 @@ plugins {
    * These are the dependencies to enable client generation for the service.
    * */
   id 'com.github.johnrengelman.processes' version '0.5.0'
-  id 'org.springdoc.openapi-gradle-plugin' version '1.3.3'
+  id 'org.springdoc.openapi-gradle-plugin' version '1.6.0'
   id 'openhouse.service-specgen-convention'
 }
 


### PR DESCRIPTION
## Summary

The build failed because of missing `khttp` library that is required by `springdoc-openapi` plugin. This library has been removed from maven2 repo from 2022, so not sure why the previous build succeeded (maybe github caches some gradle libraries). The `springdoc-openapi` plugin has removed the usage of `khttp` too since `1.5.0`. I'm upgrading the version to `1.6.0` which is the latest that gradle 6 supports.

More details in this issue: https://github.com/springdoc/springdoc-openapi-gradle-plugin/pull/92.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [x] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
