### PR TITLE
Skip compaction on non-partitioned tables

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
@@ -113,7 +113,7 @@ public class TablesClient {
     return response != null
         && checkCreationTimeEligibility(response)
         && isPrimaryTable(response)
-        && (response.getTimePartitioning() != null || response.getClustering() != null);
+        && response.getTimePartitioning() != null;
   }
 
   /**

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
@@ -110,7 +110,10 @@ public class TablesClient {
    */
   public boolean canRunDataCompaction(TableMetadata tableMetadata) {
     GetTableResponseBody response = getTable(tableMetadata);
-    return response != null && checkCreationTimeEligibility(response) && isPrimaryTable(response);
+    return response != null
+        && checkCreationTimeEligibility(response)
+        && isPrimaryTable(response)
+        && (response.getTimePartitioning() != null || response.getClustering() != null);
   }
 
   /**

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/clients/TablesClientTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/clients/TablesClientTest.java
@@ -455,7 +455,23 @@ public class TablesClientTest {
     Mockito.when(apiMock.getTableV1(testDbName, testReplicaTableName))
         .thenReturn(replicaResponseMock);
 
+    GetTableResponseBody primaryPartitionedTableResponseBodyMock =
+        createPartitionedTableResponseBodyMock(
+            testDbName, testTableNamePartitioned, testPartitionColumnName, 1);
+    Mono<GetTableResponseBody> partitionedResponseMock =
+        (Mono<GetTableResponseBody>) Mockito.mock(Mono.class);
+    Mockito.when(partitionedResponseMock.block(any(Duration.class)))
+        .thenReturn(primaryPartitionedTableResponseBodyMock);
+    Mockito.when(apiMock.getTableV1(testDbName, testTableNamePartitioned))
+        .thenReturn(partitionedResponseMock);
+
     Assertions.assertTrue(
+        client.canRunDataCompaction(
+            TableMetadata.builder()
+                .dbName(testDbName)
+                .tableName(testTableNamePartitioned)
+                .build()));
+    Assertions.assertFalse(
         client.canRunDataCompaction(
             TableMetadata.builder().dbName(testDbName).tableName(testTableName).build()));
     Assertions.assertFalse(


### PR DESCRIPTION
## Summary
Currently, there is no reason to run data compaction on non-partitioned tables since most of those tables get overwritten.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
