### PR TITLE
Added table storage deletion to the Storage layer and removed the del…

### DIFF
--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/Storage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/Storage.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.cluster.storage;
 
+import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -70,4 +71,13 @@ public interface Storage {
    */
   String allocateTableLocation(
       String databaseId, String tableId, String tableUUID, String tableCreator);
+
+  /**
+   * Deallocates/deletes Table Storage location
+   *
+   * @param location the base location of the table
+   * @param tableCreator the creator of the table
+   * @throws IOException
+   */
+  void deallocateTableLocation(String location, String tableCreator) throws IOException;
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/hdfs/HdfsStorage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/hdfs/HdfsStorage.java
@@ -3,7 +3,9 @@ package com.linkedin.openhouse.cluster.storage.hdfs;
 import com.linkedin.openhouse.cluster.storage.BaseStorage;
 import com.linkedin.openhouse.cluster.storage.StorageClient;
 import com.linkedin.openhouse.cluster.storage.StorageType;
+import java.io.IOException;
 import java.nio.file.Paths;
+import org.apache.hadoop.fs.Path;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
@@ -51,5 +53,17 @@ public class HdfsStorage extends BaseStorage {
   public String allocateTableLocation(
       String databaseId, String tableId, String tableUUID, String tableCreator) {
     return Paths.get(getClient().getRootPrefix(), databaseId, tableId + "-" + tableUUID).toString();
+  }
+
+  /**
+   * Deallocates/deletes Table Storage location recursively for Hdfs storage
+   *
+   * @param location the base location of the table
+   * @param tableCreator the creator of the table
+   * @throws IOException
+   */
+  @Override
+  public void deallocateTableLocation(String location, String tableCreator) throws IOException {
+    this.hdfsStorageClient.getNativeClient().delete(new Path(location), true);
   }
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorage.java
@@ -4,7 +4,9 @@ import com.linkedin.openhouse.cluster.storage.BaseStorage;
 import com.linkedin.openhouse.cluster.storage.StorageClient;
 import com.linkedin.openhouse.cluster.storage.StorageType;
 import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
+import java.io.IOException;
 import java.nio.file.Paths;
+import org.apache.hadoop.fs.Path;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
@@ -64,5 +66,16 @@ public class LocalStorage extends BaseStorage {
   public String allocateTableLocation(
       String databaseId, String tableId, String tableUUID, String tableCreator) {
     return Paths.get(getClient().getRootPrefix(), databaseId, tableId + "-" + tableUUID).toString();
+  }
+  /**
+   * Deallocates/deletes Table Storage location recursively for Local storage
+   *
+   * @param location the base location of the table
+   * @param tableCreator the creator of the table
+   * @throws IOException
+   */
+  @Override
+  public void deallocateTableLocation(String location, String tableCreator) throws IOException {
+    this.localStorageClient.getNativeClient().delete(new Path(location), true);
   }
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/s3/S3Storage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/s3/S3Storage.java
@@ -3,9 +3,11 @@ package com.linkedin.openhouse.cluster.storage.s3;
 import com.linkedin.openhouse.cluster.storage.BaseStorage;
 import com.linkedin.openhouse.cluster.storage.StorageClient;
 import com.linkedin.openhouse.cluster.storage.StorageType;
+import java.io.IOException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
 
 /**
  * The S3Storage class is an implementation of the Storage interface for S3 storage. It uses a
@@ -33,5 +35,23 @@ public class S3Storage extends BaseStorage {
   @Override
   public StorageClient<?> getClient() {
     return s3StorageClient;
+  }
+
+  /**
+   * Deallocates/deletes Table Storage location for S3 storage
+   *
+   * @param location the base location of the table
+   * @param tableCreator the creator of the table
+   * @throws IOException
+   */
+  @Override
+  public void deallocateTableLocation(String location, String tableCreator) throws IOException {
+    try {
+      this.s3StorageClient
+          .getNativeClient()
+          .deleteBucket(DeleteBucketRequest.builder().bucket(location).build());
+    } catch (Exception e) {
+      throw new IOException(String.format("Unable to delete table location %s", location), e);
+    }
   }
 }

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -19,8 +19,6 @@ import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.ValidationException;
-import org.apache.iceberg.io.FileIO;
-import org.apache.iceberg.io.SupportsPrefixOperations;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -99,20 +97,7 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
           String.format("The table %s cannot be dropped due to the server side error:", identifier),
           houseTableRepositoryException);
     }
-    if (purge) {
-      // Delete data and metadata files from storage.
-      FileIO fileIO = fileIOManager.getFileIO(storageManager.getDefaultStorage().getType());
-      if (fileIO instanceof SupportsPrefixOperations) {
-        log.debug("Deleting files for table {}", tableLocation);
-        ((SupportsPrefixOperations) fileIO).deletePrefix(tableLocation);
-      } else {
-        log.debug(
-            "Failed to delete files for table {}. fileIO does not support prefix operations.",
-            tableLocation);
-        throw new UnsupportedOperationException(
-            "Drop table is supported only with a fileIO instance that SupportsPrefixOperations");
-      }
-    }
+
     return true;
   }
 

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/base/BaseStorageTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/base/BaseStorageTest.java
@@ -9,9 +9,13 @@ import com.linkedin.openhouse.cluster.storage.StorageClient;
 import com.linkedin.openhouse.cluster.storage.StorageType;
 import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
 import com.linkedin.openhouse.cluster.storage.hdfs.HdfsStorageClient;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import javax.annotation.PostConstruct;
 import lombok.Setter;
 import org.apache.hadoop.fs.FileSystem;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -92,6 +96,21 @@ public class BaseStorageTest {
     assertEquals(
         "hdfs:///data/openhouse/db1/table1-uuid1",
         baseStorage.allocateTableLocation(databaseId, tableId, tableUUID, tableCreator));
+  }
+
+  @Test
+  public void testDeallocateTableLocation() throws IOException {
+
+    Path dir = Files.createTempDirectory("test");
+    // Create some files and subdirectories within the test directory
+    Files.createFile(dir.resolve("file1.txt"));
+    Files.createFile(dir.resolve("file2.txt"));
+    Path subdir = Files.createDirectory(dir.resolve("subdir"));
+    Files.createFile(dir.resolve("subdir").resolve("file3.txt"));
+
+    baseStorage.deallocateTableLocation(dir.toString(), "tableCreator");
+    Assertions.assertFalse(Files.exists(dir));
+    Assertions.assertFalse(Files.exists(subdir));
   }
 
   void mockStorageProperties(String endpoint, String rootPrefix) {

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/local/LocalStorageTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/local/LocalStorageTest.java
@@ -9,8 +9,13 @@ import com.linkedin.openhouse.cluster.storage.StorageType;
 import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
 import com.linkedin.openhouse.cluster.storage.local.LocalStorage;
 import com.linkedin.openhouse.cluster.storage.local.LocalStorageClient;
+import java.io.IOException;
 import java.util.HashMap;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalFileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -96,5 +101,28 @@ public class LocalStorageTest {
     String expected = "/tmp/db1/table1-uuid1";
     assertEquals(
         expected, localStorage.allocateTableLocation(databaseId, tableId, tableUUID, tableCreator));
+  }
+
+  @Test
+  public void testDeallocateTableLocation() throws IOException {
+
+    String tableLocation = String.format("%s/db/table", this.getClass().getSimpleName());
+    FileSystem fs = FileSystem.get(new Configuration());
+    if (fs.exists(new Path(tableLocation))) {
+      fs.delete(new Path(tableLocation), true);
+    }
+    fs.mkdirs(new Path(tableLocation));
+    Assertions.assertTrue(fs.exists(new Path(tableLocation)));
+    String metadataLocation = String.format("%s/metadata", tableLocation);
+    fs.mkdirs(new Path(metadataLocation));
+    Assertions.assertTrue(fs.exists(new Path(metadataLocation)));
+    String dataLocation = String.format("%s/data", tableLocation);
+    fs.mkdirs(new Path(dataLocation));
+    Assertions.assertTrue(fs.exists(new Path(dataLocation)));
+    when(localStorageClient.getNativeClient()).thenReturn(fs);
+    localStorage.deallocateTableLocation(tableLocation, "tableCreator");
+    Assertions.assertFalse(fs.exists(new Path(tableLocation)));
+    Assertions.assertFalse(fs.exists(new Path(metadataLocation)));
+    Assertions.assertFalse(fs.exists(new Path(dataLocation)));
   }
 }


### PR DESCRIPTION
…etion logic from the catalog layer

## Summary
Added table location deletion logic in the Storage API layer. 
1. Created a Table deallocation method in the Storage interface for deleting table location along with implementations for various storages (LocalStorage, HdfsStorage, S3Storage)
2. Integrated the above logic into the catalog and repo layer. 

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  


## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Updated LocalStorgeTest and BaseStorageTest with testing for deallocateTableLocation
# Additional Information
- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
