### PR TITLE
Disable gradle 7 module metadata publication

### DIFF
--- a/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
+++ b/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
@@ -12,6 +12,10 @@ task javadocJar(type: Jar) {
   from javadoc.destinationDir
 }
 
+tasks.withType(GenerateModuleMetadata) {
+  enabled = false
+}
+
 [jar, sourcesJar, javadocJar].each { task ->
   task.from(rootDir) {
     include 'LICENSE'


### PR DESCRIPTION
## Summary
As part of gradle 7 update PR #124, observed that there is a change the way gradle manages the metadata and they are published as part of [module metadata](https://docs.gradle.org/current/userguide/publishing_gradle_module_metadata.html). So it generates and published separate `.module` file with dependencies and artifact details. As module metadata format is not internally supported within Linkedin, runtime dependencies defined for shadow (fat) jars are not pulled in automatically as part of build when OSS artifacts are applied internally. This PR disables module metadata publication so that ivy publication still works.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

**Gradle location publication works:**
```
anath1@anath1-mn1 openhouse % ./gradlew -V publishToMavenLocal -Pversion=1.0.8-snapshot
```

**Before the change in this PR:**

```
anath1@anath1-mn1 openhouse % ls -lrt ~/.m2/repository/com/linkedin/openhouse/openhouse-java-runtime/1.0.7-snapshot/
total 41352
-rw-r--r--  1 anath1  101      1509 Aug  5 13:20 maven-metadata-local.xml
-rw-r--r--  1 anath1  101     39625 Aug  5 13:20 openhouse-java-runtime-1.0.7-snapshot.jar
-rw-r--r--  1 anath1  101      3037 Aug  5 13:20 openhouse-java-runtime-1.0.7-snapshot.pom
-rw-r--r--  1 anath1  101      1288 Aug  5 13:20 openhouse-java-runtime-1.0.7-snapshot-javadoc.jar
-rw-r--r--  1 anath1  101  21089240 Aug  5 13:20 openhouse-java-runtime-1.0.7-snapshot-uber.jar
-rw-r--r--  1 anath1  101     20189 Aug  5 13:20 openhouse-java-runtime-1.0.7-snapshot-sources.jar
-rw-r--r--  1 anath1  101      4261 Aug  5 13:20 openhouse-java-runtime-1.0.7-snapshot.module
```

**After the change in this PR:**

```
anath1@anath1-mn1 openhouse % ls -lrt ~/.m2/repository/com/linkedin/openhouse/openhouse-java-runtime/1.0.8-snapshot/
total 41336
-rw-r--r--  1 anath1  101      1342 Aug  6 11:32 maven-metadata-local.xml
-rw-r--r--  1 anath1  101     39625 Aug  6 11:32 openhouse-java-runtime-1.0.8-snapshot.jar
-rw-r--r--  1 anath1  101      2680 Aug  6 11:32 openhouse-java-runtime-1.0.8-snapshot.pom
-rw-r--r--  1 anath1  101      1288 Aug  6 11:32 openhouse-java-runtime-1.0.8-snapshot-javadoc.jar
-rw-r--r--  1 anath1  101     20189 Aug  6 11:32 openhouse-java-runtime-1.0.8-snapshot-sources.jar
-rw-r--r--  1 anath1  101  21089240 Aug  6 11:32 openhouse-java-runtime-1.0.8-snapshot-uber.jar

```

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
