### PR TITLE
Make the rest of the modules forward compatible with Java 17

### DIFF
--- a/apps/spark/build.gradle
+++ b/apps/spark/build.gradle
@@ -47,14 +47,14 @@ dependencies {
         exclude group: 'io.netty'
         exclude group: 'org.apache.curator', module: 'curator-client'
         exclude group: 'org.apache.commons', module: 'commons-lang3'
-        
+
     }
     implementation ('org.apache.iceberg:iceberg-spark-runtime-3.1_2.12:' + icebergVersion) {
         exclude group: 'io.netty'
     }
     implementation 'commons-cli:commons-cli:1.5.0'
     implementation 'org.reflections:reflections:0.10.2'
-    implementation ('org.springframework.boot:spring-boot-starter-webflux:2.7.8')
+    implementation 'org.springframework.boot:spring-boot-starter-webflux:2.7.8'
     implementation 'io.netty:netty-resolver-dns-native-macos:4.1.75.Final:osx-x86_64'
     implementation 'org.springframework.retry:spring-retry:1.3.3'
     implementation 'org.apache.logging.log4j:log4j-core:2.18.0'
@@ -68,8 +68,13 @@ dependencies {
     implementation 'com.fasterxml.woodstox:woodstox-core:6.2.7'
 
     // open telemetry related classed. Latest Okhttp version is 4.10.0, pinning to 4.9.3 to avoid dependency issues
-    implementation 'com.squareup.okhttp3:okhttp:4.9.3'
+    implementation 'com.squareup.okhttp3:okhttp:' + ok_http3_version
+    implementation 'com.squareup.okhttp:okhttp:2.7.5'
     implementation 'com.squareup.okio:okio:3.2.0'
+    implementation 'com.squareup.okio:okio-jvm:3.2.0'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:2.0.20'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:2.0.20'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.0.20'
     implementation 'io.opentelemetry:opentelemetry-api:1.18.0'
     implementation 'io.opentelemetry:opentelemetry-exporter-otlp:1.18.0'
     implementation 'io.opentelemetry:opentelemetry-sdk:1.18.0'
@@ -142,3 +147,12 @@ shadowJar {
 // By default shadow doesn't configure the build task to depend on the shadowJar task.
 tasks.build.dependsOn tasks.shadowJar
 
+test {
+    if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
+        jvmArgs \
+            '--add-opens=java.base/java.nio=ALL-UNNAMED',
+            '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED',
+            '--add-opens=java.base/sun.util.calendar=ALL-UNNAMED',
+            '--add-exports=java.base/sun.util.calendar=ALL-UNNAMED'
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ buildscript {
 ext {
   spring_web_version = "2.7.8"
   spark_version = "3.1.1"
+  ok_http3_version = "4.11.0"
+  junit_version = "5.11.0"
 }
 
 group = 'com.linkedin.openhouse'
@@ -68,10 +70,10 @@ allprojects {
     dependencies {
 
       testImplementation "org.assertj:assertj-core:3.24.2" //assertions library
-      testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.0"
-      testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.0"
+      testImplementation "org.junit.jupiter:junit-jupiter-api:" + junit_version
+      testImplementation "org.junit.jupiter:junit-jupiter-params:" + junit_version
       testImplementation "org.mockito:mockito-core:4.11.0"
-      testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.0"
+      testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:" + junit_version
     }
 
     tasks.withType(Test) {

--- a/buildSrc/src/main/groovy/openhouse.client-codegen-convention.gradle
+++ b/buildSrc/src/main/groovy/openhouse.client-codegen-convention.gradle
@@ -7,7 +7,7 @@ ext {
   jakarta_annotation_version = "1.3.5"
   reactor_version = "3.4.3"
   jodatime_version = "2.9.9"
-  junit_version = "4.13.1"
+  junit_version = "5.11.0"
 }
 
 // All of these are copied from generated

--- a/buildSrc/src/main/groovy/openhouse.hadoop-conventions.gradle
+++ b/buildSrc/src/main/groovy/openhouse.hadoop-conventions.gradle
@@ -9,6 +9,7 @@ dependencies {
     exclude group: 'com.zaxxer', module: 'HikariCP-java7'
     exclude group: 'org.apache.commons', module: 'commons-lang3'
     exclude group: 'com.codahale.metrics', module: 'metrics-core'
+    exclude group: 'com.squareup.okhttp', module: 'okhttp'
   }
   implementation 'org.apache.commons:commons-lang3:3.12.0'
 }

--- a/buildSrc/src/main/groovy/openhouse.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/openhouse.java-conventions.gradle
@@ -2,6 +2,9 @@ plugins {
   id 'openhouse.java-minimal-conventions'
 }
 
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
+
 ext {
   gsonVersion = '2.8.9'
   micrometerVersion = '1.9.13'

--- a/buildSrc/src/main/groovy/openhouse.java-minimal-conventions.gradle
+++ b/buildSrc/src/main/groovy/openhouse.java-minimal-conventions.gradle
@@ -26,10 +26,10 @@ dependencies {
 
   annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
 
-  testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
+  testImplementation 'org.junit.jupiter:junit-jupiter:' + junit_version
   testImplementation "org.mockito:mockito-core:4.10.0"
 
-  implementation("javax.servlet:javax.servlet-api:4.0.1")
+  implementation "javax.servlet:javax.servlet-api:4.0.1"
 
 }
 

--- a/client/hts/build.gradle
+++ b/client/hts/build.gradle
@@ -1,7 +1,6 @@
 plugins {
-  id 'java'
-  id 'openhouse.client-codegen-convention'
   id 'openhouse.java-minimal-conventions'
+  id 'openhouse.client-codegen-convention'
   id 'openhouse.maven-publish'
 }
 

--- a/client/jobsclient/build.gradle
+++ b/client/jobsclient/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'java'
+    id 'openhouse.java-minimal-conventions'
     id 'openhouse.client-codegen-convention'
     id 'openhouse.maven-publish'
 }

--- a/client/secureclient/build.gradle
+++ b/client/secureclient/build.gradle
@@ -11,8 +11,8 @@ dependencies {
     implementation project(':client:hts')
     implementation 'org.springframework.boot:spring-boot-starter-webflux:2.7.8'
     testImplementation 'io.netty:netty-resolver-dns-native-macos:4.1.70.Final:osx-x86_64'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:' + junit_version
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:' + junit_version
     testImplementation 'org.mockito:mockito-inline:4.11.0'
 
 }

--- a/client/tableclient/build.gradle
+++ b/client/tableclient/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'java'
+  id 'openhouse.java-minimal-conventions'
   id 'openhouse.client-codegen-convention'
   id 'openhouse.maven-publish'
 }

--- a/iceberg/openhouse/internalcatalog/build.gradle
+++ b/iceberg/openhouse/internalcatalog/build.gradle
@@ -20,8 +20,8 @@ dependencies {
   // Needed for testing against manually bootstrapped HTS server through bootRun task.
   testImplementation "io.netty:netty-resolver-dns-native-macos:4.1.70.Final:osx-x86_64"
   // Needed for testing against mock HTS server along with other constructs in /tables module.
-  testImplementation "com.squareup.okhttp3:okhttp:4.9.3"
-  testImplementation "com.squareup.okhttp3:mockwebserver:4.9.3"
+  testImplementation "com.squareup.okhttp3:okhttp:" + ok_http3_version
+  testImplementation "com.squareup.okhttp3:mockwebserver:" + ok_http3_version
   testImplementation "org.mockito:mockito-inline:4.11.0"
 }
 

--- a/integrations/java/openhouse-java-itest/build.gradle
+++ b/integrations/java/openhouse-java-itest/build.gradle
@@ -6,10 +6,11 @@ plugins {
 ext {
   icebergVersion = '1.2.0'
 }
+
 dependencies {
   testImplementation(project(path: ':integrations:java:openhouse-java-runtime', configuration: 'shadow'))
 
-  testImplementation "com.squareup.okhttp3:okhttp:4.9.3"
-  testImplementation "com.squareup.okhttp3:mockwebserver:4.9.3"
+  testImplementation "com.squareup.okhttp3:okhttp:" + ok_http3_version
+  testImplementation "com.squareup.okhttp3:mockwebserver:" + ok_http3_version
   testImplementation "org.apache.iceberg:iceberg-bundled-guava:" + icebergVersion
 }

--- a/integrations/spark/openhouse-spark-itest/build.gradle
+++ b/integrations/spark/openhouse-spark-itest/build.gradle
@@ -6,7 +6,7 @@ plugins {
 dependencies {
 
   testImplementation 'com.google.code.gson:gson:2.8.9'
-  
+
   testImplementation(project(path: ':integrations:spark:openhouse-spark-runtime_2.12', configuration: 'shadow')) {
     exclude group: 'org.apache.commons', module: 'commons-lang3'
   }
@@ -17,11 +17,12 @@ dependencies {
   }
 
   testImplementation project(':tables-test-fixtures_2.12')
-  testImplementation 'org.junit.platform:junit-platform-runner:1.8.2'
+  testImplementation 'org.junit.platform:junit-platform-runner:1.11.0'
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'
   // Required to test /tables mockserver
   testImplementation 'org.apache.commons:commons-lang3:3.12.0'
-  testImplementation "com.squareup.okhttp3:okhttp:4.9.3"
-  testImplementation "com.squareup.okhttp3:mockwebserver:4.9.3"
+  testImplementation "com.squareup.okhttp3:okhttp:" + ok_http3_version
+  testImplementation "com.squareup.okhttp3:mockwebserver:" + ok_http3_version
   // Otherwise throws the error: Scala module 2.10.0 requires Jackson Databind version >= 2.10.0 and < 2.11.0
   testImplementation "com.fasterxml.jackson.module:jackson-module-scala_2.12:2.13.1"
   testImplementation "org.openapitools:jackson-databind-nullable:0.2.1"
@@ -46,11 +47,21 @@ task statementTest(type: Test) {
   filter {
     includeTestsMatching 'com.linkedin.openhouse.spark.statementtest.*'
   }
+  if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
+    jvmArgs \
+        '--add-opens=java.base/java.nio=ALL-UNNAMED',
+        '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED'
+  }
 }
 
 task catalogTest(type: Test) {
   filter {
     includeTestsMatching 'com.linkedin.openhouse.spark.catalogtest.*'
+  }
+  if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
+    jvmArgs \
+        '--add-opens=java.base/java.nio=ALL-UNNAMED',
+        '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED'
   }
 }
 
@@ -58,6 +69,13 @@ test {
   filter {
     excludeTestsMatching 'com.linkedin.openhouse.spark.statementtest.*'
     excludeTestsMatching 'com.linkedin.openhouse.spark.catalogtest.*'
+  }
+  if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
+    jvmArgs \
+        '--add-opens=java.base/java.nio=ALL-UNNAMED',
+        '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED',
+        '--add-opens=java.base/sun.util.calendar=ALL-UNNAMED',
+        '--add-exports=java.base/sun.util.calendar=ALL-UNNAMED'
   }
 }
 

--- a/libs/datalayout/build.gradle
+++ b/libs/datalayout/build.gradle
@@ -41,3 +41,13 @@ dependencies {
     testImplementation(project(':tables-test-fixtures_2.12'))
     testRuntimeOnly("org.eclipse.jetty:jetty-server:11.0.2")
 }
+
+test {
+    if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
+        jvmArgs \
+            '--add-opens=java.base/java.nio=ALL-UNNAMED',
+            '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED',
+            '--add-opens=java.base/sun.util.calendar=ALL-UNNAMED',
+            '--add-exports=java.base/sun.util.calendar=ALL-UNNAMED'
+    }
+}

--- a/services/jobs/build.gradle
+++ b/services/jobs/build.gradle
@@ -34,6 +34,12 @@ dependencies {
   implementation 'org.apache.livy:livy-client-common:0.7.0-incubating'
   implementation 'org.apache.livy:livy-client-http:0.7.0-incubating'
   testImplementation(testFixtures(project(':services:common')))
-  testImplementation "com.squareup.okhttp3:okhttp:4.9.3"
-  testImplementation "com.squareup.okhttp3:mockwebserver:4.9.3"
+  testImplementation "com.squareup.okhttp3:okhttp:" + ok_http3_version
+  testImplementation "com.squareup.okhttp3:mockwebserver:" + ok_http3_version
+}
+
+test {
+  if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
+    jvmArgs '--add-opens=java.base/java.util=ALL-UNNAMED'
+  }
 }

--- a/services/tables/build.gradle
+++ b/services/tables/build.gradle
@@ -29,10 +29,10 @@ dependencies {
   implementation project(':cluster:configs')
   implementation project(':cluster:storage')
   implementation project(':cluster:metrics')
-  implementation 'org.springframework.security:spring-security-config:' + '5.7.2'
+  implementation 'org.springframework.security:spring-security-config:5.7.2'
   implementation 'org.springframework.boot:spring-boot-starter-webflux:2.7.8'
-  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
-  testImplementation 'org.springframework.security:spring-security-test:' + '5.7.3'
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:' + junit_version
+  testImplementation 'org.springframework.security:spring-security-test:5.7.3'
   testImplementation(testFixtures(project(':services:common')))
   testImplementation project(':tables-test-fixtures_2.12')
 }

--- a/tables-test-fixtures/build.gradle
+++ b/tables-test-fixtures/build.gradle
@@ -14,7 +14,7 @@ configurations {
 }
 
 dependencies {
-  implementation 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+  implementation 'org.junit.jupiter:junit-jupiter-engine:' + junit_version
   implementation 'org.springframework.boot:spring-boot-starter-test:' + spring_web_version
   implementation(project(':services:tables'))
   compileOnly 'org.springframework.boot:spring-boot-starter-tomcat:' + spring_web_version
@@ -71,6 +71,7 @@ shadowJar {
       // e.g. java.lang.NoClassDefFoundError: openhouse/relocated/com/google/protobuf/GeneratedMessageV3
       // when users use fixtures library in their tests
       exclude 'com.google.protobuf.**'
+      exclude 'com.google.gson.**'
     }
   }
 }


### PR DESCRIPTION
## Summary
The following changes were made:
1) upgrade libraries and pick consistent versions
2) add jvm flags to allow forbidden export and opening private methods, this is currently enabled for tests, similar flags will need to be added when running OH services/apps as long as the dependencies use deprecated APIs

The changes are expected to be non-consequential since the target bytecode is Java 8.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests
- [x] Upgrade

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
