### PR TITLE
Self serve replication SQL API

### DIFF
--- a/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/SetTableReplicationPolicyStatementTest.java
+++ b/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/SetTableReplicationPolicyStatementTest.java
@@ -1,0 +1,158 @@
+package com.linkedin.openhouse.spark.statementtest;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseParseException;
+import java.nio.file.Files;
+import lombok.SneakyThrows;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.execution.ExplainMode;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class SetTableReplicationPolicyStatementTest {
+  private static SparkSession spark = null;
+
+  @SneakyThrows
+  @BeforeAll
+  public void setupSpark() {
+    Path unittest = new Path(Files.createTempDirectory("unittest_settablepolicy").toString());
+    spark =
+        SparkSession.builder()
+            .master("local[2]")
+            .config(
+                "spark.sql.extensions",
+                ("org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,"
+                    + "com.linkedin.openhouse.spark.extensions.OpenhouseSparkSessionExtensions"))
+            .config("spark.sql.catalog.openhouse", "org.apache.iceberg.spark.SparkCatalog")
+            .config("spark.sql.catalog.openhouse.type", "hadoop")
+            .config("spark.sql.catalog.openhouse.warehouse", unittest.toString())
+            .getOrCreate();
+  }
+
+  @Test
+  public void testSimpleSetReplicationPolicy() {
+    String replicationConfigJson =
+        "{\"cluster\":\"a\", \"schedule\":\"b\"}, {\"cluster\": \"aa\", \"schedule\": \"bb\"}";
+    Dataset<Row> ds =
+        spark.sql(
+            "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = "
+                + "({cluster:'a', schedule:'b'}, {cluster: 'aa', schedule: 'bb'}))");
+    assert isPlanValid(ds, replicationConfigJson);
+
+    replicationConfigJson = "{\"cluster\":\"a\", \"schedule\":\"b\"}";
+    ds =
+        spark.sql(
+            "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({cluster:'a', schedule:'b'}))");
+    assert isPlanValid(ds, replicationConfigJson);
+  }
+
+  @Test
+  public void testReplicationPolicyWithoutProperSyntax() {
+    // missing schedule keyword
+    Assertions.assertThrows(
+        OpenhouseParseException.class,
+        () ->
+            spark
+                .sql("ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({cluster: 'aa'}))")
+                .show());
+
+    // Missing cluster keyword
+    Assertions.assertThrows(
+        OpenhouseParseException.class,
+        () ->
+            spark
+                .sql("ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({schedule: 'ss'}))")
+                .show());
+
+    // Typo in keyword schedule
+    Assertions.assertThrows(
+        OpenhouseParseException.class,
+        () ->
+            spark
+                .sql(
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({cluster: 'aa', schedul: 'ss'}))")
+                .show());
+
+    // Typo in keyword cluster
+    Assertions.assertThrows(
+        OpenhouseParseException.class,
+        () ->
+            spark
+                .sql(
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({clustr: 'aa', schedule: 'ss'}))")
+                .show());
+
+    // Missing quote in cluster value
+    Assertions.assertThrows(
+        OpenhouseParseException.class,
+        () ->
+            spark
+                .sql(
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({cluster: aa', schedule: 'ss}))")
+                .show());
+
+    // Type in REPLICATION keyword
+    Assertions.assertThrows(
+        OpenhouseParseException.class,
+        () ->
+            spark
+                .sql(
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICAT = ({cluster: 'aa', schedule: 'ss}))")
+                .show());
+
+    // Missing cluster and schedule value
+    Assertions.assertThrows(
+        OpenhouseParseException.class,
+        () -> spark.sql("ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({}))").show());
+  }
+
+  @BeforeEach
+  public void setup() {
+    spark.sql("CREATE TABLE openhouse.db.table (id bigint, data string) USING iceberg").show();
+    spark.sql("CREATE TABLE openhouse.0_.0_ (id bigint, data string) USING iceberg").show();
+    spark
+        .sql("ALTER TABLE openhouse.db.table SET TBLPROPERTIES ('openhouse.tableId' = 'tableid')")
+        .show();
+    spark
+        .sql("ALTER TABLE openhouse.0_.0_ SET TBLPROPERTIES ('openhouse.tableId' = 'tableid')")
+        .show();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    spark.sql("DROP TABLE openhouse.db.table").show();
+    spark.sql("DROP TABLE openhouse.0_.0_").show();
+  }
+
+  @AfterAll
+  public void tearDownSpark() {
+    spark.close();
+  }
+
+  @SneakyThrows
+  private boolean isPlanValid(Dataset<Row> dataframe, String replicationConfigJson) {
+    replicationConfigJson = "[" + replicationConfigJson + "]";
+    String queryStr = dataframe.queryExecution().explainString(ExplainMode.fromString("simple"));
+    JsonArray jsonArray = new Gson().fromJson(replicationConfigJson, JsonArray.class);
+    boolean isValid = false;
+    for (JsonElement element : jsonArray) {
+      JsonObject entry = element.getAsJsonObject();
+      String cluster = entry.get("cluster").getAsString();
+      String schedule = entry.get("schedule").getAsString();
+      isValid = queryStr.contains(cluster) && queryStr.contains(schedule);
+    }
+    return isValid;
+  }
+}

--- a/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/SetTableReplicationPolicyStatementTest.java
+++ b/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/SetTableReplicationPolicyStatementTest.java
@@ -195,6 +195,22 @@ public class SetTableReplicationPolicyStatementTest {
                     "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({cluster: 'aa', interval: '12'}))")
                 .show());
 
+    Assertions.assertThrows(
+        OpenhouseParseException.class,
+        () ->
+            spark
+                .sql(
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({cluster: 'aa', interval: '1D'}))")
+                .show());
+
+    Assertions.assertThrows(
+        OpenhouseParseException.class,
+        () ->
+            spark
+                .sql(
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({cluster: 'aa', interval: '12d'}))")
+                .show());
+
     // Missing cluster and interval values
     Assertions.assertThrows(
         OpenhouseParseException.class,

--- a/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/SetTableReplicationPolicyStatementTest.java
+++ b/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/SetTableReplicationPolicyStatementTest.java
@@ -43,37 +43,38 @@ public class SetTableReplicationPolicyStatementTest {
 
   @Test
   public void testSimpleSetReplicationPolicy() {
-    String replicationConfigJson = "[{\"cluster\":\"a\", \"interval\":\"24H\"}]";
+    String replicationConfigJson = "[{\"destination\":\"a\", \"interval\":\"24H\"}]";
     Dataset<Row> ds =
         spark.sql(
             "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = "
-                + "({cluster:'a', interval:24H}))");
+                + "({destination:'a', interval:24H}))");
     assert isPlanValid(ds, replicationConfigJson);
 
     // Test support with multiple clusters
     replicationConfigJson =
-        "[{\"cluster\":\"a\", \"interval\":\"12H\"}, {\"cluster\":\"aa\", \"interval\":\"12H\"}]";
+        "[{\"destination\":\"a\", \"interval\":\"12H\"}, {\"destination\":\"aa\", \"interval\":\"12H\"}]";
     ds =
         spark.sql(
             "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = "
-                + "({cluster:'a', interval:12h}, {cluster:'aa', interval:12H}))");
+                + "({destination:'a', interval:12h}, {destination:'aa', interval:12H}))");
     assert isPlanValid(ds, replicationConfigJson);
   }
 
   @Test
   public void testSimpleSetReplicationPolicyOptionalInterval() {
     // Test with optional interval
-    String replicationConfigJson = "[{\"cluster\":\"a\"}]";
+    String replicationConfigJson = "[{\"destination\":\"a\"}]";
     Dataset<Row> ds =
-        spark.sql("ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = " + "({cluster:'a'}))");
+        spark.sql(
+            "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = " + "({destination:'a'}))");
     assert isPlanValid(ds, replicationConfigJson);
 
     // Test with optional interval for multiple clusters
-    replicationConfigJson = "[{\"cluster\":\"a\"}, {\"cluster\":\"b\"}]";
+    replicationConfigJson = "[{\"destination\":\"a\"}, {\"destination\":\"b\"}]";
     ds =
         spark.sql(
             "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = "
-                + "({cluster:'a'}, {cluster:'b'}))");
+                + "({destination:'a'}, {destination:'b'}))");
     assert isPlanValid(ds, replicationConfigJson);
   }
 
@@ -84,7 +85,7 @@ public class SetTableReplicationPolicyStatementTest {
         OpenhouseParseException.class,
         () ->
             spark
-                .sql("ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({cluster:}))")
+                .sql("ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination:}))")
                 .show());
 
     // Empty interval value
@@ -93,7 +94,7 @@ public class SetTableReplicationPolicyStatementTest {
         () ->
             spark
                 .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({cluster: 'aa', interval:}))")
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination: 'aa', interval:}))")
                 .show());
 
     // Empty interval value
@@ -102,7 +103,7 @@ public class SetTableReplicationPolicyStatementTest {
         () ->
             spark
                 .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({cluster: 'aa', interval:}))")
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination: 'aa', interval:}))")
                 .show());
 
     // Missing cluster value but interval present
@@ -111,7 +112,7 @@ public class SetTableReplicationPolicyStatementTest {
         () ->
             spark
                 .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({cluster:, interval: '12h'}))")
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination:, interval: '12h'}))")
                 .show());
 
     // Missing interval value but keyword present
@@ -120,7 +121,7 @@ public class SetTableReplicationPolicyStatementTest {
         () ->
             spark
                 .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({cluster: 'a', interval:}))")
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination: 'a', interval:}))")
                 .show());
 
     // Missing cluster value for multiple clusters
@@ -129,7 +130,7 @@ public class SetTableReplicationPolicyStatementTest {
         () ->
             spark
                 .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({cluster:, interval:'12H'}, {cluster:, interval: '12H'}))")
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination:, interval:'12H'}, {cluster:, interval: '12H'}))")
                 .show());
 
     // Missing cluster keyword for multiple clusters
@@ -138,7 +139,7 @@ public class SetTableReplicationPolicyStatementTest {
         () ->
             spark
                 .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({interval:'a'}, {interval: '12h'}))")
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination:'a'}, {interval: '12h'}))")
                 .show());
 
     // Missing cluster keyword
@@ -156,7 +157,7 @@ public class SetTableReplicationPolicyStatementTest {
         () ->
             spark
                 .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({cluster: 'aa', interv: '12h'}))")
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination: 'aa', interv: '12h'}))")
                 .show());
 
     // Typo in keyword cluster
@@ -165,7 +166,7 @@ public class SetTableReplicationPolicyStatementTest {
         () ->
             spark
                 .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({clustr: 'aa', interval: '12h'}))")
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destina: 'aa', interval: '12h'}))")
                 .show());
 
     // Missing quote in cluster value
@@ -174,7 +175,7 @@ public class SetTableReplicationPolicyStatementTest {
         () ->
             spark
                 .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({cluster: aa', interval: '12h}))")
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination: aa', interval: '12h}))")
                 .show());
 
     // Typo in REPLICATION keyword
@@ -183,7 +184,7 @@ public class SetTableReplicationPolicyStatementTest {
         () ->
             spark
                 .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICAT = ({cluster: 'aa', interval: '12h'}))")
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICAT = ({destination: 'aa', interval: '12h'}))")
                 .show());
 
     // Interval input does not follow 'h/H' format
@@ -192,7 +193,7 @@ public class SetTableReplicationPolicyStatementTest {
         () ->
             spark
                 .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({cluster: 'aa', interval: '12'}))")
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination: 'aa', interval: '12'}))")
                 .show());
 
     Assertions.assertThrows(
@@ -200,7 +201,7 @@ public class SetTableReplicationPolicyStatementTest {
         () ->
             spark
                 .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({cluster: 'aa', interval: '1D'}))")
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination: 'aa', interval: '1D'}))")
                 .show());
 
     Assertions.assertThrows(
@@ -208,7 +209,7 @@ public class SetTableReplicationPolicyStatementTest {
         () ->
             spark
                 .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({cluster: 'aa', interval: '12d'}))")
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination: 'aa', interval: '12d'}))")
                 .show());
 
     // Missing cluster and interval values
@@ -247,11 +248,11 @@ public class SetTableReplicationPolicyStatementTest {
     boolean isValid = false;
     for (JsonElement element : jsonArray) {
       JsonObject entry = element.getAsJsonObject();
-      String cluster = entry.get("cluster").getAsString();
-      isValid = queryStr.contains(cluster);
+      String destination = entry.get("destination").getAsString();
+      isValid = queryStr.contains(destination);
       if (entry.has("interval")) {
         String interval = entry.get("interval").getAsString();
-        isValid = queryStr.contains(cluster) && queryStr.contains(interval);
+        isValid = queryStr.contains(destination) && queryStr.contains(interval);
       }
     }
     return isValid;

--- a/integrations/spark/openhouse-spark-runtime/src/main/antlr/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensions.g4
+++ b/integrations/spark/openhouse-spark-runtime/src/main/antlr/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensions.g4
@@ -89,11 +89,15 @@ replicationPolicy
     ;
 
 tableReplicationPolicy
-    : '(' replicationPolicyClause (',' replicationPolicyClause)* ')'
+    : '(' '{' replicationPolicyClusterClause (',' replicationPolicyIntervalClause)? '}' ')'
     ;
 
-replicationPolicyClause
-    : '{' CLUSTER ':' STRING ',' SCHEDULE ':' STRING '}'
+replicationPolicyClusterClause
+    : CLUSTER ':' STRING
+    ;
+
+replicationPolicyIntervalClause
+    : INTERVAL ':' STRING
     ;
 
 columnRetentionPolicyPatternClause
@@ -165,7 +169,7 @@ SHOW: 'SHOW';
 GRANTS: 'GRANTS';
 PATTERN: 'PATTERN';
 CLUSTER: 'CLUSTER';
-SCHEDULE: 'SCHEDULE';
+INTERVAL: 'INTERVAL';
 WHERE: 'WHERE';
 COLUMN: 'COLUMN';
 PII: 'PII';

--- a/integrations/spark/openhouse-spark-runtime/src/main/antlr/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensions.g4
+++ b/integrations/spark/openhouse-spark-runtime/src/main/antlr/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensions.g4
@@ -24,6 +24,7 @@ singleStatement
 
 statement
   : ALTER TABLE multipartIdentifier SET POLICY '(' retentionPolicy (columnRetentionPolicy)? ')'        #setRetentionPolicy
+  | ALTER TABLE multipartIdentifier SET POLICY '(' replicationPolicy ')'                               #setReplicationPolicy
   | ALTER TABLE multipartIdentifier SET POLICY '(' sharingPolicy ')'                                   #setSharingPolicy
   | ALTER TABLE multipartIdentifier MODIFY columnNameClause SET columnPolicy                           #setColumnPolicyTag
   | GRANT privilege ON grantableResource TO principal                                                  #grantStatement
@@ -64,7 +65,7 @@ quotedIdentifier
     ;
 
 nonReserved
-    : ALTER | TABLE | SET | POLICY | RETENTION | SHARING
+    : ALTER | TABLE | SET | POLICY | RETENTION | SHARING | REPLICATION
     | GRANT | REVOKE | ON | TO | SHOW | GRANTS | PATTERN | WHERE | COLUMN
     ;
 
@@ -81,6 +82,18 @@ retentionPolicy
 
 columnRetentionPolicy
     : ON columnNameClause (columnRetentionPolicyPatternClause)?
+    ;
+
+replicationPolicy
+    : REPLICATION '=' tableReplicationPolicy
+    ;
+
+tableReplicationPolicy
+    : '(' replicationPolicyClause (',' replicationPolicyClause)* ')'
+    ;
+
+replicationPolicyClause
+    : '{' CLUSTER ':' STRING ',' SCHEDULE ':' STRING '}'
     ;
 
 columnRetentionPolicyPatternClause
@@ -136,6 +149,7 @@ TABLE: 'TABLE';
 SET: 'SET';
 POLICY: 'POLICY';
 RETENTION: 'RETENTION';
+REPLICATION: 'REPLICATION';
 SHARING: 'SHARING';
 GRANT: 'GRANT';
 REVOKE: 'REVOKE';
@@ -150,6 +164,8 @@ DATABASE: 'DATABASE';
 SHOW: 'SHOW';
 GRANTS: 'GRANTS';
 PATTERN: 'PATTERN';
+CLUSTER: 'CLUSTER';
+SCHEDULE: 'SCHEDULE';
 WHERE: 'WHERE';
 COLUMN: 'COLUMN';
 PII: 'PII';

--- a/integrations/spark/openhouse-spark-runtime/src/main/antlr/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensions.g4
+++ b/integrations/spark/openhouse-spark-runtime/src/main/antlr/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensions.g4
@@ -89,7 +89,11 @@ replicationPolicy
     ;
 
 tableReplicationPolicy
-    : '(' '{' replicationPolicyClusterClause (',' replicationPolicyIntervalClause)? '}' ')'
+    : '(' replicationPolicyClause (',' replicationPolicyClause)* ')'
+    ;
+
+replicationPolicyClause
+    : '{' replicationPolicyClusterClause (',' replicationPolicyIntervalClause)? '}'
     ;
 
 replicationPolicyClusterClause

--- a/integrations/spark/openhouse-spark-runtime/src/main/antlr/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensions.g4
+++ b/integrations/spark/openhouse-spark-runtime/src/main/antlr/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensions.g4
@@ -101,7 +101,7 @@ replicationPolicyClusterClause
     ;
 
 replicationPolicyIntervalClause
-    : INTERVAL ':' STRING
+    : INTERVAL ':' RETENTION_HOUR
     ;
 
 columnRetentionPolicyPatternClause

--- a/integrations/spark/openhouse-spark-runtime/src/main/antlr/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensions.g4
+++ b/integrations/spark/openhouse-spark-runtime/src/main/antlr/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensions.g4
@@ -97,7 +97,7 @@ replicationPolicyClause
     ;
 
 replicationPolicyClusterClause
-    : CLUSTER ':' STRING
+    : DESTINATION ':' STRING
     ;
 
 replicationPolicyIntervalClause
@@ -172,7 +172,7 @@ DATABASE: 'DATABASE';
 SHOW: 'SHOW';
 GRANTS: 'GRANTS';
 PATTERN: 'PATTERN';
-CLUSTER: 'CLUSTER';
+DESTINATION: 'DESTINATION';
 INTERVAL: 'INTERVAL';
 WHERE: 'WHERE';
 COLUMN: 'COLUMN';

--- a/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensionsAstBuilder.scala
+++ b/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensionsAstBuilder.scala
@@ -2,13 +2,14 @@ package com.linkedin.openhouse.spark.sql.catalyst.parser.extensions
 
 import com.linkedin.openhouse.spark.sql.catalyst.enums.GrantableResourceTypes
 import com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseSqlExtensionsParser._
-import com.linkedin.openhouse.spark.sql.catalyst.plans.logical.{GrantRevokeStatement, SetRetentionPolicy, SetSharingPolicy, SetColumnPolicyTag, ShowGrantsStatement}
+import com.linkedin.openhouse.spark.sql.catalyst.plans.logical.{GrantRevokeStatement, SetColumnPolicyTag, SetReplicationPolicy, SetRetentionPolicy, SetSharingPolicy, ShowGrantsStatement}
 import com.linkedin.openhouse.spark.sql.catalyst.enums.GrantableResourceTypes.GrantableResourceType
 import com.linkedin.openhouse.gen.tables.client.model.TimePartitionSpec
 import org.antlr.v4.runtime.tree.ParseTree
 import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 
+import scala.collection.JavaConversions.iterableAsScalaIterable
 import scala.collection.JavaConverters._
 
 class OpenhouseSqlExtensionsAstBuilder (delegate: ParserInterface) extends OpenhouseSqlExtensionsBaseVisitor[AnyRef] {
@@ -24,6 +25,12 @@ class OpenhouseSqlExtensionsAstBuilder (delegate: ParserInterface) extends Openh
       typedVisit[(String, String)](ctx.columnRetentionPolicy())
       else (null, null)
     SetRetentionPolicy(tableName, granularity, count, Option(colName), Option(colPattern))
+  }
+
+  override def visitSetReplicationPolicy(ctx: SetReplicationPolicyContext): SetReplicationPolicy = {
+    val tableName = typedVisit[Seq[String]](ctx.multipartIdentifier)
+    val replicationPolicies = typedVisit[Seq[String]](ctx.replicationPolicy())
+    SetReplicationPolicy(tableName, replicationPolicies)
   }
 
   override def visitSetSharingPolicy(ctx: SetSharingPolicyContext): SetSharingPolicy = {
@@ -84,6 +91,19 @@ class OpenhouseSqlExtensionsAstBuilder (delegate: ParserInterface) extends Openh
 
   override def visitRetentionPolicy(ctx: RetentionPolicyContext): (String, Int) = {
     typedVisit[(String, Int)](ctx.duration())
+  }
+
+  override def visitReplicationPolicy(ctx: ReplicationPolicyContext): (Seq[String]) = {
+    typedVisit[(Seq[String])](ctx.tableReplicationPolicy())
+  }
+
+  override def visitTableReplicationPolicy(ctx: TableReplicationPolicyContext): (Seq[String]) = {
+    ctx.replicationPolicyClause().map(ele => typedVisit[String](ele)).toSeq
+  }
+
+  override def visitReplicationPolicyClause(ctx: ReplicationPolicyClauseContext): (String) = {
+    val replicationPolicy = ctx.STRING().map(_.getText)
+    replicationPolicy.mkString(":")
   }
 
   override def visitColumnRetentionPolicy(ctx: ColumnRetentionPolicyContext): (String, String) = {

--- a/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensionsAstBuilder.scala
+++ b/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensionsAstBuilder.scala
@@ -105,7 +105,8 @@ class OpenhouseSqlExtensionsAstBuilder (delegate: ParserInterface) extends Openh
     val cluster = typedVisit[String](ctx.replicationPolicyClusterClause())
     val interval = if (ctx.replicationPolicyIntervalClause() != null)
       typedVisit[String](ctx.replicationPolicyIntervalClause())
-    else null
+    else
+      null
     (cluster, Option(interval))
   }
 
@@ -114,7 +115,7 @@ class OpenhouseSqlExtensionsAstBuilder (delegate: ParserInterface) extends Openh
   }
 
   override def visitReplicationPolicyIntervalClause(ctx: ReplicationPolicyIntervalClauseContext): (String) = {
-    ctx.STRING().getText
+    ctx.RETENTION_HOUR().getText.toUpperCase
   }
 
   override def visitColumnRetentionPolicy(ctx: ColumnRetentionPolicyContext): (String, String) = {

--- a/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/plans/logical/SetReplicationPolicy.scala
+++ b/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/plans/logical/SetReplicationPolicy.scala
@@ -2,8 +2,8 @@ package com.linkedin.openhouse.spark.sql.catalyst.plans.logical
 
 import org.apache.spark.sql.catalyst.plans.logical.Command
 
-case class SetReplicationPolicy(tableName: Seq[String], clusterName: String, interval: String) extends Command {
+case class SetReplicationPolicy(tableName: Seq[String], replicationPolicies: Seq[(String, Option[String])]) extends Command {
   override def simpleString(maxFields: Int): String = {
-    s"SetReplicationPolicy: ${tableName} ${clusterName} ${interval}"
+    s"SetReplicationPolicy: ${tableName} ${replicationPolicies}"
   }
 }

--- a/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/plans/logical/SetReplicationPolicy.scala
+++ b/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/plans/logical/SetReplicationPolicy.scala
@@ -2,8 +2,8 @@ package com.linkedin.openhouse.spark.sql.catalyst.plans.logical
 
 import org.apache.spark.sql.catalyst.plans.logical.Command
 
-case class SetReplicationPolicy(tableName: Seq[String], replicationPolicies: Seq[String]) extends Command {
+case class SetReplicationPolicy(tableName: Seq[String], clusterName: String, interval: String) extends Command {
   override def simpleString(maxFields: Int): String = {
-    s"SetReplicationPolicy: ${tableName} ${replicationPolicies}}"
+    s"SetReplicationPolicy: ${tableName} ${clusterName} ${interval}"
   }
 }

--- a/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/plans/logical/SetReplicationPolicy.scala
+++ b/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/plans/logical/SetReplicationPolicy.scala
@@ -1,0 +1,9 @@
+package com.linkedin.openhouse.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.plans.logical.Command
+
+case class SetReplicationPolicy(tableName: Seq[String], replicationPolicies: Seq[String]) extends Command {
+  override def simpleString(maxFields: Int): String = {
+    s"SetReplicationPolicy: ${tableName} ${replicationPolicies}}"
+  }
+}

--- a/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/OpenhouseDataSourceV2Strategy.scala
+++ b/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/OpenhouseDataSourceV2Strategy.scala
@@ -1,6 +1,6 @@
 package com.linkedin.openhouse.spark.sql.execution.datasources.v2
 
-import com.linkedin.openhouse.spark.sql.catalyst.plans.logical.{GrantRevokeStatement, SetRetentionPolicy, SetSharingPolicy, SetColumnPolicyTag, ShowGrantsStatement}
+import com.linkedin.openhouse.spark.sql.catalyst.plans.logical.{GrantRevokeStatement, SetColumnPolicyTag, SetReplicationPolicy, SetRetentionPolicy, SetSharingPolicy, ShowGrantsStatement}
 import org.apache.iceberg.spark.{Spark3Util, SparkCatalog, SparkSessionCatalog}
 import org.apache.spark.sql.{SparkSession, Strategy}
 import org.apache.spark.sql.catalyst.expressions.PredicateHelper
@@ -15,6 +15,8 @@ case class OpenhouseDataSourceV2Strategy(spark: SparkSession) extends Strategy w
   override def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
     case SetRetentionPolicy(CatalogAndIdentifierExtractor(catalog, ident), granularity, count, colName, colPattern) =>
       SetRetentionPolicyExec(catalog, ident, granularity, count, colName, colPattern) :: Nil
+    case SetReplicationPolicy(CatalogAndIdentifierExtractor(catalog, ident), replicationPolicies) =>
+      SetReplicationPolicyExec(catalog, ident, replicationPolicies) :: Nil
     case SetSharingPolicy(CatalogAndIdentifierExtractor(catalog, ident), sharing) =>
       SetSharingPolicyExec(catalog, ident, sharing) :: Nil
     case SetColumnPolicyTag(CatalogAndIdentifierExtractor(catalog, ident), policyTag, cols) =>

--- a/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/OpenhouseDataSourceV2Strategy.scala
+++ b/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/OpenhouseDataSourceV2Strategy.scala
@@ -15,8 +15,8 @@ case class OpenhouseDataSourceV2Strategy(spark: SparkSession) extends Strategy w
   override def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
     case SetRetentionPolicy(CatalogAndIdentifierExtractor(catalog, ident), granularity, count, colName, colPattern) =>
       SetRetentionPolicyExec(catalog, ident, granularity, count, colName, colPattern) :: Nil
-    case SetReplicationPolicy(CatalogAndIdentifierExtractor(catalog, ident), replicationPolicies) =>
-      SetReplicationPolicyExec(catalog, ident, replicationPolicies) :: Nil
+    case SetReplicationPolicy(CatalogAndIdentifierExtractor(catalog, ident), clusterName, interval) =>
+      SetReplicationPolicyExec(catalog, ident, clusterName, interval) :: Nil
     case SetSharingPolicy(CatalogAndIdentifierExtractor(catalog, ident), sharing) =>
       SetSharingPolicyExec(catalog, ident, sharing) :: Nil
     case SetColumnPolicyTag(CatalogAndIdentifierExtractor(catalog, ident), policyTag, cols) =>

--- a/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/OpenhouseDataSourceV2Strategy.scala
+++ b/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/OpenhouseDataSourceV2Strategy.scala
@@ -15,8 +15,8 @@ case class OpenhouseDataSourceV2Strategy(spark: SparkSession) extends Strategy w
   override def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
     case SetRetentionPolicy(CatalogAndIdentifierExtractor(catalog, ident), granularity, count, colName, colPattern) =>
       SetRetentionPolicyExec(catalog, ident, granularity, count, colName, colPattern) :: Nil
-    case SetReplicationPolicy(CatalogAndIdentifierExtractor(catalog, ident), clusterName, interval) =>
-      SetReplicationPolicyExec(catalog, ident, clusterName, interval) :: Nil
+    case SetReplicationPolicy(CatalogAndIdentifierExtractor(catalog, ident), replicationPolicies) =>
+      SetReplicationPolicyExec(catalog, ident, replicationPolicies) :: Nil
     case SetSharingPolicy(CatalogAndIdentifierExtractor(catalog, ident), sharing) =>
       SetSharingPolicyExec(catalog, ident, sharing) :: Nil
     case SetColumnPolicyTag(CatalogAndIdentifierExtractor(catalog, ident), policyTag, cols) =>

--- a/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/SetReplicationPolicyExec.scala
+++ b/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/SetReplicationPolicyExec.scala
@@ -1,0 +1,26 @@
+package com.linkedin.openhouse.spark.sql.execution.datasources.v2
+
+import org.apache.iceberg.spark.source.SparkTable
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
+import org.apache.spark.sql.execution.datasources.v2.V2CommandExec
+
+case class SetReplicationPolicyExec(catalog: TableCatalog, ident: Identifier, replicationPolicies: Seq[String]) extends V2CommandExec{
+  override protected def run(): Seq[InternalRow] = {
+    catalog.loadTable(ident) match {
+      case iceberg: SparkTable if iceberg.table().properties().containsKey("openhouse.tableId") =>
+        val key = "updated.openhouse.policy"
+        val value = s"""{"replication":{"schedules":[${replicationPolicies.map(replication => s"""{config:{${replication}}}""").mkString(",")}]}}"""
+        iceberg.table().updateProperties()
+          .set(key, value)
+          .commit()
+
+      case table =>
+        throw new UnsupportedOperationException(s"Cannot set replication policy for non-Openhouse table: $table")
+    }
+    Nil
+  }
+
+  override def output: Seq[Attribute] = Nil
+}

--- a/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/SetReplicationPolicyExec.scala
+++ b/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/SetReplicationPolicyExec.scala
@@ -6,12 +6,12 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
 import org.apache.spark.sql.execution.datasources.v2.V2CommandExec
 
-case class SetReplicationPolicyExec(catalog: TableCatalog, ident: Identifier, replicationPolicies: Seq[String]) extends V2CommandExec{
+case class SetReplicationPolicyExec(catalog: TableCatalog, ident: Identifier, clusterName: String, interval: String) extends V2CommandExec{
   override protected def run(): Seq[InternalRow] = {
     catalog.loadTable(ident) match {
       case iceberg: SparkTable if iceberg.table().properties().containsKey("openhouse.tableId") =>
         val key = "updated.openhouse.policy"
-        val value = s"""{"replication":{"schedules":[${replicationPolicies.map(replication => s"""{config:{${replication}}}""").mkString(",")}]}}"""
+        val value = s"""{"replication":{"config":[{"destination":"$clusterName","interval":"$interval"}]}}"""
         iceberg.table().updateProperties()
           .set(key, value)
           .commit()


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

Branched off from https://github.com/linkedin/openhouse/pull/220, this PR contains only the scope for SQL API support for self serve replication. The changes include SQL API support for adding replication configs to table policies within table properties. 

SQL API that is supported:
```
ALTER TABLE db.testTable SET POLICY (REPLICATION=({destination:'a', interval:12h}))
```
```
ALTER TABLE db.testTable SET POLICY (REPLICATION=({destination:'a'}))
```
where interval is defined as the interval at which the replication job is run and cluster is the destination cluster. 
Interval is an optional parameter where users can define an interval from 12 to 72 as `12h/H`, `24h/H`, etc. If interval is not given, the replication schedule will be set up as daily (24h intervals).

We also allow a list input with multiple clusters to enable multi-cluster table replication.
```
ALTER TABLE db.testTable SET POLICY (REPLICATION=({destination:'a', interval:12H}, {destination:'aa', interval:12h}))
```

**Future Scope:**
Add validations to check that the destination cluster != source cluster, and that the replication interval follows rules defined for data freshness and compliance.
Separate PR for server-side implementation: https://github.com/linkedin/openhouse/pull/227 which will contain validation for SQL string input and cron schedule.

## Changes

- [x] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

Added unit tests.

Ran following commands on local docker:
```
scala> spark.sql("alter table u_tableowner.test_table set policy (replication=({destination:'WAR'}))").show(false)
ANTLR Tool version 4.7.1 used for code generation does not match the current runtime version 4.8ANTLR Tool version 4.7.1 used for code generation does not match the current runtime version 4.8++
||
++
++
```

```
scala> spark.sql("alter table u_tableowner.test_table set policy (replication=({destination:'WAR', interval:12H}))").show(false)
++
||
++
++
```

```
scala> spark.sql("alter table u_tableowner.test_table set policy (replication=({interval:'12H'}))").show(false)
com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseParseException: mismatched input 'interval' expecting {'.', 'SET'}; line 1 pos 62
```

```
scala> spark.sql("alter table u_tableowner.test_table set policy (replication=({destination:'A', interval:12d}))").show(false)
com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseParseException: mismatched input '12d' expecting RETENTION_HOUR; line 1 pos 84
```

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [x] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
