### PR TITLE
Bug fix metric value for rewritten bytes 

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataCompactionSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataCompactionSparkApp.java
@@ -83,7 +83,7 @@ public class DataCompactionSparkApp extends BaseTableSparkApp {
         .counterBuilder(AppConstants.REWRITTEN_DATA_FILE_BYTES)
         .build()
         .add(
-            result.rewrittenDataFilesCount(),
+            result.rewrittenBytesCount(),
             Attributes.of(AttributeKey.stringKey(AppConstants.TABLE_NAME), fqtn));
     METER
         .counterBuilder(AppConstants.REWRITTEN_DATA_FILE_GROUP_COUNT)

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGenerator.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGenerator.java
@@ -29,7 +29,7 @@ public class OpenHouseDataLayoutStrategyGenerator implements DataLayoutStrategyG
   private static final long NUM_FILE_GROUPS_PER_COMMIT = 100;
   private static final long MAX_NUM_COMMITS = 30;
   private static final long MAX_BYTES_SIZE_RATIO = 10;
-  private static final long REWRITE_BYTES_PER_SECOND = 3 * MB;
+  private static final long REWRITE_BYTES_PER_SECOND = 2 * MB;
   private static final long EXECUTOR_MEMORY_GB = 2;
   private static final int MAX_CONCURRENT_FILE_GROUP_REWRITES = 50;
   private static final int REWRITE_PARALLELISM = 900; // number of Spark tasks to run in parallel

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGenerator.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGenerator.java
@@ -29,7 +29,7 @@ public class OpenHouseDataLayoutStrategyGenerator implements DataLayoutStrategyG
   private static final long NUM_FILE_GROUPS_PER_COMMIT = 100;
   private static final long MAX_NUM_COMMITS = 30;
   private static final long MAX_BYTES_SIZE_RATIO = 10;
-  private static final long REWRITE_BYTES_PER_SECOND = 2 * MB;
+  private static final long REWRITE_BYTES_PER_SECOND = 3 * MB;
   private static final long EXECUTOR_MEMORY_GB = 2;
   private static final int MAX_CONCURRENT_FILE_GROUP_REWRITES = 50;
   private static final int REWRITE_PARALLELISM = 900; // number of Spark tasks to run in parallel


### PR DESCRIPTION
## Summary

Looks like a typo in metric value being logged for rewritten bytes

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [X] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [X] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Metric fix will be deployed and tested.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
