### PR TITLE
Reverted mysql connector version pin

### DIFF
--- a/services/housetables/build.gradle
+++ b/services/housetables/build.gradle
@@ -32,7 +32,7 @@ dependencies {
   // See https://stackoverflow.com/questions/43574426 for details.
   implementation "jakarta.xml.bind:jakarta.xml.bind-api:2.3.2"
   implementation "org.glassfish.jaxb:jaxb-runtime:2.3.2"
-  implementation "mysql:mysql-connector-java:8.0.32"
+  implementation "mysql:mysql-connector-java:8.+"
   implementation "org.jetbrains:annotations:16.0.3"
   testImplementation(testFixtures(project(':services:common')))
 }


### PR DESCRIPTION
## Summary
Reverted mysql connector version pin which was done as part of the PR [#124](https://github.com/linkedin/openhouse/pull/124/files#diff-285e7477352b975161896329241cf301c0ade9019786b674afb66aa7110b4b1dR35). This was an ELR issue as the process could not determine the license for mysql:mysql-connector-java:8.0.32. 

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [x] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

Verified that `./gradlew clean build` works.

Verified that `./gradlew publishToMavenLocal -Pversion=1.0.6-snapshot` and LICENSE is present in the extracted jar.

```
anath1@anath1-mn1 jars % ls -lrt 
total 256
-rw-r--r--  1 anath1  101     203 Jul 26 15:58 NOTICE
-rw-r--r--  1 anath1  101    1329 Jul 26 15:58 LICENSE
-rw-r--r--  1 anath1  101    2116 Aug  5 11:45 schema.sql
-rw-r--r--  1 anath1  101     309 Aug  5 11:45 data.sql
drwxr-xr-x  3 anath1  101      96 Aug  5 11:45 com
-rw-r--r--  1 anath1  101     810 Aug  5 11:45 application.properties
drwxr-xr-x  3 anath1  101      96 Aug  5 12:06 META-INF
-rw-r--r--  1 anath1  101  109053 Aug  5 13:02 housetables-1.0.6-snapshot-lib.jar
```

Verified that latest mysql connector has the license. 

```
anath1@anath1-mn1 mysql % ls -lrt
total 5016
drwxr-xr-x  3 anath1  101       96 Mar  7  2023 com
-rw-r--r--  1 anath1  101     1628 Mar  7  2023 README
-rw-r--r--  1 anath1  101    71003 Mar  7  2023 LICENSE
-rw-r--r--  1 anath1  101      136 Mar  7  2023 INFO_SRC
-rw-r--r--  1 anath1  101      185 Mar  7  2023 INFO_BIN
drwxr-xr-x  5 anath1  101      160 Mar  7  2023 META-INF
-rw-r--r--  1 anath1  101  2481560 Aug  5 13:44 mysql-connector-j-8.0.33.jar
```

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
