### PR TITLE
Support table level props for maintenance jobs configuration

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/JobsClient.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/JobsClient.java
@@ -7,7 +7,9 @@ import com.linkedin.openhouse.jobs.client.model.JobConf;
 import com.linkedin.openhouse.jobs.client.model.JobResponseBody;
 import com.linkedin.openhouse.jobs.util.RetryUtil;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,13 +27,18 @@ public class JobsClient {
 
   /** Returns job id iff job launch was successful. */
   public Optional<String> launch(
-      String jobName, JobConf.JobTypeEnum jobType, String proxyUser, List<String> args) {
+      String jobName,
+      JobConf.JobTypeEnum jobType,
+      String proxyUser,
+      Map<String, String> executionProperties,
+      List<String> args) {
     final CreateJobRequestBody request = new CreateJobRequestBody();
     request.setClusterId(clusterId);
     request.setJobName(jobName);
     JobConf jobConf = new JobConf();
     jobConf.setJobType(jobType);
     jobConf.setProxyUser(proxyUser);
+    jobConf.executionConf(executionProperties);
     jobConf.setArgs(args);
     request.setJobConf(jobConf);
     return Optional.ofNullable(
@@ -44,6 +51,11 @@ public class JobsClient {
                   return response != null ? response.getJobId() : null;
                 },
             null));
+  }
+
+  public Optional<String> launch(
+      String jobName, JobConf.JobTypeEnum jobType, String proxyUser, List<String> args) {
+    return launch(jobName, jobType, proxyUser, Collections.emptyMap(), args);
   }
 
   /** Returns (@link com.linkedin.openhouse.common.JobState) given job id. */

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
@@ -95,6 +95,11 @@ public class TablesClient {
         null);
   }
 
+  public Map<String, String> getTableProperties(TableMetadata tableMetadata) {
+    GetTableResponseBody response = getTable(tableMetadata);
+    return response == null ? Collections.emptyMap() : response.getTableProperties();
+  }
+
   /**
    * Scans all databases and tables in the databases, converts Tables Service responses to {@link
    * TableMetadata}, filters out using {@link DatabaseTableFilter}, and returns as a list.

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableOperationTask.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableOperationTask.java
@@ -25,19 +25,17 @@ public abstract class TableOperationTask extends OperationTask<TableMetadata> {
 
   protected boolean launchJob() {
     String jobName =
-        String.format(
-            "%s_%s_%s", getType(), getMetadata().getDbName(), getMetadata().getTableName());
+        String.format("%s_%s_%s", getType(), metadata.getDbName(), metadata.getTableName());
     jobId =
         jobsClient
-            .launch(
-                jobName, getType(), getMetadata().getCreator(), getExecutionProperties(), getArgs())
+            .launch(jobName, getType(), metadata.getCreator(), getExecutionProperties(), getArgs())
             .orElse(null);
     return jobId != null;
   }
 
   protected Map<String, String> getExecutionProperties() {
     final String propertyPrefix = MAINTENANCE_PROPERTY_PREFIX + getType().name() + ".";
-    return tablesClient.getTableProperties(getMetadata()).entrySet().stream()
+    return tablesClient.getTableProperties(metadata).entrySet().stream()
         .filter(e -> e.getKey().startsWith(propertyPrefix))
         .map(
             e ->

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableOperationTask.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableOperationTask.java
@@ -36,12 +36,13 @@ public abstract class TableOperationTask extends OperationTask<TableMetadata> {
   }
 
   protected Map<String, String> getExecutionProperties() {
+    final String propertyPrefix = MAINTENANCE_PROPERTY_PREFIX + getType().name() + ".";
     return tablesClient.getTableProperties(getMetadata()).entrySet().stream()
-        .filter(e -> e.getKey().startsWith(MAINTENANCE_PROPERTY_PREFIX))
+        .filter(e -> e.getKey().startsWith(propertyPrefix))
         .map(
             e ->
                 new AbstractMap.SimpleEntry<>(
-                    e.getKey().substring(MAINTENANCE_PROPERTY_PREFIX.length()), e.getValue()))
+                    e.getKey().substring(propertyPrefix.length()), e.getValue()))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 }

--- a/infra/recipes/docker-compose/oh-hadoop-spark/jobs.yaml
+++ b/infra/recipes/docker-compose/oh-hadoop-spark/jobs.yaml
@@ -1,7 +1,7 @@
 jobs:
   defaults:
     &apps-defaults
-      spark-properties: {
+      spark-properties: &spark-defaults {
         "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,com.linkedin.openhouse.spark.extensions.OpenhouseSparkSessionExtensions",
         "spark.sql.catalog.openhouse": "org.apache.iceberg.spark.SparkCatalog",
         "spark.sql.catalog.openhouse.catalog-impl": "com.linkedin.openhouse.spark.OpenHouseCatalog",
@@ -9,7 +9,7 @@ jobs:
         "spark.sql.catalog.openhouse.cluster": "LocalHadoopCluster",
         "spark.jars.packages": "org.apache.iceberg:iceberg-spark-runtime-3.1_2.12:1.2.0",
         "spark.sql.autoBroadcastJoinThreshold": "-1",
-        "spark.driver.memory": "2g"
+        "spark.driver.memory": "1g"
       }
       jar-path: local:/opt/spark/openhouse-spark-apps_2.12-latest-all.jar
       dependencies:
@@ -45,6 +45,9 @@ jobs:
         class-name: com.linkedin.openhouse.jobs.spark.OrphanFilesDeletionSparkApp
         args: ["--trashDir", ".trash"]
         <<: *apps-defaults
+        spark-properties:
+          <<: *spark-defaults
+          "spark.driver.memory": "2g"
       - type: STAGED_FILES_DELETION
         class-name: com.linkedin.openhouse.jobs.spark.StagedFilesDeletionSparkApp
         args: ["--trashDir", ".trash", "--daysOld", "10", "--recursive", "true"]

--- a/services/common/src/main/java/com/linkedin/openhouse/common/api/validator/ValidatorConstants.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/api/validator/ValidatorConstants.java
@@ -12,10 +12,6 @@ public final class ValidatorConstants {
   // supported memory format: Integer values ending with G or M
   public static final String ALPHA_NUM_UNDERSCORE_ERROR_MSG_HYPHEN_ALLOW =
       "Only alphanumerics, hyphen and underscore supported";
-  public static final String SPARK_MEMORY_REGEX_ALLOW = "^(?!0[MG])(\\d+[MG])$";
-  public static final String SPARK_MEMORY_ERROR_MSG_ALLOW =
-      "Only positive integer values ending with G or M supported";
   public static final int MAX_ALLOWED_CLUSTERING_COLUMNS = 4;
   public static final String INITIAL_TABLE_VERSION = "INITIAL_VERSION";
-  public static final String JOB_MEMORY_CONFIG = "memory";
 }

--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/api/validator/impl/OpenHouseJobsApiValidator.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/api/validator/impl/OpenHouseJobsApiValidator.java
@@ -51,19 +51,19 @@ public class OpenHouseJobsApiValidator implements JobsApiValidator {
 
   // inner class to validate jobConf fields.
   private static class JobConfValidator {
-    private static boolean validateExecutionConfig(Map<String, String> conf) {
-      String memory = conf.getOrDefault(JOB_MEMORY_CONFIG, "");
-      return memory.matches(SPARK_MEMORY_REGEX_ALLOW);
+    private static boolean validateSparkKeys(Map<String, String> conf) {
+      for (Map.Entry<String, String> entry : conf.entrySet()) {
+        if (!entry.getKey().startsWith("spark.")) {
+          return false;
+        }
+      }
+      return true;
     }
 
     private static void validate(@NonNull JobConf conf, List<String> validationFailures) {
       final Map<String, String> executionConfig = conf.getExecutionConf();
-      if (MapUtils.isNotEmpty(executionConfig)
-          && !JobConfValidator.validateExecutionConfig(executionConfig)) {
-        validationFailures.add(
-            String.format(
-                "jobConf.executionConf.memory : provided %s, %s",
-                executionConfig.get(JOB_MEMORY_CONFIG), SPARK_MEMORY_ERROR_MSG_ALLOW));
+      if (MapUtils.isNotEmpty(executionConfig) && !validateSparkKeys(executionConfig)) {
+        validationFailures.add("jobConf.executionConf should contain keys starting with 'spark.'");
       }
     }
   }

--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/api/validator/impl/OpenHouseJobsApiValidator.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/api/validator/impl/OpenHouseJobsApiValidator.java
@@ -1,6 +1,8 @@
 package com.linkedin.openhouse.jobs.api.validator.impl;
 
-import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.*;
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.ALPHA_NUM_UNDERSCORE_ERROR_MSG_HYPHEN_ALLOW;
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.ALPHA_NUM_UNDERSCORE_REGEX_HYPHEN_ALLOW;
+import static com.linkedin.openhouse.jobs.model.JobConf.EXECUTION_CONF_KEY_PREFIX;
 
 import com.linkedin.openhouse.common.api.validator.ApiValidatorUtil;
 import com.linkedin.openhouse.common.exception.RequestValidationFailureException;
@@ -53,7 +55,7 @@ public class OpenHouseJobsApiValidator implements JobsApiValidator {
   private static class JobConfValidator {
     private static boolean validateSparkKeys(Map<String, String> conf) {
       for (Map.Entry<String, String> entry : conf.entrySet()) {
-        if (!entry.getKey().startsWith("spark.")) {
+        if (!entry.getKey().startsWith(EXECUTION_CONF_KEY_PREFIX)) {
           return false;
         }
       }

--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/api/validator/impl/OpenHouseJobsApiValidator.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/api/validator/impl/OpenHouseJobsApiValidator.java
@@ -2,21 +2,16 @@ package com.linkedin.openhouse.jobs.api.validator.impl;
 
 import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.ALPHA_NUM_UNDERSCORE_ERROR_MSG_HYPHEN_ALLOW;
 import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.ALPHA_NUM_UNDERSCORE_REGEX_HYPHEN_ALLOW;
-import static com.linkedin.openhouse.jobs.model.JobConf.EXECUTION_CONF_KEY_PREFIX;
 
 import com.linkedin.openhouse.common.api.validator.ApiValidatorUtil;
 import com.linkedin.openhouse.common.exception.RequestValidationFailureException;
 import com.linkedin.openhouse.jobs.api.spec.request.CreateJobRequestBody;
 import com.linkedin.openhouse.jobs.api.validator.JobsApiValidator;
-import com.linkedin.openhouse.jobs.model.JobConf;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
-import lombok.NonNull;
-import org.apache.commons.collections.MapUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -45,28 +40,8 @@ public class OpenHouseJobsApiValidator implements JobsApiValidator {
               "clusterId : provided %s, %s",
               createJobRequestBody.getClusterId(), ALPHA_NUM_UNDERSCORE_ERROR_MSG_HYPHEN_ALLOW));
     }
-    JobConfValidator.validate(createJobRequestBody.getJobConf(), validationFailures);
     if (!validationFailures.isEmpty()) {
       throw new RequestValidationFailureException(validationFailures);
-    }
-  }
-
-  // inner class to validate jobConf fields.
-  private static class JobConfValidator {
-    private static boolean validateSparkKeys(Map<String, String> conf) {
-      for (Map.Entry<String, String> entry : conf.entrySet()) {
-        if (!entry.getKey().startsWith(EXECUTION_CONF_KEY_PREFIX)) {
-          return false;
-        }
-      }
-      return true;
-    }
-
-    private static void validate(@NonNull JobConf conf, List<String> validationFailures) {
-      final Map<String, String> executionConfig = conf.getExecutionConf();
-      if (MapUtils.isNotEmpty(executionConfig) && !validateSparkKeys(executionConfig)) {
-        validationFailures.add("jobConf.executionConf should contain keys starting with 'spark.'");
-      }
     }
   }
 }

--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/config/JobLaunchConf.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/config/JobLaunchConf.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.jobs.config;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -19,7 +20,7 @@ import lombok.ToString;
 @ToString
 @Builder(toBuilder = true)
 @EqualsAndHashCode
-public class JobLaunchConf {
+public class JobLaunchConf implements Serializable {
   private String type;
   private String className;
   private String proxyUser;

--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/model/JobConf.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/model/JobConf.java
@@ -17,7 +17,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class JobConf {
-  public static final String EXECUTION_CONF_KEY_PREFIX = "spark.";
   private JobType jobType;
   private String proxyUser;
   @Builder.Default private Map<String, String> executionConf = new HashMap<>();

--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/model/JobConf.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/model/JobConf.java
@@ -17,6 +17,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class JobConf {
+  public static final String EXECUTION_CONF_KEY_PREFIX = "spark.";
   private JobType jobType;
   private String proxyUser;
   @Builder.Default private Map<String, String> executionConf = new HashMap<>();

--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/services/JobsRegistry.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/services/JobsRegistry.java
@@ -34,7 +34,7 @@ public class JobsRegistry {
     }
     JobLaunchConf extendedRequestConf = createDefaultLaunchConf(requestConf.getJobType());
     if (MapUtils.isNotEmpty(requestConf.getExecutionConf())) {
-      populateSparkProperties(
+      populateAllSparkProperties(
           requestConf.getExecutionConf(), extendedRequestConf.getSparkProperties());
     }
     // required arguments
@@ -57,7 +57,7 @@ public class JobsRegistry {
     return SerializationUtils.clone(jobLaunchDefaultConfByType.get(type.name()));
   }
 
-  private void populateSparkProperties(
+  private void populateAllSparkProperties(
       @NonNull Map<String, String> executionConf, Map<String, String> sparkProperties) {
     /*
     if properties has authTokenPath, read and set authToken as spark.sql.catalog.openhouse.auth-token

--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/services/JobsRegistry.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/services/JobsRegistry.java
@@ -1,7 +1,5 @@
 package com.linkedin.openhouse.jobs.services;
 
-import static com.linkedin.openhouse.jobs.model.JobConf.EXECUTION_CONF_KEY_PREFIX;
-
 import com.linkedin.openhouse.common.exception.JobEngineException;
 import com.linkedin.openhouse.jobs.config.JobLaunchConf;
 import com.linkedin.openhouse.jobs.config.JobsProperties;
@@ -68,12 +66,7 @@ public class JobsRegistry {
     if (authTokenPath != null) {
       sparkProperties.put("spark.sql.catalog.openhouse.auth-token", getToken(authTokenPath));
     }
-
-    for (Map.Entry<String, String> entry : executionConf.entrySet()) {
-      if (entry.getKey().startsWith(EXECUTION_CONF_KEY_PREFIX)) {
-        sparkProperties.put(entry.getKey(), entry.getValue());
-      }
-    }
+    sparkProperties.putAll(executionConf);
   }
 
   public static JobsRegistry from(JobsProperties properties, Map<String, String> storageProps) {

--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/services/JobsRegistry.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/services/JobsRegistry.java
@@ -1,5 +1,7 @@
 package com.linkedin.openhouse.jobs.services;
 
+import static com.linkedin.openhouse.jobs.model.JobConf.EXECUTION_CONF_KEY_PREFIX;
+
 import com.linkedin.openhouse.common.exception.JobEngineException;
 import com.linkedin.openhouse.jobs.config.JobLaunchConf;
 import com.linkedin.openhouse.jobs.config.JobsProperties;
@@ -68,7 +70,7 @@ public class JobsRegistry {
     }
 
     for (Map.Entry<String, String> entry : executionConf.entrySet()) {
-      if (entry.getKey().startsWith("spark.")) {
+      if (entry.getKey().startsWith(EXECUTION_CONF_KEY_PREFIX)) {
         sparkProperties.put(entry.getKey(), entry.getValue());
       }
     }

--- a/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsApiValidatorTest.java
+++ b/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsApiValidatorTest.java
@@ -31,9 +31,9 @@ class JobsApiValidatorTest {
         .build();
   }
 
-  private CreateJobRequestBody makeJobRequestBodyFromJobNameJobConf(String jobName, String memory) {
+  private CreateJobRequestBody makeJobRequestBodyFromJobNameJobConf(String jobName, String prefix) {
     Map<String, String> executionConf = new HashMap<>();
-    executionConf.put("memory", memory);
+    executionConf.put(prefix + "driver.memory", "10G");
     return CreateJobRequestBody.builder()
         .jobName(jobName)
         .clusterId("clusterId")
@@ -61,59 +61,15 @@ class JobsApiValidatorTest {
   }
 
   @Test
-  public void testValidMemoryFormatInJobRequestBody() {
-    assertDoesNotThrow(
-        () ->
-            jobsApiValidator.validateCreateJob(
-                makeJobRequestBodyFromJobNameJobConf("job-name", "4G")));
-
-    assertDoesNotThrow(
-        () ->
-            jobsApiValidator.validateCreateJob(
-                makeJobRequestBodyFromJobNameJobConf("job-name", "10G")));
-
-    assertDoesNotThrow(
-        () ->
-            jobsApiValidator.validateCreateJob(
-                makeJobRequestBodyFromJobNameJobConf("job-name", "256M")));
-  }
-
-  @Test
-  public void testInValidMemoryFormatInJobRequestBody() {
+  public void testValidExecutionConfInJobRequestBody() {
     assertThrows(
         RequestValidationFailureException.class,
         () ->
             jobsApiValidator.validateCreateJob(
                 makeJobRequestBodyFromJobNameJobConf("job-name", "")));
-
-    assertThrows(
-        RequestValidationFailureException.class,
+    assertDoesNotThrow(
         () ->
             jobsApiValidator.validateCreateJob(
-                makeJobRequestBodyFromJobNameJobConf("job-name", "10MG")));
-
-    assertThrows(
-        RequestValidationFailureException.class,
-        () ->
-            jobsApiValidator.validateCreateJob(
-                makeJobRequestBodyFromJobNameJobConf("job-name", "-10G")));
-
-    assertThrows(
-        RequestValidationFailureException.class,
-        () ->
-            jobsApiValidator.validateCreateJob(
-                makeJobRequestBodyFromJobNameJobConf("job-name", "10P")));
-
-    assertThrows(
-        RequestValidationFailureException.class,
-        () ->
-            jobsApiValidator.validateCreateJob(
-                makeJobRequestBodyFromJobNameJobConf("job-name", "0G")));
-
-    assertThrows(
-        RequestValidationFailureException.class,
-        () ->
-            jobsApiValidator.validateCreateJob(
-                makeJobRequestBodyFromJobNameJobConf("job-name", "G")));
+                makeJobRequestBodyFromJobNameJobConf("job-name", "spark.")));
   }
 }

--- a/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsApiValidatorTest.java
+++ b/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsApiValidatorTest.java
@@ -1,9 +1,7 @@
 package com.linkedin.openhouse.jobs.mock;
 
-import static com.linkedin.openhouse.jobs.model.JobConf.EXECUTION_CONF_KEY_PREFIX;
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.linkedin.openhouse.common.exception.RequestValidationFailureException;
 import com.linkedin.openhouse.jobs.api.spec.request.CreateJobRequestBody;
 import com.linkedin.openhouse.jobs.api.validator.JobsApiValidator;
 import com.linkedin.openhouse.jobs.model.JobConf;
@@ -32,9 +30,9 @@ class JobsApiValidatorTest {
         .build();
   }
 
-  private CreateJobRequestBody makeJobRequestBodyFromJobNameJobConf(String jobName, String prefix) {
+  private CreateJobRequestBody makeJobRequestBodyFromJobNameJobConf(String jobName) {
     Map<String, String> executionConf = new HashMap<>();
-    executionConf.put(prefix + "driver.memory", "10G");
+    executionConf.put("spark.driver.memory", "10G");
     return CreateJobRequestBody.builder()
         .jobName(jobName)
         .clusterId("clusterId")
@@ -63,14 +61,7 @@ class JobsApiValidatorTest {
 
   @Test
   public void testValidExecutionConfInJobRequestBody() {
-    assertThrows(
-        RequestValidationFailureException.class,
-        () ->
-            jobsApiValidator.validateCreateJob(
-                makeJobRequestBodyFromJobNameJobConf("job-name", "")));
     assertDoesNotThrow(
-        () ->
-            jobsApiValidator.validateCreateJob(
-                makeJobRequestBodyFromJobNameJobConf("job-name", EXECUTION_CONF_KEY_PREFIX)));
+        () -> jobsApiValidator.validateCreateJob(makeJobRequestBodyFromJobNameJobConf("job-name")));
   }
 }

--- a/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsApiValidatorTest.java
+++ b/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsApiValidatorTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.jobs.mock;
 
+import static com.linkedin.openhouse.jobs.model.JobConf.EXECUTION_CONF_KEY_PREFIX;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.linkedin.openhouse.common.exception.RequestValidationFailureException;
@@ -70,6 +71,6 @@ class JobsApiValidatorTest {
     assertDoesNotThrow(
         () ->
             jobsApiValidator.validateCreateJob(
-                makeJobRequestBodyFromJobNameJobConf("job-name", "spark.")));
+                makeJobRequestBodyFromJobNameJobConf("job-name", EXECUTION_CONF_KEY_PREFIX)));
   }
 }


### PR DESCRIPTION
## Summary
The following changes were introduced:
* Fetch table properties and propagate to jobs request in the scheduler
* Verify execution properties are Spark properties and propagate to execution endpoint

Fixed bug with default conf stored in the registry being modified.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

## Create test table and set maintenance property
```
scala> spark.sql("create table openhouse.db.test (id int, data string)")
res0: org.apache.spark.sql.DataFrame = []

scala> spark.sql("alter table openhouse.db.test set tblproperties ('maintenance.ORPHAN_FILES_DELETION.spark.kryoserializer.buffer.max'='256m')")
2024-09-29 17:26:53,387 WARN iceberg.BaseTransaction: Failed to load metadata for a committed snapshot, skipping clean-up
res1: org.apache.spark.sql.DataFrame = []
```
## Run scheduler for OFD
```
docker compose --profile with_jobs_scheduler run openhouse-jobs-scheduler - --type ORPHAN_FILES_DELETION --cluster local --tablesURL http://openhouse-tables:8080/ --jobsURL http://openhouse-jobs:8080/

2024-09-29 18:08:28 INFO  OtelConfig:70 - initializing open-telemetry sdk
2024-09-29 18:08:29 INFO  Reflections:219 - Reflections took 153 ms to scan 1 urls, producing 4 keys and 11 values
2024-09-29 18:08:29 INFO  JobsScheduler:110 - Starting scheduler
2024-09-29 18:08:29 INFO  WebClientFactory:121 - Using connection pool strategy
2024-09-29 18:08:29 INFO  WebClientFactory:218 - Creating custom connection provider
2024-09-29 18:08:29 INFO  WebClientFactory:196 - Client session id: 11fcb5b7-a5e1-4c36-abe2-10a487a92a7f
2024-09-29 18:08:30 INFO  WebClientFactory:209 - Client name: null
2024-09-29 18:08:30 INFO  JobsScheduler:133 - Fetching task list based on the job type: ORPHAN_FILES_DELETION
2024-09-29 18:08:32 INFO  OperationTasksBuilder:29 - metadata: dbName: db, tableName: test, creator: openhouse
2024-09-29 18:08:32 INFO  JobsScheduler:143 - Submitting and running 1 jobs based on the job type: ORPHAN_FILES_DELETION
2024-09-29 18:08:38 INFO  OperationTask:97 - Launched a job with id ORPHAN_FILES_DELETION_db_test_8d574239-c8f6-485e-a1c3-1447e89f28f8 for dbName: db, tableName: test, creator: openhouse
2024-09-29 18:13:38 INFO  OperationTask:143 - Finished job for entity dbName: db, tableName: test, creator: openhouse: JobId ORPHAN_FILES_DELETION_db_test_8d574239-c8f6-485e-a1c3-1447e89f28f8, executionId 0, runTime 41250, queuedTime 17146, state SUCCEEDED
2024-09-29 18:13:38 INFO  JobsScheduler:189 - Finishing scheduler for job type ORPHAN_FILES_DELETION, tasks stats: 1 created, 1 succeeded, 0 cancelled (timeout), 0 failed, 0 skipped (no state)
```

## Livy logs
```
2024-09-29 11:08:37 2024-09-29 18:08:37,862 INFO utils.SparkProcessBuilder: Running '/opt/spark/bin/spark-submit'
'--class' 'com.linkedin.openhouse.jobs.spark.OrphanFilesDeletionSparkApp'
'--conf' 'spark.sql.catalog.openhouse.auth-token=eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2NTk2ODI4MDAsImp0aSI6Im9wZW5ob3VzZTA3M2JjYWM2LTVjZjYtNDJmNC04ZjQxLWMxNzBjNjg2NjMwYSIsInN1YiI6IntcIkNPREVcIjpcIkRVTU1ZX0NPREVcIixcIlVTRVItSURcIjpcIm9wZW5ob3VzZVwifSJ9.46TbOeXeSIW7QfJatSh1Z62Pc6FTQLuBLOhBmFDOXTs' 
'--conf' 'spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,com.linkedin.openhouse.spark.extensions.OpenhouseSparkSessionExtensions' 
'--conf' 'spark.sql.catalog.openhouse.cluster=LocalHadoopCluster'
'--conf' 'spark.driver.memory=2g'
'--conf' 'fs.defaultFS=hdfs://namenode:9000/'
'--conf' 'spark.jars.packages=org.apache.iceberg:iceberg-spark-runtime-3.1_2.12:1.2.0'
'--conf' 'spark.sql.catalog.openhouse.uri=http://openhouse-tables:8080/'
'--conf' 'spark.jars=local:/opt/spark/openhouse-spark-runtime_2.12-latest-all.jar'
'--conf' 'spark.kryoserializer.buffer.max=256m'     // <--------------
'--conf' 'spark.master=spark://spark-master:7077'
'--conf' 'spark.sql.catalog.openhouse=org.apache.iceberg.spark.SparkCatalog'
'--conf' 'spark.sql.autoBroadcastJoinThreshold=-1'
'--conf' 'spark.sql.catalog.openhouse.catalog-impl=com.linkedin.openhouse.spark.OpenHouseCatalog' 'local:/opt/spark/openhouse-spark-apps_2.12-latest-all.jar'
'--jobId' 'ORPHAN_FILES_DELETION_db_test_8d574239-c8f6-485e-a1c3-1447e89f28f8'
'--storageURL' 'http://openhouse-housetables:8080/'
'--trashDir' '.trash'
'--tableName' 'db.test'
```

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
