### PR TITLE
[openhouse] Implement TableOperations-specific FileIO instance

### DIFF
--- a/integrations/java/openhouse-java-runtime/build.gradle
+++ b/integrations/java/openhouse-java-runtime/build.gradle
@@ -23,6 +23,7 @@ ext {
   sparkVersion = '3.1.1'
   springVersion = '2.7.8'
   hadoopVersion = '2.10.0'
+  caffeineVersion = '2.9.3'
 }
 
 dependencies {
@@ -41,6 +42,7 @@ dependencies {
     exclude group: 'com.zaxxer', module: 'HikariCP-java7'
     exclude group: 'org.apache.commons', module: 'commons-lang3'
   }
+  implementation("com.github.ben-manes.caffeine:caffeine:" + caffeineVersion)
 }
 
 // Following codeblock completely relocates contents of the jar


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue][(https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.](https://github.com/linkedin/openhouse/issues/240)

In order to implement FileIOs that are TableOperations-specific, creating a FileIO instance on a per TableOperations-basis is required.

This is similar to how other Iceberg-compliant Catalogs are implemented: https://github.com/apache/iceberg/pull/10893 and implemented in the same way (taken from the HiveCatalog / GlueCatalog implementations before it got refactored into FileIOTracker)

This feature is needed to implement data access tokens. 

## Changes

- [ ] Client-facing API Changes
- [ x ] Internal API Changes
- [ ] Bug Fixes
- [ x ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

TODO

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
