### PR TITLE
Refactor HTS listing api

### DIFF
--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -84,8 +84,7 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
     }
     if (namespace.isEmpty()) {
       return StreamSupport.stream(houseTableRepository.findAll().spliterator(), false)
-          .map(
-              houseTable -> TableIdentifier.of(houseTable.getDatabaseId(), houseTable.getTableId()))
+          .map(houseTable -> TableIdentifier.of(houseTable.getDatabaseId(), "Unused"))
           .collect(Collectors.toList());
     }
     return houseTableRepository.findAllByDatabaseId(namespace.toString()).stream()

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -82,6 +82,8 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
       throw new ValidationException(
           "Input namespace has more than one levels " + String.join(".", namespace.levels()));
     }
+    // TODO: Implement SupportsNamespace interface and listNamespaces() method to remove this
+    //  branch. This is anti-pattern and only a temporary solution.
     if (namespace.isEmpty()) {
       return StreamSupport.stream(houseTableRepository.findAll().spliterator(), false)
           .map(houseTable -> TableIdentifier.of(houseTable.getDatabaseId(), "Unused"))

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/mapper/HouseTableMapper.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/mapper/HouseTableMapper.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.io.FileIO;
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
@@ -28,6 +29,14 @@ public abstract class HouseTableMapper {
   public HouseTable toHouseTable(TableMetadata tableMetadata, FileIO fileIO) {
     return toHouseTable(extractRawHTSFields(tableMetadata.properties()), fileIO);
   }
+
+  @BeanMapping(ignoreByDefault = true)
+  @Mapping(target = "databaseId", source = "userTable.databaseId")
+  public abstract HouseTable toHouseTableWithDatabaseId(UserTable userTable);
+
+  @BeanMapping(ignoreByDefault = true)
+  @Mapping(target = "databaseId", source = "houseTable.databaseId")
+  public abstract UserTable toUserTableWithDatabaseId(HouseTable houseTable);
 
   @Mappings({@Mapping(target = "tableLocation", source = "userTable.metadataLocation")})
   public abstract HouseTable toHouseTable(UserTable userTable);

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepositoryImpl.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepositoryImpl.java
@@ -199,7 +199,18 @@ public class HouseTableRepositoryImpl implements HouseTableRepository {
 
   @Override
   public Iterable<HouseTable> findAll() {
-    return this.findAllByDatabaseId("");
+    return getHtsRetryTemplate(
+            Arrays.asList(
+                HouseTableRepositoryStateUnknownException.class, IllegalStateException.class))
+        .execute(
+            context ->
+                apiInstance
+                    .getUserTables(new HashMap<>())
+                    .map(GetAllEntityResponseBodyUserTable::getResults)
+                    .flatMapMany(Flux::fromIterable)
+                    .map(houseTableMapper::toHouseTableWithDatabaseId)
+                    .collectList()
+                    .block(Duration.ofSeconds(READ_REQUEST_TIMEOUT_SECONDS)));
   }
 
   @Override

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepositoryImplTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepositoryImplTest.java
@@ -338,9 +338,9 @@ public class HouseTableRepositoryImplTest {
   @Test
   public void testListOfAllTables() {
     List<UserTable> tables = new ArrayList<>();
-    tables.add(houseTableMapper.toUserTable(HOUSE_TABLE));
-    tables.add(houseTableMapper.toUserTable(HOUSE_TABLE_SAME_DB));
-    tables.add(houseTableMapper.toUserTable(HOUSE_TABLE_DIFF_DB));
+    tables.add(houseTableMapper.toUserTableWithDatabaseId(HOUSE_TABLE));
+    tables.add(houseTableMapper.toUserTableWithDatabaseId(HOUSE_TABLE_SAME_DB));
+    tables.add(houseTableMapper.toUserTableWithDatabaseId(HOUSE_TABLE_DIFF_DB));
     GetAllEntityResponseBodyUserTable listResponse = new GetAllEntityResponseBodyUserTable();
 
     Field resultField =

--- a/services/common/src/main/java/com/linkedin/openhouse/common/api/validator/ValidatorConstants.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/api/validator/ValidatorConstants.java
@@ -4,6 +4,11 @@ public final class ValidatorConstants {
 
   private ValidatorConstants() {}
 
+  public static final String ALPHA_NUM_UNDERSCORE_PATTERN_SEARCH_REGEX = "^%?[a-zA-Z0-9_]+%?$";
+
+  public static final String ALPHA_NUM_UNDERSCORE_PATTERN_SEARCH_ERROR_MSG =
+      "Only alphanumerics and underscore supported. The wildcard '%' can only be at the beginning or end of the string";
+
   public static final String ALPHA_NUM_UNDERSCORE_REGEX = "^[a-zA-Z0-9_]+$";
   public static final String ALPHA_NUM_UNDERSCORE_ERROR_MSG =
       "Only alphanumerics and underscore supported";

--- a/services/common/src/main/java/com/linkedin/openhouse/common/metrics/MetricsConstant.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/metrics/MetricsConstant.java
@@ -16,6 +16,7 @@ public final class MetricsConstant {
 
   // Components sections
   public static final String JOBS_SERVICE = "jobs";
+  public static final String HOUSETABLES_SERVICE = "housetables";
   public static final String SERVICE_AUDIT = "service_audit";
 
   // Common metric constants section
@@ -26,6 +27,7 @@ public final class MetricsConstant {
   public static final String CREATE = "create";
   public static final String REQUEST_COUNT = "request_count";
   public static final String REQUEST = "request";
+  public static final String HTS_GENERAL_SEARCH_REQUEST = "hts_general_search_request";
 
   // Metrics for auditing
   public static final String FAILED_SERVICE_AUDIT = "failed_service_audit";

--- a/services/common/src/main/java/com/linkedin/openhouse/common/metrics/MetricsConstant.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/metrics/MetricsConstant.java
@@ -44,4 +44,5 @@ public final class MetricsConstant {
       "repo_tables_search_by_database_time";
   public static final String REPO_TABLE_IDS_FIND_ALL_TIME = "repo_table_ids_find_all_time";
   public static final String REPO_TABLES_FIND_ALL_TIME = "repo_tables_find_all_time";
+  public static final String HTS_LIST_DATABASES_TIME = "hts_list_databases_time";
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/validator/impl/OpenHouseUserTableHtsApiValidator.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/validator/impl/OpenHouseUserTableHtsApiValidator.java
@@ -67,16 +67,17 @@ public class OpenHouseUserTableHtsApiValidator
               userTable.getDatabaseId(), ALPHA_NUM_UNDERSCORE_ERROR_MSG));
     }
 
-    if (userTable.getTableId() != null
-        && !userTable.getTableId().matches(ALPHA_NUM_UNDERSCORE_PATTERN_SEARCH_REGEX)) {
-      validationFailures.add(
-          String.format(
-              "tableId provided: %s, %s",
-              userTable.getTableId(), ALPHA_NUM_UNDERSCORE_PATTERN_SEARCH_ERROR_MSG));
-    }
+    if (userTable.getTableId() != null) {
+      if (userTable.getDatabaseId() == null) {
+        validationFailures.add("tableId cannot be provided without databaseId");
+      }
 
-    if (userTable.getDatabaseId() == null && userTable.getTableId() != null) {
-      validationFailures.add("tableId cannot be provided without databaseId");
+      if (!userTable.getTableId().matches(ALPHA_NUM_UNDERSCORE_PATTERN_SEARCH_REGEX)) {
+        validationFailures.add(
+            String.format(
+                "tableId provided: %s, %s",
+                userTable.getTableId(), ALPHA_NUM_UNDERSCORE_PATTERN_SEARCH_ERROR_MSG));
+      }
     }
 
     if (!validationFailures.isEmpty()) {

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/validator/impl/OpenHouseUserTableHtsApiValidator.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/validator/impl/OpenHouseUserTableHtsApiValidator.java
@@ -51,6 +51,14 @@ public class OpenHouseUserTableHtsApiValidator
   public void validateGetEntities(UserTable userTable) {
     List<String> validationFailures = new ArrayList<>();
 
+    // This will be removed when we start to support general filters
+    if (!(userTable.getTableVersion() == null
+        && userTable.getMetadataLocation() == null
+        && userTable.getStorageType() == null
+        && userTable.getCreationTime() == null)) {
+      validationFailures.add("Only databaseId and tableId are supported for the query");
+    }
+
     if (userTable.getDatabaseId() != null
         && !userTable.getDatabaseId().matches(ALPHA_NUM_UNDERSCORE_REGEX)) {
       validationFailures.add(
@@ -60,10 +68,15 @@ public class OpenHouseUserTableHtsApiValidator
     }
 
     if (userTable.getTableId() != null
-        && !userTable.getTableId().matches(ALPHA_NUM_UNDERSCORE_REGEX)) {
+        && !userTable.getTableId().matches(ALPHA_NUM_UNDERSCORE_PATTERN_SEARCH_REGEX)) {
       validationFailures.add(
           String.format(
-              "tableId provided: %s, %s", userTable.getTableId(), ALPHA_NUM_UNDERSCORE_ERROR_MSG));
+              "tableId provided: %s, %s",
+              userTable.getTableId(), ALPHA_NUM_UNDERSCORE_PATTERN_SEARCH_ERROR_MSG));
+    }
+
+    if (userTable.getDatabaseId() == null && userTable.getTableId() != null) {
+      validationFailures.add("tableId cannot be provided without databaseId");
     }
 
     if (!validationFailures.isEmpty()) {

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/config/MainApplicationConfig.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/config/MainApplicationConfig.java
@@ -2,6 +2,7 @@ package com.linkedin.openhouse.housetables.config;
 
 import com.linkedin.openhouse.cluster.metrics.TagUtils;
 import com.linkedin.openhouse.common.config.BaseApplicationConfig;
+import com.linkedin.openhouse.common.metrics.MetricsConstant;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -10,11 +11,12 @@ import org.springframework.context.annotation.Configuration;
 /** Main application configuration to load cluster properties and define required beans */
 @Configuration
 public class MainApplicationConfig extends BaseApplicationConfig {
-  public static final String APP_NAME = "housetables";
-
   @Bean
   MeterRegistryCustomizer<MeterRegistry> provideMeterRegistry() {
     return registry ->
-        registry.config().commonTags(TagUtils.buildCommonTag(clusterProperties, APP_NAME));
+        registry
+            .config()
+            .commonTags(
+                TagUtils.buildCommonTag(clusterProperties, MetricsConstant.HOUSETABLES_SERVICE));
   }
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/config/MainApplicationConfig.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/config/MainApplicationConfig.java
@@ -11,6 +11,8 @@ import org.springframework.context.annotation.Configuration;
 /** Main application configuration to load cluster properties and define required beans */
 @Configuration
 public class MainApplicationConfig extends BaseApplicationConfig {
+  public static final String APP_NAME = "housetables";
+
   @Bean
   MeterRegistryCustomizer<MeterRegistry> provideMeterRegistry() {
     return registry ->

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/jdbc/UserTableHtsJdbcRepository.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/jdbc/UserTableHtsJdbcRepository.java
@@ -6,6 +6,7 @@ import com.linkedin.openhouse.housetables.model.UserTableRowPrimaryKey;
 import com.linkedin.openhouse.housetables.repository.HtsRepository;
 import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.data.jpa.repository.Query;
 
 /**
  * JDBC-backed {@link HtsRepository} for CRUDing {@link UserTableRow}
@@ -32,6 +33,14 @@ public interface UserTableHtsJdbcRepository
   boolean existsByDatabaseIdIgnoreCaseAndTableIdIgnoreCase(String databaseId, String tableId);
 
   void deleteByDatabaseIdIgnoreCaseAndTableIdIgnoreCase(String databaseId, String tableId);
+
+  @Query("SELECT DISTINCT databaseId FROM UserTableRow")
+  Iterable<String> findAllDistinctDatabaseIds();
+
+  Iterable<UserTableRow> findAllByDatabaseIdIgnoreCase(String databaseId);
+
+  Iterable<UserTableRow> findAllByDatabaseIdAndTableIdLikeAllIgnoreCase(
+      String databaseId, String tableIdPattern);
 
   /*
    * The following methods are required to maintain the generality of the interface {@link com.linkedin.openhouse.housetables.repository.HtsRepository}

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesServiceImpl.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesServiceImpl.java
@@ -108,9 +108,13 @@ public class UserTablesServiceImpl implements UserTablesService {
   }
 
   private List<UserTableDto> listDatabases() {
-    return StreamSupport.stream(htsJdbcRepository.findAllDistinctDatabaseIds().spliterator(), false)
-        .map(databaseId -> UserTableDto.builder().databaseId(databaseId).build())
-        .collect(Collectors.toList());
+    return METRICS_REPORTER.executeWithStats(
+        () ->
+            StreamSupport.stream(
+                    htsJdbcRepository.findAllDistinctDatabaseIds().spliterator(), false)
+                .map(databaseId -> UserTableDto.builder().databaseId(databaseId).build())
+                .collect(Collectors.toList()),
+        MetricsConstant.HTS_LIST_DATABASES_TIME);
   }
 
   private List<UserTableDto> listTables(UserTable userTable) {

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/HtsControllerTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/HtsControllerTest.java
@@ -58,6 +58,78 @@ public class HtsControllerTest {
   }
 
   @Test
+  public void testFindAllFromDbWithTableId() throws Exception {
+    // TODO: Use rest API to create the table
+    htsRepository.save(TEST_TUPLE_1_0.get_userTableRow());
+    htsRepository.save(TEST_TUPLE_2_0.get_userTableRow());
+    htsRepository.save(TEST_TUPLE_1_1.get_userTableRow());
+
+    Map<String, List<String>> paramsInternal = new HashMap<>();
+    paramsInternal.put("databaseId", Collections.singletonList(TEST_DB_ID));
+    paramsInternal.put("tableId", Collections.singletonList("test_table0"));
+    MultiValueMap<String, String> params = new MultiValueMapAdapter(paramsInternal);
+    mvc.perform(
+            MockMvcRequestBuilders.get("/hts/tables/query")
+                .params(params)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(
+            content()
+                .json(
+                    GetAllEntityResponseBody.builder()
+                        .results(
+                            Arrays.asList(TEST_USER_TABLE).stream()
+                                .map(
+                                    userTable ->
+                                        userTable
+                                            .toBuilder()
+                                            .tableVersion(userTable.getMetadataLocation())
+                                            .build())
+                                .collect(Collectors.toList()))
+                        .build()
+                        .toJson()));
+  }
+
+  @Test
+  public void testFindAllFromDbWithTablePattern() throws Exception {
+    // TODO: Use rest API to create the table
+    htsRepository.save(TEST_TUPLE_1_0.get_userTableRow());
+    htsRepository.save(TEST_TUPLE_2_0.get_userTableRow());
+    htsRepository.save(TEST_TUPLE_1_1.get_userTableRow());
+
+    Map<String, List<String>> paramsInternal = new HashMap<>();
+    paramsInternal.put("databaseId", Collections.singletonList(TEST_DB_ID));
+    paramsInternal.put("tableId", Collections.singletonList("test_table%"));
+    MultiValueMap<String, String> params = new MultiValueMapAdapter(paramsInternal);
+    mvc.perform(
+            MockMvcRequestBuilders.get("/hts/tables/query")
+                .params(params)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(
+            content()
+                .json(
+                    GetAllEntityResponseBody.builder()
+                        .results(
+                            Arrays.asList(
+                                    TEST_USER_TABLE,
+                                    TEST_TUPLE_1_0.get_userTable(),
+                                    TEST_TUPLE_2_0.get_userTable())
+                                .stream()
+                                .map(
+                                    userTable ->
+                                        userTable
+                                            .toBuilder()
+                                            .tableVersion(userTable.getMetadataLocation())
+                                            .build())
+                                .collect(Collectors.toList()))
+                        .build()
+                        .toJson()));
+  }
+
+  @Test
   /** Using LIST endpoint to test a partially filled user table object as request body */
   public void testFindAllFromDb() throws Exception {
     // TODO: Use rest API to create the table
@@ -98,13 +170,12 @@ public class HtsControllerTest {
 
   /** Using LIST endpoint to test an empty user table object request body */
   @Test
-  public void testFindAllTables() throws Exception {
+  public void testFindAllDatabases() throws Exception {
     // TODO: Use rest API to create the table
     htsRepository.save(TEST_TUPLE_1_0.get_userTableRow());
     htsRepository.save(TEST_TUPLE_2_0.get_userTableRow());
     htsRepository.save(TEST_TUPLE_1_1.get_userTableRow());
 
-    // Inserted three tables, combining the one in the setup method there should be 4
     mvc.perform(MockMvcRequestBuilders.get("/hts/tables/query").accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -114,10 +185,8 @@ public class HtsControllerTest {
                     GetAllEntityResponseBody.builder()
                         .results(
                             Arrays.asList(
-                                    TEST_USER_TABLE,
-                                    TEST_TUPLE_1_0.get_userTable(),
-                                    TEST_TUPLE_2_0.get_userTable(),
-                                    TEST_TUPLE_1_1.get_userTable())
+                                    UserTable.builder().databaseId("test_db0").build(),
+                                    UserTable.builder().databaseId("test_db1").build())
                                 .stream()
                                 .map(
                                     userTable ->

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/UserTablesServiceTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/UserTablesServiceTest.java
@@ -128,10 +128,23 @@ public class UserTablesServiceTest {
             .tableVersion(TEST_USER_TABLE_DTO.getMetadataLocation())
             .build());
 
+    // No filter, should return all tables.
+    List<UserTableDto> actual = userTablesService.getAllUserTables(UserTable.builder().build());
+    assertThat(actual.size()).isEqualTo(4);
+
     // Only specify the database ID to find all tables under this database.
-    List<UserTableDto> actual =
+    actual =
         userTablesService.getAllUserTables(
             UserTable.builder().databaseId(TEST_TUPLE_1_0.getDatabaseId()).build());
+    assertThat(results).hasSameElementsAs(actual);
+
+    // Specify the database ID and table ID to find matched tables.
+    actual =
+        userTablesService.getAllUserTables(
+            UserTable.builder()
+                .databaseId(TEST_TUPLE_1_0.getDatabaseId())
+                .tableId("test_table%")
+                .build());
     assertThat(results).hasSameElementsAs(actual);
 
     // Only specify the table Id to find matched tables.

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/mock/api/OpenHouseUserTablesValidatorTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/mock/api/OpenHouseUserTablesValidatorTest.java
@@ -33,16 +33,42 @@ public class OpenHouseUserTablesValidatorTest {
   }
 
   @Test
-  public void validateGetAllEntitiesSuccess() {
-    UserTable userTable = UserTable.builder().tableId("tb1").databaseId("db1").build();
+  public void validateGetAllEntitiesSuccessEmptyParams() {
+    UserTable userTable = UserTable.builder().build();
     assertDoesNotThrow(() -> userTablesHtsApiValidator.validateGetEntities(userTable));
   }
 
   @Test
-  public void validateInValidGetAllEntities() {
-    UserTable userTable = UserTable.builder().databaseId("db??").build();
+  public void validateGetAllEntitiesSuccessTablePattern() {
+    UserTable userTable = UserTable.builder().tableId("%tb%").databaseId("db1").build();
+    assertDoesNotThrow(() -> userTablesHtsApiValidator.validateGetEntities(userTable));
+  }
 
-    // Invalid databaseId and empty tableId.
+  @Test
+  public void validateInValidGetAllEntitiesBadDatabaseId() {
+    UserTable userTable = UserTable.builder().databaseId("db%").build();
+
+    // Invalid databaseId
+    assertThrows(
+        RequestValidationFailureException.class,
+        () -> userTablesHtsApiValidator.validateGetEntities(userTable));
+  }
+
+  @Test
+  public void validateInValidGetAllEntitiesTableIdWithoutDatabaseId() {
+    UserTable userTable = UserTable.builder().tableId("tb").build();
+
+    // Provide tableId without databaseId
+    assertThrows(
+        RequestValidationFailureException.class,
+        () -> userTablesHtsApiValidator.validateGetEntities(userTable));
+  }
+
+  @Test
+  public void validateInValidGetAllEntitiesUnsupportedField() {
+    UserTable userTable = UserTable.builder().creationTime(1L).build();
+
+    // Search by creationTime not supported.
     assertThrows(
         RequestValidationFailureException.class,
         () -> userTablesHtsApiValidator.validateGetEntities(userTable));


### PR DESCRIPTION
## Summary
Refactor HTS listing api to reduce bandwidth though mysql pushdown.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [ ] Tests

The service layer provide ability for general search, but in the validation layer we expose the minimal capability to table services to accommodate current use cases. We can relax it whenever there is a new use case.

Added new `HouseTable` mapping methods to only map `databaseId` to avoid NPE. Changed `OpenHouseInternalCatalog` to use a fake `tableId` to avoid NPE.

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Docker tests:
```
scala> spark.sql("create table d1.t1 (col string)")
res4: org.apache.spark.sql.DataFrame = []

scala> spark.sql("create table d1.t2 (col string)")
res1: org.apache.spark.sql.DataFrame = []

scala> spark.sql("create table d2.t1 (col string)")
res4: org.apache.spark.sql.DataFrame = []

scala> spark.sql("show databases").show
+---------+
|namespace|
+---------+
|       d1|
|       d2|
+---------+

scala> spark.sql("show tables in d1").show
+---------+---------+
|namespace|tableName|
+---------+---------+
|       d1|       t1|
|       d1|       t2|
+---------+---------+
```

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
