### PR TITLE
downgrading broken table client

### DIFF
--- a/client/common/codegen.build.gradle
+++ b/client/common/codegen.build.gradle
@@ -5,7 +5,7 @@ def commonDir = "${project(':client:common').projectDir}"
  * Change the service name to produce respective client
  */
 def serviceName = project.ext.get("codeGenForService")
-def openApiCliVersion = "6.6.0"
+def openApiCliVersion = "5.3.0"
 
 task setUp(type: Exec) {
   commandLine "sh", "$commonDir/jar_download.sh",


### PR DESCRIPTION
## Summary
rolling back openapi-cli version because it changes the default value of nullable fields and downstream consumers are affected.

> The issue is autogen field variable com.linkedin.openhouse.tables.client.model.Policies#columnTags has the initialized value from null to new HashMap<>. it should impact the default initialization value for all non-primitive optional field, so columnTags within policies is one of them. There shouldn't be an issue if we let users to pick up this autogen client but I am not 100% sure: The certain part here is, the persisted the metadata.json will now have this empty columnTag. Will that cause issue when someone is reading ? Probably, if they somehow had assumption for things like number of segments in policies object. My preference is to avoid this kind of uncertainty.



[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
