### PR TITLE
Handle tblProperties for replication flow

### DIFF
--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/InternalRepositoryUtils.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/InternalRepositoryUtils.java
@@ -64,6 +64,7 @@ public final class InternalRepositoryUtils {
     // Due to the SerDe process, null-map is possible.
     if (providedTableProps != null) {
       for (Map.Entry<String, String> entry : providedTableProps.entrySet()) {
+        String key = entry.getKey();
         unsetKeys.remove(entry.getKey());
         if (!existingTableProps.containsKey(entry.getKey())
             || !existingTableProps.get(entry.getKey()).equals(entry.getValue())) {

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/InternalRepositoryUtils.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/InternalRepositoryUtils.java
@@ -64,7 +64,6 @@ public final class InternalRepositoryUtils {
     // Due to the SerDe process, null-map is possible.
     if (providedTableProps != null) {
       for (Map.Entry<String, String> entry : providedTableProps.entrySet()) {
-        String key = entry.getKey();
         unsetKeys.remove(entry.getKey());
         if (!existingTableProps.containsKey(entry.getKey())
             || !existingTableProps.get(entry.getKey()).equals(entry.getValue())) {

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -131,12 +131,7 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
     } else {
       table = catalog.loadTable(tableIdentifier);
       Transaction transaction = table.newTransaction();
-      if (!skipEligibilityCheck(table.properties(), tableDto.getTableProperties())) {
-        // eligibility check is relaxed for request from replication flow since preserved properties
-        // & tableType
-        // will differ in tableDto and existing table.
-        updateEligibilityCheck(table, tableDto);
-      }
+      updateEligibilityCheck(table, tableDto);
 
       boolean schemaUpdated =
           doUpdateSchemaIfNeeded(transaction, writeSchema, table.schema(), tableDto);
@@ -193,11 +188,15 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
    * {@link com.linkedin.openhouse.common.exception.handler.OpenHouseExceptionHandler} to deal with
    */
   protected void updateEligibilityCheck(Table existingTable, TableDto tableDto) {
-    PartitionSpec partitionSpec = partitionSpecMapper.toPartitionSpec(tableDto);
-    versionCheck(existingTable, tableDto);
-    checkIfPreservedTblPropsModified(tableDto, existingTable);
-    checkIfTableTypeModified(tableDto, existingTable);
-    checkPartitionSpecEvolution(partitionSpec, existingTable.spec());
+    if (!skipEligibilityCheck(existingTable.properties(), tableDto.getTableProperties())) {
+      // eligibility check is relaxed for request from replication flow since preserved properties
+      // & tableType will differ in tableDto and existing table.
+      PartitionSpec partitionSpec = partitionSpecMapper.toPartitionSpec(tableDto);
+      versionCheck(existingTable, tableDto);
+      checkIfPreservedTblPropsModified(tableDto, existingTable);
+      checkIfTableTypeModified(tableDto, existingTable);
+      checkPartitionSpecEvolution(partitionSpec, existingTable.spec());
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Table commits have strict checks for reserved table properties to avoid modifying them. This leads to issues for use cases  where cross cluster iceberg commits for tables with same tableId should be compatible which allows features like table backup. 
This PR introduces conditions when such check can be relaxed. Specifically for cross cluster table replication.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
