### PR TITLE
Refactor replication SQL API to not allow single quote input for destination

### DIFF
--- a/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/SetTableReplicationPolicyStatementTest.java
+++ b/integrations/spark/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/SetTableReplicationPolicyStatementTest.java
@@ -47,7 +47,7 @@ public class SetTableReplicationPolicyStatementTest {
     Dataset<Row> ds =
         spark.sql(
             "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = "
-                + "({destination:'a', interval:12H}))");
+                + "({destination:a, interval:12H}))");
     assert isPlanValid(ds, replicationConfigJson);
 
     // Test support with multiple clusters
@@ -56,7 +56,7 @@ public class SetTableReplicationPolicyStatementTest {
     ds =
         spark.sql(
             "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = "
-                + "({destination:'a', interval:12h}, {destination:'aa', interval:2d}))");
+                + "({destination:a, interval:12h}, {destination:aa, interval:2d}))");
     assert isPlanValid(ds, replicationConfigJson);
   }
 
@@ -66,7 +66,7 @@ public class SetTableReplicationPolicyStatementTest {
     String replicationConfigJson = "[{\"destination\":\"a\"}]";
     Dataset<Row> ds =
         spark.sql(
-            "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = " + "({destination:'a'}))");
+            "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = " + "({destination:a}))");
     assert isPlanValid(ds, replicationConfigJson);
 
     // Test with optional interval for multiple clusters
@@ -74,7 +74,7 @@ public class SetTableReplicationPolicyStatementTest {
     ds =
         spark.sql(
             "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = "
-                + "({destination:'a'}, {destination:'b'}))");
+                + "({destination:a}, {destination:b}))");
     assert isPlanValid(ds, replicationConfigJson);
   }
 
@@ -94,7 +94,7 @@ public class SetTableReplicationPolicyStatementTest {
         () ->
             spark
                 .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination: 'aa', interval:}))")
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination: aa, interval:}))")
                 .show());
 
     // Empty interval value
@@ -112,7 +112,7 @@ public class SetTableReplicationPolicyStatementTest {
         () ->
             spark
                 .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination:, interval: '12h'}))")
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination:, interval: 12h}))")
                 .show());
 
     // Missing interval value but keyword present
@@ -121,34 +121,33 @@ public class SetTableReplicationPolicyStatementTest {
         () ->
             spark
                 .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination: 'a', interval:}))")
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination: a, interval:}))")
                 .show());
 
-    // Missing cluster value for multiple clusters
+    // Missing destination value for multiple clusters
     Assertions.assertThrows(
         OpenhouseParseException.class,
         () ->
             spark
                 .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination:, interval:'12H'}, {cluster:, interval: '12H'}))")
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination:, interval:12H}, {cluster:, interval: 12H}))")
                 .show());
 
-    // Missing cluster keyword for multiple clusters
+    // Missing destination keyword for multiple clusters
     Assertions.assertThrows(
         OpenhouseParseException.class,
         () ->
             spark
                 .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination:'a'}, {interval: '12h'}))")
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({a}, {interval: 12h}))")
                 .show());
 
-    // Missing cluster keyword
+    // Missing destination keyword
     Assertions.assertThrows(
         OpenhouseParseException.class,
         () ->
             spark
-                .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({interval: '12h'}))")
+                .sql("ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({interval: 12h}))")
                 .show());
 
     // Typo in keyword interval
@@ -157,25 +156,16 @@ public class SetTableReplicationPolicyStatementTest {
         () ->
             spark
                 .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination: 'aa', interv: '12h'}))")
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination: aa, interv: 12h}))")
                 .show());
 
-    // Typo in keyword cluster
+    // Typo in keyword destination
     Assertions.assertThrows(
         OpenhouseParseException.class,
         () ->
             spark
                 .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destina: 'aa', interval: '12h'}))")
-                .show());
-
-    // Missing quote in cluster value
-    Assertions.assertThrows(
-        OpenhouseParseException.class,
-        () ->
-            spark
-                .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination: aa', interval: '12h}))")
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destina: aa, interval: 12h}))")
                 .show());
 
     // Typo in REPLICATION keyword
@@ -184,7 +174,7 @@ public class SetTableReplicationPolicyStatementTest {
         () ->
             spark
                 .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICAT = ({destination: 'aa', interval: '12h'}))")
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICAT = ({destination: aa, interval: 12h}))")
                 .show());
 
     // Interval input does not follow 'h/H' or 'd/D' format
@@ -193,13 +183,22 @@ public class SetTableReplicationPolicyStatementTest {
         () ->
             spark
                 .sql(
-                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination: 'aa', interval: '12'}))")
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination: aa, interval: 12}))")
                 .show());
 
-    // Missing cluster and interval values
+    // Missing destination and interval values
     Assertions.assertThrows(
         OpenhouseParseException.class,
         () -> spark.sql("ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({}))").show());
+
+    // Single quote destination name should not be accepted
+    Assertions.assertThrows(
+        OpenhouseParseException.class,
+        () ->
+            spark
+                .sql(
+                    "ALTER TABLE openhouse.db.table SET POLICY (REPLICATION = ({destination: 'aa', interval: 12}))")
+                .show());
   }
 
   @BeforeEach

--- a/integrations/spark/openhouse-spark-runtime/src/main/antlr/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensions.g4
+++ b/integrations/spark/openhouse-spark-runtime/src/main/antlr/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensions.g4
@@ -97,7 +97,7 @@ replicationPolicyClause
     ;
 
 replicationPolicyClusterClause
-    : DESTINATION ':' STRING
+    : DESTINATION ':' identifier
     ;
 
 replicationPolicyIntervalClause

--- a/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensionsAstBuilder.scala
+++ b/integrations/spark/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensionsAstBuilder.scala
@@ -102,16 +102,12 @@ class OpenhouseSqlExtensionsAstBuilder (delegate: ParserInterface) extends Openh
   }
 
   override def visitReplicationPolicyClause(ctx: ReplicationPolicyClauseContext): (String, Option[String]) = {
-    val cluster = typedVisit[String](ctx.replicationPolicyClusterClause())
+    val cluster = ctx.replicationPolicyClusterClause().identifier().getText
     val interval = if (ctx.replicationPolicyIntervalClause() != null)
       typedVisit[String](ctx.replicationPolicyIntervalClause())
     else
       null
     (cluster, Option(interval))
-  }
-
-  override def visitReplicationPolicyClusterClause(ctx: ReplicationPolicyClusterClauseContext): (String) = {
-    ctx.STRING().getText
   }
 
   override def visitReplicationPolicyIntervalClause(ctx: ReplicationPolicyIntervalClauseContext): (String) = {


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

This PR refactors the replication SQL API to not allow single quote inputs for the destination parameter.
Previously we were allowing the following SQL:
```
ALTER TABLE db.testTable SET POLICY (REPLICATION=({destination:'clusterA'}))
ALTER TABLE db.testTable SET POLICY (REPLICATION=({destination:'clusterA', interval:'<X>h/H'}))
```
Updated to allow:
```
ALTER TABLE db.testTable SET POLICY (REPLICATION=({destination:clusterA}))
ALTER TABLE db.testTable SET POLICY (REPLICATION=({destination:clusterA, interval:'<X>h/H'}))
```

## Changes

- [x] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

Updated unit testing.

Tested on local docker setup:
```
scala> spark.sql("ALTER TABLE u_tableowner.test_table2 SET POLICY ( REPLICATION=({destination:a, interval:12H}) )")
res5: org.apache.spark.sql.DataFrame = []
```
```
scala> spark.sql("ALTER TABLE u_tableowner.test_table2 SET POLICY ( REPLICATION=({destination:'a', interval:12H}) )")
com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseParseException: mismatched input ''a'' expecting {'ALTER', 'TABLE', 'SET', 'POLICY', 'RETENTION', 'REPLICATION', 'SHARING', 'GRANT', 'REVOKE', 'ON', 'TO', 'SHOW', 'GRANTS', 'PATTERN', 'WHERE', 'COLUMN', IDENTIFIER, BACKQUOTED_IDENTIFIER}; line 1 pos 76
  at com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseParseErrorListener$.syntaxError(OpenhouseSparkSqlExtensionsParser.scala:123)
```

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
