### PR TITLE
Move away from gradle antlr plugin to use antlr tool to generate grammar sources

### DIFF
--- a/integrations/spark/openhouse-spark-runtime/build.gradle
+++ b/integrations/spark/openhouse-spark-runtime/build.gradle
@@ -28,6 +28,7 @@ configurations {
     exclude(group: 'org.mapstruct')
   }
   shadow.extendsFrom implementation
+  runtime.exclude group: 'org.antlr', module: 'antlr4'
 }
 
 

--- a/integrations/spark/openhouse-spark-runtime/build.gradle
+++ b/integrations/spark/openhouse-spark-runtime/build.gradle
@@ -98,12 +98,5 @@ shadowJar {
   zip64 true
 }
 
-jar {
-  enabled=true
-  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-}
-
-sourcesJar {
-  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-}
+jar.enabled=true
 

--- a/integrations/spark/openhouse-spark-runtime/build.gradle
+++ b/integrations/spark/openhouse-spark-runtime/build.gradle
@@ -3,7 +3,6 @@ plugins {
   id 'openhouse.maven-publish'
   id 'com.github.johnrengelman.shadow' version '7.1.2'
   id 'scala'
-  id 'antlr'
 }
 
 ext {
@@ -12,23 +11,15 @@ ext {
 }
 
 configurations {
-  /*
-     The Gradle Antlr plugin erroneously adds both antlr-build and runtime dependencies to the runtime path. This
-     bug https://github.com/gradle/gradle/issues/820 exists because older versions of Antlr do not have separate
-     runtime and implementation dependencies and they do not want to break backwards compatibility. So to only end up with
-     the runtime dependency on the runtime classpath we remove the dependencies added by the plugin here. Then add
-     the runtime dependency back to only the runtime configuration manually.
-    */
-  implementation {
-    extendsFrom = extendsFrom.findAll { it != configurations.antlr }
-  }
 
   fatJarPackagedDependencies {
     exclude(group: 'org.antlr') // included in spark
     exclude(group: 'org.mapstruct')
   }
+  
   shadow.extendsFrom implementation
-  runtime.exclude group: 'org.antlr', module: 'antlr4'
+  
+  antlr
 }
 
 
@@ -62,23 +53,57 @@ dependencies {
     transitive = false
   }
   implementation("org.apache.iceberg:iceberg-spark-runtime-3.1_2.12:" + icebergVersion)
+}
 
-  generateGrammarSource {
-    maxHeapSize = "64m"
-    arguments += ['-visitor', '-package', 'com.linkedin.openhouse.spark.sql.catalyst.parser.extensions']
+// Define antlr directories for source generation
+ext {
+  antlrPackageDirPrefix="com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/"
+  antlrMainDir="${projectDir}/src/main/antlr/${antlrPackageDirPrefix}"
+  antlrMainGeneratedSrcDir="${project.buildDir}/generated-src/antlr/main/"
+}
+
+// Set source for antlr generated directory
+sourceSets {
+  main {
+    java {
+      srcDirs antlrMainGeneratedSrcDir
+    }
   }
 }
 
+// Task to generate java sources using Antlr tool
+task runAntlr(type:JavaExec) {
+  inputs.dir antlrMainDir
+  outputs.dir antlrMainGeneratedSrcDir
+
+  main = "org.antlr.v4.Tool"
+  args = ["${antlrMainDir}/OpenhouseSqlExtensions.g4", 
+          "-visitor", 
+          "-o", "${antlrMainGeneratedSrcDir}/${antlrPackageDirPrefix}", 
+          "-package", "com.linkedin.openhouse.spark.sql.catalyst.parser.extensions"]
+  maxHeapSize = "64m"
+  classpath = configurations.antlr
+}
+
+compileJava.dependsOn runAntlr
 
 shadowJar {
   dependencies {
     exclude("javax/**")
   }
-
+  
   configurations = [project.configurations.fatJarPackagedDependencies]
   mergeServiceFiles()
   archiveClassifier.set('uber')
   zip64 true
 }
 
-jar.enabled=true
+jar {
+  enabled=true
+  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+sourcesJar {
+  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+


### PR DESCRIPTION
## Summary

The `antlr4` library is being added as runtime dependency (in the internally ELRed ivy file) post gradle 7 upgrade - #124 and this caused issues in the spark environment. Observed that POM file has the compile time dependency for `antlr4` which is correct as per the dependency declared in build.gradle, but the ELRed ivy file has `antlr4` as compile and runtime dependency. So this is an ELR issue. Although `antlr4` dependency is added as compile time we could exclude that from published pom dependency in gradle 6, but gradle 7 is strict in that sense and not allowing such hack/customization. The effort for addressing this issue in the internal ELR process seems to high. Also there is a plan to migrate from ivy to pom based publication and this migration would take time. Hence, moving away from gradle antlr plugin to generate grammar sources using Antlr tool. With this change there is no explicit antlr4 dependency in the published pom file.


## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [X] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

`./gradlew clean` build passed

`./gradlew publishToMavenLocal -Pversion=1.0.3-snapshot` works and verified the updated POM file has no `antlr4` dependency now.

```
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.linkedin.openhouse</groupId>
  <artifactId>openhouse-spark-runtime_2.12</artifactId>
  <version>1.0.3-snapshot</version>
  <name>OpenHouse</name>
  <description>Control Plane for Tables in Open Data Lakehouse</description>
  <url>https://github.com/linkedin/openhouse</url>
  <licenses>
    <license>
      <name>BSD 2-Clause License</name>
      <url>https://raw.githubusercontent.com/linkedin/openhouse/main/LICENSE</url>
    </license>
  </licenses>
  <scm>
    <connection>scm:git:git://github.com/linkedin/openhouse.git</connection>
    <developerConnection>scm:git:ssh://github.com/linkedin/openhouse.git</developerConnection>
    <url>https://github.com/linkedin/openhouse</url>
  </scm>
  <dependencies>
    <dependency>
      <groupId>org.mapstruct</groupId>
      <artifactId>mapstruct</artifactId>
      <version>1.5.0.Beta1</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>javax.servlet</groupId>
      <artifactId>javax.servlet-api</artifactId>
      <version>4.0.1</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.apache.iceberg</groupId>
      <artifactId>iceberg-spark-runtime-3.1_2.12</artifactId>
      <version>1.2.0</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.antlr</groupId>
      <artifactId>antlr4-runtime</artifactId>
      <version>4.7.1</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>
</project>
```

openhouse-spark-runtime size before the change:
```
% ls -lrt build/openhouse-spark-runtime_2.12/libs                                        
total 43512
-rw-r--r--  1 anath1  101  21260793 Sep 24 21:48 openhouse-spark-runtime_2.12-uber.jar
-rw-r--r--  1 anath1  101    166197 Sep 24 21:50 openhouse-spark-runtime_2.12.jar
```

openhouse-spark-runtime size after the change:
```
% ls -lrt build/openhouse-spark-runtime_2.12/libs 
total 41856
-rw-r--r--  1 anath1  101    166197 Sep 24 17:03 openhouse-spark-runtime_2.12.jar
-rw-r--r--  1 anath1  101  21260720 Sep 24 17:03 openhouse-spark-runtime_2.12-uber.jar
```
Compared openhouse-spark-runtime jar before and after the change using [pkgdiff](https://lvc.github.io/pkgdiff/#Downloads) tool.

No changes for jar (thin) before and after change.
```
% pkgdiff ../jar4/openhouse-spark-runtime_2.12-before.jar openhouse-spark-runtime_2.12-after.jar 
WARNING: wdiff is not installed
reading packages ...
comparing packages ...
creating report ...
result: UNCHANGED
report: pkgdiff_reports/openhouse-spark-runtime/2.12-before_to_2.12-after/changes_report.html
```

Only informational file changed for uber jar before and after the change.
```
% pkgdiff ../jar4/openhouse-spark-runtime_2.12-uber-before.jar openhouse-spark-runtime_2.12-uber-after.jar 
WARNING: wdiff is not installed
reading packages ...
comparing packages ...
creating report ...
result: CHANGED (0.001%)
report: pkgdiff_reports/openhouse-spark-runtime/2.12-uber-before_to_2.12-uber-after/changes_report.html
```

1. Comparison report:
<img width="1442" alt="Screenshot 2024-09-24 at 10 46 10 PM" src="https://github.com/user-attachments/assets/fa1c326e-8671-459f-b518-3e4be974bc68">
2. Diff file (only manifest file):
<img width="1098" alt="Screenshot 2024-09-24 at 11 03 53 PM" src="https://github.com/user-attachments/assets/d4c1476e-b683-4f5a-8df0-918ee04cbd47">
3. Diff content
<img width="1442" alt="Screenshot 2024-09-24 at 10 46 10 PM" src="https://github.com/user-attachments/assets/5594bc96-d186-4b98-bca9-fc0ebdb1e432">

[pkgdiff_reports.zip](https://github.com/user-attachments/files/17125746/pkgdiff_reports.zip)

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
