### PR TITLE
Introduced StorageSelector interface to StorageProperties

### DIFF
--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/configs/StorageProperties.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/configs/StorageProperties.java
@@ -30,6 +30,7 @@ import org.springframework.context.annotation.PropertySource;
 public class StorageProperties {
   private String defaultType;
   private Map<String, StorageTypeProperties> types;
+  private StorageSelectorProperties storageSelector;
 
   @Getter
   @Setter
@@ -39,6 +40,16 @@ public class StorageProperties {
   public static class StorageTypeProperties {
     private String rootPath;
     private String endpoint;
+    @Builder.Default private Map<String, String> parameters = new HashMap<>();
+  }
+
+  @Getter
+  @Setter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Builder(toBuilder = true)
+  public static class StorageSelectorProperties {
+    private String name;
     @Builder.Default private Map<String, String> parameters = new HashMap<>();
   }
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/BaseStorageSelector.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/BaseStorageSelector.java
@@ -1,0 +1,15 @@
+package com.linkedin.openhouse.cluster.storage.selector;
+
+import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/** An abstract class for all Storage selectors */
+public abstract class BaseStorageSelector implements StorageSelector {
+
+  @Autowired private StorageProperties storageProperties;
+
+  @Override
+  public String getName() {
+    return storageProperties.getStorageSelector().getName();
+  }
+}

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/BaseStorageSelector.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/BaseStorageSelector.java
@@ -1,15 +1,10 @@
 package com.linkedin.openhouse.cluster.storage.selector;
 
-import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
-import org.springframework.beans.factory.annotation.Autowired;
-
 /** An abstract class for all Storage selectors */
 public abstract class BaseStorageSelector implements StorageSelector {
 
-  @Autowired private StorageProperties storageProperties;
-
   @Override
   public String getName() {
-    return storageProperties.getStorageSelector().getName();
+    return this.getClass().getSimpleName();
   }
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/DefaultStorageSelector.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/DefaultStorageSelector.java
@@ -1,0 +1,27 @@
+package com.linkedin.openhouse.cluster.storage.selector;
+
+import com.linkedin.openhouse.cluster.storage.Storage;
+import com.linkedin.openhouse.cluster.storage.StorageManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * An implementation of {@link StorageSelector} that returns cluster level storage for all tables
+ */
+@Component
+public class DefaultStorageSelector extends BaseStorageSelector {
+
+  @Autowired private StorageManager storageManager;
+
+  /**
+   * Get the cluster level storage for all tables
+   *
+   * @param db
+   * @param table
+   * @return {@link Storage}
+   */
+  @Override
+  public Storage selectStorage(String db, String table) {
+    return storageManager.getDefaultStorage();
+  }
+}

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelector.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelector.java
@@ -1,0 +1,28 @@
+package com.linkedin.openhouse.cluster.storage.selector;
+
+import com.linkedin.openhouse.cluster.storage.Storage;
+
+/**
+ * The StorageSelector interface provides a way to select storage per table
+ *
+ * <p>Implementations of this interface can choose to return different storages for different db and
+ * tables For Example {@link DefaultStorageSelector} returns the cluster level storage for all
+ * tables
+ */
+public interface StorageSelector {
+  /**
+   * Select the storage for given db and table
+   *
+   * @param db
+   * @param table
+   * @return {@link Storage}
+   */
+  Storage selectStorage(String db, String table);
+
+  /**
+   * Get the Simple class name of the implementing class
+   *
+   * @return
+   */
+  String getName();
+}

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelector.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelector.java
@@ -11,7 +11,8 @@ import com.linkedin.openhouse.cluster.storage.Storage;
  */
 public interface StorageSelector {
   /**
-   * Select the storage for given db and table
+   * Select the storage for given db and table. This call should be idempotent, same db and table
+   * should return same storage
    *
    * @param db
    * @param table
@@ -20,9 +21,10 @@ public interface StorageSelector {
   Storage selectStorage(String db, String table);
 
   /**
-   * Get the Simple class name of the implementing class
+   * Get the Simple class name of the implementing class. This name will be used to configure the
+   * Storage Selector from cluster.yaml
    *
-   * @return
+   * @return Simple name of implementing class
    */
   String getName();
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelector.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelector.java
@@ -1,6 +1,7 @@
 package com.linkedin.openhouse.cluster.storage.selector;
 
 import com.linkedin.openhouse.cluster.storage.Storage;
+import com.linkedin.openhouse.cluster.storage.selector.impl.DefaultStorageSelector;
 
 /**
  * The StorageSelector interface provides a way to select storage per table

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelectorConfig.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelectorConfig.java
@@ -37,12 +37,16 @@ public class StorageSelectorConfig {
     // If storage selector or its name is not configured. Return DefaultStorageSelector.
     if (storageProperties.getStorageSelector() == null
         || storageProperties.getStorageSelector().getName() == null) {
+      log.info(
+          "storage selector or its name is not configured. Defaulting to {}",
+          DefaultStorageSelector.class.getSimpleName());
       return new DefaultStorageSelector();
     }
 
     String selectorName = storageProperties.getStorageSelector().getName();
     for (StorageSelector selector : storageSelectors) {
       if (selectorName.equals(selector.getName())) {
+        log.info("Found Storage Selector {}", selectorName);
         return selector;
       }
     }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelectorConfig.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelectorConfig.java
@@ -34,21 +34,17 @@ public class StorageSelectorConfig {
   @Primary
   StorageSelector provideStorageSelector() {
 
-    String selectorName;
-    try {
-      selectorName = storageProperties.getStorageSelector().getName();
-      for (StorageSelector selector : storageSelectors) {
-        if (selectorName.equals(selector.getName())) {
-          return selector;
-        }
-      }
-    } catch (NullPointerException e) {
-      // We get NPE if storage selector or its name is not configured. Return
-      // DefaultStorageSelector.
-      log.error(
-          "Missing storage selector config or name. Defaulting to {}.",
-          DefaultStorageSelector.class.getSimpleName());
+    // If storage selector or its name is not configured. Return DefaultStorageSelector.
+    if (storageProperties.getStorageSelector() == null
+        || storageProperties.getStorageSelector().getName() == null) {
       return new DefaultStorageSelector();
+    }
+
+    String selectorName = storageProperties.getStorageSelector().getName();
+    for (StorageSelector selector : storageSelectors) {
+      if (selectorName.equals(selector.getName())) {
+        return selector;
+      }
     }
 
     throw new IllegalArgumentException("Could not find Storage selector with name=" + selectorName);

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelectorConfig.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelectorConfig.java
@@ -1,0 +1,49 @@
+package com.linkedin.openhouse.cluster.storage.selector;
+
+import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configures the StorageSelector bean for storage-selector configured in {@link StorageProperties}
+ * The return value of the bean is the {@link StorageSelector} implementation that matches the name
+ * in storage-selector or is null if the storage selector is not configured.
+ */
+@Slf4j
+@Configuration
+public class StorageSelectorConfig {
+
+  @Autowired StorageProperties storageProperties;
+
+  @Autowired List<StorageSelector> storageSelectors;
+
+  /**
+   * Checks the name of storage-selector from {@link StorageProperties} against all implementations
+   * of {@link StorageSelector} and returns the implementation that matches the name. returns null
+   * if not configured
+   *
+   * @return
+   */
+  @Bean("StorageSelector")
+  StorageSelector provideStorageSelector() {
+    String selectorName;
+    try {
+      selectorName = storageProperties.getStorageSelector().getName();
+      for (StorageSelector selector : storageSelectors) {
+        if (selectorName.equals(selector.getName())) {
+          return selector;
+        }
+      }
+    } catch (Exception e) {
+      // if storage selector is not configured. Return null.
+      // Spring doesn't define the bean if the return value is null
+      log.error("Exception initializing Storage selector.");
+      return null;
+    }
+
+    throw new IllegalArgumentException("Could not find Storage selector with name=" + selectorName);
+  }
+}

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelectorConfig.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelectorConfig.java
@@ -1,6 +1,7 @@
 package com.linkedin.openhouse.cluster.storage.selector;
 
 import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
+import com.linkedin.openhouse.cluster.storage.selector.impl.DefaultStorageSelector;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,8 +11,9 @@ import org.springframework.context.annotation.Primary;
 
 /**
  * Configures the StorageSelector bean for storage-selector configured in {@link StorageProperties}
- * The return value of the bean is the {@link StorageSelector} implementation that matches the name
- * in storage-selector or is null if the storage selector is not configured.
+ * The return value of the bean is the {@link
+ * com.linkedin.openhouse.cluster.storage.selector.StorageSelector} implementation that matches the
+ * name in storage-selector or is null if the storage selector is not configured.
  */
 @Slf4j
 @Configuration
@@ -23,8 +25,8 @@ public class StorageSelectorConfig {
 
   /**
    * Checks the name of storage-selector from {@link StorageProperties} against all implementations
-   * of {@link StorageSelector} and returns the implementation that matches the name. Returns {@link
-   * DefaultStorageSelector}if not configured
+   * of {@link com.linkedin.openhouse.cluster.storage.selector.StorageSelector} and returns the
+   * implementation that matches the name. Returns {@link DefaultStorageSelector}if not configured
    *
    * @return
    */

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelectorConfig.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelectorConfig.java
@@ -23,6 +23,8 @@ public class StorageSelectorConfig {
 
   @Autowired List<StorageSelector> storageSelectors;
 
+  @Autowired DefaultStorageSelector defaultStorageSelector;
+
   /**
    * Checks the name of storage-selector from {@link StorageProperties} against all implementations
    * of {@link com.linkedin.openhouse.cluster.storage.selector.StorageSelector} and returns the
@@ -40,7 +42,7 @@ public class StorageSelectorConfig {
       log.info(
           "storage selector or its name is not configured. Defaulting to {}",
           DefaultStorageSelector.class.getSimpleName());
-      return new DefaultStorageSelector();
+      return defaultStorageSelector;
     }
 
     String selectorName = storageProperties.getStorageSelector().getName();

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/impl/DefaultStorageSelector.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/impl/DefaultStorageSelector.java
@@ -1,12 +1,15 @@
-package com.linkedin.openhouse.cluster.storage.selector;
+package com.linkedin.openhouse.cluster.storage.selector.impl;
 
 import com.linkedin.openhouse.cluster.storage.Storage;
 import com.linkedin.openhouse.cluster.storage.StorageManager;
+import com.linkedin.openhouse.cluster.storage.selector.BaseStorageSelector;
+import com.linkedin.openhouse.cluster.storage.selector.StorageSelector;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
- * An implementation of {@link StorageSelector} that returns cluster level storage for all tables
+ * An implementation of {@link StorageSelector} that returns storage that's marked as default-type
+ * for the cluster in yaml configuration for all tables
  */
 @Component
 public class DefaultStorageSelector extends BaseStorageSelector {
@@ -14,7 +17,7 @@ public class DefaultStorageSelector extends BaseStorageSelector {
   @Autowired private StorageManager storageManager;
 
   /**
-   * Get the cluster level storage for all tables
+   * Get default-type storage for all tables
    *
    * @param db
    * @param table

--- a/cluster/storage/src/test/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelectorConfigTest.java
+++ b/cluster/storage/src/test/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelectorConfigTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
+import com.linkedin.openhouse.cluster.storage.selector.impl.DefaultStorageSelector;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/cluster/storage/src/test/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelectorConfigTest.java
+++ b/cluster/storage/src/test/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelectorConfigTest.java
@@ -54,4 +54,15 @@ public class StorageSelectorConfigTest {
     assertThrows(
         IllegalArgumentException.class, () -> storageSelectorConfig.provideStorageSelector());
   }
+
+  @Test
+  public void testProvideStorageSelectorMissingConfig() {
+    when(selector1.getName()).thenReturn("selector1");
+    when(selector2.getName()).thenReturn("selector2");
+    storageSelectorConfig.storageSelectors = Arrays.asList(selector1, selector2);
+
+    assertEquals(
+        DefaultStorageSelector.class.getSimpleName(),
+        storageSelectorConfig.provideStorageSelector().getName());
+  }
 }

--- a/cluster/storage/src/test/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelectorConfigTest.java
+++ b/cluster/storage/src/test/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelectorConfigTest.java
@@ -1,0 +1,57 @@
+package com.linkedin.openhouse.cluster.storage.selector;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+
+public class StorageSelectorConfigTest {
+
+  @Mock private StorageProperties storageProperties;
+
+  @Mock private StorageProperties.StorageSelectorProperties storageSelectorProperties;
+
+  @Mock private StorageSelector selector1;
+
+  @Mock private StorageSelector selector2;
+
+  @InjectMocks private StorageSelectorConfig storageSelectorConfig;
+
+  @BeforeEach
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  public void testProvideStorageSelector_Found() {
+    when(storageSelectorProperties.getName()).thenReturn("selector1");
+    when(storageSelectorProperties.getParameters())
+        .thenReturn(ImmutableMap.of("key1", "value1", "key2", "value2"));
+    when(storageProperties.getStorageSelector()).thenReturn(storageSelectorProperties);
+    when(selector1.getName()).thenReturn("selector1");
+    when(selector2.getName()).thenReturn("selector2");
+    storageSelectorConfig.storageSelectors = Arrays.asList(selector1, selector2);
+
+    assertEquals(selector1, storageSelectorConfig.provideStorageSelector());
+  }
+
+  @Test
+  public void testProvideStorageSelectorNotFound() {
+    when(storageSelectorProperties.getName()).thenReturn("selector3");
+    when(storageProperties.getStorageSelector()).thenReturn(storageSelectorProperties);
+    when(selector1.getName()).thenReturn("selector1");
+    when(selector2.getName()).thenReturn("selector2");
+    storageSelectorConfig.storageSelectors = Arrays.asList(selector1, selector2);
+
+    assertThrows(
+        IllegalArgumentException.class, () -> storageSelectorConfig.provideStorageSelector());
+  }
+}

--- a/cluster/storage/src/test/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelectorConfigTest.java
+++ b/cluster/storage/src/test/java/com/linkedin/openhouse/cluster/storage/selector/StorageSelectorConfigTest.java
@@ -24,6 +24,8 @@ public class StorageSelectorConfigTest {
 
   @Mock private StorageSelector selector2;
 
+  @Mock private DefaultStorageSelector defaultStorageSelector;
+
   @InjectMocks private StorageSelectorConfig storageSelectorConfig;
 
   @BeforeEach
@@ -60,6 +62,8 @@ public class StorageSelectorConfigTest {
   public void testProvideStorageSelectorMissingConfig() {
     when(selector1.getName()).thenReturn("selector1");
     when(selector2.getName()).thenReturn("selector2");
+    when(defaultStorageSelector.getName()).thenReturn(DefaultStorageSelector.class.getSimpleName());
+    storageSelectorConfig.defaultStorageSelector = defaultStorageSelector;
     storageSelectorConfig.storageSelectors = Arrays.asList(selector1, selector2);
 
     assertEquals(

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/StoragePropertiesConfigTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/StoragePropertiesConfigTest.java
@@ -2,6 +2,7 @@ package com.linkedin.openhouse.tables.mock.storage;
 
 import com.linkedin.openhouse.cluster.storage.StorageManager;
 import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
+import com.linkedin.openhouse.cluster.storage.selector.DefaultStorageSelector;
 import com.linkedin.openhouse.tables.mock.properties.CustomClusterPropertiesInitializer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -17,7 +18,6 @@ public class StoragePropertiesConfigTest {
   @Autowired private StorageProperties storageProperties;
 
   @MockBean private StorageManager storageManager;
-
   private static final String DEFAULT_TYPE = "hdfs";
 
   private static final String DEFAULT_ENDPOINT = "hdfs://localhost:9000";
@@ -53,6 +53,20 @@ public class StoragePropertiesConfigTest {
   @Test
   public void testUnsetPropertiesAreNull() {
     Assertions.assertNull(storageProperties.getTypes().get(NON_EXISTING_TYPE));
+  }
+
+  @Test
+  public void testStorageSelector() {
+    Assertions.assertNotNull(storageProperties.getStorageSelector());
+    Assertions.assertEquals(
+        storageProperties.getStorageSelector().getName(),
+        DefaultStorageSelector.class.getSimpleName());
+    Assertions.assertNotNull(storageProperties.getStorageSelector().getParameters());
+    Assertions.assertEquals(storageProperties.getStorageSelector().getParameters().size(), 2);
+    Assertions.assertEquals(
+        storageProperties.getStorageSelector().getParameters().get("prop1"), "value1");
+    Assertions.assertEquals(
+        storageProperties.getStorageSelector().getParameters().get("prop2"), "value2");
   }
 
   @AfterAll

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/StoragePropertiesConfigTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/storage/StoragePropertiesConfigTest.java
@@ -2,7 +2,7 @@ package com.linkedin.openhouse.tables.mock.storage;
 
 import com.linkedin.openhouse.cluster.storage.StorageManager;
 import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
-import com.linkedin.openhouse.cluster.storage.selector.DefaultStorageSelector;
+import com.linkedin.openhouse.cluster.storage.selector.impl.DefaultStorageSelector;
 import com.linkedin.openhouse.tables.mock.properties.CustomClusterPropertiesInitializer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;

--- a/services/tables/src/test/resources/cluster-test-properties.yaml
+++ b/services/tables/src/test/resources/cluster-test-properties.yaml
@@ -16,6 +16,11 @@ cluster:
         parameters:
           key2: value2
           token: xyz
+    storage-selector:
+      name: "DefaultStorageSelector"
+      parameters:
+        prop1: "value1"
+        prop2: "value2"
   housetables:
     base-uri: "http://localhost:8080"
   tables:


### PR DESCRIPTION
## Summary

Introduce table level storage selection.

1. Introduced StorageSelector interface to allow the ability to select a storage (Hdfs, S3 etc) at table level
2. Added binding for it in StorageProperties. 
3. Added a default implementation "DefaultStorageSelector" that selects the cluster storage for all tables.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

1. Testing using yaml syntax in by adding a unit test in StoragePropertiesConfigTest
2. Tested by mocks in a new test case StorageSelectorConfigTest

