### PR TITLE
Add an option to enable/disable storage stats collection as part of TableStatsCollector

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -430,13 +430,15 @@ public final class Operations implements AutoCloseable {
    * Collect and publish table stats for a given fully-qualified table name.
    *
    * @param fqtn fully-qualified table name
+   * @param skipStorageStatsCollection whether to skip storage stats collection
    */
-  public IcebergTableStats collectTableStats(String fqtn) {
+  public IcebergTableStats collectTableStats(String fqtn, Boolean skipStorageStatsCollection) {
     Table table = getTable(fqtn);
 
     TableStatsCollector tableStatsCollector;
     try {
-      tableStatsCollector = new TableStatsCollector(fs(), spark, fqtn, table);
+      tableStatsCollector =
+          new TableStatsCollector(fs(), spark, fqtn, table, skipStorageStatsCollection);
     } catch (IOException e) {
       log.error("Unable to initialize file system for table stats collection", e);
       return null;

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableStatsCollector.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableStatsCollector.java
@@ -16,6 +16,7 @@ public class TableStatsCollector {
   private SparkSession spark;
   String fqtn;
   Table table;
+  Boolean skipStorageStatsCollection;
 
   /** Collect table stats. */
   public IcebergTableStats collectTableStats() {
@@ -29,6 +30,10 @@ public class TableStatsCollector {
     IcebergTableStats statsWithCurrentSnapshot =
         TableStatsCollectorUtil.populateStatsForSnapshots(
             fqtn, table, spark, statsWithReferenceFiles);
+
+    if (skipStorageStatsCollection) {
+      return statsWithCurrentSnapshot;
+    }
 
     IcebergTableStats tableStats =
         TableStatsCollectorUtil.populateStorageStats(fqtn, table, fs, statsWithCurrentSnapshot);

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -533,7 +533,7 @@ public class OperationsTest extends OpenHouseSparkITest {
     final int numInserts = 3;
     try (Operations ops = Operations.withCatalog(getSparkSession(), meter)) {
       prepareTable(ops, tableName);
-      IcebergTableStats stats = ops.collectTableStats(tableName);
+      IcebergTableStats stats = ops.collectTableStats(tableName, true);
 
       // Validate empty data files case
       Assertions.assertEquals(stats.getNumReferencedDataFiles(), 0);
@@ -541,7 +541,7 @@ public class OperationsTest extends OpenHouseSparkITest {
       long modifiedTimeStamp = System.currentTimeMillis();
 
       populateTable(ops, tableName, 1);
-      stats = ops.collectTableStats(tableName);
+      stats = ops.collectTableStats(tableName, true);
       Assertions.assertEquals(stats.getNumReferencedDataFiles(), 1);
       Assertions.assertTrue(stats.getTableLastUpdatedTimestamp() >= modifiedTimeStamp);
 
@@ -553,13 +553,15 @@ public class OperationsTest extends OpenHouseSparkITest {
       populateTable(ops, tableName, numInserts);
       table = ops.getTable(tableName);
       log.info("Loaded table {}, location {}", table.name(), table.location());
-      stats = ops.collectTableStats(tableName);
+      stats = ops.collectTableStats(tableName, true);
       Assertions.assertEquals(stats.getCurrentSnapshotId(), table.currentSnapshot().snapshotId());
       Assertions.assertEquals(stats.getNumReferencedDataFiles(), numInserts + 1);
       Assertions.assertEquals(stats.getNumExistingMetadataJsonFiles(), numInserts + 2);
       Assertions.assertEquals(
           stats.getCurrentSnapshotTimestamp(), table.currentSnapshot().timestampMillis());
       Assertions.assertEquals(stats.getOldestSnapshotTimestamp(), oldestSnapshot);
+      Assertions.assertEquals(stats.getNumObjectsInDirectory(), null);
+      stats = ops.collectTableStats(tableName, false);
       Assertions.assertEquals(
           stats.getNumObjectsInDirectory(),
           stats.getNumReferencedDataFiles()


### PR DESCRIPTION

## Summary

Storage stats computation can be expensive as this could involve recursive directory walk in the file system.  Hence making the storage stats computation optional so that this can be invoked as needed. 

## Changes

- [ ] Client-facing API Changes
- [X] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [X] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
