### PR TITLE
Disable gradle 7 module metadata publication

### DIFF
--- a/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
+++ b/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
@@ -12,6 +12,10 @@ task javadocJar(type: Jar) {
   from javadoc.destinationDir
 }
 
+tasks.withType(GenerateModuleMetadata) {
+  enabled = false
+}
+
 [jar, sourcesJar, javadocJar].each { task ->
   task.from(rootDir) {
     include 'LICENSE'


### PR DESCRIPTION
## Summary

This previous PR #160 addresses the runtime dependencies for fat jar. The runtime dependencies are present in pom file, but not in ELRed ivy file. Instead they are present in gradle module metadata file. It seems ELR process is considering gradle module metadata file once they are published hence dependencies are not present is the ivy file. So disabling gradle module metadata publish.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

**Gradle location publication works:**

```
anath1@anath1-mn1 openhouse % ./gradlew -V publishToMavenLocal -Pversion=1.0.11-snapshot
```
**Before the change in this PR:**

```
anath1@anath1-mn1 openhouse % ls -lrt ~/.m2/repository/com/linkedin/openhouse/openhouse-java-runtime/1.0.7-snapshot/
total 41352
-rw-r--r--  1 anath1  101      1509 Aug  5 13:20 maven-metadata-local.xml
-rw-r--r--  1 anath1  101     39625 Aug  5 13:20 openhouse-java-runtime-1.0.7-snapshot.jar
-rw-r--r--  1 anath1  101      3037 Aug  5 13:20 openhouse-java-runtime-1.0.7-snapshot.pom
-rw-r--r--  1 anath1  101      1288 Aug  5 13:20 openhouse-java-runtime-1.0.7-snapshot-javadoc.jar
-rw-r--r--  1 anath1  101  21089240 Aug  5 13:20 openhouse-java-runtime-1.0.7-snapshot-uber.jar
-rw-r--r--  1 anath1  101     20189 Aug  5 13:20 openhouse-java-runtime-1.0.7-snapshot-sources.jar
-rw-r--r--  1 anath1  101      4261 Aug  5 13:20 openhouse-java-runtime-1.0.7-snapshot.module
```

**After the changes in the PR:**
```
anath1@anath1-mn1 openhouse % ls -lrt ~/.m2/repository/com/linkedin/openhouse/openhouse-java-runtime/1.0.11-snapshot/
total 41336
-rw-r--r--  1 anath1  101      1348 Aug  7 16:57 maven-metadata-local.xml
-rw-r--r--  1 anath1  101     39692 Aug  7 16:57 openhouse-java-runtime-1.0.11-snapshot.jar
-rw-r--r--  1 anath1  101      2617 Aug  7 16:57 openhouse-java-runtime-1.0.11-snapshot.pom
-rw-r--r--  1 anath1  101      1288 Aug  7 16:57 openhouse-java-runtime-1.0.11-snapshot-javadoc.jar
-rw-r--r--  1 anath1  101  21089501 Aug  7 16:57 openhouse-java-runtime-1.0.11-snapshot-uber.jar
-rw-r--r--  1 anath1  101     20231 Aug  7 16:57 openhouse-java-runtime-1.0.11-snapshot-sources.jar
```

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
