### PR TITLE
[openhouse] Create GET /accesss endpoint for fetching DataAccessCredentials for a given table

### DIFF
--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/BaseStorage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/BaseStorage.java
@@ -1,6 +1,7 @@
 package com.linkedin.openhouse.cluster.storage;
 
 import com.google.common.base.Preconditions;
+import com.linkedin.openhouse.cluster.storage.auth.DataAccessCredential;
 import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
 import java.net.URI;
 import java.util.HashMap;
@@ -75,5 +76,12 @@ public abstract class BaseStorage implements Storage {
                 + tableUUID)
         .normalize()
         .toString();
+  }
+
+  /** Default implementation returns Optional.empty. */
+  @Override
+  public Optional<DataAccessCredential> getDataAccessCredentialForTableLocation(
+      String tableLocation, Map<String, String> params) {
+    return Optional.empty();
   }
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/Storage.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/Storage.java
@@ -1,6 +1,8 @@
 package com.linkedin.openhouse.cluster.storage;
 
+import com.linkedin.openhouse.cluster.storage.auth.DataAccessCredential;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * The Storage interface represents a storage system in OpenHouse. It provides methods to check if
@@ -70,4 +72,15 @@ public interface Storage {
    */
   String allocateTableLocation(
       String databaseId, String tableId, String tableUUID, String tableCreator);
+
+  /**
+   * Returns an optional DataAccessCredential for the given table location.
+   *
+   * @param tableLocation the table location
+   * @param params input parameters needed to get a data access credential for the given table
+   *     location
+   * @return DataAccessCredential for the given table location if possible. Otherwise, empty.
+   */
+  Optional<DataAccessCredential> getDataAccessCredentialForTableLocation(
+      String tableLocation, Map<String, String> params);
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/auth/DataAccessCredential.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/auth/DataAccessCredential.java
@@ -1,0 +1,22 @@
+package com.linkedin.openhouse.cluster.storage.auth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class DataAccessCredential {
+
+  @Schema(
+      description = "Map with the access credentials",
+      example = "{'token':'header.payload.signature', 'path':'/my/table'}")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private Map<String, String> credential;
+
+  @Schema(description = "Expiration date of token in millis since epoch", example = "0")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private long expirationMillisSinceEpoch;
+}

--- a/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -92,6 +92,7 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
                 WebClientRequestException.class,
                 e -> Mono.error(new WebClientRequestWithMessageException(e)))
             .blockOptional();
+
     if (!tableLocation.isPresent() && currentMetadataLocation() != null) {
       throw new NoSuchTableException(
           "Cannot find table %s after refresh, maybe another process deleted it", tableName());

--- a/services/common/src/main/java/com/linkedin/openhouse/common/exception/UnsupportedClientOperationException.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/exception/UnsupportedClientOperationException.java
@@ -18,6 +18,7 @@ public class UnsupportedClientOperationException extends RuntimeException {
     ALTER_RESERVED_TBLPROPS,
     ALTER_RESERVED_ROLES,
     GRANT_ON_UNSHARED_TABLES,
-    ALTER_TABLE_TYPE
+    ALTER_TABLE_TYPE,
+    DATA_ACCESS_CREDENTIAL_UNSUPPORTED
   }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/TablesApiHandler.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/TablesApiHandler.java
@@ -5,7 +5,9 @@ import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableReques
 import com.linkedin.openhouse.tables.api.spec.v0.request.UpdateAclPoliciesRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAclPoliciesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllTablesResponseBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetDataAccessCredentialResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
+import java.util.Map;
 
 /**
  * Interface layer between REST and Tables backend. The implementation is injected into the Service
@@ -108,4 +110,17 @@ public interface TablesApiHandler {
    */
   ApiResponse<GetAclPoliciesResponseBody> getAclPoliciesForUserPrincipal(
       String databaseId, String tableId, String actingPrincipal, String userPrincipal);
+
+  /**
+   * Function to get data access credential for a Table Resource identified by tableId in a given
+   * databaseId.
+   *
+   * @param databaseId
+   * @param tableId
+   * @param params
+   * @return an access token to read data for the tableId if supported by the table's underlying
+   *     data storage.
+   */
+  ApiResponse<GetDataAccessCredentialResponseBody> getDataAccessCredential(
+      String databaseId, String tableId, Map<String, String> params);
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/response/GetDataAccessCredentialResponseBody.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/response/GetDataAccessCredentialResponseBody.java
@@ -1,0 +1,27 @@
+package com.linkedin.openhouse.tables.api.spec.v0.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.Gson;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Value;
+
+@Builder(toBuilder = true)
+@Value
+public class GetDataAccessCredentialResponseBody {
+
+  @Schema(
+      description = "Map with the access credentials",
+      example = "{'token':'header.payload.signature', 'path':'/my/table'}")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private Map<String, String> credential;
+
+  @Schema(description = "Expiration date of token in millis since epoch", example = "0")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private long expirationMillisSinceEpoch;
+
+  public String toJson() {
+    return new Gson().toJson(this);
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/TablesController.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/TablesController.java
@@ -7,6 +7,7 @@ import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableReques
 import com.linkedin.openhouse.tables.api.spec.v0.request.UpdateAclPoliciesRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAclPoliciesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllTablesResponseBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetDataAccessCredentialResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
 import com.linkedin.openhouse.tables.authorization.Privileges;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,6 +15,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.util.Collections;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
@@ -288,6 +291,41 @@ public class TablesController {
     com.linkedin.openhouse.common.api.spec.ApiResponse<GetAclPoliciesResponseBody> apiResponse =
         tablesApiHandler.getAclPoliciesForUserPrincipal(
             databaseId, tableId, extractAuthenticatedUserPrincipal(), principal);
+    return new ResponseEntity<>(
+        apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
+  }
+
+  @Operation(
+      summary = "Get temporary credentials to access data in a given table",
+      description =
+          "Returns the temporary credentials which have data access to the Table resource identified by by "
+              + "databaseId and tableId. The expiration time of the temporary credentials is returned "
+              + "in millis since epoch.",
+      tags = {"Table"})
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "Access GET: OK"),
+        @ApiResponse(responseCode = "400", description = "Access GET: ACCESS_UNSUPPORTED"),
+      })
+  @GetMapping(
+      value = {
+        "/v0/databases/{databaseId}/tables/{tableId}/access",
+        "/v1/databases/{databaseId}/tables/{tableId}/access"
+      },
+      produces = {"application/json"})
+  public ResponseEntity<GetDataAccessCredentialResponseBody> getDataAccessCredential(
+      @Parameter(description = "Database ID", required = true) @PathVariable String databaseId,
+      @Parameter(description = "Table ID", required = true) @PathVariable String tableId,
+      @Parameter(description = "Other Params", required = false) @PathVariable
+          Map<String, String> params) {
+
+    if (params == null) {
+      params = Collections.emptyMap();
+    }
+
+    com.linkedin.openhouse.common.api.spec.ApiResponse<GetDataAccessCredentialResponseBody>
+        apiResponse = tablesApiHandler.getDataAccessCredential(databaseId, tableId, params);
+
     return new ResponseEntity<>(
         apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
   }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesService.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesService.java
@@ -1,10 +1,13 @@
 package com.linkedin.openhouse.tables.services;
 
+import com.linkedin.openhouse.cluster.storage.auth.DataAccessCredential;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.UpdateAclPoliciesRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.components.AclPolicy;
 import com.linkedin.openhouse.tables.model.TableDto;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.springframework.data.util.Pair;
 
 /** Service Interface for Implementing /tables endpoint. */
@@ -93,4 +96,8 @@ public interface TablesService {
    */
   List<AclPolicy> getAclPolicies(
       String databaseId, String tableId, String actingPrincipal, String userPrincipal);
+
+  /** Get DataAccessCredential for the given table */
+  Optional<DataAccessCredential> getDataAccessCredential(
+      String databaseId, String tableId, Map<String, String> params);
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/MockTablesApiHandler.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/MockTablesApiHandler.java
@@ -14,7 +14,9 @@ import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableReques
 import com.linkedin.openhouse.tables.api.spec.v0.request.UpdateAclPoliciesRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAclPoliciesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllTablesResponseBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetDataAccessCredentialResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
+import java.util.Map;
 import org.springframework.context.annotation.Primary;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
@@ -184,6 +186,23 @@ public class MockTablesApiHandler implements TablesApiHandler {
         throw new AuthorizationServiceException("Internal authz service not available");
       default:
         return null;
+    }
+  }
+
+  @Override
+  public ApiResponse<GetDataAccessCredentialResponseBody> getDataAccessCredential(
+      String databaseId, String tableId, Map<String, String> params) {
+    switch (databaseId) {
+      case "d200":
+        return ApiResponse.<GetDataAccessCredentialResponseBody>builder()
+            .httpStatus(HttpStatus.OK)
+            .responseBody(RequestConstants.TEST_GET_DATA_ACCESS_CREDENTIAL_RESPONSE_BODY)
+            .build();
+      case "d400":
+        throw new UnsupportedClientOperationException(
+            UnsupportedClientOperationException.Operation.DATA_ACCESS_CREDENTIAL_UNSUPPORTED, "");
+      default:
+        throw new RuntimeException("Unknown databaseId: " + databaseId);
     }
   }
 

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/RequestConstants.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/RequestConstants.java
@@ -6,6 +6,7 @@ import com.linkedin.openhouse.tables.api.spec.v0.request.UpdateAclPoliciesReques
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAclPoliciesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllDatabasesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllTablesResponseBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetDataAccessCredentialResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetDatabaseResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.components.AclPolicy;
@@ -114,4 +115,11 @@ public final class RequestConstants {
       AclPolicy.builder().principal("TEST_USER").role("TABLE_ADMIN").build();
   public static final GetAclPoliciesResponseBody TEST_GET_ACL_POLICIES_RESPONSE_BODY =
       GetAclPoliciesResponseBody.builder().results(Collections.singletonList(ACL_POLICY)).build();
+
+  public static final GetDataAccessCredentialResponseBody
+      TEST_GET_DATA_ACCESS_CREDENTIAL_RESPONSE_BODY =
+          GetDataAccessCredentialResponseBody.builder()
+              .credential(Collections.singletonMap("token", "header.payload.signature"))
+              .expirationMillisSinceEpoch(0)
+              .build();
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/controller/TablesControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/controller/TablesControllerTest.java
@@ -416,4 +416,37 @@ public class TablesControllerTest {
           .andReturn();
     }
   }
+
+  @Test
+  public void testGetDataAccessCredentialSuccessful() throws Exception {
+    mvcUnauthenticated
+        .perform(
+            MockMvcRequestBuilders.get(
+                    String.format(
+                        CURRENT_MAJOR_VERSION_PREFIX + "/databases/d200/tables/tb1/access"))
+                .header("Authorization", "Bearer " + jwtAccessToken))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(
+            content()
+                .json(RequestConstants.TEST_GET_DATA_ACCESS_CREDENTIAL_RESPONSE_BODY.toJson()));
+  }
+
+  @Test
+  public void testGetDataAccessCredentialForVariousExceptions() throws Exception {
+    List<AbstractMap.SimpleEntry<String, HttpStatus>> list =
+        Arrays.asList(new AbstractMap.SimpleEntry<>("d400", HttpStatus.BAD_REQUEST));
+
+    for (AbstractMap.SimpleEntry<String, HttpStatus> pair : list) {
+      String db = pair.getKey();
+      HttpStatus status = pair.getValue();
+      mvcUnauthenticated
+          .perform(
+              MockMvcRequestBuilders.get(
+                      String.format(
+                          CURRENT_MAJOR_VERSION_PREFIX + "/databases/" + db + "/tables/tb1/access"))
+                  .header("Authorization", "Bearer " + jwtAccessToken))
+          .andExpect(status().is(status.value()));
+    }
+  }
 }


### PR DESCRIPTION

## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue] https://github.com/linkedin/openhouse/issues/242] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

DataAccessCredentials are credentials that grant you access to a given table. 

This commit introduces the /access endpoint for minting DataAccessCredentials that can be subsequently leveraged by clients to get a credential that grants access to the underlying storage of their tables

## Changes

- [x] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
TODO

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
