### PR TITLE
Add an option to configure Job specific timeout values

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
@@ -394,7 +394,6 @@ public class JobsScheduler {
   }
 
   protected static int getTaskTimeOut(CommandLine cmdLine) {
-    return NumberUtils.toInt(
-        cmdLine.getOptionValue("taskTimeOutInHours"), DEFAULT_TASKS_WAIT_HOURS);
+    return NumberUtils.toInt(cmdLine.getOptionValue("tasksWaitHours"), DEFAULT_TASKS_WAIT_HOURS);
   }
 }


### PR DESCRIPTION
## Summary

Current default value of timeout is 12 hours. Since how long an entire job can take depend on number of tables and also on concurreny, making the timeout configurable in this PR.


## Changes

- [ ] Client-facing API Changes
- [X] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [X] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
