### PR TITLE
Add error handling for tables with no registered partitions

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableStatsCollectorUtil.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableStatsCollectorUtil.java
@@ -226,12 +226,14 @@ public final class TableStatsCollectorUtil {
         SparkTableUtil.loadMetadataTable(spark, table, MetadataTableType.PARTITIONS);
     String partitionColumn = String.format("partition.%s", partitionColumnName);
 
-    return partitionData
-        .select(partitionColumn)
-        .orderBy(functions.asc(partitionColumn))
-        .first()
-        .get(0)
-        .toString();
+    if (partitionData.isEmpty()) {
+      return null;
+    }
+
+    Row firstRow =
+        partitionData.select(partitionColumn).orderBy(functions.asc(partitionColumn)).first();
+
+    return firstRow != null ? firstRow.get(0).toString() : null;
   }
 
   private static String getPartitionColumnName(Table table) {

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -569,6 +569,28 @@ public class OperationsTest extends OpenHouseSparkITest {
   }
 
   @Test
+  public void testCollectTableStatsWithEmptyPartitions() throws Exception {
+    final String tableName = "db.test_empty_partitions";
+
+    try (Operations ops = Operations.withCatalog(getSparkSession(), meter)) {
+      // Create table with partition but no data
+      prepareTableWithPolicies(ops, tableName, "30d", true);
+
+      // Collect stats without any data
+      IcebergTableStats stats = ops.collectTableStats(tableName);
+
+      // Verify stats are collected without NPE and partition date is null
+      Assertions.assertNotNull(stats);
+      Assertions.assertNull(stats.getEarliestPartitionDate());
+
+      // Add some data and verify stats again
+      populateTable(ops, tableName, 2, 2);
+      stats = ops.collectTableStats(tableName);
+      Assertions.assertNotNull(stats.getEarliestPartitionDate());
+    }
+  }
+
+  @Test
   public void testCollectTablePolicyStats() throws Exception {
     final String tableName = "db.test_collect_table_stats_with_policy";
     List<String> rowValue = new ArrayList<>();


### PR DESCRIPTION
## Summary

It is possible for some tables to have a retention policy defined on them but no registered partitions. In this case, the following error is thrown

`java.util.NoSuchElementException: next on empty iterator
	at scala.collection.Iterator$$anon$2.next(Iterator.scala:41)
	at scala.collection.Iterator$$anon$2.next(Iterator.scala:39)
	at scala.collection.IndexedSeqLike$Elements.next(IndexedSeqLike.scala:63)
	at scala.collection.IterableLike.head(IterableLike.scala:109)
	at scala.collection.IterableLike.head$(IterableLike.scala:108)
	at scala.collection.mutable.ArrayOps$ofRef.scala$collection$IndexedSeqOptimized$$super$head(ArrayOps.scala:198)
	at scala.collection.IndexedSeqOptimized.head(IndexedSeqOptimized.scala:129)
	at scala.collection.IndexedSeqOptimized.head$(IndexedSeqOptimized.scala:129)
	at scala.collection.mutable.ArrayOps$ofRef.head(ArrayOps.scala:198)
	at org.apache.spark.sql.Dataset.head(Dataset.scala:2729)
	at org.apache.spark.sql.Dataset.first(Dataset.scala:2736)
	at com.linkedin.openhouse.jobs.util.TableStatsCollectorUtil.getEarliestPartitionDate(TableStatsCollectorUtil.java:232)`

This PR adds a check to handle the above case where retention policy is set but no partitions are registered. 
Ensured the added UT fails without the fix and passes with the fix.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [X] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [X] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
