### PR TITLE
Downgrade hadoop to 2.8 for docker setup

### DIFF
--- a/infra/recipes/docker-compose/common/hadoop/hadoop.env
+++ b/infra/recipes/docker-compose/common/hadoop/hadoop.env
@@ -39,6 +39,6 @@ MAPRED_CONF_mapreduce_map_memory_mb=4096
 MAPRED_CONF_mapreduce_reduce_memory_mb=8192
 MAPRED_CONF_mapreduce_map_java_opts=-Xmx3072m
 MAPRED_CONF_mapreduce_reduce_java_opts=-Xmx6144m
-MAPRED_CONF_yarn_app_mapreduce_am_env=HADOOP_MAPRED_HOME=/opt/hadoop-3.2.1/
-MAPRED_CONF_mapreduce_map_env=HADOOP_MAPRED_HOME=/opt/hadoop-3.2.1/
-MAPRED_CONF_mapreduce_reduce_env=HADOOP_MAPRED_HOME=/opt/hadoop-3.2.1/
+MAPRED_CONF_yarn_app_mapreduce_am_env=HADOOP_MAPRED_HOME=/opt/hadoop-2.8.0/
+MAPRED_CONF_mapreduce_map_env=HADOOP_MAPRED_HOME=/opt/hadoop-2.8.0/
+MAPRED_CONF_mapreduce_reduce_env=HADOOP_MAPRED_HOME=/opt/hadoop-2.8.0/

--- a/infra/recipes/docker-compose/common/hdfs-services.yml
+++ b/infra/recipes/docker-compose/common/hdfs-services.yml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   namenode:
-    image: bde2020/hadoop-namenode:2.0.0-hadoop3.2.1-java8
+    image: bde2020/hadoop-namenode:1.2.0-hadoop2.8-java8
     restart: always
     ports:
       - 9870:9870
@@ -12,7 +12,7 @@ services:
       - hadoop/hadoop.env
 
   datanode:
-    image: bde2020/hadoop-datanode:2.0.0-hadoop3.2.1-java8
+    image: bde2020/hadoop-datanode:1.2.0-hadoop2.8-java8
     restart: always
     environment:
       SERVICE_PRECONDITION: "namenode:9870"

--- a/infra/recipes/docker-compose/common/spark-services.yml
+++ b/infra/recipes/docker-compose/common/spark-services.yml
@@ -3,7 +3,7 @@ services:
   spark-master:
     build:
       context: ../../../../
-      dockerfile: infra/recipes/docker-compose/common/spark/spark-base-hadoop3.2.dockerfile
+      dockerfile: infra/recipes/docker-compose/common/spark/spark-base-hadoop2.8.dockerfile
     ports:
       - 9001:8080
       - 7077:7077
@@ -17,7 +17,7 @@ services:
   spark-worker-a:
     build:
       context: ../../../../
-      dockerfile: infra/recipes/docker-compose/common/spark/spark-base-hadoop3.2.dockerfile
+      dockerfile: infra/recipes/docker-compose/common/spark/spark-base-hadoop2.8.dockerfile
     ports:
       - 9002:8080
       - 7000:7000
@@ -34,7 +34,7 @@ services:
   spark-livy:
     build:
       context: ../../../../
-      dockerfile: infra/recipes/docker-compose/common/spark/spark-base-hadoop3.2.dockerfile
+      dockerfile: infra/recipes/docker-compose/common/spark/spark-base-hadoop2.8.dockerfile
     ports:
       - 9003:8998
     environment:

--- a/infra/recipes/docker-compose/common/spark/livy_spark3_hadoop3.patch
+++ b/infra/recipes/docker-compose/common/spark/livy_spark3_hadoop3.patch
@@ -7,7 +7,7 @@ index d2e535a..2a3718f 100644
    <properties>
      <asynchttpclient.version>2.10.1</asynchttpclient.version>
 -    <hadoop.version>2.7.3</hadoop.version>
-+    <hadoop.version>3.2.1</hadoop.version>
++    <hadoop.version>2.8.0</hadoop.version>
      <hadoop.scope>compile</hadoop.scope>
      <spark.scala-2.11.version>2.4.5</spark.scala-2.11.version>
 -    <spark.scala-2.12.version>2.4.5</spark.scala-2.12.version>
@@ -51,10 +51,10 @@ index d2e535a..2a3718f 100644
      <spark.home>${execution.root}/dev/spark</spark.home>
      <spark.bin.download.url>
 -      https://archive.apache.org/dist/spark/spark-2.4.5/spark-2.4.5-bin-hadoop2.7.tgz
-+      https://archive.apache.org/dist/spark/spark-3.1.2/spark-3.1.2-bin-hadoop3.2.tgz
++      https://archive.apache.org/dist/spark/spark-3.1.1/spark-3.1.1-bin-hadoop2.7.tgz
      </spark.bin.download.url>
 -    <spark.bin.name>spark-2.4.5-bin-hadoop2.7</spark.bin.name>
-+    <spark.bin.name>spark-3.1.2-bin-hadoop3.3</spark.bin.name>
++    <spark.bin.name>spark-3.1.1-bin-hadoop2.7</spark.bin.name>
      <!--  used for testing, NCSARequestLog use it for access log  -->
      <livy.log.dir>${basedir}/target</livy.log.dir>
  
@@ -80,7 +80,7 @@ index d2e535a..2a3718f 100644
        </activation>
        <properties>
 -        <spark.scala-2.12.version>3.0.0</spark.scala-2.12.version>
-+        <spark.scala-2.12.version>3.1.2</spark.scala-2.12.version>
++        <spark.scala-2.12.version>3.1.1</spark.scala-2.12.version>
          <spark.scala-2.11.version>2.4.5</spark.scala-2.11.version>
 -        <spark.version>${spark.scala-2.11.version}</spark.version>
 +        <spark.version>${spark.scala-2.12.version}</spark.version>
@@ -96,10 +96,10 @@ index d2e535a..2a3718f 100644
 +        <json4s.version>${json4s.spark-2.12.version}</json4s.version>
          <spark.bin.download.url>
 -          https://archive.apache.org/dist/spark/spark-3.0.0/spark-3.0.0-bin-hadoop2.7.tgz
-+          https://archive.apache.org/dist/spark/spark-3.1.2/spark-3.1.2-bin-hadoop3.2.tgz
++          https://archive.apache.org/dist/spark/spark-3.1.1/spark-3.1.1-bin-hadoop2.7.tgz
          </spark.bin.download.url>
 -        <spark.bin.name>spark-3.0.0-bin-hadoop2.7</spark.bin.name>
-+        <spark.bin.name>spark-3.1.1-bin-hadoop3.2</spark.bin.name>
++        <spark.bin.name>spark-3.1.1-bin-hadoop2.7</spark.bin.name>
        </properties>
      </profile>
  

--- a/infra/recipes/docker-compose/common/spark/spark-base-hadoop2.8.dockerfile
+++ b/infra/recipes/docker-compose/common/spark/spark-base-hadoop2.8.dockerfile
@@ -12,7 +12,7 @@ RUN update-alternatives --install "/usr/bin/python" "python" "$(which python3)" 
 ENV SPARK_VERSION=3.1.1 \
 LIVY_VERSION=0.8.0-incubating-SNAPSHOT \
 LIVY_HOME=/opt/livy \
-HADOOP_VERSION=3.2 \
+HADOOP_VERSION=2.7 \
 SPARK_HOME=/opt/spark \
 MAVEN_VERSION=3.9.4 \
 PYTHONHASHSEED=1
@@ -44,7 +44,7 @@ RUN git clone https://github.com/apache/incubator-livy \
     && rm -rf "/incubator-livy"
 
 
-FROM bde2020/hadoop-namenode:2.0.0-hadoop3.2.1-java8
+FROM bde2020/hadoop-namenode:1.2.0-hadoop2.8-java8
 
 ENV LIVY_HOME=/opt/livy \
 SPARK_HOME=/opt/spark
@@ -54,7 +54,7 @@ COPY --from=builder /opt/spark /opt/spark
 
 WORKDIR $SPARK_HOME
 
-ENV HADOOP_HOME=/opt/hadoop-3.2.1
+ENV HADOOP_HOME=/opt/hadoop-2.8.0
 ENV HADOOP_CONF_DIR=$HADOOP_HOME/etc/hadoop
 ENV SPARK_MASTER_PORT=7077 \
 SPARK_MASTER_WEBUI_PORT=8080 \


### PR DESCRIPTION
## Summary
Maintenance apps happened to work on hadoop3 docker cluster, DLO apps didn't work due to incompatibility between source that depends on 2.10 and runtime jars on the cluster. DLO app example error:
```
2024-08-08 09:07:22 2024-08-08 16:07:22,005 INFO utils.LineBufferedStream: 2024-08-08 16:07:22,004 WARN scheduler.TaskSetManager: Lost task 0.0 in stage 0.0 (TID 0) (172.20.0.8 executor 0): java.lang.IllegalAccessError: class org.apache.hadoop.hdfs.web.HftpFileSystem cannot access its superinterface org.apache.hadoop.hdfs.web.TokenAspect$TokenManagementDelegator
2024-08-08 09:07:22 2024-08-08 16:07:22,005 INFO utils.LineBufferedStream:      at java.lang.ClassLoader.defineClass1(Native Method)
2024-08-08 09:07:22 2024-08-08 16:07:22,005 INFO utils.LineBufferedStream:      at java.lang.ClassLoader.defineClass(ClassLoader.java:756)
2024-08-08 09:07:22 2024-08-08 16:07:22,005 INFO utils.LineBufferedStream:      at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at java.net.URLClassLoader.defineClass(URLClassLoader.java:468)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at java.security.AccessController.doPrivileged(Native Method)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at java.lang.Class.forName0(Native Method)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at java.lang.Class.forName(Class.java:348)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at java.util.ServiceLoader$LazyIterator.nextService(ServiceLoader.java:370)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:404)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at java.util.ServiceLoader$1.next(ServiceLoader.java:480)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at org.apache.hadoop.fs.FileSystem.loadFileSystems(FileSystem.java:3217)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at org.apache.hadoop.fs.FileSystem.getFileSystemClass(FileSystem.java:3262)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:3301)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at org.apache.hadoop.fs.FileSystem.access$200(FileSystem.java:124)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:3352)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:3320)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:479)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at org.apache.hadoop.fs.Path.getFileSystem(Path.java:361)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at org.apache.iceberg.hadoop.Util.getFs(Util.java:56)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at org.apache.iceberg.hadoop.HadoopInputFile.fromLocation(HadoopInputFile.java:56)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at org.apache.iceberg.hadoop.HadoopFileIO.newInputFile(HadoopFileIO.java:90)
2024-08-08 09:07:22 2024-08-08 16:07:22,006 INFO utils.LineBufferedStream:      at org.apache.iceberg.spark.source.BaseDataReader.lambda$new$2(BaseDataReader.java:87)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at java.util.HashMap$EntrySpliterator.tryAdvance(HashMap.java:1720)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at java.util.stream.StreamSpliterators$WrappingSpliterator.lambda$initPartialTraversalState$0(StreamSpliterators.java:295)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.fillBuffer(StreamSpliterators.java:207)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.doAdvance(StreamSpliterators.java:162)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at java.util.stream.StreamSpliterators$WrappingSpliterator.tryAdvance(StreamSpliterators.java:301)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at java.util.Spliterators$1Adapter.hasNext(Spliterators.java:681)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at java.lang.Iterable.forEach(Iterable.java:74)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at org.apache.iceberg.relocated.com.google.common.collect.Iterables$5.forEach(Iterables.java:752)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at org.apache.iceberg.spark.source.BaseDataReader.<init>(BaseDataReader.java:93)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at org.apache.iceberg.spark.source.RowDataReader.<init>(RowDataReader.java:57)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at org.apache.iceberg.spark.source.SparkBatchScan$RowReader.<init>(SparkBatchScan.java:301)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at org.apache.iceberg.spark.source.SparkBatchScan$ReaderFactory.createReader(SparkBatchScan.java:278)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at org.apache.spark.sql.execution.datasources.v2.DataSourceRDD.compute(DataSourceRDD.scala:60)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:373)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at org.apache.spark.rdd.RDD.iterator(RDD.scala:337)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:373)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at org.apache.spark.rdd.RDD.iterator(RDD.scala:337)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:373)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at org.apache.spark.rdd.RDD.iterator(RDD.scala:337)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:373)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at org.apache.spark.rdd.RDD.iterator(RDD.scala:337)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at org.apache.spark.scheduler.Task.run(Task.scala:131)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:497)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1439)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:500)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream:      at java.lang.Thread.run(Thread.java:748)
2024-08-08 09:07:22 2024-08-08 16:07:22,007 INFO utils.LineBufferedStream: 
```

Works after downgrade.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
