### PR TITLE
Fix runtime dependencies for shadow jars

### DIFF
--- a/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
+++ b/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
@@ -12,10 +12,6 @@ task javadocJar(type: Jar) {
   from javadoc.destinationDir
 }
 
-tasks.withType(GenerateModuleMetadata) {
-  enabled = false
-}
-
 [jar, sourcesJar, javadocJar].each { task ->
   task.from(rootDir) {
     include 'LICENSE'

--- a/infra/recipes/docker-compose/common/spark/spark-base-hadoop3.2.dockerfile
+++ b/infra/recipes/docker-compose/common/spark/spark-base-hadoop3.2.dockerfile
@@ -80,7 +80,7 @@ WORKDIR $LIVY_HOME
 RUN mkdir -p "${LIVY_HOME}/logs"
 
 COPY /infra/recipes/docker-compose/common/spark/start-spark.sh /
-COPY /build/openhouse-spark-runtime_2.12/libs/*[^sources][^javadoc].jar $SPARK_HOME/openhouse-spark-runtime_2.12-latest-all.jar
+COPY /build/openhouse-spark-runtime_2.12/libs/openhouse-spark-runtime_2.12-uber.jar $SPARK_HOME/openhouse-spark-runtime_2.12-latest-all.jar
 COPY /build/openhouse-spark-apps_2.12/libs/openhouse-spark-apps_2.12-uber.jar $SPARK_HOME/openhouse-spark-apps_2.12-latest-all.jar
 COPY /build/dummytokens/libs/dummytokens*.jar /dummytokens.jar
 RUN java -jar /dummytokens.jar -d /var/config/

--- a/integrations/java/openhouse-java-runtime/build.gradle
+++ b/integrations/java/openhouse-java-runtime/build.gradle
@@ -15,8 +15,7 @@ configurations {
     exclude(group: 'io.micrometer') // not used in client
     exclude(group: 'ch.qos.logback')
   }
-  fatJarRuntimeDependencies
-  shadow.extendsFrom fatJarRuntimeDependencies
+  shadow.extendsFrom implementation
 }
 
 ext {
@@ -34,8 +33,8 @@ dependencies {
 
   implementation 'org.apache.commons:commons-lang3:3.12.0'
   fatJarPackagedDependencies(project(':client:secureclient'))
-  fatJarRuntimeDependencies("org.apache.iceberg:iceberg-core:" + icebergVersion)
-  fatJarRuntimeDependencies("org.apache.hadoop:hadoop-client:" + hadoopVersion) {
+  implementation("org.apache.iceberg:iceberg-core:" + icebergVersion)
+  implementation("org.apache.hadoop:hadoop-client:" + hadoopVersion) {
     exclude group: 'junit', module: 'junit'
     exclude group: 'javax', module: 'servlet-api'
     exclude group: "io.netty"

--- a/integrations/spark/openhouse-spark-runtime/build.gradle
+++ b/integrations/spark/openhouse-spark-runtime/build.gradle
@@ -27,8 +27,7 @@ configurations {
     exclude(group: 'org.antlr') // included in spark
     exclude(group: 'org.mapstruct')
   }
-  fatJarRuntimeDependencies
-  shadow.extendsFrom fatJarRuntimeDependencies
+  shadow.extendsFrom implementation
 }
 
 
@@ -61,7 +60,7 @@ dependencies {
   fatJarPackagedDependencies(project(path: ':integrations:java:openhouse-java-runtime', configuration: 'shadow')) {
     transitive = false
   }
-  fatJarRuntimeDependencies("org.apache.iceberg:iceberg-spark-runtime-3.1_2.12:" + icebergVersion)
+  implementation("org.apache.iceberg:iceberg-spark-runtime-3.1_2.12:" + icebergVersion)
 
   generateGrammarSource {
     maxHeapSize = "64m"


### PR DESCRIPTION
## Summary
This is a follow up of the the previous PR #157 as the PR did not address the issue. After gradle 7 upgrade, observed that the `runtime` scoped dependencies for `openhouse-java-runtime` fat jar are listed as `compile` time dependency in `.pom` file after the publish. It seems custom `fatJarRuntimeDependencies` does not seem to be working as expected. Also the `.ivy` file generated as part of ELR process contains only the `implementation` configuration dependencies as runtime scoped dependencies and does not contain any dependency with compile time scope. As `hadoop-client` and `iceberg-core` both are listed as `compile` time scope dependency on `.pom` file, they are not present in the ELRed `.ivy` file.  Hence, changed the to dependency to `implementation` configuration from custom  `fatJarRuntimeDependencies`. This seem to include all the `implementation` configuration dependencies as runtime scoped jars but not bundled in the fat jar, which is good. 

Enabled back gradle module metadata publish as this is used in some other modules like storage. If the ELRed ivy file contains the required runtime dependencies gradle module metadata does not matter as this is internally not supported.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

**Gradle location publication works:**

```
anath1@anath1-mn1 openhouse % ./gradlew -V publishToMavenLocal -Pversion=1.0.10-snapshot
```
Here is the locally published pom file.
```
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <!-- This module was also published with a richer model, Gradle metadata,  -->
  <!-- which should be used instead. Do not delete the following line which  -->
  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
  <!-- that they should prefer consuming it instead. -->
  <!-- do_not_remove: published-with-gradle-metadata -->
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.linkedin.openhouse</groupId>
  <artifactId>openhouse-java-runtime</artifactId>
  <version>1.0.10-snapshot</version>
  <name>OpenHouse</name>
  <description>Control Plane for Tables in Open Data Lakehouse</description>
  <url>https://github.com/linkedin/openhouse</url>
  <licenses>
    <license>
      <name>BSD 2-Clause License</name>
      <url>https://raw.githubusercontent.com/linkedin/openhouse/main/LICENSE</url>
    </license>
  </licenses>
  <scm>
    <connection>scm:git:git://github.com/linkedin/openhouse.git</connection>
    <developerConnection>scm:git:ssh://github.com/linkedin/openhouse.git</developerConnection>
    <url>https://github.com/linkedin/openhouse</url>
  </scm>
  <dependencies>
    <dependency>
      <groupId>org.mapstruct</groupId>
      <artifactId>mapstruct</artifactId>
      <version>1.5.0.Beta1</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>javax.servlet</groupId>
      <artifactId>javax.servlet-api</artifactId>
      <version>4.0.1</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.apache.commons</groupId>
      <artifactId>commons-lang3</artifactId>
      <version>3.12.0</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.apache.iceberg</groupId>
      <artifactId>iceberg-core</artifactId>
      <version>1.2.0</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.apache.hadoop</groupId>
      <artifactId>hadoop-client</artifactId>
      <version>2.10.0</version>
      <scope>runtime</scope>
      <exclusions>
        <exclusion>
          <artifactId>servlet-api</artifactId>
          <groupId>javax</groupId>
        </exclusion>
        <exclusion>
          <artifactId>commons-lang3</artifactId>
          <groupId>org.apache.commons</groupId>
        </exclusion>
        <exclusion>
          <artifactId>junit</artifactId>
          <groupId>junit</groupId>
        </exclusion>
        <exclusion>
          <artifactId>*</artifactId>
          <groupId>io.netty</groupId>
        </exclusion>
        <exclusion>
          <artifactId>HikariCP-java7</artifactId>
          <groupId>com.zaxxer</groupId>
        </exclusion>

```

Verified using spark shell and the table operation works.

```
anath1@anath1-mn1 openhouse % docker exec -it local.spark-master /bin/bash
openhouse@b57e76233ba7:/opt/spark$ bin/spark-shell --packages org.apache.iceberg:iceberg-spark-runtime-3.1_2.12:1.2.0   \
>   --jars openhouse-spark-runtime_2.12-*-all.jar  \
>   --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,com.linkedin.openhouse.spark.extensions.OpenhouseSparkSessionExtensions   \
>   --conf spark.sql.catalog.openhouse=org.apache.iceberg.spark.SparkCatalog   \
>   --conf spark.sql.catalog.openhouse.catalog-impl=com.linkedin.openhouse.spark.OpenHouseCatalog     \
>   --conf spark.sql.catalog.openhouse.metrics-reporter-impl=com.linkedin.openhouse.javaclient.OpenHouseMetricsReporter    \
>   --conf spark.sql.catalog.openhouse.uri=http://openhouse-tables:8080   \
>   --conf spark.sql.catalog.openhouse.auth-token=$(cat /var/config/$(whoami).token) \
>   --conf spark.sql.catalog.openhouse.cluster=LocalHadoopCluster
:: loading settings :: url = jar:file:/opt/spark/jars/ivy-2.4.0.jar!/org/apache/ivy/core/settings/ivysettings.xml
Ivy Default Cache set to: /home/openhouse/.ivy2/cache
The jars for the packages stored in: /home/openhouse/.ivy2/jars
org.apache.iceberg#iceberg-spark-runtime-3.1_2.12 added as a dependency
:: resolving dependencies :: org.apache.spark#spark-submit-parent-59ba3ffc-81dd-4a58-a773-77c90adc3609;1.0
	confs: [default]
	found org.apache.iceberg#iceberg-spark-runtime-3.1_2.12;1.2.0 in central
downloading https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.1_2.12/1.2.0/iceberg-spark-runtime-3.1_2.12-1.2.0.jar ...
	[SUCCESSFUL ] org.apache.iceberg#iceberg-spark-runtime-3.1_2.12;1.2.0!iceberg-spark-runtime-3.1_2.12.jar (3484ms)
:: resolution report :: resolve 770ms :: artifacts dl 3486ms
	:: modules in use:
	org.apache.iceberg#iceberg-spark-runtime-3.1_2.12;1.2.0 from central in [default]
	---------------------------------------------------------------------
	|                  |            modules            ||   artifacts   |
	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
	---------------------------------------------------------------------
	|      default     |   1   |   1   |   1   |   0   ||   1   |   1   |
	---------------------------------------------------------------------
:: retrieving :: org.apache.spark#spark-submit-parent-59ba3ffc-81dd-4a58-a773-77c90adc3609
	confs: [default]
	1 artifacts copied, 0 already retrieved (26650kB/71ms)
2024-08-07 16:57:25,930 WARN util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
Spark context Web UI available at http://b57e76233ba7:4040
Spark context available as 'sc' (master = local[*], app id = local-1723049851016).
Spark session available as 'spark'.
Welcome to
      ____              __
     / __/__  ___ _____/ /__
    _\ \/ _ \/ _ `/ __/  '_/
   /___/ .__/\_,_/_/ /_/\_\   version 3.1.1
      /_/
         
Using Scala version 2.12.10 (OpenJDK 64-Bit Server VM, Java 1.8.0_232)
Type in expressions to have them evaluated.
Type :help for more information.

scala> spark.sql("CREATE TABLE openhouse.db.tb (ts timestamp, col1 string, col2 string) PARTITIONED BY (days(ts))").show()
++
||
++
++


scala> spark.sql("DESCRIBE TABLE openhouse.db.tb").show()
+--------------+---------+-------+
|      col_name|data_type|comment|
+--------------+---------+-------+
|            ts|timestamp|       |
|          col1|   string|       |
|          col2|   string|       |
|              |         |       |
|# Partitioning|         |       |
|        Part 0| days(ts)|       |
+--------------+---------+-------+


scala> spark.sql("INSERT INTO TABLE openhouse.db.tb VALUES (current_timestamp(), 'val1', 'val2')")
res2: org.apache.spark.sql.DataFrame = []                                       

scala> spark.sql("SELECT * FROM openhouse.db.tb").show()
+--------------------+----+----+
|                  ts|col1|col2|
+--------------------+----+----+
|2024-08-07 16:58:...|val1|val2|
+--------------------+----+----+

```

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
