### PR TITLE
Revert "Add an option to enable/disable storage stats collection as part of TableStatsCollector"

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -430,15 +430,13 @@ public final class Operations implements AutoCloseable {
    * Collect and publish table stats for a given fully-qualified table name.
    *
    * @param fqtn fully-qualified table name
-   * @param skipStorageStatsCollection whether to skip storage stats collection
    */
-  public IcebergTableStats collectTableStats(String fqtn, Boolean skipStorageStatsCollection) {
+  public IcebergTableStats collectTableStats(String fqtn) {
     Table table = getTable(fqtn);
 
     TableStatsCollector tableStatsCollector;
     try {
-      tableStatsCollector =
-          new TableStatsCollector(fs(), spark, fqtn, table, skipStorageStatsCollection);
+      tableStatsCollector = new TableStatsCollector(fs(), spark, fqtn, table);
     } catch (IOException e) {
       log.error("Unable to initialize file system for table stats collection", e);
       return null;

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/TableStatsCollectionSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/TableStatsCollectionSparkApp.java
@@ -13,24 +13,20 @@ import org.apache.commons.cli.Option;
  * Class with main entry point to collect Iceberg stats for a table.
  *
  * <p>Example of invocation: com.linkedin.openhouse.jobs.spark.TableStatsCollectionSparkApp
- * --tableName db.testTable --skipStorageStats true
+ * --tableName db.testTable
  */
 @Slf4j
 public class TableStatsCollectionSparkApp extends BaseTableSparkApp {
 
-  private final Boolean skipStorageStatsCollection;
-
-  public TableStatsCollectionSparkApp(
-      String jobId, StateManager stateManager, String fqtn, Boolean skipStorageStatsCollection) {
+  public TableStatsCollectionSparkApp(String jobId, StateManager stateManager, String fqtn) {
     super(jobId, stateManager, fqtn);
-    this.skipStorageStatsCollection = skipStorageStatsCollection;
   }
 
   @Override
   protected void runInner(Operations ops) {
     log.info("Running TableStatsCollectorApp for table {}", fqtn);
 
-    IcebergTableStats icebergTableStats = ops.collectTableStats(fqtn, skipStorageStatsCollection);
+    IcebergTableStats icebergTableStats = ops.collectTableStats(fqtn);
     publishStats(icebergTableStats);
   }
 
@@ -47,16 +43,10 @@ public class TableStatsCollectionSparkApp extends BaseTableSparkApp {
   public static void main(String[] args) {
     List<Option> extraOptions = new ArrayList<>();
     extraOptions.add(new Option("t", "tableName", true, "Fully-qualified table name"));
-    extraOptions.add(
-        new Option("s", "skipStorageStats", false, "Whether to skip storage stats collection"));
-
     CommandLine cmdLine = createCommandLine(args, extraOptions);
     TableStatsCollectionSparkApp app =
         new TableStatsCollectionSparkApp(
-            getJobId(cmdLine),
-            createStateManager(cmdLine),
-            cmdLine.getOptionValue("tableName"),
-            cmdLine.hasOption("skipStorageStats"));
+            getJobId(cmdLine), createStateManager(cmdLine), cmdLine.getOptionValue("tableName"));
     app.run();
   }
 }

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableStatsCollector.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableStatsCollector.java
@@ -16,7 +16,6 @@ public class TableStatsCollector {
   private SparkSession spark;
   String fqtn;
   Table table;
-  Boolean skipStorageStatsCollection;
 
   /** Collect table stats. */
   public IcebergTableStats collectTableStats() {
@@ -30,10 +29,6 @@ public class TableStatsCollector {
     IcebergTableStats statsWithCurrentSnapshot =
         TableStatsCollectorUtil.populateStatsForSnapshots(
             fqtn, table, spark, statsWithReferenceFiles);
-
-    if (skipStorageStatsCollection) {
-      return statsWithCurrentSnapshot;
-    }
 
     IcebergTableStats tableStats =
         TableStatsCollectorUtil.populateStorageStats(fqtn, table, fs, statsWithCurrentSnapshot);

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -533,7 +533,7 @@ public class OperationsTest extends OpenHouseSparkITest {
     final int numInserts = 3;
     try (Operations ops = Operations.withCatalog(getSparkSession(), meter)) {
       prepareTable(ops, tableName);
-      IcebergTableStats stats = ops.collectTableStats(tableName, true);
+      IcebergTableStats stats = ops.collectTableStats(tableName);
 
       // Validate empty data files case
       Assertions.assertEquals(stats.getNumReferencedDataFiles(), 0);
@@ -541,7 +541,7 @@ public class OperationsTest extends OpenHouseSparkITest {
       long modifiedTimeStamp = System.currentTimeMillis();
 
       populateTable(ops, tableName, 1);
-      stats = ops.collectTableStats(tableName, true);
+      stats = ops.collectTableStats(tableName);
       Assertions.assertEquals(stats.getNumReferencedDataFiles(), 1);
       Assertions.assertTrue(stats.getTableLastUpdatedTimestamp() >= modifiedTimeStamp);
 
@@ -553,15 +553,13 @@ public class OperationsTest extends OpenHouseSparkITest {
       populateTable(ops, tableName, numInserts);
       table = ops.getTable(tableName);
       log.info("Loaded table {}, location {}", table.name(), table.location());
-      stats = ops.collectTableStats(tableName, true);
+      stats = ops.collectTableStats(tableName);
       Assertions.assertEquals(stats.getCurrentSnapshotId(), table.currentSnapshot().snapshotId());
       Assertions.assertEquals(stats.getNumReferencedDataFiles(), numInserts + 1);
       Assertions.assertEquals(stats.getNumExistingMetadataJsonFiles(), numInserts + 2);
       Assertions.assertEquals(
           stats.getCurrentSnapshotTimestamp(), table.currentSnapshot().timestampMillis());
       Assertions.assertEquals(stats.getOldestSnapshotTimestamp(), oldestSnapshot);
-      Assertions.assertEquals(stats.getNumObjectsInDirectory(), null);
-      stats = ops.collectTableStats(tableName, false);
       Assertions.assertEquals(
           stats.getNumObjectsInDirectory(),
           stats.getNumReferencedDataFiles()


### PR DESCRIPTION
Reverts linkedin/openhouse#186

Reverting disabling storage stats completely. Will consider skipping this only for certain tables or databases eventually. 