### PR TITLE
Add null check for tables stats collector when collecting table policies

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableStatsCollectorUtil.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableStatsCollectorUtil.java
@@ -210,6 +210,10 @@ public final class TableStatsCollectorUtil {
 
   private static String getEarliestPartitionDate(
       Table table, SparkSession spark, Map<String, Object> policyMap) {
+    // Check if retention policy is present by checking if granularity exists
+    if (!policyMap.containsKey("granularity")) {
+      return null;
+    }
     String partitionColumnName =
         policyMap.containsKey("columnName")
             ? (String) policyMap.get("columnName")
@@ -246,10 +250,13 @@ public final class TableStatsCollectorUtil {
     if (policies.isEmpty()) {
       return policyMap;
     }
-
-    addEntriesToMap(policiesObject.getAsJsonObject("retention"), policyMap);
-    policyMap.put(
-        "sharingEnabled", Boolean.valueOf(policiesObject.get("sharingEnabled").getAsString()));
+    if (policiesObject.get("retention") != null) {
+      addEntriesToMap(policiesObject.getAsJsonObject("retention"), policyMap);
+    }
+    if (policiesObject.get("sharingEnabled") != null) {
+      policyMap.put(
+          "sharingEnabled", Boolean.valueOf(policiesObject.get("sharingEnabled").getAsString()));
+    }
 
     return policyMap;
   }


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

This PR fixes the issue where tables that had a sharing policy set without a retention policy set would throw a null pointer exception when trying to collect retention stats.
```
java.lang.NullPointerException
	at com.linkedin.openhouse.jobs.util.TableStatsCollectorUtil.addEntriesToMap(TableStatsCollectorUtil.java:271)
	at com.linkedin.openhouse.jobs.util.TableStatsCollectorUtil.getTablePolicies(TableStatsCollectorUtil.java:250)
	at com.linkedin.openhouse.jobs.util.TableStatsCollectorUtil.populateTableMetadata(TableStatsCollectorUtil.java:155)
	at com.linkedin.openhouse.jobs.util.TableStatsCollector.collectTableStats(TableStatsCollector.java:25)
	at com.linkedin.openhouse.jobs.spark.Operations.collectTableStats(Operations.java:445)
	at com.linkedin.openhouse.jobs.spark.OperationsTest.testCollectTablePolicyStats(OperationsTest.java:603)
```
A null check is added to `getTablePolicies` so if sharing or retention policies do not exist on the table it will not collect those stats.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

Added unit tests for testing stat collection on tables without a retention policy.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
