### PR TITLE
Rohitkumar/time filter

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.jobs.client;
 
+import com.linkedin.openhouse.jobs.util.CreationTimeFilter;
 import com.linkedin.openhouse.jobs.util.DatabaseTableFilter;
 import com.linkedin.openhouse.jobs.util.DirectoryMetadata;
 import com.linkedin.openhouse.jobs.util.RetentionConfig;
@@ -42,6 +43,7 @@ public class TablesClient {
   private final TableApi tableApi;
   private final DatabaseApi databaseApi;
   private final DatabaseTableFilter databaseFilter;
+  private final CreationTimeFilter creationTimeFilter;
   @VisibleForTesting private final StorageClient storageClient;
 
   public Optional<RetentionConfig> getTableRetention(TableMetadata tableMetadata) {
@@ -152,6 +154,7 @@ public class TablesClient {
                           .orElseGet(Stream::empty)
                           .map(this::mapTableResponseToTableMetadata)
                           .filter(databaseFilter::apply)
+                          .filter(creationTimeFilter::apply)
                           .collect(Collectors.toList());
                     },
                 Collections.emptyList()));

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
@@ -258,6 +258,7 @@ public class TablesClient {
         .creator(creator)
         .dbName(responseBody.getDatabaseId())
         .tableName(responseBody.getTableId())
+        .creationTime(responseBody.getCreationTime())
         .build();
   }
 

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClientFactory.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClientFactory.java
@@ -3,6 +3,7 @@ package com.linkedin.openhouse.jobs.client;
 import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.openhouse.client.ssl.TablesApiClientFactory;
 import com.linkedin.openhouse.cluster.storage.filesystem.FsStorageProvider;
+import com.linkedin.openhouse.jobs.util.CreationTimeFilter;
 import com.linkedin.openhouse.jobs.util.DatabaseTableFilter;
 import com.linkedin.openhouse.jobs.util.RetryUtil;
 import com.linkedin.openhouse.tables.client.api.DatabaseApi;
@@ -21,6 +22,7 @@ import org.springframework.retry.support.RetryTemplate;
 public class TablesClientFactory {
   private final String basePath;
   private final DatabaseTableFilter filter;
+  private final CreationTimeFilter timeFilter;
   private final @Nullable String token;
   protected final FsStorageProvider fsStorageProvider;
 
@@ -42,12 +44,12 @@ public class TablesClientFactory {
 
   public TablesClient create(RetryTemplate retryTemplate, TableApi tableApi, DatabaseApi dbApi) {
     return new TablesClient(
-        retryTemplate, tableApi, dbApi, filter, new StorageClient(fsStorageProvider));
+        retryTemplate, tableApi, dbApi, filter, timeFilter, new StorageClient(fsStorageProvider));
   }
 
   @VisibleForTesting
   public TablesClient create(
       RetryTemplate retryTemplate, TableApi tableApi, DatabaseApi dbApi, StorageClient client) {
-    return new TablesClient(retryTemplate, tableApi, dbApi, filter, client);
+    return new TablesClient(retryTemplate, tableApi, dbApi, filter, timeFilter, client);
   }
 }

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
@@ -12,6 +12,7 @@ import com.linkedin.openhouse.jobs.scheduler.tasks.OperationTasksBuilder;
 import com.linkedin.openhouse.jobs.scheduler.tasks.TableDirectoryOperationTask;
 import com.linkedin.openhouse.jobs.scheduler.tasks.TableOperationTask;
 import com.linkedin.openhouse.jobs.util.AppConstants;
+import com.linkedin.openhouse.jobs.util.CreationTimeFilter;
 import com.linkedin.openhouse.jobs.util.DatabaseTableFilter;
 import com.linkedin.openhouse.jobs.util.OtelConfig;
 import io.opentelemetry.api.common.AttributeKey;
@@ -278,6 +279,13 @@ public class JobsScheduler {
     options.addOption(
         Option.builder(null)
             .required(false)
+            .hasArg()
+            .longOpt("timeFilter")
+            .desc("Time in hour for filtering older tables, defaults to 1")
+            .build());
+    options.addOption(
+        Option.builder(null)
+            .required(false)
             .hasArg(false)
             .longOpt("dryRun")
             .desc("Dry run without actual action")
@@ -350,6 +358,8 @@ public class JobsScheduler {
         DatabaseTableFilter.of(
             cmdLine.getOptionValue("databaseFilter", ".*"),
             cmdLine.getOptionValue("tableFilter", ".*"));
+    CreationTimeFilter timeFilter =
+        CreationTimeFilter.of(Integer.parseInt(cmdLine.getOptionValue("timeFilter", "1")));
     ParameterizedHdfsStorageProvider hdfsStorageProvider =
         ParameterizedHdfsStorageProvider.of(
             cmdLine.getOptionValue("storageType", null),
@@ -357,7 +367,7 @@ public class JobsScheduler {
             cmdLine.getOptionValue("rootPath", null));
 
     return new TablesClientFactory(
-        cmdLine.getOptionValue("tablesURL"), filter, token, hdfsStorageProvider);
+        cmdLine.getOptionValue("tablesURL"), filter, timeFilter, token, hdfsStorageProvider);
   }
 
   protected static JobsClientFactory getJobsClientFactory(CommandLine cmdLine) {

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/CreationTimeFilter.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/CreationTimeFilter.java
@@ -3,6 +3,7 @@ package com.linkedin.openhouse.jobs.util;
 import java.util.concurrent.TimeUnit;
 import lombok.AllArgsConstructor;
 
+/** Filter class to collect table with creation time less than currentTime - cutoffHour */
 @AllArgsConstructor
 public class CreationTimeFilter implements TableFilter {
 

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/CreationTimeFilter.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/CreationTimeFilter.java
@@ -1,0 +1,20 @@
+package com.linkedin.openhouse.jobs.util;
+
+import java.util.concurrent.TimeUnit;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class CreationTimeFilter implements TableFilter {
+
+  private int cutoffHour;
+
+  public static CreationTimeFilter of(int timeInHour) {
+    return new CreationTimeFilter(timeInHour);
+  }
+
+  @Override
+  public boolean apply(TableMetadata metadata) {
+    return metadata.getCreationTime()
+        < System.currentTimeMillis() - TimeUnit.HOURS.toMillis(cutoffHour);
+  }
+}

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/DatabaseTableFilter.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/DatabaseTableFilter.java
@@ -4,7 +4,7 @@ import java.util.regex.Pattern;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
-public class DatabaseTableFilter {
+public class DatabaseTableFilter implements TableFilter {
   private final Pattern databasePattern;
   private final Pattern tablePattern;
 

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableFilter.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableFilter.java
@@ -1,0 +1,10 @@
+package com.linkedin.openhouse.jobs.util;
+
+public interface TableFilter {
+  /**
+   * Function to apply filtering condition on tableMetadata.
+   *
+   * @param tableMetadata
+   */
+  boolean apply(TableMetadata tableMetadata);
+}

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableMetadata.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableMetadata.java
@@ -10,12 +10,14 @@ import lombok.Getter;
 public class TableMetadata extends Metadata {
   String dbName;
   String tableName;
+  Long creationTime;
 
   @Builder
-  public TableMetadata(String creator, String dbName, String tableName) {
+  public TableMetadata(String creator, String dbName, String tableName, Long creationTime) {
     super(creator);
     this.dbName = dbName;
     this.tableName = tableName;
+    this.creationTime = creationTime;
   }
 
   @Override

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/clients/TablesClientTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/clients/TablesClientTest.java
@@ -121,6 +121,8 @@ public class TablesClientTest {
         (Mono<GetTableResponseBody>) Mockito.mock(Mono.class);
     Mono<GetTableResponseBody> partitionedTableResponseMock =
         (Mono<GetTableResponseBody>) Mockito.mock(Mono.class);
+    Mono<GetTableResponseBody> olderTableResponseMock =
+        (Mono<GetTableResponseBody>) Mockito.mock(Mono.class);
 
     Mockito.when(responseMock.block(any(Duration.class))).thenReturn(allTablesResponseBodyMock);
     Mockito.when(dbResponseMock.block(any(Duration.class)))
@@ -129,23 +131,36 @@ public class TablesClientTest {
         .thenReturn(unPartitionedTableResponseBodyMock);
     Mockito.when(partitionedTableResponseMock.block(any(Duration.class)))
         .thenReturn(partitionedTableResponseBodyMock);
+    Mockito.when(olderTableResponseMock.block(any(Duration.class)))
+        .thenReturn(olderTableResponseBodyMock);
     Mockito.when(dbApiMock.getAllDatabasesV1()).thenReturn(dbResponseMock);
     Mockito.when(apiMock.searchTablesV1(testDbName)).thenReturn(responseMock);
     Mockito.when(apiMock.getTableV1(testDbName, testTableNamePartitioned))
         .thenReturn(unPartitionedTableResponseMock);
     Mockito.when(apiMock.getTableV1(testDbName, testTableName))
         .thenReturn(partitionedTableResponseMock);
+    Mockito.when(apiMock.getTableV1(testDbName, testTableNameOlder))
+        .thenReturn(olderTableResponseMock);
     List<TableMetadata> tableMetadataList = client.getTables();
     Assertions.assertEquals(
         Arrays.asList(
-            TableMetadata.builder().dbName(testDbName).tableName(testTableName).build(),
-            TableMetadata.builder().dbName(testDbName).tableName(testTableNamePartitioned).build()),
+            TableMetadata.builder()
+                .dbName(testDbName)
+                .tableName(testTableName)
+                .creationTime(0L)
+                .build(),
+            TableMetadata.builder()
+                .dbName(testDbName)
+                .tableName(testTableNamePartitioned)
+                .creationTime(0L)
+                .build()),
         tableMetadataList);
     for (TableMetadata tableMetadata : tableMetadataList) {
       Assertions.assertFalse(tableMetadata.getTableName().contains(testTableNameOlder));
     }
     Mockito.verify(unPartitionedTableResponseMock, Mockito.times(1)).block(any(Duration.class));
     Mockito.verify(partitionedTableResponseMock, Mockito.times(1)).block(any(Duration.class));
+    Mockito.verify(olderTableResponseMock, Mockito.times(1)).block(any(Duration.class));
     Mockito.verify(responseMock, Mockito.times(1)).block(any(Duration.class));
     Mockito.verify(dbResponseMock, Mockito.times(1)).block(any(Duration.class));
     Mockito.verify(allTablesResponseBodyMock, Mockito.times(1)).getResults();


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->
JobsScheduler considers tables which are recently created also for running maintenance jobs. This has two concerns:

Newly created tables ( < 1 hour) seldom require maintenance hence launching jobs for them is un-neccesary
Some accounts which table creation process followed by immediate deletion lead to race conditions where jobs scheduler get a table but during spark job execution, the table may be deleted leading to job failures. Testing flows from downstream systems is one example which can lead to this case.
Solution:
Only consider tables which have spent significant time in Openhouse catalog.

Implementation:
Added integer timeFilter option in JobsScheduler cmd options which translates to hours before which a table should be created to be included in Job runs.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
