### PR TITLE
Skip field-id re-assignment during table creation

### DIFF
--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/CatalogConstants.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/CatalogConstants.java
@@ -17,6 +17,8 @@ public final class CatalogConstants {
 
   static final String FEATURE_TOGGLE_STOP_CREATE = "stop_create";
 
+  public static final String CLIENT_TABLE_SCHEMA = "client.table.schema";
+
   private CatalogConstants() {
     // Noop
   }

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/CatalogConstants.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/CatalogConstants.java
@@ -17,7 +17,7 @@ public final class CatalogConstants {
 
   static final String FEATURE_TOGGLE_STOP_CREATE = "stop_create";
 
-  public static final String CLIENT_TABLE_SCHEMA = "client.table.schema";
+  static final String CLIENT_TABLE_SCHEMA = "client.table.schema";
 
   private CatalogConstants() {
     // Noop

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -186,8 +186,8 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
           TableMetadata.buildFromEmpty()
               .setLocation(metadata.location())
               .addSchema(sourceSchema, metadata.lastColumnId())
-              .addPartitionSpec(clonePartitionSpec(metadata.spec(), sourceSchema))
-              .addSortOrder(cloneSortOrder(metadata.sortOrder(), sourceSchema))
+              .addPartitionSpec(rebuildPartitionSpec(metadata.spec(), sourceSchema))
+              .addSortOrder(rebuildSortOrder(metadata.sortOrder(), sourceSchema))
               .setProperties(metadata.properties())
               .build();
       metadata = newTableMetadata;
@@ -307,7 +307,7 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
     }
   }
 
-  public static PartitionSpec clonePartitionSpec(PartitionSpec original, Schema schema) {
+  public static PartitionSpec rebuildPartitionSpec(PartitionSpec original, Schema schema) {
     // Create a builder with the new schema
     PartitionSpec.Builder builder = PartitionSpec.builderFor(schema);
 
@@ -342,7 +342,7 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
     return builder.build();
   }
 
-  public static SortOrder cloneSortOrder(SortOrder original, Schema newSchema) {
+  public static SortOrder rebuildSortOrder(SortOrder original, Schema newSchema) {
     SortOrder.Builder builder = SortOrder.builderFor(newSchema).withOrderId(original.orderId());
 
     for (SortField field : original.fields()) {

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -333,41 +333,46 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
         throw new IllegalArgumentException(
             "Field " + fieldName + " does not exist in the new schema");
       }
-
-      // Recreate the transform using the string representation
-      String transformString = field.transform().toString();
-
-      // Add the field to the new PartitionSpec based on the transform type
-      if ("identity".equalsIgnoreCase(transformString)) {
-        builder.identity(fieldName);
-      } else if (transformString.startsWith("bucket[")) {
-        // Extract bucket number from the string (e.g., bucket[16])
-        int numBuckets =
-            Integer.parseInt(
-                transformString.substring(
-                    transformString.indexOf('[') + 1, transformString.indexOf(']')));
-        builder.bucket(fieldName, numBuckets);
-      } else if (transformString.startsWith("truncate[")) {
-        // Extract width from the string (e.g., truncate[10])
-        int width =
-            Integer.parseInt(
-                transformString.substring(
-                    transformString.indexOf('[') + 1, transformString.indexOf(']')));
-        builder.truncate(fieldName, width);
-      } else if ("year".equalsIgnoreCase(transformString)) {
-        builder.year(fieldName);
-      } else if ("month".equalsIgnoreCase(transformString)) {
-        builder.month(fieldName);
-      } else if ("day".equalsIgnoreCase(transformString)) {
-        builder.day(fieldName);
-      } else if ("hour".equalsIgnoreCase(transformString)) {
-        builder.hour(fieldName);
-      } else {
-        throw new UnsupportedOperationException("Unsupported transform: " + transformString);
-      }
+      // build the pspec from transform string representation
+      buildPspecFromTransform(builder, field, fieldName);
     }
 
     return builder.build();
+  }
+
+  static void buildPspecFromTransform(
+      PartitionSpec.Builder builder, PartitionField field, String fieldName) {
+    // Recreate the transform using the string representation
+    String transformString = field.transform().toString();
+
+    // Add the field to the new PartitionSpec based on the transform type
+    if ("identity".equalsIgnoreCase(transformString)) {
+      builder.identity(fieldName);
+    } else if (transformString.startsWith("bucket[")) {
+      // Extract bucket number from the string (e.g., bucket[16])
+      int numBuckets =
+          Integer.parseInt(
+              transformString.substring(
+                  transformString.indexOf('[') + 1, transformString.indexOf(']')));
+      builder.bucket(fieldName, numBuckets);
+    } else if (transformString.startsWith("truncate[")) {
+      // Extract width from the string (e.g., truncate[10])
+      int width =
+          Integer.parseInt(
+              transformString.substring(
+                  transformString.indexOf('[') + 1, transformString.indexOf(']')));
+      builder.truncate(fieldName, width);
+    } else if ("year".equalsIgnoreCase(transformString)) {
+      builder.year(fieldName);
+    } else if ("month".equalsIgnoreCase(transformString)) {
+      builder.month(fieldName);
+    } else if ("day".equalsIgnoreCase(transformString)) {
+      builder.day(fieldName);
+    } else if ("hour".equalsIgnoreCase(transformString)) {
+      builder.hour(fieldName);
+    } else {
+      throw new UnsupportedOperationException("Unsupported transform: " + transformString);
+    }
   }
 
   /**

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -320,7 +320,7 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
    * @param newSchema
    * @return new partition spec
    */
-  public static PartitionSpec rebuildPartitionSpec(
+  static PartitionSpec rebuildPartitionSpec(
       PartitionSpec originalPspec, Schema originalSchema, Schema newSchema) {
     PartitionSpec.Builder builder = PartitionSpec.builderFor(newSchema);
 
@@ -378,7 +378,7 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
    * @param newSchema
    * @return new SortOrder
    */
-  public static SortOrder rebuildSortOrder(SortOrder originalSortOrder, Schema newSchema) {
+  static SortOrder rebuildSortOrder(SortOrder originalSortOrder, Schema newSchema) {
     SortOrder.Builder builder = SortOrder.builderFor(newSchema);
 
     for (SortField field : originalSortOrder.fields()) {

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/CatalogOperationTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/CatalogOperationTest.java
@@ -83,7 +83,7 @@ public class CatalogOperationTest extends OpenHouseSparkITest {
               Types.NestedField.required(3, "c", Types.StringType.get()));
 
       // Field ids reassigned (Status quo)
-      TableIdentifier tableIdentifier = TableIdentifier.of("db", "t1");
+      TableIdentifier tableIdentifier = TableIdentifier.of("replication_test", "t1");
       Map<String, String> props = new HashMap<>();
       Table table = icebergCatalog.createTable(tableIdentifier, schema, null, props);
       Schema schemaAfterCreation = table.schema();
@@ -99,7 +99,7 @@ public class CatalogOperationTest extends OpenHouseSparkITest {
       Assertions.assertEquals(5, table.schema().findField("a.e").fieldId());
 
       // Field ids not reassigned (new changes)
-      tableIdentifier = TableIdentifier.of("db", "t2");
+      tableIdentifier = TableIdentifier.of("replication_test", "t2");
       props.put("client.table.schema", SchemaParser.toJson(schema));
       table = icebergCatalog.createTable(tableIdentifier, schema, null, props);
       schemaAfterCreation = table.schema();
@@ -131,7 +131,7 @@ public class CatalogOperationTest extends OpenHouseSparkITest {
       PartitionSpec partitionSpec = PartitionSpec.builderFor(schema).identity("c").build();
 
       // Field ids reassigned (Status quo)
-      TableIdentifier tableIdentifier = TableIdentifier.of("db", "t3");
+      TableIdentifier tableIdentifier = TableIdentifier.of("replication_test", "t3");
       Map<String, String> props = new HashMap<>();
       Table table = icebergCatalog.createTable(tableIdentifier, schema, partitionSpec, props);
       Schema schemaAfterCreation = table.schema();
@@ -150,7 +150,7 @@ public class CatalogOperationTest extends OpenHouseSparkITest {
       Assertions.assertEquals(5, table.schema().findField("a.e").fieldId());
 
       // Field ids not reassigned (new changes)
-      tableIdentifier = TableIdentifier.of("db", "t4");
+      tableIdentifier = TableIdentifier.of("replication_test", "t4");
       props.put("client.table.schema", SchemaParser.toJson(schema));
       table = icebergCatalog.createTable(tableIdentifier, schema, partitionSpec, props);
       schemaAfterCreation = table.schema();

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/CatalogOperationTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/CatalogOperationTest.java
@@ -88,7 +88,7 @@ public class CatalogOperationTest extends OpenHouseSparkITest {
       props.put("client.table.schema", SchemaParser.toJson(schema));
       Table table = icebergCatalog.createTable(tableIdentifier, schema, null, props);
       Schema schemaAfterCreation = table.schema();
-      Assertions.assertFalse(schemaAfterCreation.sameSchema(schema));
+      Assertions.assertTrue(schemaAfterCreation.sameSchema(schema));
       Assertions.assertEquals(1, schemaAfterCreation.findField("a").fieldId());
       Assertions.assertNotEquals(3, schemaAfterCreation.findField("a.b").fieldId());
       Assertions.assertNotEquals(2, schemaAfterCreation.findField("c").fieldId());
@@ -116,12 +116,12 @@ public class CatalogOperationTest extends OpenHouseSparkITest {
       PartitionSpec partitionSpec = PartitionSpec.builderFor(schema).identity("c").build();
 
       // Field ids not reassigned
-      TableIdentifier tableIdentifier = TableIdentifier.of("replication_test", "t1");
+      TableIdentifier tableIdentifier = TableIdentifier.of("replication_test", "t2");
       Map<String, String> props = new HashMap<>();
       props.put("client.table.schema", SchemaParser.toJson(schema));
       Table table = icebergCatalog.createTable(tableIdentifier, schema, null, props);
       Schema schemaAfterCreation = table.schema();
-      Assertions.assertFalse(schemaAfterCreation.sameSchema(schema));
+      Assertions.assertTrue(schemaAfterCreation.sameSchema(schema));
       Assertions.assertEquals(1, schemaAfterCreation.findField("a").fieldId());
       Assertions.assertNotEquals(3, schemaAfterCreation.findField("a.b").fieldId());
       Assertions.assertNotEquals(2, schemaAfterCreation.findField("c").fieldId());

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/CatalogOperationTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/CatalogOperationTest.java
@@ -83,7 +83,7 @@ public class CatalogOperationTest extends OpenHouseSparkITest {
               Types.NestedField.required(3, "c", Types.StringType.get()));
 
       // Field ids reassigned (Status quo)
-      TableIdentifier tableIdentifier = TableIdentifier.of("db", "table");
+      TableIdentifier tableIdentifier = TableIdentifier.of("db", "t1");
       Map<String, String> props = new HashMap<>();
       Table table = icebergCatalog.createTable(tableIdentifier, schema, null, props);
       Schema schemaAfterCreation = table.schema();
@@ -99,7 +99,7 @@ public class CatalogOperationTest extends OpenHouseSparkITest {
       Assertions.assertEquals(5, table.schema().findField("a.e").fieldId());
 
       // Field ids not reassigned (new changes)
-      tableIdentifier = TableIdentifier.of("db", "table1");
+      tableIdentifier = TableIdentifier.of("db", "t2");
       props.put("client.table.schema", SchemaParser.toJson(schema));
       table = icebergCatalog.createTable(tableIdentifier, schema, null, props);
       schemaAfterCreation = table.schema();
@@ -131,7 +131,7 @@ public class CatalogOperationTest extends OpenHouseSparkITest {
       PartitionSpec partitionSpec = PartitionSpec.builderFor(schema).identity("c").build();
 
       // Field ids reassigned (Status quo)
-      TableIdentifier tableIdentifier = TableIdentifier.of("db", "table");
+      TableIdentifier tableIdentifier = TableIdentifier.of("db", "t3");
       Map<String, String> props = new HashMap<>();
       Table table = icebergCatalog.createTable(tableIdentifier, schema, partitionSpec, props);
       Schema schemaAfterCreation = table.schema();
@@ -150,7 +150,7 @@ public class CatalogOperationTest extends OpenHouseSparkITest {
       Assertions.assertEquals(5, table.schema().findField("a.e").fieldId());
 
       // Field ids not reassigned (new changes)
-      tableIdentifier = TableIdentifier.of("db", "table1");
+      tableIdentifier = TableIdentifier.of("db", "t4");
       props.put("client.table.schema", SchemaParser.toJson(schema));
       table = icebergCatalog.createTable(tableIdentifier, schema, partitionSpec, props);
       schemaAfterCreation = table.schema();


### PR DESCRIPTION
## Summary
Doc: https://docs.google.com/document/d/152W319aqZMWpxnAbEoO6L86vM8jObC5vkZrRNLqMvHs/edit?tab=t.0#heading=h.tpufqkd57g2w

During table creation, iceberg reassigns the field-ids of client supplied schema and recreates table metadata. This can cause schema field-id mismatch during replica table creation if source table schema has evolved. This change ensures that replica table schema will always have same field-ids as the source table schema during replica table creation.

Changes
1. Client adds table level property "client.table.schema" with serialized iceberg schema 
2. During table creation, new code creates a new table metadata object using the schema provided in step 1

## Changes

- [ ] Client-facing API Changes
- [x] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
