### PR TITLE
Setup Java 17 when building repo in github CI workflow

### DIFF
--- a/.github/workflows/build-tag-publish.yml
+++ b/.github/workflows/build-tag-publish.yml
@@ -18,11 +18,11 @@ jobs:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
           distribution: 'microsoft'
-          java-version: '1.8'
+          java-version: '17'
 
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ data services.
 For building and running locally in [Docker Compose](SETUP.md), you would need the following:
 
 - [Java](https://www.oracle.com/java/technologies/downloads/)
-  - OpenHouse is currently built with Java 8, and will be modernized soon.
-  - Set the `JAVA_HOME` environment variable to the location of your JDK8.
+  - OpenHouse is currently built with Java 17.
+  - Set the `JAVA_HOME` environment variable to the location of your JDK17.
 - [Docker](https://www.docker.com/)
 - [Docker Compose](https://docs.docker.com/compose/)
 - [Python3](https://www.python.org/downloads/)

--- a/SETUP.md
+++ b/SETUP.md
@@ -21,7 +21,7 @@ Run OpenHouse Services Only | oh-only                  | Stores data on local fi
 Run OpenHouse Services on HDFS | oh-hadoop                | Stores data on locally running Hadoop HDFS containers, with iceberg-backed database.
 Run OpenHouse Services on HDFS. Also, available Spark | oh-hadoop-spark          | Stores data on locally running Hadoop HDFS containers, with MySQL database. Spark available for end to end testing. Most resource consuming. Spark container might need more memory at time. Starts Livy server.
 
-Before building docker images, you would need to build the openhouse project (only java8 is supported) by running the following command.
+Before building docker images, you would need to build the openhouse project by running the following command.
 ```
 ./gradlew clean build
 ```


### PR DESCRIPTION
## Summary
Update setup java action to build with Java17, update docs. The change should be non-consequential since the source and target byte code are still Java 1.8 compatible.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [x] Documentation
- [ ] Tests
- [x] Upgrade

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [x] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
