### PR TITLE
Inferfacify TblPropsToggleRegistry for internal extension

### DIFF
--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/config/TblPropsToggleRegistry.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/config/TblPropsToggleRegistry.java
@@ -1,31 +1,8 @@
 package com.linkedin.openhouse.tables.config;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
-import javax.annotation.PostConstruct;
-import org.springframework.stereotype.Component;
 
-/** A central registry for all table properties that are managed through Feature Toggle */
-@Component
-public class TblPropsToggleRegistry {
+public interface TblPropsToggleRegistry {
 
-  public static final String ENABLE_TBLTYPE = "enable_tabletype";
-
-  // TODO: Using these vocabularies as MySQL validation
-  private final Map<String, String> featureKeys = new HashMap<>();
-
-  @PostConstruct
-  public void initializeKeys() {
-    // placeholders: demo purpose
-    featureKeys.put("openhouse.tableType", ENABLE_TBLTYPE);
-  }
-
-  public Optional<String> obtainFeatureByKey(String key) {
-    return Optional.ofNullable(featureKeys.get(key));
-  }
-
-  public boolean isFeatureRegistered(String featureId) {
-    return featureKeys.containsValue(featureId);
-  }
+  Optional<String> obtainFeatureByKey(String key);
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/config/TblPropsToggleRegistryBaseImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/config/TblPropsToggleRegistryBaseImpl.java
@@ -1,0 +1,26 @@
+package com.linkedin.openhouse.tables.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.PostConstruct;
+import org.springframework.stereotype.Component;
+
+/** A central registry for all table properties that are managed through Feature Toggle */
+@Component
+public class TblPropsToggleRegistryBaseImpl implements TblPropsToggleRegistry {
+
+  public static final String ENABLE_TBLTYPE = "enable_tabletype";
+  // TODO: Using these vocabularies as MySQL validation
+  private final Map<String, String> featureKeys = new HashMap<>();
+
+  @PostConstruct
+  public void initializeKeys() {
+    // placeholders: demo purpose
+    featureKeys.put("openhouse.tableType", ENABLE_TBLTYPE);
+  }
+
+  public Optional<String> obtainFeatureByKey(String key) {
+    return Optional.ofNullable(featureKeys.get(key));
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesControllerTest.java
@@ -3,8 +3,6 @@ package com.linkedin.openhouse.tables.e2e.h2;
 import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.INITIAL_TABLE_VERSION;
 import static com.linkedin.openhouse.common.schema.IcebergSchemaHelper.*;
 import static com.linkedin.openhouse.tables.config.TablesMvcConstants.*;
-import static com.linkedin.openhouse.tables.config.TblPropsToggleRegistry.*;
-import static com.linkedin.openhouse.tables.e2e.h2.ToggleH2StatusesRepository.*;
 import static com.linkedin.openhouse.tables.e2e.h2.ValidationUtilities.*;
 import static com.linkedin.openhouse.tables.model.DatabaseModelConstants.*;
 import static com.linkedin.openhouse.tables.model.ServiceAuditModelConstants.*;
@@ -36,6 +34,7 @@ import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllTablesResponseBo
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
 import com.linkedin.openhouse.tables.audit.model.TableAuditEvent;
 import com.linkedin.openhouse.tables.common.TableType;
+import com.linkedin.openhouse.tables.config.TblPropsToggleRegistryBaseImpl;
 import com.linkedin.openhouse.tables.mock.properties.AuthorizationPropertiesInitializer;
 import com.linkedin.openhouse.tables.model.ServiceAuditModelConstants;
 import com.linkedin.openhouse.tables.model.TableAuditModelConstants;
@@ -318,7 +317,7 @@ public class TablesControllerTest {
      */
     inMemToggleStatusRepo.save(
         TableToggleStatus.builder()
-            .featureId(ENABLE_TBLTYPE)
+            .featureId(TblPropsToggleRegistryBaseImpl.ENABLE_TBLTYPE)
             .tableId(GET_TABLE_RESPONSE_BODY.getTableId())
             .databaseId(GET_TABLE_RESPONSE_BODY.getDatabaseId())
             .toggleStatusEnum(ToggleStatus.StatusEnum.ACTIVE)


### PR DESCRIPTION
## Summary

This PR makes `TblPropsToggleRegistry` an interface (instead of an implementation) so that we can extend the behavior of preserved table properties registration by overriding the injected bean. 

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
There's no new features added, passing existing tests should be good enough. 

<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [x] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
