### PR TITLE
Refactor dropTable in catalog to use Mono.error

### DIFF
--- a/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
+++ b/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
@@ -211,14 +211,10 @@ public class OpenHouseCatalog extends BaseMetastoreCatalog
           .deleteTableV1(identifier.namespace().toString(), identifier.name())
           .onErrorResume(
               WebClientResponseException.NotFound.class,
-              e -> {
-                throw new NoSuchTableException("Table " + identifier + " does not exist");
-              })
+              e -> Mono.error(new NoSuchTableException("Table " + identifier + " does not exist")))
           .onErrorResume(
               WebClientResponseException.class,
-              e -> {
-                throw new WebClientResponseWithMessageException(e);
-              })
+              e -> Mono.error(new WebClientResponseWithMessageException(e)))
           .onErrorResume(
               WebClientRequestException.class,
               e -> Mono.error(new WebClientRequestWithMessageException(e)))


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->
Refactor `dropTable` in OpenHouseCatalog to use `Mono.error()` instead of `throw new` to follow convention in the catalog. Change discussed in [this PR](url).

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
