### PR TITLE
Add creationTime in mysql column

### DIFF
--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/mapper/HouseTableMapper.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/mapper/HouseTableMapper.java
@@ -20,7 +20,6 @@ public abstract class HouseTableMapper {
   @Autowired FileIOManager fileIOManager;
 
   @Mapping(target = "lastModifiedTime", ignore = true)
-  @Mapping(target = "creationTime", ignore = true)
   @Mapping(
       target = "storageType",
       expression = "java(fileIOManager.getStorage(fileIO).getType().getValue())")

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/spec/model/UserTable.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/spec/model/UserTable.java
@@ -57,6 +57,10 @@ public class UserTable {
   @JsonProperty(value = "storageType")
   private String storageType;
 
+  @Schema(description = "Creation time of the table.", example = "1651002318265")
+  @JsonProperty(value = "creationTime")
+  private Long creationTime;
+
   public String toJson() {
     return new Gson().toJson(this);
   }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/dto/mapper/UserTablesMapper.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/dto/mapper/UserTablesMapper.java
@@ -44,6 +44,7 @@ public interface UserTablesMapper {
    */
   @Mapping(target = "version", source = "userTable", qualifiedByName = "toVersion")
   @Mapping(target = "storageType", source = "userTable.storageType", defaultValue = DEFAULT_STORAGE)
+  @Mapping(target = "creationTime", source = "userTable.creationTime")
   UserTableRow toUserTableRow(
       UserTable userTable, @Context Optional<UserTableRow> existingUserTableRow);
 

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/dto/model/UserTableDto.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/dto/model/UserTableDto.java
@@ -21,6 +21,8 @@ public class UserTableDto {
 
   String storageType;
 
+  Long creationTime;
+
   /**
    * Compare if a given {@link UserTable} matches the current one if all non-null fields are equal.
    *
@@ -32,6 +34,7 @@ public class UserTableDto {
         && Utilities.fieldMatchCaseInsensitive(this.tableId, userTable.tableId)
         && Utilities.fieldMatch(this.metadataLocation, userTable.metadataLocation)
         && Utilities.fieldMatch(this.tableVersion, userTable.tableVersion)
-        && Utilities.fieldMatch(this.storageType, userTable.storageType);
+        && Utilities.fieldMatch(this.storageType, userTable.storageType)
+        && Utilities.fieldMatch(this.creationTime, userTable.creationTime);
   }
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/model/UserTableRow.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/model/UserTableRow.java
@@ -30,4 +30,6 @@ public class UserTableRow {
   String metadataLocation;
 
   String storageType;
+
+  Long creationTime;
 }

--- a/services/housetables/src/main/resources/schema.sql
+++ b/services/housetables/src/main/resources/schema.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS user_table_row (
                          version             BIGINT            NOT NULL,
                          metadata_location   VARCHAR (512)     ,
                          storage_type        VARCHAR (128)     DEFAULT 'hdfs' NOT NULL,
+                         creation_time       BIGINT            DEFAULT NULL,
                          last_modified_time  TIMESTAMP         DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
                          ETL_TS              DATETIME(6)       DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
                          PRIMARY KEY (database_id, table_id)

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/model/TestHouseTableModelConstants.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/model/TestHouseTableModelConstants.java
@@ -20,6 +20,8 @@ public final class TestHouseTableModelConstants {
 
   public static final String TEST_DEFAULT_STORAGE_TYPE = "hdfs";
 
+  public static final long TEST_CREATION_TIME = 123;
+
   public static final UserTableDto TEST_USER_TABLE_DTO = TUPLE_0.get_userTableDto();
   public static final UserTable TEST_USER_TABLE = TUPLE_0.get_userTable();
 
@@ -43,6 +45,7 @@ public final class TestHouseTableModelConstants {
     private final String databaseId;
     private final String tableLoc;
     private final String storageType;
+    private final long creationTime;
 
     public TestTuple(int tbSeq) {
       this(tbSeq, 0);
@@ -58,6 +61,7 @@ public final class TestHouseTableModelConstants {
               .replace("$test_table", tableId)
               .replace("$version", "v0");
       this.storageType = TEST_DEFAULT_STORAGE_TYPE;
+      this.creationTime = TEST_CREATION_TIME;
       this._userTable =
           UserTable.builder()
               .tableId(tableId)
@@ -65,6 +69,7 @@ public final class TestHouseTableModelConstants {
               .tableVersion(ver)
               .metadataLocation(tableLoc)
               .storageType(storageType)
+              .creationTime(TEST_CREATION_TIME)
               .build();
 
       this._userTableDto =
@@ -74,6 +79,7 @@ public final class TestHouseTableModelConstants {
               .tableVersion(ver)
               .metadataLocation(tableLoc)
               .storageType(storageType)
+              .creationTime(TEST_CREATION_TIME)
               .build();
 
       this._userTableRow =
@@ -83,6 +89,7 @@ public final class TestHouseTableModelConstants {
               .version(null)
               .metadataLocation(tableLoc)
               .storageType(storageType)
+              .creationTime(TEST_CREATION_TIME)
               .build();
     }
   }


### PR DESCRIPTION
## Summary

Add creationTime in mysql column. This column will be used in multiple cases, such as Orion inventory, dual-writer HI data collection, and stats-collection job monitoring.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Manually insert a row without creationTime:
```
mysql> select * from user_table_row;
+-------------+----------+---------+-------------------+--------------+---------------+---------------------+----------------------------+
| database_id | table_id | version | metadata_location | storage_type | creation_time | last_modified_time  | ETL_TS                     |
+-------------+----------+---------+-------------------+--------------+---------------+---------------------+----------------------------+
| d1          | t1       |       0 | /data/v1          | hdfs         |             0 | 2024-11-05 23:42:09 | 2024-11-05 23:42:09.745050 |
+-------------+----------+---------+-------------------+--------------+---------------+---------------------+----------------------------+
```

Create a table:
```
scala> spark.sql("create table d1.t2 (col string)")
res0: org.apache.spark.sql.DataFrame = []

scala> spark.sql("insert into d1.t2 values ('a')")
res1: org.apache.spark.sql.DataFrame = []                                       

scala> spark.sql("select * from d1.t2").show
+---+                                                                           
|col|
+---+
|  a|
+---+

scala> spark.sql("show tables in d1").show
+---------+---------+
|namespace|tableName|
+---------+---------+
|       d1|       t1|
+---------+---------+

scala> spark.sql("show databases").show
+---------+
|namespace|
+---------+
|       d1|
+---------+
```
After creating a table:
```
mysql> select * from user_table_row;
+-------------+----------+---------+---------------------------------------------------------------------------------------------------------------------+--------------+---------------+---------------------+----------------------------+
| database_id | table_id | version | metadata_location                                                                                                   | storage_type | creation_time | last_modified_time  | ETL_TS                     |
+-------------+----------+---------+---------------------------------------------------------------------------------------------------------------------+--------------+---------------+---------------------+----------------------------+
| d1          | t1       |       0 | /data/v1                                                                                                            | hdfs         |             0 | 2024-11-05 23:42:09 | 2024-11-05 23:42:09.745050 |
| d1          | t2       |       0 | /data/openhouse/d1/t2-43cb50ee-f1f7-4383-a262-4b0bf507d02e/00000-5724f70d-a526-48d1-8620-9d3c513ae3e2.metadata.json | hdfs         | 1730850353924 | 2024-11-05 23:45:56 | 2024-11-05 23:45:56.030361 |
+-------------+----------+---------+---------------------------------------------------------------------------------------------------------------------+--------------+---------------+---------------------+----------------------------+
```

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
