### PR TITLE
Tiny fix to javadoc for MetricsReporter

### DIFF
--- a/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseMetricsReporter.java
+++ b/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseMetricsReporter.java
@@ -10,8 +10,8 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 /**
  * OpenHouseMetricsReporter receives audit events from Iceberg commit and scan operations. Plugged
- * to OpenHouseCatalog by passing as metrics-reporter-impl=
- * com.linkedin.openhouse.spark.OpenHouseMetricsReporter property
+ * to OpenHouseCatalog by passing a property with the key metrics-reporter-impl=
+ * com.linkedin.openhouse.javaclient.OpenHouseMetricsReporter property
  */
 @Slf4j
 public class OpenHouseMetricsReporter implements MetricsReporter {


### PR DESCRIPTION
## Summary

We plumb metrics reporter as part of the catalog init. Javadoc had incorrect information about the package for the MetricsReporter implementation.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [X] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [X] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
