### PR TITLE
ExceptionHandler for requests gated by feature toggle

### DIFF
--- a/services/common/src/main/java/com/linkedin/openhouse/common/exception/ResourceGatedByToggledOnFeatureException.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/exception/ResourceGatedByToggledOnFeatureException.java
@@ -1,4 +1,4 @@
-package com.linkedin.openhouse.tables.toggle;
+package com.linkedin.openhouse.common.exception;
 
 /**
  * The exception thrown when the request feature of a resource is toggled on thus being gated access

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/config/TblPropsToggleRegistryBaseImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/config/TblPropsToggleRegistryBaseImpl.java
@@ -12,7 +12,7 @@ public class TblPropsToggleRegistryBaseImpl implements TblPropsToggleRegistry {
 
   public static final String ENABLE_TBLTYPE = "enable_tabletype";
   // TODO: Using these vocabularies as MySQL validation
-  private final Map<String, String> featureKeys = new HashMap<>();
+  protected final Map<String, String> featureKeys = new HashMap<>();
 
   @PostConstruct
   public void initializeKeys() {

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/toggle/FeatureToggleAspect.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/toggle/FeatureToggleAspect.java
@@ -1,6 +1,7 @@
 package com.linkedin.openhouse.tables.toggle;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.linkedin.openhouse.common.exception.ResourceGatedByToggledOnFeatureException;
 import com.linkedin.openhouse.internal.catalog.toggle.IcebergFeatureGate;
 import com.linkedin.openhouse.tables.config.TblPropsToggleRegistry;
 import com.linkedin.openhouse.tables.model.TableDto;

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/toggle/FeatureToggleAspectTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/toggle/FeatureToggleAspectTest.java
@@ -3,6 +3,7 @@ package com.linkedin.openhouse.tables.toggle;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.linkedin.openhouse.common.exception.ResourceGatedByToggledOnFeatureException;
 import com.linkedin.openhouse.internal.catalog.toggle.IcebergFeatureGate;
 import com.linkedin.openhouse.tables.config.TblPropsToggleRegistry;
 import com.linkedin.openhouse.tables.model.TableDto;


### PR DESCRIPTION
## Summary

This PR adds the handler method for `ResourceGatedByToggledOnFeatureException` so to avoid it throwing 5xx error which is not accurate. 

Also, it has one tiny modifier tweak for `featureKeys` within `services/tables/src/main/java/com/linkedin/openhouse/tables/config/TblPropsToggleRegistryBaseImpl.java` for sake of extension within LI's setup

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->
There's no new feature added, passing existing tests should be sufficient. 

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [x] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
