### PR TITLE
Put table properties in a key value pair for stats collector

### DIFF
--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -543,7 +543,8 @@ public class OperationsTest extends OpenHouseSparkITest {
       populateTable(ops, tableName, 1);
       stats = ops.collectTableStats(tableName);
       Assertions.assertEquals(stats.getNumReferencedDataFiles(), 1);
-      Assertions.assertTrue(stats.getTableLastUpdatedTimestamp() >= modifiedTimeStamp);
+      Assertions.assertTrue(
+          (Long) stats.getTableProperties().get("tableLastUpdatedTimestamp") >= modifiedTimeStamp);
 
       // Capture first snapshot timestamp
       Table table = ops.getTable(tableName);

--- a/services/common/src/main/java/com/linkedin/openhouse/common/stats/model/BaseTableMetadata.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/stats/model/BaseTableMetadata.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.common.stats.model;
 
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,23 +13,5 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder(toBuilder = true)
 public class BaseTableMetadata {
 
-  private Long recordTimestamp;
-
-  private String clusterName;
-
-  private String databaseName;
-
-  private String tableName;
-
-  private String tableUUID;
-
-  private String tableLocation;
-
-  private String tableCreator;
-
-  private Long tableCreationTimestamp;
-
-  private Long tableLastUpdatedTimestamp;
-
-  private String tableType;
+  private Map<String, Object> tableProperties;
 }


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

This PR moves the table properties into a key value store in the table stats collector in be use for Openhouse alerting.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
