### PR TITLE
Self serve replication SQL API and server side support

### DIFF
--- a/integrations/java/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
+++ b/integrations/java/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
@@ -249,16 +249,69 @@ public class OpenHouseTableOperationsTest {
   }
 
   @Test
-  public void testPoliciesReplicationUpdate() {
+  public void testPoliciesReplicationExistsButNoUpdate() {
     Map<String, String> props = new HashMap<>();
-    props.put(
-        "updated.openhouse.policy",
-        "{\"replication\":{\"schedules\":[{\"config\":{'a':'b','aa':'bb'}}]}}");
+    props.put("policies", "{\"replication\":{\"schedules\":[{\"config\":{'a':'b'}}]}}");
     TableMetadata metadata = mock(TableMetadata.class);
     when(metadata.properties()).thenReturn(props);
     OpenHouseTableOperations openHouseTableOperations = mock(OpenHouseTableOperations.class);
     when(openHouseTableOperations.buildUpdatedPolicies(metadata)).thenCallRealMethod();
     Policies updatedPolicies = openHouseTableOperations.buildUpdatedPolicies(metadata);
     Assertions.assertNotNull(updatedPolicies);
+    Assertions.assertTrue(
+        updatedPolicies.getReplication().getSchedules().get(0).getConfig().containsKey("a"));
+  }
+
+  @Test
+  public void testNoPoliciesReplicationButUpdateExists() {
+    Map<String, String> props = new HashMap<>();
+    props.put(
+        "updated.openhouse.policy",
+        "{\"replication\":{\"schedules\":[{\"config\":{'a':'b'}}, {\"config\":{'aa':'bb'}}]}}");
+    TableMetadata metadata = mock(TableMetadata.class);
+    when(metadata.properties()).thenReturn(props);
+    OpenHouseTableOperations openHouseTableOperations = mock(OpenHouseTableOperations.class);
+    when(openHouseTableOperations.buildUpdatedPolicies(metadata)).thenCallRealMethod();
+    Policies updatedPolicies = openHouseTableOperations.buildUpdatedPolicies(metadata);
+    Assertions.assertNotNull(updatedPolicies);
+    Assertions.assertTrue(
+        updatedPolicies.getReplication().getSchedules().get(0).getConfig().containsKey("a"));
+    Assertions.assertTrue(
+        updatedPolicies.getReplication().getSchedules().get(1).getConfig().containsKey("aa"));
+  }
+
+  @Test
+  public void testPoliciesReplicationExistsUpdateExists() {
+    Map<String, String> props = new HashMap<>();
+    props.put("policies", "{\"replication\":{\"schedules\":[{\"config\":{'a':'b'}}]}}");
+    props.put(
+        "updated.openhouse.policy", "{\"replication\":{\"schedules\":[{\"config\":{'aa':'bb'}}]}}");
+    TableMetadata metadata = mock(TableMetadata.class);
+    when(metadata.properties()).thenReturn(props);
+    OpenHouseTableOperations openHouseTableOperations = mock(OpenHouseTableOperations.class);
+    when(openHouseTableOperations.buildUpdatedPolicies(metadata)).thenCallRealMethod();
+    Policies updatedPolicies = openHouseTableOperations.buildUpdatedPolicies(metadata);
+    Assertions.assertNotNull(updatedPolicies);
+    Assertions.assertTrue(
+        updatedPolicies.getReplication().getSchedules().get(0).getConfig().containsKey("aa"));
+  }
+
+  @Test
+  public void testPoliciesReplicationMultipleExistsUpdateExists() {
+    Map<String, String> props = new HashMap<>();
+    props.put(
+        "policies",
+        "{\"replication\":{\"schedules\":[{\"config\":{'a':'b'}}, {\"config\":{'aa':'bb'}}]}}");
+    props.put(
+        "updated.openhouse.policy",
+        "{\"replication\":{\"schedules\":[{\"config\":{'aaa':'bbb'}}]}}");
+    TableMetadata metadata = mock(TableMetadata.class);
+    when(metadata.properties()).thenReturn(props);
+    OpenHouseTableOperations openHouseTableOperations = mock(OpenHouseTableOperations.class);
+    when(openHouseTableOperations.buildUpdatedPolicies(metadata)).thenCallRealMethod();
+    Policies updatedPolicies = openHouseTableOperations.buildUpdatedPolicies(metadata);
+    Assertions.assertNotNull(updatedPolicies);
+    Assertions.assertTrue(
+        updatedPolicies.getReplication().getSchedules().get(0).getConfig().containsKey("aaa"));
   }
 }

--- a/integrations/java/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
+++ b/integrations/java/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
@@ -247,4 +247,18 @@ public class OpenHouseTableOperationsTest {
     Assertions.assertTrue(updatedPolicies.getColumnTags().containsKey("col1"));
     Assertions.assertEquals(tagHC, updatedPolicies.getColumnTags().get("col1").getTags());
   }
+
+  @Test
+  public void testPoliciesReplicationUpdate() {
+    Map<String, String> props = new HashMap<>();
+    props.put(
+        "updated.openhouse.policy",
+        "{\"replication\":{\"schedules\":[{\"config\":{'a':'b','aa':'bb'}}]}}");
+    TableMetadata metadata = mock(TableMetadata.class);
+    when(metadata.properties()).thenReturn(props);
+    OpenHouseTableOperations openHouseTableOperations = mock(OpenHouseTableOperations.class);
+    when(openHouseTableOperations.buildUpdatedPolicies(metadata)).thenCallRealMethod();
+    Policies updatedPolicies = openHouseTableOperations.buildUpdatedPolicies(metadata);
+    Assertions.assertNotNull(updatedPolicies);
+  }
 }

--- a/integrations/java/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
+++ b/integrations/java/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
@@ -260,6 +260,7 @@ public class OpenHouseTableOperationsTest {
     Assertions.assertNotNull(updatedPolicies);
     Assertions.assertTrue(
         updatedPolicies.getReplication().getSchedules().get(0).getConfig().containsKey("a"));
+    Assertions.assertEquals(updatedPolicies.getReplication().getSchedules().size(), 1);
   }
 
   @Test
@@ -278,6 +279,7 @@ public class OpenHouseTableOperationsTest {
         updatedPolicies.getReplication().getSchedules().get(0).getConfig().containsKey("a"));
     Assertions.assertTrue(
         updatedPolicies.getReplication().getSchedules().get(1).getConfig().containsKey("aa"));
+    Assertions.assertEquals(updatedPolicies.getReplication().getSchedules().size(), 2);
   }
 
   @Test
@@ -294,6 +296,7 @@ public class OpenHouseTableOperationsTest {
     Assertions.assertNotNull(updatedPolicies);
     Assertions.assertTrue(
         updatedPolicies.getReplication().getSchedules().get(0).getConfig().containsKey("aa"));
+    Assertions.assertEquals(updatedPolicies.getReplication().getSchedules().size(), 1);
   }
 
   @Test
@@ -313,5 +316,6 @@ public class OpenHouseTableOperationsTest {
     Assertions.assertNotNull(updatedPolicies);
     Assertions.assertTrue(
         updatedPolicies.getReplication().getSchedules().get(0).getConfig().containsKey("aaa"));
+    Assertions.assertEquals(updatedPolicies.getReplication().getSchedules().size(), 1);
   }
 }

--- a/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -170,7 +170,6 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
           CreateUpdateTableRequestBody.TableTypeEnum.valueOf(
               metadata.properties().get(OPENHOUSE_TABLE_TYPE_KEY)));
     }
-
     return createUpdateTableRequestBody;
   }
 

--- a/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -211,6 +211,10 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
       }
       policies.setColumnTags(patchUpdatedPolicy.getColumnTags());
     }
+    // Update replication config
+    if (patchUpdatedPolicy.getReplication() != null) {
+      policies.replication(patchUpdatedPolicy.getReplication());
+    }
     return policies;
   }
 

--- a/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/SetTableReplicationPolicyStatementTest.java
+++ b/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/SetTableReplicationPolicyStatementTest.java
@@ -1,0 +1,158 @@
+package com.linkedin.openhouse.spark.statementtest;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseParseException;
+import java.nio.file.Files;
+import lombok.SneakyThrows;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.execution.ExplainMode;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class SetTableReplicationPolicyStatementTest {
+  private static SparkSession spark = null;
+
+  @SneakyThrows
+  @BeforeAll
+  public void setupSpark() {
+    Path unittest = new Path(Files.createTempDirectory("unittest_settablepolicy").toString());
+    spark =
+        SparkSession.builder()
+            .master("local[2]")
+            .config(
+                "spark.sql.extensions",
+                ("org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,"
+                    + "com.linkedin.openhouse.spark.extensions.OpenhouseSparkSessionExtensions"))
+            .config("spark.sql.catalog.openhouse", "org.apache.iceberg.spark.SparkCatalog")
+            .config("spark.sql.catalog.openhouse.type", "hadoop")
+            .config("spark.sql.catalog.openhouse.warehouse", unittest.toString())
+            .getOrCreate();
+  }
+
+  @Test
+  public void testSimpleSetReplicationPolicy() {
+    String replicationConfigJson =
+        "{\"cluster\":\"a\", \"schedule\":\"b\"}, {\"cluster\": \"aa\", \"schedule\": \"bb\"}";
+    Dataset<Row> ds =
+        spark.sql(
+            "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = "
+                + "({cluster:'a', schedule:'b'}, {cluster: 'aa', schedule: 'bb'}))");
+    assert isPlanValid(ds, replicationConfigJson);
+
+    replicationConfigJson = "{\"cluster\":\"a\", \"schedule\":\"b\"}";
+    ds =
+        spark.sql(
+            "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({cluster:'a', schedule:'b'}))");
+    assert isPlanValid(ds, replicationConfigJson);
+  }
+
+  @Test
+  public void testReplicationPolicyWithoutProperSyntax() {
+    // missing schedule keyword
+    Assertions.assertThrows(
+        OpenhouseParseException.class,
+        () ->
+            spark
+                .sql("ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({cluster: 'aa'}))")
+                .show());
+
+    // Missing cluster keyword
+    Assertions.assertThrows(
+        OpenhouseParseException.class,
+        () ->
+            spark
+                .sql("ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({schedule: 'ss'}))")
+                .show());
+
+    // Typo in keyword schedule
+    Assertions.assertThrows(
+        OpenhouseParseException.class,
+        () ->
+            spark
+                .sql(
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({cluster: 'aa', schedul: 'ss'}))")
+                .show());
+
+    // Typo in keyword cluster
+    Assertions.assertThrows(
+        OpenhouseParseException.class,
+        () ->
+            spark
+                .sql(
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({clustr: 'aa', schedule: 'ss'}))")
+                .show());
+
+    // Missing quote in cluster value
+    Assertions.assertThrows(
+        OpenhouseParseException.class,
+        () ->
+            spark
+                .sql(
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({cluster: aa', schedule: 'ss}))")
+                .show());
+
+    // Type in REPLICATION keyword
+    Assertions.assertThrows(
+        OpenhouseParseException.class,
+        () ->
+            spark
+                .sql(
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICAT = ({cluster: 'aa', schedule: 'ss}))")
+                .show());
+
+    // Missing cluster and schedule value
+    Assertions.assertThrows(
+        OpenhouseParseException.class,
+        () -> spark.sql("ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({}))").show());
+  }
+
+  @BeforeEach
+  public void setup() {
+    spark.sql("CREATE TABLE openhouse.db.table (id bigint, data string) USING iceberg").show();
+    spark.sql("CREATE TABLE openhouse.0_.0_ (id bigint, data string) USING iceberg").show();
+    spark
+        .sql("ALTER TABLE openhouse.db.table SET TBLPROPERTIES ('openhouse.tableId' = 'tableid')")
+        .show();
+    spark
+        .sql("ALTER TABLE openhouse.0_.0_ SET TBLPROPERTIES ('openhouse.tableId' = 'tableid')")
+        .show();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    spark.sql("DROP TABLE openhouse.db.table").show();
+    spark.sql("DROP TABLE openhouse.0_.0_").show();
+  }
+
+  @AfterAll
+  public void tearDownSpark() {
+    spark.close();
+  }
+
+  @SneakyThrows
+  private boolean isPlanValid(Dataset<Row> dataframe, String replicationConfigJson) {
+    replicationConfigJson = "[" + replicationConfigJson + "]";
+    String queryStr = dataframe.queryExecution().explainString(ExplainMode.fromString("simple"));
+    JsonArray jsonArray = new Gson().fromJson(replicationConfigJson, JsonArray.class);
+    boolean isValid = false;
+    for (JsonElement element : jsonArray) {
+      JsonObject entry = element.getAsJsonObject();
+      String cluster = entry.get("cluster").getAsString();
+      String schedule = entry.get("schedule").getAsString();
+      isValid = queryStr.contains(cluster) && queryStr.contains(schedule);
+    }
+    return isValid;
+  }
+}

--- a/integrations/spark/openhouse-spark-runtime/src/main/antlr/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensions.g4
+++ b/integrations/spark/openhouse-spark-runtime/src/main/antlr/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensions.g4
@@ -24,6 +24,7 @@ singleStatement
 
 statement
   : ALTER TABLE multipartIdentifier SET POLICY '(' retentionPolicy (columnRetentionPolicy)? ')'        #setRetentionPolicy
+  | ALTER TABLE multipartIdentifier SET POLICY '(' replicationPolicy ')'                               #setReplicationPolicy
   | ALTER TABLE multipartIdentifier SET POLICY '(' sharingPolicy ')'                                   #setSharingPolicy
   | ALTER TABLE multipartIdentifier MODIFY columnNameClause SET columnPolicy                           #setColumnPolicyTag
   | GRANT privilege ON grantableResource TO principal                                                  #grantStatement
@@ -64,7 +65,7 @@ quotedIdentifier
     ;
 
 nonReserved
-    : ALTER | TABLE | SET | POLICY | RETENTION | SHARING
+    : ALTER | TABLE | SET | POLICY | RETENTION | SHARING | REPLICATION
     | GRANT | REVOKE | ON | TO | SHOW | GRANTS | PATTERN | WHERE | COLUMN
     ;
 
@@ -81,6 +82,18 @@ retentionPolicy
 
 columnRetentionPolicy
     : ON columnNameClause (columnRetentionPolicyPatternClause)?
+    ;
+
+replicationPolicy
+    : REPLICATION '=' tableReplicationPolicy
+    ;
+
+tableReplicationPolicy
+    : '(' replicationPolicyClause (',' replicationPolicyClause)* ')'
+    ;
+
+replicationPolicyClause
+    : '{' CLUSTER ':' STRING ',' SCHEDULE ':' STRING '}'
     ;
 
 columnRetentionPolicyPatternClause
@@ -136,6 +149,7 @@ TABLE: 'TABLE';
 SET: 'SET';
 POLICY: 'POLICY';
 RETENTION: 'RETENTION';
+REPLICATION: 'REPLICATION';
 SHARING: 'SHARING';
 GRANT: 'GRANT';
 REVOKE: 'REVOKE';
@@ -150,6 +164,8 @@ DATABASE: 'DATABASE';
 SHOW: 'SHOW';
 GRANTS: 'GRANTS';
 PATTERN: 'PATTERN';
+CLUSTER: 'CLUSTER';
+SCHEDULE: 'SCHEDULE';
 WHERE: 'WHERE';
 COLUMN: 'COLUMN';
 PII: 'PII';

--- a/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensionsAstBuilder.scala
+++ b/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensionsAstBuilder.scala
@@ -103,8 +103,9 @@ class OpenhouseSqlExtensionsAstBuilder (delegate: ParserInterface) extends Openh
     policy.mkString(",")
   }
 
-  override def visitReplicationPolicyClause(ctx: ReplicationPolicyClauseContext): AnyRef = {
-    ctx.getText
+  override def visitReplicationPolicyClause(ctx: ReplicationPolicyClauseContext): (String) = {
+    val replicationPolicy = ctx.STRING().map(_.getText)
+    replicationPolicy.mkString(":")
   }
 
   override def visitColumnRetentionPolicy(ctx: ColumnRetentionPolicyContext): (String, String) = {

--- a/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensionsAstBuilder.scala
+++ b/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensionsAstBuilder.scala
@@ -98,9 +98,7 @@ class OpenhouseSqlExtensionsAstBuilder (delegate: ParserInterface) extends Openh
   }
 
   override def visitTableReplicationPolicy(ctx: TableReplicationPolicyContext): (Seq[String]) = {
-    ctx.replicationPolicyClause().forEach(ele => print(ele))
-    val policy = ctx.replicationPolicyClause().map(ele => typedVisit[String](ele)).toSeq
-    policy
+    ctx.replicationPolicyClause().map(ele => typedVisit[String](ele)).toSeq
   }
 
   override def visitReplicationPolicyClause(ctx: ReplicationPolicyClauseContext): (String) = {

--- a/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensionsAstBuilder.scala
+++ b/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensionsAstBuilder.scala
@@ -29,7 +29,7 @@ class OpenhouseSqlExtensionsAstBuilder (delegate: ParserInterface) extends Openh
 
   override def visitSetReplicationPolicy(ctx: SetReplicationPolicyContext): SetReplicationPolicy = {
     val tableName = typedVisit[Seq[String]](ctx.multipartIdentifier)
-    val replicationPolicies = typedVisit[String](ctx.replicationPolicy())
+    val replicationPolicies = typedVisit[Seq[String]](ctx.replicationPolicy())
     SetReplicationPolicy(tableName, replicationPolicies)
   }
 
@@ -93,14 +93,14 @@ class OpenhouseSqlExtensionsAstBuilder (delegate: ParserInterface) extends Openh
     typedVisit[(String, Int)](ctx.duration())
   }
 
-  override def visitReplicationPolicy(ctx: ReplicationPolicyContext): (String) = {
-    typedVisit[(String)](ctx.tableReplicationPolicy())
+  override def visitReplicationPolicy(ctx: ReplicationPolicyContext): (Seq[String]) = {
+    typedVisit[(Seq[String])](ctx.tableReplicationPolicy())
   }
 
-  override def visitTableReplicationPolicy(ctx: TableReplicationPolicyContext): (String) = {
+  override def visitTableReplicationPolicy(ctx: TableReplicationPolicyContext): (Seq[String]) = {
     ctx.replicationPolicyClause().forEach(ele => print(ele))
-    val policy = ctx.replicationPolicyClause().map(ele => typedVisit[String](ele))
-    policy.mkString(",")
+    val policy = ctx.replicationPolicyClause().map(ele => typedVisit[String](ele)).toSeq
+    policy
   }
 
   override def visitReplicationPolicyClause(ctx: ReplicationPolicyClauseContext): (String) = {

--- a/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/plans/logical/SetReplicationPolicy.scala
+++ b/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/plans/logical/SetReplicationPolicy.scala
@@ -2,7 +2,7 @@ package com.linkedin.openhouse.spark.sql.catalyst.plans.logical
 
 import org.apache.spark.sql.catalyst.plans.logical.Command
 
-case class SetReplicationPolicy(tableName: Seq[String], replicationPolicies: String) extends Command {
+case class SetReplicationPolicy(tableName: Seq[String], replicationPolicies: Seq[String]) extends Command {
   override def simpleString(maxFields: Int): String = {
     s"SetReplicationPolicy: ${tableName} ${replicationPolicies}}"
   }

--- a/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/plans/logical/SetReplicationPolicy.scala
+++ b/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/plans/logical/SetReplicationPolicy.scala
@@ -1,0 +1,9 @@
+package com.linkedin.openhouse.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.plans.logical.Command
+
+case class SetReplicationPolicy(tableName: Seq[String], replicationPolicies: String) extends Command {
+  override def simpleString(maxFields: Int): String = {
+    s"SetReplicationPolicy: ${tableName} ${replicationPolicies}}"
+  }
+}

--- a/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/OpenhouseDataSourceV2Strategy.scala
+++ b/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/OpenhouseDataSourceV2Strategy.scala
@@ -1,6 +1,6 @@
 package com.linkedin.openhouse.spark.sql.execution.datasources.v2
 
-import com.linkedin.openhouse.spark.sql.catalyst.plans.logical.{GrantRevokeStatement, SetRetentionPolicy, SetSharingPolicy, SetColumnPolicyTag, ShowGrantsStatement}
+import com.linkedin.openhouse.spark.sql.catalyst.plans.logical.{GrantRevokeStatement, SetColumnPolicyTag, SetReplicationPolicy, SetRetentionPolicy, SetSharingPolicy, ShowGrantsStatement}
 import org.apache.iceberg.spark.{Spark3Util, SparkCatalog, SparkSessionCatalog}
 import org.apache.spark.sql.{SparkSession, Strategy}
 import org.apache.spark.sql.catalyst.expressions.PredicateHelper
@@ -15,6 +15,8 @@ case class OpenhouseDataSourceV2Strategy(spark: SparkSession) extends Strategy w
   override def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
     case SetRetentionPolicy(CatalogAndIdentifierExtractor(catalog, ident), granularity, count, colName, colPattern) =>
       SetRetentionPolicyExec(catalog, ident, granularity, count, colName, colPattern) :: Nil
+    case SetReplicationPolicy(CatalogAndIdentifierExtractor(catalog, ident), replicationPolicies) =>
+      SetReplicationPolicyExec(catalog, ident, replicationPolicies) :: Nil
     case SetSharingPolicy(CatalogAndIdentifierExtractor(catalog, ident), sharing) =>
       SetSharingPolicyExec(catalog, ident, sharing) :: Nil
     case SetColumnPolicyTag(CatalogAndIdentifierExtractor(catalog, ident), policyTag, cols) =>

--- a/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/SetReplicationPolicyExec.scala
+++ b/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/SetReplicationPolicyExec.scala
@@ -6,12 +6,12 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
 import org.apache.spark.sql.execution.datasources.v2.V2CommandExec
 
-case class SetReplicationPolicyExec(catalog: TableCatalog, ident: Identifier, replicationPolicies: String) extends V2CommandExec{
+case class SetReplicationPolicyExec(catalog: TableCatalog, ident: Identifier, replicationPolicies: Seq[String]) extends V2CommandExec{
   override protected def run(): Seq[InternalRow] = {
     catalog.loadTable(ident) match {
       case iceberg: SparkTable if iceberg.table().properties().containsKey("openhouse.tableId") =>
         val key = "updated.openhouse.policy"
-        val value = s"""{"replication":{"schedules":[{"config":{${replicationPolicies}}}]}}"""
+        val value = s"""{"replication":{"schedules":[{${replicationPolicies.map(replication => s"""config:{${replication}}}""").mkString(",")}]}}"""
         iceberg.table().updateProperties()
           .set(key, value)
           .commit()

--- a/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/SetReplicationPolicyExec.scala
+++ b/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/SetReplicationPolicyExec.scala
@@ -11,7 +11,7 @@ case class SetReplicationPolicyExec(catalog: TableCatalog, ident: Identifier, re
     catalog.loadTable(ident) match {
       case iceberg: SparkTable if iceberg.table().properties().containsKey("openhouse.tableId") =>
         val key = "updated.openhouse.policy"
-        val value = s"""{"replication": [${replicationPolicies}]}"""
+        val value = s"""{"replication":{"schedules":[{"config":{${replicationPolicies}}}]}}"""
         iceberg.table().updateProperties()
           .set(key, value)
           .commit()

--- a/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/SetReplicationPolicyExec.scala
+++ b/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/SetReplicationPolicyExec.scala
@@ -1,0 +1,26 @@
+package com.linkedin.openhouse.spark.sql.execution.datasources.v2
+
+import org.apache.iceberg.spark.source.SparkTable
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
+import org.apache.spark.sql.execution.datasources.v2.V2CommandExec
+
+case class SetReplicationPolicyExec(catalog: TableCatalog, ident: Identifier, replicationPolicies: String) extends V2CommandExec{
+  override protected def run(): Seq[InternalRow] = {
+    catalog.loadTable(ident) match {
+      case iceberg: SparkTable if iceberg.table().properties().containsKey("openhouse.tableId") =>
+        val key = "updated.openhouse.policy"
+        val value = s"""{"replication": [${replicationPolicies}]}"""
+        iceberg.table().updateProperties()
+          .set(key, value)
+          .commit()
+
+      case table =>
+        throw new UnsupportedOperationException(s"Cannot set replication policy for non-Openhouse table: $table")
+    }
+    Nil
+  }
+
+  override def output: Seq[Attribute] = Nil
+}

--- a/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/SetReplicationPolicyExec.scala
+++ b/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/SetReplicationPolicyExec.scala
@@ -11,7 +11,7 @@ case class SetReplicationPolicyExec(catalog: TableCatalog, ident: Identifier, re
     catalog.loadTable(ident) match {
       case iceberg: SparkTable if iceberg.table().properties().containsKey("openhouse.tableId") =>
         val key = "updated.openhouse.policy"
-        val value = s"""{"replication":{"schedules":[{${replicationPolicies.map(replication => s"""config:{${replication}}}""").mkString(",")}]}}"""
+        val value = s"""{"replication":{"schedules":[${replicationPolicies.map(replication => s"""{config:{${replication}}}""").mkString(",")}]}}"""
         iceberg.table().updateProperties()
           .set(key, value)
           .commit()

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/Policies.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/Policies.java
@@ -44,8 +44,8 @@ public class Policies {
 
   @Schema(
       description =
-          "Replication as required in /tables API request. This column holds the replication Policy.",
-      example = "{\"cluster\":\"a\", \"schedule\":\"b\"}")
+          "Replication as required in /tables API request. This column holds the replication spec config.",
+      example = "{cluster: a, schedule: 0 0 1 * * ?}")
   @Valid
   Replication replication;
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/Policies.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/Policies.java
@@ -41,4 +41,11 @@ public class Policies {
       example = "{'colName': [PII, HC]}")
   @Valid
   Map<String, PolicyTag> columnTags;
+
+  @Schema(
+      description =
+          "Replication as required in /tables API request. This column holds the replication Policy.",
+      example = "{\"cluster\":\"a\", \"schedule\":\"b\"}")
+  @Valid
+  Replication replication;
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/Replication.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/Replication.java
@@ -1,0 +1,24 @@
+package com.linkedin.openhouse.tables.api.spec.v0.request.components;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder(toBuilder = true)
+@EqualsAndHashCode
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Replication {
+  @Schema(description = "List of replication Schedule for replication flow setup", example = "")
+  @NotNull(message = "Incorrect replication policy specified. Replication.policy cannot be null")
+  @Valid
+  List<Schedule> schedules;
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/Replication.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/Replication.java
@@ -17,8 +17,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Replication {
-  @Schema(description = "List of replication Schedule for replication flow setup", example = "")
-  @NotNull(message = "Incorrect replication policy specified. Replication.policy cannot be null")
+  @Schema(
+      description = "List of replication Schedules for replication flow setup.",
+      example = "clusterA: 0 0 1 * * ?, clusterB: 0 0 1 * * ?")
+  @NotNull(message = "Incorrect replication policy specified. Replication spec cannot be null.")
   @Valid
   List<Schedule> schedules;
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/Schedule.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/Schedule.java
@@ -1,0 +1,24 @@
+package com.linkedin.openhouse.tables.api.spec.v0.request.components;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Map;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder(toBuilder = true)
+@EqualsAndHashCode
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Schedule {
+  @Schema(description = "Map of cluster and cron schedule for replication flow setup", example = "")
+  @NotNull(message = "Incorrect schedule config specified. schedule.policy cannot be null")
+  @Valid
+  Map<String, String> config;
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/Schedule.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/Schedule.java
@@ -17,8 +17,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Schedule {
-  @Schema(description = "Map of cluster and cron schedule for replication flow setup", example = "")
-  @NotNull(message = "Incorrect schedule config specified. schedule.policy cannot be null")
+  @Schema(
+      description = "Map of cluster and cron schedule for replication flow setup.",
+      example = "clusterName: 0 0 1 * * ?")
+  @NotNull(message = "Incorrect schedule config specified. Schedule config cannot be null")
   @Valid
   Map<String, String> config;
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RequestAndValidateHelper.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RequestAndValidateHelper.java
@@ -219,6 +219,7 @@ public final class RequestAndValidateHelper {
     ValidationUtilities.validateSchema(result, getTableResponseBody.getSchema());
     validateWritableTableProperties(result, getTableResponseBody.getTableProperties());
     ValidationUtilities.validatePolicies(result, getTableResponseBody.getPolicies());
+    ValidationUtilities.tableReplicationConfig(result, getTableResponseBody.getPolicies());
     ValidationUtilities.validateLocation(
         result, storageManager.getDefaultStorage().getClient().getRootPrefix());
     Assertions.assertTrue(

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/ValidationUtilities.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/ValidationUtilities.java
@@ -13,6 +13,7 @@ import com.linkedin.openhouse.tables.model.IcebergSnapshotsModelTestUtilities;
 import java.io.UnsupportedEncodingException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -55,6 +56,22 @@ public final class ValidationUtilities {
         JsonPath.read(result.getResponse().getContentAsString(), "$.policies.retention.count");
 
     Assertions.assertEquals(tableRetentionDays, policies.getRetention().getCount());
+  }
+
+  /**
+   * validation which verify all policies json are as per the Policies class in the return value.
+   */
+  static void tableReplicationConfig(MvcResult result, Policies policies)
+      throws UnsupportedEncodingException {
+    if (policies.getReplication() != null) {
+      HashMap<String, String> tableReplicationConfig =
+          JsonPath.read(
+              result.getResponse().getContentAsString(),
+              "$.policies.replication.schedules[0].config");
+
+      Assertions.assertEquals(
+          policies.getReplication().getSchedules().get(0).getConfig(), tableReplicationConfig);
+    }
   }
 
   static void validateUUID(MvcResult result, String uuid) throws UnsupportedEncodingException {

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/mapper/PoliciesSpecMapperTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/mapper/PoliciesSpecMapperTest.java
@@ -34,6 +34,14 @@ public class PoliciesSpecMapperTest {
     Assertions.assertEquals(
         (Integer) JsonPath.read(policiesSpec, "$.retention.count"),
         TableModelConstants.TABLE_POLICIES.getRetention().getCount());
+    Assertions.assertEquals(
+        JsonPath.read(policiesSpec, "$.replication.schedules[0].config.cluster1"),
+        TableModelConstants.TABLE_POLICIES
+            .getReplication()
+            .getSchedules()
+            .get(0)
+            .getConfig()
+            .get("cluster1"));
   }
 
   @Test

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/mapper/TablesMapperTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/mapper/TablesMapperTest.java
@@ -168,6 +168,32 @@ public class TablesMapperTest {
   }
 
   @Test
+  public void testToTableDtoWithReplicationPolicy() {
+    IcebergSnapshotsRequestBody icebergSnapshotsRequestBody =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion("v1")
+            .createUpdateTableRequestBody(
+                CREATE_TABLE_REQUEST_BODY_WITHIN_SNAPSHOTS_REQUEST
+                    .toBuilder()
+                    .policies(TABLE_POLICIES)
+                    .build())
+            .jsonSnapshots(Collections.singletonList("dummy"))
+            .build();
+    TableDto tableDto1 = tablesMapper.toTableDto(TABLE_DTO, icebergSnapshotsRequestBody);
+    Assertions.assertEquals(
+        tableDto1.getDatabaseId(),
+        CREATE_TABLE_REQUEST_BODY_WITHIN_SNAPSHOTS_REQUEST.getDatabaseId());
+    Assertions.assertEquals(
+        tableDto1.getTableId(), CREATE_TABLE_REQUEST_BODY_WITHIN_SNAPSHOTS_REQUEST.getTableId());
+    Assertions.assertEquals(
+        tableDto1.getClusterId(),
+        CREATE_TABLE_REQUEST_BODY_WITHIN_SNAPSHOTS_REQUEST.getClusterId());
+    Assertions.assertEquals(
+        tableDto1.getPolicies().getReplication().getSchedules().get(0).getConfig().get("cluster1"),
+        "1 1 * 1 * *");
+  }
+
+  @Test
   public void testToTableDtoWithStagedCreate() {
     TableDto tableDto = TableDto.builder().build();
     TableDto tableDto1 =

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/model/TableModelConstants.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/model/TableModelConstants.java
@@ -9,8 +9,10 @@ import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableReques
 import com.linkedin.openhouse.tables.api.spec.v0.request.IcebergSnapshotsRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.ClusteringColumn;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.Policies;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.Replication;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.Retention;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.RetentionColumnPattern;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.Schedule;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.TimePartitionSpec;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.Transform;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
@@ -20,6 +22,7 @@ import com.linkedin.openhouse.tables.dto.mapper.attribute.PoliciesSpecConverter;
 import com.linkedin.openhouse.tables.dto.mapper.attribute.TimePartitionSpecConverter;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -37,8 +40,9 @@ public final class TableModelConstants {
   // this is evolved on top of HEALTH_SCHEMA_LITERAL.
   public static final String ADD_OPTIONAL_FIELD;
 
-  public static final RetentionColumnPattern COL_PAT;
-  public static final Retention RETENTION_POLICY;
+  public static RetentionColumnPattern COL_PAT;
+  public static Retention RETENTION_POLICY;
+  public static Replication REPLICATION_POLICY;
 
   public static final Retention RETENTION_POLICY_WITH_PATTERN;
   public static final Retention RETENTION_POLICY_WITH_EMPTY_PATTERN;
@@ -58,6 +62,12 @@ public final class TableModelConstants {
     RETENTION_POLICY =
         Retention.builder().count(3).granularity(TimePartitionSpec.Granularity.HOUR).build();
 
+    ArrayList<Schedule> schedules = new ArrayList<>();
+    Map<String, String> schedule = new HashMap<>();
+    schedule.put("cluster1", "1 1 * 1 * *");
+    Schedule sc = Schedule.builder().config(schedule).build();
+    schedules.add(sc);
+    REPLICATION_POLICY = Replication.builder().schedules(schedules).build();
     RETENTION_POLICY_WITH_PATTERN =
         Retention.builder()
             .count(3)
@@ -71,7 +81,8 @@ public final class TableModelConstants {
             .columnPattern(COL_PAT.toBuilder().pattern("").build())
             .build();
 
-    TABLE_POLICIES = Policies.builder().retention(RETENTION_POLICY).build();
+    TABLE_POLICIES =
+        Policies.builder().retention(RETENTION_POLICY).replication(REPLICATION_POLICY).build();
     TABLE_POLICIES_COMPLEX = Policies.builder().retention(RETENTION_POLICY_WITH_PATTERN).build();
     SHARED_TABLE_POLICIES =
         Policies.builder().retention(RETENTION_POLICY).sharingEnabled(true).build();


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

This PR builds off of @rohitkum2506's PR https://github.com/linkedin/openhouse/pull/185 to add support for the SQL API for self serve replication.

Self serve replication allows users to add their own replication config as part of the table policies to specify a destination cluster and cron schedule for cross cluster table replication. Using the replication config in table properties, we can trigger the replication job, removing the manual process of requiring users to open a ticket to specify a table replication.
 
The scope of this PR is to add the SQL API and server-side support for adding replication configs to table policies within table properties. SQL API that is supported:
```
ALTER TABLE db.testTable SET POLICY (REPLICATION=({cluster:'a', schedule:'b'}, {cluster:'aa', schedule:'bb'}))
```

Future Scope: 
Add validations to support replication schedule within a scope and according to rules defined for data freshness and compliance.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

Added unit tests.

Local docker testing:
```
ALTER TABLE db.testTable SET POLICY (REPLICATION=({cluster:'a', schedule:'0 0 0 9 0 ?'}))
```
This will store the replication config as part of table properties:
```
  "replication": {
    "schedules": [
      {
        "config": {
          "a": "0 0 0 9 0 ?"
        }
      }
    ]
  }
```
Re-running with:
```
ALTER TABLE db.testTable SET POLICY (REPLICATION=({cluster:'a', schedule:'0 0 0 9 0 ?'}, {cluster:'b', schedule:'0 0 0 9 0 ?'}))
```
```
  "replication": {
    "schedules": [
      {
        "config": {
          "a": "0 0 0 9 0 ?"
        }
      },
      {
        "config": {
          "b": "0 0 0 9 0 ?"
        }
      }
    ]
  }
```


# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
