### PR TITLE
Use storage selector in create table path and fileio read path

### DIFF
--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/impl/DefaultStorageSelector.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/impl/DefaultStorageSelector.java
@@ -4,6 +4,7 @@ import com.linkedin.openhouse.cluster.storage.Storage;
 import com.linkedin.openhouse.cluster.storage.StorageManager;
 import com.linkedin.openhouse.cluster.storage.selector.BaseStorageSelector;
 import com.linkedin.openhouse.cluster.storage.selector.StorageSelector;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Component;
  * for the cluster in yaml configuration for all tables
  */
 @Component
+@Slf4j
 public class DefaultStorageSelector extends BaseStorageSelector {
 
   @Autowired private StorageManager storageManager;
@@ -25,6 +27,8 @@ public class DefaultStorageSelector extends BaseStorageSelector {
    */
   @Override
   public Storage selectStorage(String db, String table) {
-    return storageManager.getDefaultStorage();
+    Storage storage = storageManager.getDefaultStorage();
+    log.info("Selected storage type={} for {}.{}", storage.getType().getValue(), db, table);
+    return storage;
   }
 }

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -65,7 +65,6 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
   protected TableOperations newTableOps(TableIdentifier tableIdentifier) {
     return new OpenHouseInternalTableOperations(
         houseTableRepository,
-        fileIOManager,
         resolveFileIO(tableIdentifier),
         snapshotInspector,
         houseTableMapper,
@@ -167,7 +166,7 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
                   .build());
     } catch (HouseTableNotFoundException e) {
       log.info(
-          "House table not found {}.{}",
+          "House table entry not found {}.{}",
           tableIdentifier.namespace().toString(),
           tableIdentifier.name());
     }

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -5,8 +5,11 @@ import static com.linkedin.openhouse.internal.catalog.InternalCatalogMetricsCons
 
 import com.linkedin.openhouse.cluster.metrics.micrometer.MetricsReporter;
 import com.linkedin.openhouse.cluster.storage.StorageManager;
+import com.linkedin.openhouse.cluster.storage.StorageType;
+import com.linkedin.openhouse.cluster.storage.selector.StorageSelector;
 import com.linkedin.openhouse.internal.catalog.fileio.FileIOManager;
 import com.linkedin.openhouse.internal.catalog.mapper.HouseTableMapper;
+import com.linkedin.openhouse.internal.catalog.model.HouseTable;
 import com.linkedin.openhouse.internal.catalog.model.HouseTablePrimaryKey;
 import com.linkedin.openhouse.internal.catalog.repository.HouseTableRepository;
 import com.linkedin.openhouse.internal.catalog.repository.exception.HouseTableRepositoryException;
@@ -14,6 +17,7 @@ import com.linkedin.openhouse.internal.catalog.toggle.IcebergFeatureGate;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import lombok.extern.slf4j.Slf4j;
@@ -46,6 +50,10 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
 
   @Autowired StorageManager storageManager;
 
+  @Autowired StorageSelector storageSelector;
+
+  @Autowired StorageType storageType;
+
   @Autowired SnapshotInspector snapshotInspector;
 
   @Autowired HouseTableMapper houseTableMapper;
@@ -56,11 +64,12 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
   protected TableOperations newTableOps(TableIdentifier tableIdentifier) {
     return new OpenHouseInternalTableOperations(
         houseTableRepository,
-        fileIOManager.getFileIO(storageManager.getDefaultStorage().getType()),
+        getFileIO(tableIdentifier),
         snapshotInspector,
         houseTableMapper,
         tableIdentifier,
-        new MetricsReporter(this.meterRegistry, METRICS_PREFIX, Lists.newArrayList()));
+        new MetricsReporter(this.meterRegistry, METRICS_PREFIX, Lists.newArrayList()),
+        fileIOManager);
   }
 
   /** Overwritten for annotation purpose. */
@@ -137,5 +146,47 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
   @Override
   public void renameTable(TableIdentifier from, TableIdentifier to) {
     throw new UnsupportedOperationException("Rename Tables not implemented yet");
+  }
+
+  /**
+   * Get the file IO for a table. if table exists, return the fileIO for the storageType in hts else
+   * return the fileio for storageType returned by storage selector
+   *
+   * @param tableIdentifier
+   * @return fileIO
+   */
+  private FileIO getFileIO(TableIdentifier tableIdentifier) {
+    Optional<HouseTable> houseTable =
+        houseTableRepository.findById(
+            HouseTablePrimaryKey.builder()
+                .databaseId(tableIdentifier.namespace().toString())
+                .tableId(tableIdentifier.name())
+                .build());
+    StorageType.Type type;
+    if (houseTable.isPresent()) {
+      System.out.println(
+          String.format(
+              "Found house table %s.%s in hts with storage type %s",
+              houseTable.get().getDatabaseId(),
+              houseTable.get().getTableId(),
+              houseTable.get().getStorageType()));
+      type = storageType.fromString(houseTable.get().getStorageType());
+    } else {
+      System.out.println(
+          String.format(
+              "house table %s.%s not found in hts, selecting storage: %s",
+              tableIdentifier.namespace().toString(),
+              tableIdentifier.name(),
+              storageSelector
+                  .selectStorage(tableIdentifier.namespace().toString(), tableIdentifier.name())
+                  .getType()
+                  .toString()));
+      type =
+          storageSelector
+              .selectStorage(tableIdentifier.namespace().toString(), tableIdentifier.name())
+              .getType();
+    }
+
+    return fileIOManager.getFileIO(type);
   }
 }

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -162,30 +162,12 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
                 .databaseId(tableIdentifier.namespace().toString())
                 .tableId(tableIdentifier.name())
                 .build());
-    StorageType.Type type;
-    if (houseTable.isPresent()) {
-      System.out.println(
-          String.format(
-              "Found house table %s.%s in hts with storage type %s",
-              houseTable.get().getDatabaseId(),
-              houseTable.get().getTableId(),
-              houseTable.get().getStorageType()));
-      type = storageType.fromString(houseTable.get().getStorageType());
-    } else {
-      System.out.println(
-          String.format(
-              "house table %s.%s not found in hts, selecting storage: %s",
-              tableIdentifier.namespace().toString(),
-              tableIdentifier.name(),
-              storageSelector
-                  .selectStorage(tableIdentifier.namespace().toString(), tableIdentifier.name())
-                  .getType()
-                  .toString()));
-      type =
-          storageSelector
-              .selectStorage(tableIdentifier.namespace().toString(), tableIdentifier.name())
-              .getType();
-    }
+    StorageType.Type type =
+        houseTable.isPresent()
+            ? storageType.fromString(houseTable.get().getStorageType())
+            : storageSelector
+                .selectStorage(tableIdentifier.namespace().toString(), tableIdentifier.name())
+                .getType();
 
     return fileIOManager.getFileIO(type);
   }

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -7,6 +7,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.gson.Gson;
 import com.linkedin.openhouse.cluster.metrics.micrometer.MetricsReporter;
 import com.linkedin.openhouse.internal.catalog.exception.InvalidIcebergSnapshotException;
+import com.linkedin.openhouse.internal.catalog.fileio.FileIOManager;
 import com.linkedin.openhouse.internal.catalog.mapper.HouseTableMapper;
 import com.linkedin.openhouse.internal.catalog.model.HouseTable;
 import com.linkedin.openhouse.internal.catalog.model.HouseTablePrimaryKey;
@@ -59,6 +60,8 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
   TableIdentifier tableIdentifier;
 
   MetricsReporter metricsReporter;
+
+  FileIOManager fileIOManager;
 
   private static final Gson GSON = new Gson();
 
@@ -224,7 +227,8 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
           InternalCatalogMetricsConstant.METADATA_UPDATE_LATENCY);
 
       houseTable = houseTableMapper.toHouseTable(updatedMetadata);
-
+      // Set the storage type of table in house table before persisting in hts
+      houseTable.setStorageType(fileIOManager.getStorage(io()).getType().getValue());
       if (!isStageCreate) {
         houseTableRepository.save(houseTable);
       } else {

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -226,9 +226,7 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
               TableMetadataParser.write(updatedMtDataRef, io().newOutputFile(newMetadataLocation)),
           InternalCatalogMetricsConstant.METADATA_UPDATE_LATENCY);
 
-      houseTable = houseTableMapper.toHouseTable(updatedMetadata);
-      // Set the storage type of table in house table before persisting in hts
-      houseTable.setStorageType(fileIOManager.getStorage(fileIO).getType().getValue());
+      houseTable = houseTableMapper.toHouseTable(updatedMetadata, fileIO);
       if (!isStageCreate) {
         houseTableRepository.save(houseTable);
       } else {

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -7,7 +7,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.gson.Gson;
 import com.linkedin.openhouse.cluster.metrics.micrometer.MetricsReporter;
 import com.linkedin.openhouse.internal.catalog.exception.InvalidIcebergSnapshotException;
-import com.linkedin.openhouse.internal.catalog.fileio.FileIOManager;
 import com.linkedin.openhouse.internal.catalog.mapper.HouseTableMapper;
 import com.linkedin.openhouse.internal.catalog.model.HouseTable;
 import com.linkedin.openhouse.internal.catalog.model.HouseTablePrimaryKey;
@@ -50,8 +49,6 @@ import org.springframework.data.util.Pair;
 public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperations {
 
   HouseTableRepository houseTableRepository;
-
-  FileIOManager fileIOManager;
 
   FileIO fileIO;
 

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -51,6 +51,8 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
 
   HouseTableRepository houseTableRepository;
 
+  FileIOManager fileIOManager;
+
   FileIO fileIO;
 
   SnapshotInspector snapshotInspector;
@@ -60,8 +62,6 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
   TableIdentifier tableIdentifier;
 
   MetricsReporter metricsReporter;
-
-  FileIOManager fileIOManager;
 
   private static final Gson GSON = new Gson();
 
@@ -228,7 +228,7 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
 
       houseTable = houseTableMapper.toHouseTable(updatedMetadata);
       // Set the storage type of table in house table before persisting in hts
-      houseTable.setStorageType(fileIOManager.getStorage(io()).getType().getValue());
+      houseTable.setStorageType(fileIOManager.getStorage(fileIO).getType().getValue());
       if (!isStageCreate) {
         houseTableRepository.save(houseTable);
       } else {

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/mapper/HouseTableMapper.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/mapper/HouseTableMapper.java
@@ -4,22 +4,30 @@ import static com.linkedin.openhouse.internal.catalog.mapper.HouseTableSerdeUtil
 import static com.linkedin.openhouse.internal.catalog.mapper.HouseTableSerdeUtils.OPENHOUSE_NAMESPACE;
 
 import com.linkedin.openhouse.housetables.client.model.UserTable;
+import com.linkedin.openhouse.internal.catalog.fileio.FileIOManager;
 import com.linkedin.openhouse.internal.catalog.model.HouseTable;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.io.FileIO;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @Mapper(componentModel = "spring")
 public abstract class HouseTableMapper {
+  @Autowired FileIOManager fileIOManager;
+
   @Mapping(target = "lastModifiedTime", ignore = true)
   @Mapping(target = "creationTime", ignore = true)
-  public abstract HouseTable toHouseTable(Map<String, String> properties);
+  @Mapping(
+      target = "storageType",
+      expression = "java(fileIOManager.getStorage(fileIO).getType().getValue())")
+  public abstract HouseTable toHouseTable(Map<String, String> properties, FileIO fileIO);
 
-  public HouseTable toHouseTable(TableMetadata tableMetadata) {
-    return toHouseTable(extractRawHTSFields(tableMetadata.properties()));
+  public HouseTable toHouseTable(TableMetadata tableMetadata, FileIO fileIO) {
+    return toHouseTable(extractRawHTSFields(tableMetadata.properties()), fileIO);
   }
 
   @Mappings({@Mapping(target = "tableLocation", source = "userTable.metadataLocation")})

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/model/HouseTable.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/model/HouseTable.java
@@ -9,7 +9,6 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 /** Data Model for persisting Table Object in the HTS-Repository. */
 @Entity
@@ -47,7 +46,5 @@ public class HouseTable {
    * com.linkedin.openhouse.cluster.storage.StorageClient} implementation that is used to interact
    * with this table.
    */
-  // Fields that are not in table properties need to be set via setter explicitly
-  // see {@link com.linkedin.openhouse.internal.catalog.mapper.HouseTableMapper}
-  @Setter private String storageType;
+  private String storageType;
 }

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/model/HouseTable.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/model/HouseTable.java
@@ -1,6 +1,5 @@
 package com.linkedin.openhouse.internal.catalog.model;
 
-import com.linkedin.openhouse.cluster.storage.StorageType;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
@@ -10,6 +9,7 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /** Data Model for persisting Table Object in the HTS-Repository. */
 @Entity
@@ -47,5 +47,7 @@ public class HouseTable {
    * com.linkedin.openhouse.cluster.storage.StorageClient} implementation that is used to interact
    * with this table.
    */
-  @Builder.Default private String storageType = StorageType.HDFS.getValue();
+  // Fields that are not in table properties need to be set via setter explicitly
+  // see {@link com.linkedin.openhouse.internal.catalog.mapper.HouseTableMapper}
+  @Setter private String storageType;
 }

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
@@ -84,7 +84,6 @@ public class OpenHouseInternalTableOperationsTest {
     openHouseInternalTableOperations =
         new OpenHouseInternalTableOperations(
             mockHouseTableRepository,
-            fileIOManager,
             fileIO,
             Mockito.mock(SnapshotInspector.class),
             mockHouseTableMapper,

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
@@ -4,6 +4,9 @@ import static com.linkedin.openhouse.internal.catalog.mapper.HouseTableSerdeUtil
 import static org.mockito.Mockito.*;
 
 import com.linkedin.openhouse.cluster.metrics.micrometer.MetricsReporter;
+import com.linkedin.openhouse.cluster.storage.StorageType;
+import com.linkedin.openhouse.cluster.storage.local.LocalStorage;
+import com.linkedin.openhouse.internal.catalog.fileio.FileIOManager;
 import com.linkedin.openhouse.internal.catalog.mapper.HouseTableMapper;
 import com.linkedin.openhouse.internal.catalog.model.HouseTable;
 import com.linkedin.openhouse.internal.catalog.repository.HouseTableRepository;
@@ -63,6 +66,7 @@ public class OpenHouseInternalTableOperationsTest {
   @Mock private HouseTableMapper mockHouseTableMapper;
   @Mock private HouseTable mockHouseTable;
   @Captor private ArgumentCaptor<TableMetadata> tblMetadataCaptor;
+  @Mock private FileIOManager fileIOManager;
 
   private OpenHouseInternalTableOperations openHouseInternalTableOperations;
 
@@ -76,14 +80,20 @@ public class OpenHouseInternalTableOperationsTest {
     MockitoAnnotations.openMocks(this);
     Mockito.when(mockHouseTableMapper.toHouseTable(Mockito.any(TableMetadata.class)))
         .thenReturn(mockHouseTable);
+    HadoopFileIO fileIO = new HadoopFileIO(new Configuration());
     openHouseInternalTableOperations =
         new OpenHouseInternalTableOperations(
             mockHouseTableRepository,
-            new HadoopFileIO(new Configuration()),
+            fileIO,
             Mockito.mock(SnapshotInspector.class),
             mockHouseTableMapper,
             TEST_TABLE_IDENTIFIER,
-            new MetricsReporter(new SimpleMeterRegistry(), "TEST_CATALOG", Lists.newArrayList()));
+            new MetricsReporter(new SimpleMeterRegistry(), "TEST_CATALOG", Lists.newArrayList()),
+            fileIOManager);
+    LocalStorage localStorage = mock(LocalStorage.class);
+    when(fileIOManager.getStorage(fileIO)).thenReturn(localStorage);
+    when(localStorage.getType()).thenReturn(StorageType.LOCAL);
+    // when(localStorage.getType()).thenReturn(StorageType.LOCAL);
   }
 
   @Test

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
@@ -78,7 +78,7 @@ public class OpenHouseInternalTableOperationsTest {
   @BeforeEach
   void setup() {
     MockitoAnnotations.openMocks(this);
-    Mockito.when(mockHouseTableMapper.toHouseTable(Mockito.any(TableMetadata.class)))
+    Mockito.when(mockHouseTableMapper.toHouseTable(Mockito.any(TableMetadata.class), Mockito.any()))
         .thenReturn(mockHouseTable);
     HadoopFileIO fileIO = new HadoopFileIO(new Configuration());
     openHouseInternalTableOperations =
@@ -111,7 +111,7 @@ public class OpenHouseInternalTableOperationsTest {
 
       TableMetadata metadata = BASE_TABLE_METADATA.replaceProperties(properties);
       openHouseInternalTableOperations.doCommit(BASE_TABLE_METADATA, metadata);
-      Mockito.verify(mockHouseTableMapper).toHouseTable(tblMetadataCaptor.capture());
+      Mockito.verify(mockHouseTableMapper).toHouseTable(tblMetadataCaptor.capture(), Mockito.any());
 
       Map<String, String> updatedProperties = tblMetadataCaptor.getValue().properties();
       Assertions.assertEquals(
@@ -152,7 +152,7 @@ public class OpenHouseInternalTableOperationsTest {
 
       TableMetadata metadata = base.replaceProperties(properties);
       openHouseInternalTableOperations.doCommit(base, metadata);
-      Mockito.verify(mockHouseTableMapper).toHouseTable(tblMetadataCaptor.capture());
+      Mockito.verify(mockHouseTableMapper).toHouseTable(tblMetadataCaptor.capture(), Mockito.any());
 
       Map<String, String> updatedProperties = tblMetadataCaptor.getValue().properties();
       Assertions.assertEquals(
@@ -202,7 +202,7 @@ public class OpenHouseInternalTableOperationsTest {
 
       TableMetadata metadata = base.replaceProperties(properties);
       openHouseInternalTableOperations.doCommit(base, metadata);
-      Mockito.verify(mockHouseTableMapper).toHouseTable(tblMetadataCaptor.capture());
+      Mockito.verify(mockHouseTableMapper).toHouseTable(tblMetadataCaptor.capture(), Mockito.any());
 
       Map<String, String> updatedProperties = tblMetadataCaptor.getValue().properties();
       Assertions.assertEquals(
@@ -256,7 +256,7 @@ public class OpenHouseInternalTableOperationsTest {
 
       TableMetadata metadata = base.replaceProperties(properties);
       openHouseInternalTableOperations.doCommit(base, metadata);
-      Mockito.verify(mockHouseTableMapper).toHouseTable(tblMetadataCaptor.capture());
+      Mockito.verify(mockHouseTableMapper).toHouseTable(tblMetadataCaptor.capture(), Mockito.any());
 
       Map<String, String> updatedProperties = tblMetadataCaptor.getValue().properties();
       Assertions.assertEquals(
@@ -369,7 +369,7 @@ public class OpenHouseInternalTableOperationsTest {
 
       TableMetadata metadata = BASE_TABLE_METADATA.replaceProperties(properties);
       openHouseInternalTableOperations.doCommit(BASE_TABLE_METADATA, metadata);
-      Mockito.verify(mockHouseTableMapper).toHouseTable(tblMetadataCaptor.capture());
+      Mockito.verify(mockHouseTableMapper).toHouseTable(tblMetadataCaptor.capture(), Mockito.any());
       Map<String, String> updatedProperties = tblMetadataCaptor.getValue().properties();
 
       // verify snapshots are staged but not appended
@@ -414,7 +414,7 @@ public class OpenHouseInternalTableOperationsTest {
 
       TableMetadata metadata = base.replaceProperties(properties);
       openHouseInternalTableOperations.doCommit(base, metadata);
-      Mockito.verify(mockHouseTableMapper).toHouseTable(tblMetadataCaptor.capture());
+      Mockito.verify(mockHouseTableMapper).toHouseTable(tblMetadataCaptor.capture(), Mockito.any());
       Map<String, String> updatedProperties = tblMetadataCaptor.getValue().properties();
 
       // verify snapshots are staged but not appended
@@ -504,7 +504,7 @@ public class OpenHouseInternalTableOperationsTest {
 
       TableMetadata metadata = base.replaceProperties(properties);
       openHouseInternalTableOperations.doCommit(base, metadata);
-      Mockito.verify(mockHouseTableMapper).toHouseTable(tblMetadataCaptor.capture());
+      Mockito.verify(mockHouseTableMapper).toHouseTable(tblMetadataCaptor.capture(), Mockito.any());
       Map<String, String> updatedProperties = tblMetadataCaptor.getValue().properties();
 
       // verify the staged snapshot is cherry picked by use the existing one
@@ -545,7 +545,7 @@ public class OpenHouseInternalTableOperationsTest {
 
       TableMetadata metadata = base.replaceProperties(properties);
       openHouseInternalTableOperations.doCommit(base, metadata);
-      Mockito.verify(mockHouseTableMapper).toHouseTable(tblMetadataCaptor.capture());
+      Mockito.verify(mockHouseTableMapper).toHouseTable(tblMetadataCaptor.capture(), Mockito.any());
       Map<String, String> updatedProperties = tblMetadataCaptor.getValue().properties();
 
       // verify the staged snapshot is cherry picked by creating a new snapshot and append it
@@ -583,7 +583,7 @@ public class OpenHouseInternalTableOperationsTest {
 
       TableMetadata metadata = base.replaceProperties(properties);
       openHouseInternalTableOperations.doCommit(base, metadata);
-      Mockito.verify(mockHouseTableMapper).toHouseTable(tblMetadataCaptor.capture());
+      Mockito.verify(mockHouseTableMapper).toHouseTable(tblMetadataCaptor.capture(), Mockito.any());
       Map<String, String> updatedProperties = tblMetadataCaptor.getValue().properties();
 
       // verify the staged snapshot is cherry picked by using the existing one
@@ -614,7 +614,7 @@ public class OpenHouseInternalTableOperationsTest {
 
       TableMetadata metadata = base.replaceProperties(properties);
       openHouseInternalTableOperations.doCommit(base, metadata);
-      Mockito.verify(mockHouseTableMapper).toHouseTable(tblMetadataCaptor.capture());
+      Mockito.verify(mockHouseTableMapper).toHouseTable(tblMetadataCaptor.capture(), Mockito.any());
       Map<String, String> updatedProperties = tblMetadataCaptor.getValue().properties();
 
       // verify nothing happens

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
@@ -84,16 +84,15 @@ public class OpenHouseInternalTableOperationsTest {
     openHouseInternalTableOperations =
         new OpenHouseInternalTableOperations(
             mockHouseTableRepository,
+            fileIOManager,
             fileIO,
             Mockito.mock(SnapshotInspector.class),
             mockHouseTableMapper,
             TEST_TABLE_IDENTIFIER,
-            new MetricsReporter(new SimpleMeterRegistry(), "TEST_CATALOG", Lists.newArrayList()),
-            fileIOManager);
+            new MetricsReporter(new SimpleMeterRegistry(), "TEST_CATALOG", Lists.newArrayList()));
     LocalStorage localStorage = mock(LocalStorage.class);
     when(fileIOManager.getStorage(fileIO)).thenReturn(localStorage);
     when(localStorage.getType()).thenReturn(StorageType.LOCAL);
-    // when(localStorage.getType()).thenReturn(StorageType.LOCAL);
   }
 
   @Test

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/mapper/HouseTableMapperTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/mapper/HouseTableMapperTest.java
@@ -1,14 +1,25 @@
 package com.linkedin.openhouse.internal.catalog.mapper;
 
+import static org.mockito.Mockito.*;
+
+import com.linkedin.openhouse.cluster.storage.StorageType;
+import com.linkedin.openhouse.cluster.storage.local.LocalStorage;
 import com.linkedin.openhouse.housetables.client.api.ToggleStatusApi;
 import com.linkedin.openhouse.housetables.client.api.UserTableApi;
 import com.linkedin.openhouse.housetables.client.invoker.ApiClient;
+import com.linkedin.openhouse.internal.catalog.fileio.FileIOManager;
+import com.linkedin.openhouse.internal.catalog.model.HouseTable;
 import com.linkedin.openhouse.internal.catalog.repository.HouseTableRepository;
 import com.linkedin.openhouse.internal.catalog.repository.HouseTableRepositoryImpl;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
 @SpringBootTest
 public class HouseTableMapperTest {
@@ -43,4 +54,20 @@ public class HouseTableMapperTest {
   }
 
   @Autowired protected HouseTableMapper houseTableMapper;
+
+  @Autowired FileIOManager fileIOManager;
+
+  @Test
+  public void simpleMapperTest() {
+    HadoopFileIO fileIO = new HadoopFileIO(new Configuration());
+    LocalStorage localStorage = mock(LocalStorage.class);
+    when(fileIOManager.getStorage(fileIO)).thenReturn(localStorage);
+    when(localStorage.getType()).thenReturn(StorageType.LOCAL);
+    HouseTable houseTable =
+        houseTableMapper.toHouseTable(
+            ImmutableMap.of("databaseId", "openhouse.database", "tableId", "table"), fileIO);
+    Assertions.assertEquals("database", houseTable.getDatabaseId());
+    Assertions.assertEquals("table", houseTable.getTableId());
+    Assertions.assertEquals("local", houseTable.getStorageType());
+  }
 }

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/model/HouseTableTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/model/HouseTableTest.java
@@ -1,6 +1,5 @@
 package com.linkedin.openhouse.internal.catalog.model;
 
-import com.linkedin.openhouse.cluster.storage.StorageType;
 import com.linkedin.openhouse.internal.catalog.mapper.HouseTableSerdeUtils;
 import java.beans.BeanInfo;
 import java.beans.Introspector;
@@ -33,9 +32,7 @@ public class HouseTableTest {
             continue;
           }
 
-          if (fieldName.equals("storageType")) {
-            Assertions.assertEquals(StorageType.HDFS.getValue(), value);
-          } else if (fieldName.equals("creationTime")) {
+          if (fieldName.equals("creationTime")) {
             Assertions.assertEquals(0L, value);
           } else if (fieldName.equals("lastModifiedTime")) {
             Assertions.assertEquals(0L, value);

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepositoryImplTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepositoryImplTest.java
@@ -125,6 +125,7 @@ public class HouseTableRepositoryImplTest {
     Assertions.assertEquals(result.getDatabaseId(), HOUSE_TABLE.getDatabaseId());
     Assertions.assertEquals(result.getTableLocation(), HOUSE_TABLE.getTableLocation());
     Assertions.assertEquals(result.getTableVersion(), HOUSE_TABLE.getTableVersion());
+    Assertions.assertEquals(result.getStorageType(), HOUSE_TABLE.getStorageType());
   }
 
   @Test

--- a/iceberg/openhouse/internalcatalog/src/testFixtures/java/com/linkedin/openhouse/internal/catalog/HouseTableModelConstants.java
+++ b/iceberg/openhouse/internalcatalog/src/testFixtures/java/com/linkedin/openhouse/internal/catalog/HouseTableModelConstants.java
@@ -25,6 +25,7 @@ public class HouseTableModelConstants {
           .tableLocation("loc1")
           .tableVersion(String.valueOf(new Random().nextLong()))
           .tableUUID(UUID.randomUUID().toString())
+          .storageType("local")
           .build();
 
   public static final HouseTable HOUSE_TABLE_SAME_DB =
@@ -36,6 +37,7 @@ public class HouseTableModelConstants {
           .tableLocation("loc2")
           .tableVersion(String.valueOf(new Random().nextLong()))
           .tableUUID(UUID.randomUUID().toString())
+          .storageType("local")
           .build();
 
   public static final HouseTable HOUSE_TABLE_DIFF_DB =
@@ -47,5 +49,6 @@ public class HouseTableModelConstants {
           .tableLocation("loc3")
           .tableVersion(String.valueOf(new Random().nextLong()))
           .tableUUID(UUID.randomUUID().toString())
+          .storageType("local")
           .build();
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -11,6 +11,7 @@ import com.google.common.collect.Maps;
 import com.google.gson.GsonBuilder;
 import com.linkedin.openhouse.cluster.configs.ClusterProperties;
 import com.linkedin.openhouse.cluster.storage.StorageManager;
+import com.linkedin.openhouse.cluster.storage.selector.StorageSelector;
 import com.linkedin.openhouse.common.api.validator.ValidatorConstants;
 import com.linkedin.openhouse.common.exception.InvalidSchemaEvolutionException;
 import com.linkedin.openhouse.common.exception.RequestValidationFailureException;
@@ -76,6 +77,8 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
 
   @Autowired StorageManager storageManager;
 
+  @Autowired StorageSelector storageSelector;
+
   @Autowired MeterRegistry meterRegistry;
 
   @Autowired SchemaValidator schemaValidator;
@@ -111,8 +114,8 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
               tableIdentifier,
               writeSchema,
               partitionSpec,
-              storageManager
-                  .getDefaultStorage()
+              storageSelector
+                  .selectStorage(tableDto.getDatabaseId(), tableDto.getTableId())
                   .allocateTableLocation(
                       tableDto.getDatabaseId(),
                       tableDto.getTableId(),

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTestWithSettableComponents.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTestWithSettableComponents.java
@@ -100,12 +100,12 @@ public class RepositoryTestWithSettableComponents {
     OpenHouseInternalTableOperations actualOps =
         new OpenHouseInternalTableOperations(
             houseTablesRepository,
+            fileIOManager,
             fileIO,
             snapshotInspector,
             houseTableMapper,
             tableIdentifier,
-            new MetricsReporter(this.meterRegistry, "test", Lists.newArrayList()),
-            fileIOManager);
+            new MetricsReporter(this.meterRegistry, "test", Lists.newArrayList()));
     ((SettableCatalogForTest) catalog).setOperation(actualOps);
     TableDto creationDTO = TABLE_DTO.toBuilder().tableVersion(INITIAL_TABLE_VERSION).build();
     creationDTO = openHouseInternalRepository.save(creationDTO);
@@ -117,12 +117,12 @@ public class RepositoryTestWithSettableComponents {
     OpenHouseInternalTableOperations mockOps =
         new OpenHouseInternalTableOperations(
             htsRepo,
+            fileIOManager,
             fileIO,
             snapshotInspector,
             houseTableMapper,
             tableIdentifier,
-            new MetricsReporter(this.meterRegistry, "test", Lists.newArrayList()),
-            fileIOManager);
+            new MetricsReporter(this.meterRegistry, "test", Lists.newArrayList()));
     OpenHouseInternalTableOperations spyOperations = Mockito.spy(mockOps);
     doReturn(actualOps.current()).when(spyOperations).refresh();
     BaseTable spyOptsMockedTable = Mockito.spy(new BaseTable(spyOperations, realTable.name()));
@@ -198,12 +198,12 @@ public class RepositoryTestWithSettableComponents {
       OpenHouseInternalTableOperations mockOps =
           new OpenHouseInternalTableOperations(
               htsRepo,
+              fileIOManager,
               fileIO,
               snapshotInspector,
               houseTableMapper,
               tableIdentifier,
-              new MetricsReporter(this.meterRegistry, "test", Lists.newArrayList()),
-              fileIOManager);
+              new MetricsReporter(this.meterRegistry, "test", Lists.newArrayList()));
       OpenHouseInternalTableOperations spyOperations = Mockito.spy(mockOps);
       BaseTable spyOptsMockedTable =
           Mockito.spy(

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTestWithSettableComponents.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTestWithSettableComponents.java
@@ -104,7 +104,8 @@ public class RepositoryTestWithSettableComponents {
             snapshotInspector,
             houseTableMapper,
             tableIdentifier,
-            new MetricsReporter(this.meterRegistry, "test", Lists.newArrayList()));
+            new MetricsReporter(this.meterRegistry, "test", Lists.newArrayList()),
+            fileIOManager);
     ((SettableCatalogForTest) catalog).setOperation(actualOps);
     TableDto creationDTO = TABLE_DTO.toBuilder().tableVersion(INITIAL_TABLE_VERSION).build();
     creationDTO = openHouseInternalRepository.save(creationDTO);
@@ -120,7 +121,8 @@ public class RepositoryTestWithSettableComponents {
             snapshotInspector,
             houseTableMapper,
             tableIdentifier,
-            new MetricsReporter(this.meterRegistry, "test", Lists.newArrayList()));
+            new MetricsReporter(this.meterRegistry, "test", Lists.newArrayList()),
+            fileIOManager);
     OpenHouseInternalTableOperations spyOperations = Mockito.spy(mockOps);
     doReturn(actualOps.current()).when(spyOperations).refresh();
     BaseTable spyOptsMockedTable = Mockito.spy(new BaseTable(spyOperations, realTable.name()));
@@ -200,7 +202,8 @@ public class RepositoryTestWithSettableComponents {
               snapshotInspector,
               houseTableMapper,
               tableIdentifier,
-              new MetricsReporter(this.meterRegistry, "test", Lists.newArrayList()));
+              new MetricsReporter(this.meterRegistry, "test", Lists.newArrayList()),
+              fileIOManager);
       OpenHouseInternalTableOperations spyOperations = Mockito.spy(mockOps);
       BaseTable spyOptsMockedTable =
           Mockito.spy(

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTestWithSettableComponents.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTestWithSettableComponents.java
@@ -100,7 +100,6 @@ public class RepositoryTestWithSettableComponents {
     OpenHouseInternalTableOperations actualOps =
         new OpenHouseInternalTableOperations(
             houseTablesRepository,
-            fileIOManager,
             fileIO,
             snapshotInspector,
             houseTableMapper,
@@ -117,7 +116,6 @@ public class RepositoryTestWithSettableComponents {
     OpenHouseInternalTableOperations mockOps =
         new OpenHouseInternalTableOperations(
             htsRepo,
-            fileIOManager,
             fileIO,
             snapshotInspector,
             houseTableMapper,
@@ -198,7 +196,6 @@ public class RepositoryTestWithSettableComponents {
       OpenHouseInternalTableOperations mockOps =
           new OpenHouseInternalTableOperations(
               htsRepo,
-              fileIOManager,
               fileIO,
               snapshotInspector,
               houseTableMapper,


### PR DESCRIPTION
## Summary
Primary changes
1. Use storage returned by Storage selector to select storage for a new table during creation
2. Use correct FileIO for the storage type returned from HTS for a table
3. Fixed bug where storage type always defaults to HDFS in hts

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.
Docker compose S3 test, Db:d3, Table:t1
1. Get table without creation -> Returns table not found with storage selected as s3 from storage selector

![Screenshot 2024-09-11 at 5 16 12 PM](https://github.com/user-attachments/assets/879a2057-d164-4dab-9b73-6536c1a01836)

2. Create table -> Returns success with storage selected as s3 from storage selector, hts row with storageTyppe=s3 in hts row, minio s3 ui shows correct metadata 

![Screenshot 2024-09-11 at 5 17 23 PM](https://github.com/user-attachments/assets/8d5a3100-ad90-44db-88dd-68df82f2ba43)
![Screenshot 2024-09-11 at 5 19 34 PM](https://github.com/user-attachments/assets/64e43fb9-ebb0-406a-ad47-7decb7a6af3a)
![Screenshot 2024-09-11 at 5 18 22 PM](https://github.com/user-attachments/assets/e4b021dd-c6a5-454a-abb6-e18464d68574)

3. Get table after table creation -> Returns success with storage selected as s3 from hts row

![Screenshot 2024-09-11 at 5 20 37 PM](https://github.com/user-attachments/assets/dc1c19d8-96cc-46bb-901e-9ed5653a420d)


# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
