### PR TITLE
Fix target bytecode for tables-test-fixtures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ allprojects {
         trimTrailingWhitespace()
 
         endWithNewline()
-        googleJavaFormat()
+        googleJavaFormat('1.7')
       }
     }
 

--- a/buildSrc/src/main/groovy/openhouse.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/openhouse.java-conventions.gradle
@@ -2,9 +2,6 @@ plugins {
   id 'openhouse.java-minimal-conventions'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 ext {
   gsonVersion = '2.8.9'
   micrometerVersion = '1.9.13'

--- a/tables-test-fixtures/build.gradle
+++ b/tables-test-fixtures/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'java'
+  id 'openhouse.java-minimal-conventions'
   id 'com.github.johnrengelman.shadow' version '7.1.2'
   id 'openhouse.maven-publish'
 }


### PR DESCRIPTION
## Summary
tables-test-fixtures module was not down-compiled to 1.8, this PR fixes that

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [x] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Before the change
```
>> find . -name '*.class' | xargs -I{} file {} | egrep -v 'Java 1.8'
./htscatalog/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./secureclient/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./internalcatalog/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./datalayout/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./tables/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./azure/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./storage/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./common/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./openhouse-java-itest/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./tables-test-fixtures_2.12/classes/java/test/com/linkedin/openhouse/tablestest/TomcatServerBootTest.class: compiled Java class data, version 61.0
./tables-test-fixtures_2.12/classes/java/test/com/linkedin/openhouse/tablestest/OpenHouseLocalServerTest.class: compiled Java class data, version 61.0
./tables-test-fixtures_2.12/classes/java/main/com/linkedin/openhouse/tablestest/OpenHouseSparkITest.class: compiled Java class data, version 61.0
./tables-test-fixtures_2.12/classes/java/main/com/linkedin/openhouse/tablestest/OpenHouseLocalServer.class: compiled Java class data, version 61.0
./tables-test-fixtures_2.12/classes/java/main/com/linkedin/openhouse/tablestest/ToggleH2StatusesRepository.class: compiled Java class data, version 61.0
./tables-test-fixtures_2.12/classes/java/main/com/linkedin/openhouse/tablestest/annotation/CustomParameterResolver.class: compiled Java class data, version 61.0
./tables-test-fixtures_2.12/classes/java/main/com/linkedin/openhouse/tablestest/annotation/MappedParameterContext.class: compiled Java class data, version 61.0
./tables-test-fixtures_2.12/classes/java/main/com/linkedin/openhouse/tablestest/SpringH2TestApplication.class: compiled Java class data, version 61.0
./tables-test-fixtures_2.12/classes/java/main/com/linkedin/openhouse/tablestest/TestSparkSessionUtil.class: compiled Java class data, version 61.0
./tables-test-fixtures_2.12/classes/java/main/com/linkedin/openhouse/tablestest/HouseTablesH2Repository.class: compiled Java class data, version 61.0
./openhouse-spark-apps_2.12/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./jobs/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./housetables/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./openhouse-spark-itest/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
```
After the change
```
>> find . -name '*.class' | xargs -I{} file {} | egrep -v 'Java 1.8'
./htscatalog/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./secureclient/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./internalcatalog/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./datalayout/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./tables/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./azure/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./storage/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./common/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./openhouse-java-itest/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./tables-test-fixtures_2.12/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./openhouse-spark-apps_2.12/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./jobs/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./housetables/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
./openhouse-spark-itest/tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/org/jacoco/agent/AgentJar.class: compiled Java class data, version 49.0 (Java 1.5)
```
61 is Java 17 byte code version
# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
