### PR TITLE
Fix test failures caused by storage config

### DIFF
--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/hdfs/HdfsDelegationTokenRefresherDisabledTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/hdfs/HdfsDelegationTokenRefresherDisabledTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import lombok.SneakyThrows;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
@@ -73,5 +74,10 @@ public class HdfsDelegationTokenRefresherDisabledTest {
                   + "          token.refresh.schedule.cron: \"* * * * * ?\"");
       return yamlMapper.writeValueAsString(jsonNode);
     }
+  }
+
+  @AfterAll
+  static void unsetSysProp() {
+    System.clearProperty("OPENHOUSE_CLUSTER_CONFIG_PATH");
   }
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/hdfs/HdfsDelegationTokenRefresherEnabledTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/hdfs/HdfsDelegationTokenRefresherEnabledTest.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import lombok.SneakyThrows;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
@@ -95,5 +96,10 @@ public class HdfsDelegationTokenRefresherEnabledTest {
                   + "          token.refresh.schedule.cron: \"* * * * * ?\"");
       return yamlMapper.writeValueAsString(jsonNode);
     }
+  }
+
+  @AfterAll
+  static void unsetSysProp() {
+    System.clearProperty("OPENHOUSE_CLUSTER_CONFIG_PATH");
   }
 }


### PR DESCRIPTION
## Summary
Github build failed due to the following error:
```
TableUUIDGeneratorTest > testUUIDExtractedFromTablePropertySuccessfulCreateTable() FAILED
    java.net.ConnectException: Call From fv-az665-635/10.1.0.7 to localhost:9000 failed on connection exception: java.net.ConnectException: Connection refused; For more details see:  http://wiki.apache.org/hadoop/ConnectionRefused
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
        at org.apache.hadoop.net.NetUtils.wrapWithMessage(NetUtils.java:824)
        at org.apache.hadoop.net.NetUtils.wrapException(NetUtils.java:754)
        at org.apache.hadoop.ipc.Client.getRpcResponse(Client.java:1544)
        at org.apache.hadoop.ipc.Client.call(Client.java:1486)
        at org.apache.hadoop.ipc.Client.call(Client.java:1385)
        at org.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:232)
        at org.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:118)
        at com.sun.proxy.$Proxy285.create(Unknown Source)
        at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolTranslatorPB.create(ClientNamenodeProtocolTranslatorPB.java:301)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:422)
        at org.apache.hadoop.io.retry.RetryInvocationHandler$Call.invokeMethod(RetryInvocationHandler.java:165)
        at org.apache.hadoop.io.retry.RetryInvocationHandler$Call.invoke(RetryInvocationHandler.java:157)
        at org.apache.hadoop.io.retry.RetryInvocationHandler$Call.invokeOnce(RetryInvocationHandler.java:95)
        at org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:359)
        at com.sun.proxy.$Proxy286.create(Unknown Source)
        at org.apache.hadoop.hdfs.DFSOutputStream.newStreamForCreate(DFSOutputStream.java:267)
        at org.apache.hadoop.hdfs.DFSClient.create(DFSClient.java:1208)
        at org.apache.hadoop.hdfs.DFSClient.create(DFSClient.java:1150)
        at org.apache.hadoop.hdfs.DistributedFileSystem$8.doCall(DistributedFileSystem.java:474)
        at org.apache.hadoop.hdfs.DistributedFileSystem$8.doCall(DistributedFileSystem.java:471)
        at org.apache.hadoop.fs.FileSystemLinkResolver.resolve(FileSystemLinkResolver.java:81)
        at org.apache.hadoop.hdfs.DistributedFileSystem.create(DistributedFileSystem.java:471)
        at org.apache.hadoop.hdfs.DistributedFileSystem.create(DistributedFileSystem.java:412)
        at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:1067)
        at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:1048)
        at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:937)
        at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:925)
        at com.linkedin.openhouse.tables.mock.uuid.TableUUIDGeneratorTest.testUUIDExtractedFromTablePropertySuccessfulCreateTable(TableUUIDGeneratorTest.java:104)
```
At first glance, `TableUUIDGeneratorTest` is trying to connect to hdfs but it shouldn't. It turned out that we are using `ContextConfiguration` to customize the system property `OPENHOUSE_CLUSTER_CONFIG_PATH` for some tests to create a custom `StorageManager`. However, we forgot to clear the system property. Thus, one other test created the bean by reading into the wrong place, and it got used by `TableUUIDGeneratorTest`.

The reason why it doesn't fail locally is because of the order. Beans are reused as much as possible in springboot, so using system properties is dangerous. We must remember to clear them after the usage.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
