### PR TITLE
Allow overriding of loadFileIO

### DIFF
--- a/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
+++ b/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
@@ -121,13 +121,16 @@ public class OpenHouseCatalog extends BaseMetastoreCatalog
     this.snapshotApi = new SnapshotApi(apiClient);
     this.databaseApi = new DatabaseApi(apiClient);
 
-    String fileIOImpl = properties.get(CatalogProperties.FILE_IO_IMPL);
-    this.fileIO =
-        fileIOImpl == null
-            ? new HadoopFileIO(this.conf)
-            : CatalogUtil.loadFileIO(fileIOImpl, properties, this.conf);
+    this.fileIO = loadFileIO(properties);
 
     this.cluster = properties.getOrDefault(CLUSTER_PROPERTY, DEFAULT_CLUSTER);
+  }
+
+  protected FileIO loadFileIO(Map<String, String> properties) {
+    String fileIOImpl = properties.get(CatalogProperties.FILE_IO_IMPL);
+    return fileIOImpl == null
+        ? new HadoopFileIO(this.conf)
+        : CatalogUtil.loadFileIO(fileIOImpl, properties, this.conf);
   }
 
   /**


### PR DESCRIPTION
## Summary

In engines like Trino that use there own fileio implementation we want catalog implementation to be able to loadFileIO of their choice. The method loadFileIO can be overridden by the extension class. 

## Changes

- [X] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

Given catalog is a client facing API this is a API change but it is backward compatible.

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [X] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Existing tests passed. 

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
