### PR TITLE
Add table policies as stats to Table Stats Collector

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableStatsCollectorUtil.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableStatsCollectorUtil.java
@@ -193,22 +193,6 @@ public final class TableStatsCollectorUtil {
                 : 0)
         .tableUUID(table.properties().get(getCanonicalFieldName("tableUUID")))
         .tableLocation(table.location())
-        .tableUri(table.properties().get(getCanonicalFieldName("tableUri")))
-        .tableVersion(table.properties().get(getCanonicalFieldName("tableVersion")))
-        .previousVersionsMax(
-            table.properties().containsKey("write.metadata.previous-versions-max")
-                ? Long.parseLong(table.properties().get("write.metadata.previous-versions-max"))
-                : 0)
-        .deleteAfterCommitEnabled(
-            table.properties().containsKey("write.metadata.delete-after-commit.enabled")
-                ? Boolean.valueOf(
-                    table.properties().get("write.metadata.delete-after-commit.enabled"))
-                : false)
-        .metaDataPath(table.properties().get("write.metadata.path"))
-        .dataPath(table.properties().get("write.data.path"))
-        .folderStoragePath(table.properties().get("write.folder-storage.path"))
-        .tableFormat(table.properties().get("format"))
-        .defaultTableFormat(table.properties().get("write.format.default"))
         .sharingEnabled(getTablePoliciesSharingEnabled(table))
         .retentionPolicies(getTablePolicyRetention(table))
         .build();

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableStatsCollectorUtil.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableStatsCollectorUtil.java
@@ -275,7 +275,7 @@ public final class TableStatsCollectorUtil {
             retentionPolicy.containsKey("count")
                 ? Integer.valueOf((String) retentionPolicy.get("count"))
                 : 0)
-        .granularity((String) retentionPolicy.get("granularity"))
+        .granularity((String) retentionPolicy.getOrDefault("granularity", null))
         .columnPattern((String) retentionPolicy.getOrDefault("pattern", null))
         .columnName((String) retentionPolicy.getOrDefault("columnName", null))
         .build();

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -528,6 +528,42 @@ public class OperationsTest extends OpenHouseSparkITest {
   }
 
   @Test
+  public void testCollectMetadataTableStats() throws Exception {
+    final String tableName = "db.test_collect_table_stats_with_policy";
+    List<String> rowValue = new ArrayList<>();
+
+    try (Operations ops = Operations.withCatalog(getSparkSession(), meter)) {
+      prepareTableWithPolicies(ops, tableName, "30d", true);
+      populateTable(ops, tableName, 2, 2);
+
+      IcebergTableStats stats = ops.collectTableStats(tableName);
+
+      Assertions.assertEquals(stats.getSharingEnabled(), true);
+      Assertions.assertEquals(stats.getRetentionPolicies().getCount(), 30);
+      Assertions.assertEquals(stats.getRetentionPolicies().getGranularity(), "DAY");
+
+      prepareTableWithPoliciesWithStringPartition(ops, tableName, "16h", false);
+      rowValue.add("202%s-07-16");
+      populateTableWithStringColumn(ops, tableName, 1, rowValue);
+      stats = ops.collectTableStats(tableName);
+      Assertions.assertEquals(stats.getSharingEnabled(), false);
+      Assertions.assertEquals(stats.getRetentionPolicies().getCount(), 16);
+      Assertions.assertEquals(stats.getRetentionPolicies().getGranularity(), "HOUR");
+      Assertions.assertEquals(stats.getRetentionPolicies().getColumnName(), "datepartition");
+      Assertions.assertEquals(stats.getRetentionPolicies().getColumnPattern(), "yyyy-MM-dd-HH");
+      rowValue.clear();
+
+      prepareTableWithPoliciesWithCustomStringPartition(ops, tableName, "2y", "yyyy-MM-dd-HH");
+      rowValue.add("202%s-07-16-12");
+      populateTableWithStringColumn(ops, tableName, 1, rowValue);
+      stats = ops.collectTableStats(tableName);
+      Assertions.assertEquals(stats.getRetentionPolicies().getCount(), 2);
+      Assertions.assertEquals(stats.getRetentionPolicies().getGranularity(), "YEAR");
+      Assertions.assertEquals(stats.getRetentionPolicies().getColumnPattern(), "'yyyy-MM-dd-HH'");
+    }
+  }
+
+  @Test
   public void testCollectTableStats() throws Exception {
     final String tableName = "db.test_collect_table_stats";
     final int numInserts = 3;
@@ -683,6 +719,41 @@ public class OperationsTest extends OpenHouseSparkITest {
     log.info("Checking snapshots");
     List<Long> foundSnapshotIds = getSnapshotIds(ops, tableName);
     Assertions.assertEquals(expectedSnapshotIds, foundSnapshotIds, "Incorrect list of snapshots");
+  }
+
+  private static void prepareTableWithPoliciesWithStringPartition(
+      Operations ops, String tableName, String retention, boolean sharing) {
+    ops.spark().sql(String.format("DROP TABLE IF EXISTS %s", tableName)).show();
+    ops.spark()
+        .sql(
+            String.format(
+                "CREATE TABLE %s (data string, datepartition string) PARTITIONED BY (datepartition)",
+                tableName))
+        .show();
+    ops.spark()
+        .sql(
+            String.format(
+                "ALTER TABLE %s SET POLICY (RETENTION=%s ON COLUMN datepartition)",
+                tableName, retention));
+    ops.spark().sql(String.format("ALTER TABLE %s SET POLICY (SHARING=%s)", tableName, sharing));
+    ops.spark().sql(String.format("DESCRIBE %s", tableName)).show();
+  }
+
+  private static void prepareTableWithPoliciesWithCustomStringPartition(
+      Operations ops, String tableName, String retention, String pattern) {
+    ops.spark().sql(String.format("DROP TABLE IF EXISTS %s", tableName)).show();
+    ops.spark()
+        .sql(
+            String.format(
+                "CREATE TABLE %s (data string, datepartition string) PARTITIONED BY (datepartition)",
+                tableName))
+        .show();
+    ops.spark()
+        .sql(
+            String.format(
+                "ALTER TABLE %s SET POLICY (RETENTION=%s ON COLUMN datepartition WHERE PATTERN = '%s')",
+                tableName, retention, pattern));
+    ops.spark().sql(String.format("DESCRIBE %s", tableName)).show();
   }
 
   private static void checkSnapshots(Table table, List<Long> expectedSnapshotIds) {

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -528,7 +528,7 @@ public class OperationsTest extends OpenHouseSparkITest {
   }
 
   @Test
-  public void testCollectMetadataTableStats() throws Exception {
+  public void testCollectTablePolicyStats() throws Exception {
     final String tableName = "db.test_collect_table_stats_with_policy";
     List<String> rowValue = new ArrayList<>();
 

--- a/services/common/src/main/java/com/linkedin/openhouse/common/stats/model/BaseTableMetadata.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/stats/model/BaseTableMetadata.java
@@ -32,24 +32,6 @@ public class BaseTableMetadata {
 
   private String tableType;
 
-  private String tableUri;
-
-  private String tableVersion;
-
-  private Long previousVersionsMax;
-
-  private Boolean deleteAfterCommitEnabled;
-
-  private String metaDataPath;
-
-  private String dataPath;
-
-  private String folderStoragePath;
-
-  private String tableFormat;
-
-  private String defaultTableFormat;
-
   private Boolean sharingEnabled;
 
   private RetentionStatsSchema retentionPolicies;

--- a/services/common/src/main/java/com/linkedin/openhouse/common/stats/model/BaseTableMetadata.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/stats/model/BaseTableMetadata.java
@@ -31,4 +31,26 @@ public class BaseTableMetadata {
   private Long tableLastUpdatedTimestamp;
 
   private String tableType;
+
+  private String tableUri;
+
+  private String tableVersion;
+
+  private Long previousVersionsMax;
+
+  private Boolean deleteAfterCommitEnabled;
+
+  private String metaDataPath;
+
+  private String dataPath;
+
+  private String folderStoragePath;
+
+  private String tableFormat;
+
+  private String defaultTableFormat;
+
+  private Boolean sharingEnabled;
+
+  private RetentionStatsSchema retentionPolicies;
 }

--- a/services/common/src/main/java/com/linkedin/openhouse/common/stats/model/RetentionStatsSchema.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/stats/model/RetentionStatsSchema.java
@@ -1,0 +1,22 @@
+package com.linkedin.openhouse.common.stats.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+/** Data Model for capturing retention stats about a table. */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+public class RetentionStatsSchema {
+
+  private Integer count;
+
+  private String granularity;
+
+  private String columnName;
+
+  private String columnPattern;
+}


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

This PR captures table policies (`sharingEnabled` and `retention`) in the table stats collector to use for Openhouse alerting.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.
Added unit test to test that the policies are correctly set in the stats collector.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
