### PR TITLE
Handle null case when table metadata is empty. Also increase timeout to 180 seconds

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
@@ -202,8 +202,12 @@ public class TablesClient {
                       return Optional.ofNullable(response.getResults())
                           .map(Collection::stream)
                           .orElseGet(Stream::empty)
-                          .map(this::mapTableResponseToTableMetadata)
-                          .filter(databaseFilter::apply)
+                          .flatMap(
+                              result ->
+                                  Optional.ofNullable(mapTableResponseToTableMetadata(result))
+                                      .filter(databaseFilter::apply)
+                                      .map(Stream::of)
+                                      .orElseGet(Stream::empty))
                           .collect(Collectors.toList());
                     },
                 Collections.emptyList()));
@@ -307,11 +311,7 @@ public class TablesClient {
 
     if (tableResponseBody == null) {
       log.error("Error while fetching metadata for table: {}", metadata);
-      return TableMetadata.builder()
-          .creator(null)
-          .dbName(responseBody.getDatabaseId())
-          .tableName(responseBody.getTableId())
-          .build();
+      return null;
     }
 
     String creator = tableResponseBody.getTableCreator();

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
@@ -38,7 +38,7 @@ import org.springframework.retry.support.RetryTemplate;
 @Slf4j
 @AllArgsConstructor
 public class TablesClient {
-  private static final int REQUEST_TIMEOUT_SECONDS = 60;
+  private static final int REQUEST_TIMEOUT_SECONDS = 180;
   private final RetryTemplate retryTemplate;
   private final TableApi tableApi;
   private final DatabaseApi databaseApi;
@@ -303,7 +303,18 @@ public class TablesClient {
             .tableName(responseBody.getTableId())
             .build();
 
-    String creator = getTable(metadata).getTableCreator();
+    GetTableResponseBody tableResponseBody = getTable(metadata);
+
+    if (tableResponseBody == null) {
+      log.error("Error while fetching metadata for table: {}", metadata);
+      return TableMetadata.builder()
+          .creator(null)
+          .dbName(responseBody.getDatabaseId())
+          .tableName(responseBody.getTableId())
+          .build();
+    }
+
+    String creator = tableResponseBody.getTableCreator();
     return TableMetadata.builder()
         .creator(creator)
         .dbName(responseBody.getDatabaseId())


### PR DESCRIPTION

## Summary

After retrieving list of tables in databases, it is possible for getTable call to error due to any intermittent issues or due to 404 if table was just deleted. But in this case, the responseBody is null and accessing tableCreator leads to NPE and thus failing to collect any table from the particular database. This PR returns null for creator in these cases and hence the client can move on to collect further tables in that database. Also 60 seconds seem less for a getTable call as it involves underlying storage, hts backend and also authorization component that is used. Hence increased to 180 seconds.


## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [X] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [X] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Existing tests passed. 
For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
