### PR TITLE
Add new exception hierarchy for WebClientException

### DIFF
--- a/integrations/java/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
+++ b/integrations/java/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
@@ -8,6 +8,7 @@ import com.linkedin.openhouse.gen.tables.client.model.CreateUpdateTableRequestBo
 import com.linkedin.openhouse.gen.tables.client.model.Policies;
 import com.linkedin.openhouse.gen.tables.client.model.PolicyTag;
 import com.linkedin.openhouse.gen.tables.client.model.Retention;
+import com.linkedin.openhouse.javaclient.exception.WebClientWithMessageException;
 import com.linkedin.openhouse.relocated.org.springframework.web.reactive.function.client.WebClientRequestException;
 import com.linkedin.openhouse.relocated.org.springframework.web.reactive.function.client.WebClientResponseException;
 import com.linkedin.openhouse.relocated.reactor.core.publisher.Mono;
@@ -107,7 +108,13 @@ public class OpenHouseTableOperationsTest {
     when(mockTableApi.updateTableV1(anyString(), anyString(), any()))
         .thenReturn(Mono.error(mock(WebClientRequestException.class)));
     Assertions.assertThrows(
-        CommitStateUnknownException.class, () -> openHouseTableOperations.doCommit(base, metadata));
+        WebClientWithMessageException.class,
+        () -> openHouseTableOperations.doCommit(base, metadata));
+    when(mockTableApi.updateTableV1(anyString(), anyString(), any()))
+        .thenReturn(Mono.error(mock(WebClientResponseException.class)));
+    Assertions.assertThrows(
+        WebClientWithMessageException.class,
+        () -> openHouseTableOperations.doCommit(base, metadata));
   }
 
   @Test

--- a/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
+++ b/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
@@ -7,6 +7,7 @@ import com.linkedin.openhouse.client.ssl.TablesApiClientFactory;
 import com.linkedin.openhouse.javaclient.api.SupportsGrantRevoke;
 import com.linkedin.openhouse.javaclient.builder.ClusteringSpecBuilder;
 import com.linkedin.openhouse.javaclient.builder.TimePartitionSpecBuilder;
+import com.linkedin.openhouse.javaclient.exception.WebClientRequestWithMessageException;
 import com.linkedin.openhouse.javaclient.exception.WebClientResponseWithMessageException;
 import com.linkedin.openhouse.javaclient.mapper.Privileges;
 import com.linkedin.openhouse.javaclient.mapper.SparkMapper;
@@ -54,6 +55,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.springframework.http.HttpHeaders;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -185,6 +187,9 @@ public class OpenHouseCatalog extends BaseMetastoreCatalog
             .onErrorResume(
                 WebClientResponseException.class,
                 e -> Mono.error(new WebClientResponseWithMessageException(e)))
+            .onErrorResume(
+                WebClientRequestException.class,
+                e -> Mono.error(new WebClientRequestWithMessageException(e)))
             .block();
     log.debug("Calling listTables succeeded");
     return tables;
@@ -214,6 +219,9 @@ public class OpenHouseCatalog extends BaseMetastoreCatalog
               e -> {
                 throw new WebClientResponseWithMessageException(e);
               })
+          .onErrorResume(
+              WebClientRequestException.class,
+              e -> Mono.error(new WebClientRequestWithMessageException(e)))
           .block();
 
     } catch (NoSuchTableException e) {
@@ -379,6 +387,9 @@ public class OpenHouseCatalog extends BaseMetastoreCatalog
         .onErrorResume(
             WebClientResponseException.class,
             e -> Mono.error(new WebClientResponseWithMessageException(e)))
+        .onErrorResume(
+            WebClientRequestException.class,
+            e -> Mono.error(new WebClientRequestWithMessageException(e)))
         .block();
     log.debug("Calling updateTableAclPolicies succeeded");
   }
@@ -396,6 +407,9 @@ public class OpenHouseCatalog extends BaseMetastoreCatalog
             .onErrorResume(
                 WebClientResponseException.class,
                 e -> Mono.error(new WebClientResponseWithMessageException(e)))
+            .onErrorResume(
+                WebClientRequestException.class,
+                e -> Mono.error(new WebClientRequestWithMessageException(e)))
             .blockOptional().map(GetAclPoliciesResponseBody::getResults)
             .orElse(Collections.emptyList()).stream()
             .map(SparkMapper::toAclPolicyDto)
@@ -432,6 +446,9 @@ public class OpenHouseCatalog extends BaseMetastoreCatalog
         .onErrorResume(
             WebClientResponseException.class,
             e -> Mono.error(new WebClientResponseWithMessageException(e)))
+        .onErrorResume(
+            WebClientRequestException.class,
+            e -> Mono.error(new WebClientRequestWithMessageException(e)))
         .block();
     log.debug("Calling updateDatabaseAclPolicies succeeded");
   }
@@ -448,6 +465,9 @@ public class OpenHouseCatalog extends BaseMetastoreCatalog
             .onErrorResume(
                 WebClientResponseException.class,
                 e -> Mono.error(new WebClientResponseWithMessageException(e)))
+            .onErrorResume(
+                WebClientRequestException.class,
+                e -> Mono.error(new WebClientRequestWithMessageException(e)))
             .blockOptional().map(GetAclPoliciesResponseBody::getResults)
             .orElse(Collections.emptyList()).stream()
             .map(SparkMapper::toAclPolicyDto)

--- a/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -298,6 +298,8 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
               casted, casted.getStatusCode().value() + " , " + casted.getResponseBodyAsString()));
     } else if (e instanceof WebClientResponseException) {
       return Mono.error(new WebClientResponseWithMessageException((WebClientResponseException) e));
+    } else if (e instanceof WebClientRequestException) {
+      return Mono.error(new WebClientRequestWithMessageException((WebClientRequestException) e));
     } else {
       /**
        * This serves as a catch-all for any unexpected exceptions that could occur during doCommit,

--- a/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -6,6 +6,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParseException;
 import com.linkedin.openhouse.javaclient.builder.ClusteringSpecBuilder;
 import com.linkedin.openhouse.javaclient.builder.TimePartitionSpecBuilder;
+import com.linkedin.openhouse.javaclient.exception.WebClientRequestWithMessageException;
 import com.linkedin.openhouse.javaclient.exception.WebClientResponseWithMessageException;
 import com.linkedin.openhouse.tables.client.api.SnapshotApi;
 import com.linkedin.openhouse.tables.client.api.TableApi;
@@ -32,6 +33,7 @@ import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.io.FileIO;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 
@@ -86,6 +88,9 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
             .onErrorResume(
                 WebClientResponseException.class,
                 e -> Mono.error(new WebClientResponseWithMessageException(e)))
+            .onErrorResume(
+                WebClientRequestException.class,
+                e -> Mono.error(new WebClientRequestWithMessageException(e)))
             .blockOptional();
     if (!tableLocation.isPresent() && currentMetadataLocation() != null) {
       throw new NoSuchTableException(

--- a/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/exception/WebClientRequestWithMessageException.java
+++ b/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/exception/WebClientRequestWithMessageException.java
@@ -1,0 +1,20 @@
+package com.linkedin.openhouse.javaclient.exception;
+
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+
+/**
+ * An exception thrown in Openhouse clients to indicate an error in a tables API request, acting as
+ * a wrapper around WebClientRequestException.
+ */
+public class WebClientRequestWithMessageException extends WebClientWithMessageException {
+  private final WebClientRequestException requestException;
+
+  public WebClientRequestWithMessageException(WebClientRequestException requestException) {
+    this.requestException = requestException;
+  }
+
+  @Override
+  public String getMessage() {
+    return requestException.getMessage();
+  }
+}

--- a/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/exception/WebClientResponseWithMessageException.java
+++ b/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/exception/WebClientResponseWithMessageException.java
@@ -20,7 +20,8 @@ public class WebClientResponseWithMessageException extends WebClientWithMessageE
    * WebClientResponseException} because the HttpRequest value is explicitly set to null in order to
    * have the message rewritten to not expose unnecessary data.
    */
-  public WebClientResponseException createWebClientResponseException(WebClientResponseException e) {
+  private WebClientResponseException createWebClientResponseException(
+      WebClientResponseException e) {
     return new WebClientResponseException(
         e.getRawStatusCode(),
         e.getStatusText(),

--- a/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/exception/WebClientResponseWithMessageException.java
+++ b/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/exception/WebClientResponseWithMessageException.java
@@ -8,10 +8,20 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
  *
  * <p>In this class we override the {@link #getMessage()} behavior, to append server response if it
  * exists. It doesn't change status code (ex: forbidden) or status int (ex. 403)
+ *
+ * <p>An exception thrown in Openhouse clients to indicate an error in a tables API request, acting
+ * as a wrapper around WebClientResponseException.
  */
-public class WebClientResponseWithMessageException extends WebClientResponseException {
-  public WebClientResponseWithMessageException(WebClientResponseException e) {
-    super(
+public class WebClientResponseWithMessageException extends WebClientWithMessageException {
+  private final WebClientResponseException responseException;
+
+  /**
+   * We want the response exception to go through the legacy constructor in {@link
+   * WebClientResponseException} because the HttpRequest value is explicitly set to null in order to
+   * have the message rewritten to not expose unnecessary data.
+   */
+  public WebClientResponseException createWebClientResponseException(WebClientResponseException e) {
+    return new WebClientResponseException(
         e.getRawStatusCode(),
         e.getStatusText(),
         e.getHeaders(),
@@ -19,10 +29,15 @@ public class WebClientResponseWithMessageException extends WebClientResponseExce
         Charset.defaultCharset());
   }
 
+  public WebClientResponseWithMessageException(WebClientResponseException exception) {
+    this.responseException = createWebClientResponseException(exception);
+  }
+
   @Override
   public String getMessage() {
-    return getResponseBodyAsString().isEmpty()
-        ? super.getMessage()
-        : String.format("%s , %s", super.getMessage(), getResponseBodyAsString());
+    return responseException.getResponseBodyAsString().isEmpty()
+        ? responseException.getMessage()
+        : String.format(
+            "%s , %s", responseException.getMessage(), responseException.getResponseBodyAsString());
   }
 }

--- a/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/exception/WebClientWithMessageException.java
+++ b/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/exception/WebClientWithMessageException.java
@@ -1,0 +1,9 @@
+package com.linkedin.openhouse.javaclient.exception;
+
+/**
+ * An exception thrown in Openhouse clients to indicate an error in a tables API response or
+ * request, acting as a wrapper around WebClientException.
+ */
+public abstract class WebClientWithMessageException extends RuntimeException {
+  public abstract String getMessage();
+}

--- a/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/ddl/CreateTableTest.java
+++ b/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/ddl/CreateTableTest.java
@@ -5,7 +5,7 @@ import static com.linkedin.openhouse.spark.SparkTestBase.baseSchema;
 import static com.linkedin.openhouse.spark.SparkTestBase.mockTableService;
 import static com.linkedin.openhouse.spark.SparkTestBase.spark;
 
-import com.linkedin.openhouse.relocated.org.springframework.web.reactive.function.client.WebClientResponseException;
+import com.linkedin.openhouse.javaclient.exception.WebClientWithMessageException;
 import com.linkedin.openhouse.spark.SparkTestBase;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
@@ -72,9 +72,9 @@ public class CreateTableTest {
         mockResponse(
             403,
             "{\"status\":\"FORBIDDEN\",\"error\":\"forbidden\",\"message\":\"Operation on database dbCreate failed as user sraikar is unauthorized\"}"));
-    WebClientResponseException exception =
+    WebClientWithMessageException exception =
         Assertions.assertThrows(
-            WebClientResponseException.class,
+            WebClientWithMessageException.class,
             () -> spark.sql("CREATE TABLE openhouse.dbCreate.tbError (col1 string, col2 string)"));
     Assertions.assertTrue(
         exception

--- a/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/ddl/DropTableTest.java
+++ b/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/ddl/DropTableTest.java
@@ -3,7 +3,7 @@ package com.linkedin.openhouse.spark.e2e.ddl;
 import static com.linkedin.openhouse.spark.MockHelpers.*;
 import static com.linkedin.openhouse.spark.SparkTestBase.*;
 
-import com.linkedin.openhouse.relocated.org.springframework.web.reactive.function.client.WebClientResponseException;
+import com.linkedin.openhouse.javaclient.exception.WebClientWithMessageException;
 import com.linkedin.openhouse.spark.SparkTestBase;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.spark.sql.AnalysisException;
@@ -95,9 +95,9 @@ public class DropTableTest {
         mockResponse(
             503,
             "{\"status\":\"SERVICE_UNAVAILABLE\",\"error\":\"Service Unavailable\",\"message\":\"Drop table failed as service is unavailable\"}"));
-    WebClientResponseException exception =
+    WebClientWithMessageException exception =
         Assertions.assertThrows(
-            WebClientResponseException.class, () -> spark.sql("DROP TABLE openhouse.dbDrop.t2"));
+            WebClientWithMessageException.class, () -> spark.sql("DROP TABLE openhouse.dbDrop.t2"));
     Assertions.assertTrue(
         exception.getMessage().contains("\"Drop table failed as service is unavailable"));
   }

--- a/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/dml/SelectFromTableTest.java
+++ b/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/dml/SelectFromTableTest.java
@@ -4,7 +4,7 @@ import static com.linkedin.openhouse.spark.MockHelpers.*;
 import static com.linkedin.openhouse.spark.SparkTestBase.*;
 
 import com.google.common.collect.ImmutableList;
-import com.linkedin.openhouse.relocated.org.springframework.web.reactive.function.client.WebClientResponseException;
+import com.linkedin.openhouse.javaclient.exception.WebClientWithMessageException;
 import com.linkedin.openhouse.spark.SparkTestBase;
 import java.sql.Timestamp;
 import java.util.List;
@@ -129,9 +129,9 @@ public class SelectFromTableTest {
         mockResponse(
             403,
             "{\"status\":\"FORBIDDEN\",\"error\":\"forbidden\",\"message\":\"Operation on table dbSelect.errorTbl failed as user sraikar is unauthorized\"}"));
-    WebClientResponseException exception =
+    WebClientWithMessageException exception =
         Assertions.assertThrows(
-            WebClientResponseException.class,
+            WebClientWithMessageException.class,
             () -> spark.sql("SELECT * FROM openhouse.dbSelect.errorTbl"));
     Assertions.assertTrue(
         exception

--- a/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/extensions/GrantStatementTest.java
+++ b/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/extensions/GrantStatementTest.java
@@ -6,7 +6,7 @@ import static com.linkedin.openhouse.spark.SparkTestBase.*;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import com.linkedin.openhouse.gen.tables.client.model.UpdateAclPoliciesRequestBody;
-import com.linkedin.openhouse.relocated.org.springframework.web.reactive.function.client.WebClientResponseException;
+import com.linkedin.openhouse.javaclient.exception.WebClientWithMessageException;
 import com.linkedin.openhouse.spark.SparkTestBase;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -170,8 +170,9 @@ public class GrantStatementTest {
             403,
             "{\"status\":\"FORBIDDEN\",\"error\":\"forbidden\",\"message\":\"Operation on table db.tb1 failed as user sraikar is unauthorized\"}"));
     String ddlWithSchema = "GRANT SELECT ON TABLE openhouse.dgrant.t1 TO sraikar";
-    WebClientResponseException exception =
-        Assertions.assertThrows(WebClientResponseException.class, () -> spark.sql(ddlWithSchema));
+    WebClientWithMessageException exception =
+        Assertions.assertThrows(
+            WebClientWithMessageException.class, () -> spark.sql(ddlWithSchema));
     Assertions.assertTrue(
         exception
             .getMessage()
@@ -182,13 +183,15 @@ public class GrantStatementTest {
             500,
             "{\"status\":\"INTERNAL_SERVER_ERROR\",\"error\":\"Internal Server Error\",\"message\":\"Something went wrong on the server\"}"));
     exception =
-        Assertions.assertThrows(WebClientResponseException.class, () -> spark.sql(ddlWithSchema));
+        Assertions.assertThrows(
+            WebClientWithMessageException.class, () -> spark.sql(ddlWithSchema));
     Assertions.assertTrue(exception.getMessage().contains("Something went wrong on the server"));
 
     // Test empty response
     mockTableService.enqueue(new MockResponse().setResponseCode(401));
     exception =
-        Assertions.assertThrows(WebClientResponseException.class, () -> spark.sql(ddlWithSchema));
+        Assertions.assertThrows(
+            WebClientWithMessageException.class, () -> spark.sql(ddlWithSchema));
     Assertions.assertTrue(exception.getMessage().equals("401 Unauthorized"));
   }
 

--- a/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/mock/DoRefreshTest.java
+++ b/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/mock/DoRefreshTest.java
@@ -4,8 +4,9 @@ import static com.linkedin.openhouse.spark.MockHelpers.*;
 import static com.linkedin.openhouse.spark.SparkTestBase.*;
 
 import com.linkedin.openhouse.javaclient.OpenHouseTableOperations;
-import com.linkedin.openhouse.relocated.org.springframework.web.reactive.function.client.WebClientResponseException;
+import com.linkedin.openhouse.javaclient.exception.WebClientWithMessageException;
 import com.linkedin.openhouse.spark.SparkTestBase;
+import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hadoop.HadoopFileIO;
@@ -69,7 +70,13 @@ public class DoRefreshTest {
   public void testSurfaceEveryOtherError() {
     for (int status : ImmutableList.of(408, 500)) {
       mockTableService.enqueue(mockResponse(status, mockGetAllTableResponseBody()));
-      Assertions.assertThrows(WebClientResponseException.class, () -> ops.doRefresh());
+      Assertions.assertThrows(WebClientWithMessageException.class, () -> ops.doRefresh());
     }
+  }
+
+  @Test
+  public void testConnectionRefusedError() throws IOException {
+    mockTableService.shutdown();
+    Assertions.assertThrows(WebClientWithMessageException.class, () -> ops.doRefresh());
   }
 }


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

Changed `WebClientResponseWithMessageException` and `WebClientRequestWithMessageException` to be composed of a new exception hierarchy starting from `WebClientWithMessageException`. This is a wrapped exception of `WebClientException`. This is done so that the shaded Spring dependency `WebClientException` is not exposed to end users.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
