### PR TITLE
Changed args for Preconditions.checkNotNull

### DIFF
--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/impl/RegexStorageSelector.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/selector/impl/RegexStorageSelector.java
@@ -54,12 +54,14 @@ public class RegexStorageSelector extends BaseStorageSelector {
       log.info("Initializing {} ", this.getName());
       String regex = storageProperties.getStorageSelector().getParameters().get(REGEX_CONFIG);
       Preconditions.checkNotNull(
-          regex, "{} pattern not defined in {} parameters", REGEX_CONFIG, this.getName());
+          regex,
+          String.format("%s pattern not defined in %s parameters", REGEX_CONFIG, this.getName()));
       pattern = Pattern.compile(regex);
       providedStorage =
           storageProperties.getStorageSelector().getParameters().get(STORAGE_TYPE_CONFIG);
       Preconditions.checkNotNull(
-          providedStorage, "{} not defined in {} parameters", STORAGE_TYPE_CONFIG, this.getName());
+          providedStorage,
+          String.format("%s not defined in %s parameters", STORAGE_TYPE_CONFIG, this.getName()));
     }
   }
 


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->
Changed Preconditions.checkNonNull method call from 

 `public static <T> T checkNotNull(@CheckForNull T obj, String errorMessageTemplate, @CheckForNull Object p1, @CheckForNull Object p2) 
`
to
` public static <T> T checkNotNull(@CheckForNull T reference, @CheckForNull Object errorMessage)`

The former was added in latest versions of guava while the latter is backward compatible with the latest and much older versions of guava. This is to avoid failure when an older version of guava is picked up in production

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [x] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Verified that the former method signature is present in guava 31.1 jre but not in guava 11.2.0
and the latter is present in both guava versions.


# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
