### PR TITLE
Enlarge the cache used to avoid retry from internal-catalog towards HTS

### DIFF
--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -63,7 +63,7 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
   private static final Gson GSON = new Gson();
 
   private static final Cache<String, Integer> CACHE =
-      CacheBuilder.newBuilder().expireAfterWrite(1, TimeUnit.MINUTES).maximumSize(100).build();
+      CacheBuilder.newBuilder().expireAfterWrite(5, TimeUnit.MINUTES).maximumSize(1000).build();
 
   @Override
   protected String tableName() {


### PR DESCRIPTION
## Summary

This change is identified as one of the action item from investigation of a table corruption issue caused by retry towards House table service. 

What we wanted to achieve here is, within a lifespan of a client-started transaction on the server side(after taking all the retry possibility into the consideration),  all of the retry attempts will be intentionally blocked from the internal catalog's perspective. 

By running the audit log internally, we have seen ~50K put requests on the table-service and that puts ~170 PUT request for every 5 minute time-window. Counting in the future growth, we reach 1k as the cache size. 


<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [x] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
There are no new features added. Passing existing tests is sufficient. 

<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
