### PR TITLE
Make leaf modules java17 forward compatible

### DIFF
--- a/buildSrc/src/main/groovy/openhouse.java-minimal-conventions.gradle
+++ b/buildSrc/src/main/groovy/openhouse.java-minimal-conventions.gradle
@@ -4,7 +4,8 @@ plugins {
   id 'jacoco'
 }
 
-sourceCompatibility = '1.8'
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 ext {
   lombokVersion = '1.18.20'

--- a/client/hts/build.gradle
+++ b/client/hts/build.gradle
@@ -1,6 +1,7 @@
 plugins {
   id 'java'
   id 'openhouse.client-codegen-convention'
+  id 'openhouse.java-minimal-conventions'
   id 'openhouse.maven-publish'
 }
 

--- a/cluster/storage/build.gradle
+++ b/cluster/storage/build.gradle
@@ -11,4 +11,5 @@ dependencies {
   implementation project(':cluster:configs')
   implementation project(':iceberg:azure')
   implementation 'org.springframework.boot:spring-boot-autoconfigure:' + spring_web_version
+  implementation 'javax.annotation:javax.annotation-api:1.3.2'
 }

--- a/tables-test-fixtures/build.gradle
+++ b/tables-test-fixtures/build.gradle
@@ -79,3 +79,8 @@ shadowJar {
 // By default shadow doesn't configure the build task to depend on the shadowJar task.
 tasks.build.dependsOn tasks.shadowJar
 
+test {
+  if (JavaVersion.current() >= JavaVersion.VERSION_1_9){
+    jvmArgs '--add-opens=java.base/java.net=ALL-UNNAMED'
+  }
+}

--- a/tables-test-fixtures/src/main/java/com/linkedin/openhouse/tablestest/OpenHouseLocalServer.java
+++ b/tables-test-fixtures/src/main/java/com/linkedin/openhouse/tablestest/OpenHouseLocalServer.java
@@ -3,7 +3,7 @@ package com.linkedin.openhouse.tablestest;
 import java.util.Collections;
 import org.springframework.boot.SpringApplication;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.util.SocketUtils;
+import org.springframework.test.util.TestSocketUtils;
 
 /**
  * Standalone embedded OH server that can be started and stopped from any Java code (to be used for
@@ -18,7 +18,7 @@ public class OpenHouseLocalServer {
   private ConfigurableApplicationContext appContext;
 
   public OpenHouseLocalServer() {
-    this.port = SocketUtils.findAvailableTcpPort();
+    this.port = TestSocketUtils.findAvailableTcpPort();
     this.appContext = null;
   }
 


### PR DESCRIPTION
## Summary
Some of the leaf modules can now build with java17, e.g. tables-test-fixtures and it's dependency modules. This is one several PRs that prepare for java17 switch. The changes are essentially non-consequential for the consumers. 

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests
- [x] Upgrade

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
