### PR TITLE
Relax LocalStorageClient's LocalFileSystem check

### DIFF
--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorageClient.java
@@ -10,6 +10,7 @@ import java.net.URISyntaxException;
 import javax.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FilterFileSystem;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
@@ -76,9 +77,21 @@ public class LocalStorageClient extends BaseStorageClient<FileSystem> {
           e);
     }
     this.fs = FileSystem.get(uri, new org.apache.hadoop.conf.Configuration());
-    Preconditions.checkArgument(
-        fs instanceof LocalFileSystem,
-        "Instantiation failed for LocalStorageClient, fileSystem is not a LocalFileSystem");
+    assertLocalFileSystem(fs);
+  }
+
+  private static void assertLocalFileSystem(FileSystem fs) {
+    if (!(fs instanceof FilterFileSystem)) {
+      // LocalFileSystem is a FilterFileSystem, so if it's not a FilterFileSystem, it's definitely
+      // not local
+      throw new IllegalArgumentException(
+          "Instantiation failed for LocalStorageClient, fileSystem is not a LocalFileSystem");
+    } else if (!(fs instanceof LocalFileSystem)) {
+      // if it's a FilterFileSystem but not a local FS, check the raw file system to see if it
+      // _wraps_ a local FS
+      assertLocalFileSystem(((FilterFileSystem) fs).getRawFileSystem());
+    }
+    // this branch is only reached if fs is a LocalFileSystem
   }
 
   @Override

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorageClient.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.cluster.storage.local;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.linkedin.openhouse.cluster.storage.BaseStorageClient;
 import com.linkedin.openhouse.cluster.storage.StorageType;
@@ -41,7 +42,13 @@ public class LocalStorageClient extends BaseStorageClient<FileSystem> {
 
   /** Initialize the LocalStorageClient when the bean is accessed for the first time. */
   @PostConstruct
-  public synchronized void init() throws URISyntaxException, IOException {
+  public void init() throws IOException {
+    init(new org.apache.hadoop.conf.Configuration());
+  }
+
+  @VisibleForTesting
+  public synchronized void init(org.apache.hadoop.conf.Configuration hadoopConfig)
+      throws IOException {
     log.info("Initializing storage client for type: " + LOCAL_TYPE);
 
     URI uri;
@@ -76,7 +83,7 @@ public class LocalStorageClient extends BaseStorageClient<FileSystem> {
               + LOCAL_TYPE.getValue(),
           e);
     }
-    this.fs = FileSystem.get(uri, new org.apache.hadoop.conf.Configuration());
+    this.fs = FileSystem.get(uri, hadoopConfig);
     assertLocalFileSystem(fs);
   }
 


### PR DESCRIPTION
## Summary

In `LocalStorageClient` we have a check to enforce that the `FileSystem` instance which is created is a `LocalFileSystem`. In some cases, for example when running within the Trino context (e.g. for an integration test), the `FileSystem` instance may be a _wrapper_ around a `LocalFileSystem`. This should still be considered valid. 

For reference, here is the code within Trino which will force that all `FileSystem` instances get wrapper inside of a custom wrapper `FileSystemWrapper`, including `LocalFileSystem`:
https://github.com/trinodb/trino/blob/f1a8feb8e4d38fc771c0d09f85c93dae3886456a/lib/trino-hdfs/src/main/java/io/trino/hdfs/TrinoFileSystemCache.java#L158-L160

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [X] Tests

## Testing Done
- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [X] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

New unit test in `LocalStorageClientTest`

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

(none apply)