### PR TITLE
Convert interval input to cron schedule for self serve replication

### DIFF
--- a/services/tables/build.gradle
+++ b/services/tables/build.gradle
@@ -31,6 +31,7 @@ dependencies {
   implementation project(':cluster:metrics')
   implementation 'org.springframework.security:spring-security-config:5.7.2'
   implementation 'org.springframework.boot:spring-boot-starter-webflux:2.7.8'
+  implementation 'com.cronutils:cron-utils:9.2.0'
   testImplementation 'org.junit.jupiter:junit-jupiter-engine:' + junit_version
   testImplementation 'org.springframework.security:spring-security-test:5.7.3'
   testImplementation(testFixtures(project(':services:common')))

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/ReplicationConfig.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/ReplicationConfig.java
@@ -26,18 +26,11 @@ public class ReplicationConfig {
   @Schema(
       description =
           "Optional parameter interval at which the replication job should run. Default value is 1D",
-      example = "1D")
+      example = "12H, 1D, 2D, 3D")
   @Valid
   String interval;
 
-  @Schema(
-      description = "Cron schedule generated from interval used for replication job scheduling",
-      example = "Schedule could be '0 3/12 * * *' if interval is 12H")
+  @Schema(description = "Cron schedule generated from the interval.", example = "0 0 1/1 * ? *")
   @Valid
   String cronSchedule;
-
-  public enum Granularity {
-    H,
-    D
-  }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/ReplicationConfig.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/ReplicationConfig.java
@@ -29,4 +29,15 @@ public class ReplicationConfig {
       example = "1D")
   @Valid
   String interval;
+
+  @Schema(
+      description = "Cron schedule generated from interval used for replication job scheduling",
+      example = "Schedule could be '0 3/12 * * *' if interval is 12H")
+  @Valid
+  String cronSchedule;
+
+  public enum Granularity {
+    H,
+    D
+  }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/iceberg/PoliciesSpecMapper.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/iceberg/PoliciesSpecMapper.java
@@ -128,14 +128,16 @@ public class PoliciesSpecMapper {
                                   ReplicationInterval.DEFAULT.getInterval()))
                           .build();
                     }
-                    return replication
-                        .toBuilder()
-                        .cronSchedule(
-                            CronScheduleGenerator.buildCronExpression(replication.getInterval()))
-                        .build();
+                    if (replication.getCronSchedule() == null) {
+                      return replication
+                          .toBuilder()
+                          .cronSchedule(
+                              CronScheduleGenerator.buildCronExpression(replication.getInterval()))
+                          .build();
+                    }
+                    return replication;
                   })
               .collect(Collectors.toList());
-
       return replicationPolicy.toBuilder().config(replicationConfig).build();
     }
     return replicationPolicy;

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/iceberg/PoliciesSpecMapper.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/iceberg/PoliciesSpecMapper.java
@@ -10,6 +10,7 @@ import com.linkedin.openhouse.tables.api.spec.v0.request.components.Retention;
 import com.linkedin.openhouse.tables.common.DefaultColumnPattern;
 import com.linkedin.openhouse.tables.common.ReplicationInterval;
 import com.linkedin.openhouse.tables.model.TableDto;
+import com.linkedin.openhouse.tables.utils.CronScheduleGenerator;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.mapstruct.Mapper;
@@ -106,8 +107,8 @@ public class PoliciesSpecMapper {
 
   /**
    * mapRetentionPolicies is a mapStruct function which assigns default interval value in
-   * replication config if the interval is empty. Default values for pattern are defined at {@link
-   * ReplicationInterval}.
+   * replication config if the interval is empty and the generated cron schedule from the interval
+   * value. Default values for pattern are defined at {@link ReplicationInterval}.
    *
    * @param replicationPolicy config for Openhouse table
    * @return mapped policies object
@@ -122,9 +123,16 @@ public class PoliciesSpecMapper {
                       return replication
                           .toBuilder()
                           .interval(ReplicationInterval.DEFAULT.getInterval())
+                          .cronSchedule(
+                              CronScheduleGenerator.buildCronExpression(
+                                  ReplicationInterval.DEFAULT.getInterval()))
                           .build();
                     }
-                    return replication;
+                    return replication
+                        .toBuilder()
+                        .cronSchedule(
+                            CronScheduleGenerator.buildCronExpression(replication.getInterval()))
+                        .build();
                   })
               .collect(Collectors.toList());
 

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/CronScheduleGenerator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/CronScheduleGenerator.java
@@ -1,0 +1,56 @@
+package com.linkedin.openhouse.tables.utils;
+
+import com.cronutils.builder.CronBuilder;
+import com.cronutils.model.CronType;
+import com.cronutils.model.definition.CronDefinitionBuilder;
+import com.cronutils.model.field.expression.FieldExpressionFactory;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.ReplicationConfig;
+import java.util.Random;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Utility class for generating cron schedules based on interval input for {@link
+ * ReplicationConfig}.
+ */
+@Slf4j
+@Component
+public class CronScheduleGenerator {
+  public static String buildCronExpression(String interval) {
+    int count = Integer.parseInt(interval.substring(0, interval.length() - 1));
+    String granularity = interval.substring(interval.length() - 1);
+    int hourSchedule = new Random().nextInt(24);
+    String schedule;
+
+    if (granularity.equals(ReplicationConfig.Granularity.H.toString())) {
+      schedule = buildHourlyCronExpression(hourSchedule, count);
+    } else {
+      schedule = buildDailyCronExpression(hourSchedule, count);
+    }
+    return schedule;
+  }
+
+  private static String buildDailyCronExpression(int hourSchedule, int dailyInterval) {
+    return CronBuilder.cron(CronDefinitionBuilder.instanceDefinitionFor(CronType.CRON4J))
+        .withDoM(FieldExpressionFactory.every(dailyInterval))
+        .withMonth(FieldExpressionFactory.always())
+        .withDoW(FieldExpressionFactory.always())
+        .withHour(FieldExpressionFactory.on(hourSchedule))
+        .withMinute(FieldExpressionFactory.on(0))
+        .instance()
+        .asString();
+  }
+
+  private static String buildHourlyCronExpression(int hourSchedule, int hourlyInterval) {
+    return CronBuilder.cron(CronDefinitionBuilder.instanceDefinitionFor(CronType.CRON4J))
+        .withDoM(FieldExpressionFactory.always())
+        .withMonth(FieldExpressionFactory.always())
+        .withDoW(FieldExpressionFactory.always())
+        .withHour(
+            FieldExpressionFactory.every(hourlyInterval)
+                .and(FieldExpressionFactory.on(hourSchedule)))
+        .withMinute(FieldExpressionFactory.on(0))
+        .instance()
+        .asString();
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/CronScheduleGenerator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/CronScheduleGenerator.java
@@ -9,46 +9,48 @@ import java.util.Random;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-/**
- * Utility class for generating cron schedules based on interval input for {@link
- * ReplicationConfig}.
- */
+/** Utility class for generating cron schedules based on interval input */
 @Slf4j
 @Component
 public class CronScheduleGenerator {
+
+  /**
+   * Public api to generate a cron schedule for a {@link ReplicationConfig} based on the interval
+   *
+   * @param interval
+   * @return schedule
+   */
   public static String buildCronExpression(String interval) {
     int count = Integer.parseInt(interval.substring(0, interval.length() - 1));
     String granularity = interval.substring(interval.length() - 1);
-    int hourSchedule = new Random().nextInt(24);
+    int hour = new Random().nextInt(24);
     String schedule;
 
-    if (granularity.equals(ReplicationConfig.Granularity.H.toString())) {
-      schedule = buildHourlyCronExpression(hourSchedule, count);
+    if (granularity.equals("H")) {
+      schedule = buildHourlyCronExpression(hour, count);
     } else {
-      schedule = buildDailyCronExpression(hourSchedule, count);
+      schedule = buildDailyCronExpression(hour, count);
     }
     return schedule;
   }
 
-  private static String buildDailyCronExpression(int hourSchedule, int dailyInterval) {
+  private static String buildDailyCronExpression(int hour, int dailyInterval) {
     return CronBuilder.cron(CronDefinitionBuilder.instanceDefinitionFor(CronType.CRON4J))
         .withDoM(FieldExpressionFactory.every(dailyInterval))
         .withMonth(FieldExpressionFactory.always())
         .withDoW(FieldExpressionFactory.always())
-        .withHour(FieldExpressionFactory.on(hourSchedule))
+        .withHour(FieldExpressionFactory.on(hour))
         .withMinute(FieldExpressionFactory.on(0))
         .instance()
         .asString();
   }
 
-  private static String buildHourlyCronExpression(int hourSchedule, int hourlyInterval) {
+  private static String buildHourlyCronExpression(int hour, int hourlyInterval) {
     return CronBuilder.cron(CronDefinitionBuilder.instanceDefinitionFor(CronType.CRON4J))
         .withDoM(FieldExpressionFactory.always())
         .withMonth(FieldExpressionFactory.always())
         .withDoW(FieldExpressionFactory.always())
-        .withHour(
-            FieldExpressionFactory.every(hourlyInterval)
-                .and(FieldExpressionFactory.on(hourSchedule)))
+        .withHour(FieldExpressionFactory.every(hourlyInterval).and(FieldExpressionFactory.on(hour)))
         .withMinute(FieldExpressionFactory.on(0))
         .instance()
         .asString();

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesControllerTest.java
@@ -1026,7 +1026,7 @@ public class TablesControllerTest {
         JsonPath.read(mvcResult.getResponse().getContentAsString(), "$.policies");
 
     ReplicationConfig replicationConfig =
-        ReplicationConfig.builder().destination("clusterA").interval("").build();
+        ReplicationConfig.builder().destination("clusterA").interval("12H").build();
     Replication replication =
         Replication.builder().config(Arrays.asList(replicationConfig)).build();
     Policies newPolicies = Policies.builder().replication(replication).build();
@@ -1051,9 +1051,14 @@ public class TablesControllerTest {
         JsonPath.read(mvcResult.getResponse().getContentAsString(), "$.policies");
 
     Assertions.assertNotEquals(currentPolicies, updatedPolicies);
-    Assertions.assertEquals(
-        updatedPolicies.get("replication").get("config").toString(),
-        "[{\"destination\":\"clusterA\",\"interval\":\"1D\"}]");
+
+    LinkedHashMap<String, LinkedHashMap> updatedReplication =
+        JsonPath.read(
+            mvcResult.getResponse().getContentAsString(), "$.policies.replication.config[0]");
+
+    Assertions.assertEquals(updatedReplication.get("destination"), "clusterA");
+    Assertions.assertEquals(updatedReplication.get("interval"), "12H");
+    System.out.println();
     RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, GET_TABLE_RESPONSE_BODY);
   }
 
@@ -1158,9 +1163,20 @@ public class TablesControllerTest {
         JsonPath.read(mvcResult.getResponse().getContentAsString(), "$.policies");
 
     Assertions.assertNotEquals(currentPolicies, updatedPolicies);
-    Assertions.assertEquals(
-        updatedPolicies.get("replication").get("config").toString(),
-        "[{\"destination\":\"clusterA\",\"interval\":\"1D\"},{\"destination\":\"clusterB\",\"interval\":\"12H\"}]");
+
+    LinkedHashMap<String, LinkedHashMap> updatedReplication =
+        JsonPath.read(
+            mvcResult.getResponse().getContentAsString(), "$.policies.replication.config[0]");
+
+    Assertions.assertEquals(updatedReplication.get("destination"), "clusterA");
+    Assertions.assertEquals(updatedReplication.get("interval"), "1D");
+
+    updatedReplication =
+        JsonPath.read(
+            mvcResult.getResponse().getContentAsString(), "$.policies.replication.config[1]");
+
+    Assertions.assertEquals(updatedReplication.get("destination"), "clusterB");
+    Assertions.assertEquals(updatedReplication.get("interval"), "12H");
     RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, GET_TABLE_RESPONSE_BODY);
   }
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesControllerTest.java
@@ -773,7 +773,8 @@ public class TablesControllerTest {
         mvc, storageManager, buildGetTableResponseBody(mvcResult), INITIAL_TABLE_VERSION, false);
     Assertions.assertEquals(
         tableType, GET_TABLE_RESPONSE_BODY_WITH_TABLE_TYPE.getTableType().toString());
-    RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, GET_TABLE_RESPONSE_BODY);
+    RequestAndValidateHelper.deleteTableAndValidateResponse(
+        mvc, GET_TABLE_RESPONSE_BODY_WITH_TABLE_TYPE);
   }
 
   @Test
@@ -1058,7 +1059,7 @@ public class TablesControllerTest {
 
     Assertions.assertEquals(updatedReplication.get("destination"), "clusterA");
     Assertions.assertEquals(updatedReplication.get("interval"), "12H");
-    System.out.println();
+    Assertions.assertNotNull(updatedReplication.get("cronSchedule"));
     RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, GET_TABLE_RESPONSE_BODY);
   }
 
@@ -1170,6 +1171,7 @@ public class TablesControllerTest {
 
     Assertions.assertEquals(updatedReplication.get("destination"), "clusterA");
     Assertions.assertEquals(updatedReplication.get("interval"), "1D");
+    Assertions.assertNotNull(updatedReplication.get("cronSchedule"));
 
     updatedReplication =
         JsonPath.read(
@@ -1177,6 +1179,7 @@ public class TablesControllerTest {
 
     Assertions.assertEquals(updatedReplication.get("destination"), "clusterB");
     Assertions.assertEquals(updatedReplication.get("interval"), "12H");
+    Assertions.assertNotNull(updatedReplication.get("cronSchedule"));
     RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, GET_TABLE_RESPONSE_BODY);
   }
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/mapper/PoliciesSpecMapperTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/mapper/PoliciesSpecMapperTest.java
@@ -37,6 +37,9 @@ public class PoliciesSpecMapperTest {
     Assertions.assertEquals(
         JsonPath.read(policiesSpec, "$.replication.config[0].destination"),
         TableModelConstants.TABLE_POLICIES.getReplication().getConfig().get(0).getDestination());
+    Assertions.assertEquals(
+        JsonPath.read(policiesSpec, "$.replication.config[0].interval"),
+        TableModelConstants.TABLE_POLICIES.getReplication().getConfig().get(0).getInterval());
   }
 
   @Test


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

This PR adds cron schedule to the replication config for the self serve replication API and converts the interval parameter to a cron schedule. Cron schedule is needed as an input for the replication job that performs the cross cluster data copy. The library `cronutils` is added to perform the cron expression generation.

The interval parameter can be validated as `12H`, `1D`, `2D`, `3D` and the cron schedule is generated based on:
- 12H schedule dictates replication should trigger every 12 hours
- The cron schedule should have an X hour to start from midnight where X can range from 0-23. E.g 12hours can lead to schedule “0 3/12 * * *” -> trigger at 3am and 3pm every day.
- If interval is not provided, a daily replication schedule should be set up with daily schedules with X hour starting from midnight. 
- X is randomized from 0-23 to spread out the cron and avoid job clusters around a time.

## Changes

- [x] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

Unit tests added to check that the cron schedule was created successfully. Since the 

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
