### PR TITLE
Remove iceberg-azure v1.5.0 package loading

### DIFF
--- a/infra/recipes/terraform/azure/environments/sandbox/scripts/spark-client.sh
+++ b/infra/recipes/terraform/azure/environments/sandbox/scripts/spark-client.sh
@@ -10,7 +10,7 @@ az aks get-credentials --resource-group ${RESOURCE_GROUP} --name ${CLUSTER_NAME}
 TABLES_ADDRESS=$(kubectl get service openhouse-tables-service -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
 TABLES_PORT=$(kubectl get service openhouse-tables-service -o jsonpath="{.spec.ports[*].port}")
 
-COMMAND="bin/spark-shell --packages org.apache.iceberg:iceberg-azure:1.5.0,org.apache.iceberg:iceberg-spark-runtime-3.1_2.12:1.2.0 \
+COMMAND="bin/spark-shell --packages org.apache.iceberg:iceberg-spark-runtime-3.1_2.12:1.2.0 \
   --jars openhouse-spark-apps_2.12-*-all.jar,openhouse-spark-runtime_2.12-latest-all.jar  \
   --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,com.linkedin.openhouse.spark.extensions.OpenhouseSparkSessionExtensions   \
   --conf spark.sql.catalog.openhouse=org.apache.iceberg.spark.SparkCatalog   \


### PR DESCRIPTION
## Summary

This PR addresses an issue encountered during smoke tests for the OpenHouse deployment, specifically related to Iceberg ADLS dependencies. The issue is caused by the inclusion of the `iceberg-azure` package 1.5.0 in the [Spark client script](https://github.com/linkedin/openhouse/blob/main/infra/recipes/terraform/azure/environments/sandbox/scripts/spark-client.sh#L13), which pulled in conflicting dependencies and caused `java.io.InvalidClassException` errors in the workers.

The fix involves removing the `org.apache.iceberg:iceberg-azure:1.5.0` dependency from the script, as OpenHouse already has the necessary ADLS file IO implementation bundled within the project. This resolves the incompatibility and allows the deployment to proceed without errors.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [X] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

Removed the `org.apache.iceberg:iceberg-azure:1.5.0` package from the Spark client script.

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [X] Some other form of testing like staging or soak time in production. Please explain.

Tested in Azure deployment.