### PR TITLE
Fix Gson non escaped chars in Table Policy

### DIFF
--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/iceberg/PoliciesSpecMapper.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/iceberg/PoliciesSpecMapper.java
@@ -18,7 +18,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Named;
 
 @Mapper(componentModel = "spring")
-public class  PoliciesSpecMapper {
+public class PoliciesSpecMapper {
 
   /**
    * Given an Iceberg {@link TableDto}, serialize to JsonString format.
@@ -30,9 +30,6 @@ public class  PoliciesSpecMapper {
   public String toPoliciesJsonString(TableDto tableDto) throws JsonParseException {
     if (tableDto.getPolicies() != null) {
       try {
-        Gson gson = new GsonBuilder().setPrettyPrinting()
-            .disableHtmlEscaping()
-            .create();
         return gson.toJson(tableDto.getPolicies());
       } catch (JsonParseException e) {
         throw new JsonParseException("Malformed policies json");
@@ -47,11 +44,8 @@ public class  PoliciesSpecMapper {
    */
   @Named("toPoliciesObject")
   public Policies toPoliciesObject(String policiesString) throws JsonParseException {
-    if (policiesString.length() != 0) {
+    if (!policiesString.isEmpty()) {
       try {
-        Gson gson = new GsonBuilder().setPrettyPrinting()
-            .disableHtmlEscaping()
-            .create();
         return gson.fromJson(policiesString, Policies.class);
       } catch (JsonParseException e) {
         throw new JsonParseException(
@@ -149,4 +143,6 @@ public class  PoliciesSpecMapper {
     }
     return replicationPolicy;
   }
+
+  private static Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/iceberg/PoliciesSpecMapper.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/iceberg/PoliciesSpecMapper.java
@@ -18,7 +18,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Named;
 
 @Mapper(componentModel = "spring")
-public class PoliciesSpecMapper {
+public class  PoliciesSpecMapper {
 
   /**
    * Given an Iceberg {@link TableDto}, serialize to JsonString format.
@@ -30,7 +30,9 @@ public class PoliciesSpecMapper {
   public String toPoliciesJsonString(TableDto tableDto) throws JsonParseException {
     if (tableDto.getPolicies() != null) {
       try {
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        Gson gson = new GsonBuilder().setPrettyPrinting()
+            .disableHtmlEscaping()
+            .create();
         return gson.toJson(tableDto.getPolicies());
       } catch (JsonParseException e) {
         throw new JsonParseException("Malformed policies json");
@@ -47,7 +49,9 @@ public class PoliciesSpecMapper {
   public Policies toPoliciesObject(String policiesString) throws JsonParseException {
     if (policiesString.length() != 0) {
       try {
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        Gson gson = new GsonBuilder().setPrettyPrinting()
+            .disableHtmlEscaping()
+            .create();
         return gson.fromJson(policiesString, Policies.class);
       } catch (JsonParseException e) {
         throw new JsonParseException(

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/mapper/PoliciesSpecMapperTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/mapper/PoliciesSpecMapperTest.java
@@ -43,6 +43,20 @@ public class PoliciesSpecMapperTest {
   }
 
   @Test
+  public void testFromPoliciesSpecJsonEscapedUnicode() {
+    TableDto tableDto =
+        TableModelConstants.buildTableDto(
+            GET_TABLE_RESPONSE_BODY
+                .toBuilder()
+                .policies(TableModelConstants.TABLE_POLICIES_COMPLEX)
+                .build());
+    String policiesSpec = policiesMapper.toPoliciesJsonString(tableDto);
+    Assertions.assertEquals(
+        (String) JsonPath.read(policiesSpec, "$.retention.columnPattern.pattern"),
+        TableModelConstants.TABLE_POLICIES_COMPLEX.getRetention().getCount());
+  }
+
+  @Test
   public void testToPoliciesSpecJsonWithNullPolicies() {
     TableDto tableDtoWithNullPolicies =
         TableModelConstants.buildTableDto(

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/model/TableModelConstants.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/model/TableModelConstants.java
@@ -50,6 +50,7 @@ public final class TableModelConstants {
   public static final Policies TABLE_POLICIES;
 
   public static final Policies TABLE_POLICIES_COMPLEX;
+  public static final String TABLE_POLICIES_COMPLEX_STRING;
   public static final Policies SHARED_TABLE_POLICIES;
   public static final String TEST_USER;
 
@@ -57,7 +58,7 @@ public final class TableModelConstants {
   public static final String CLUSTER_NAME;
 
   static {
-    COL_PAT = RetentionColumnPattern.builder().columnName("name").pattern("yyyy").build();
+    COL_PAT = RetentionColumnPattern.builder().columnName("name").pattern("'yyyy'").build();
 
     RETENTION_POLICY =
         Retention.builder().count(3).granularity(TimePartitionSpec.Granularity.HOUR).build();
@@ -81,6 +82,18 @@ public final class TableModelConstants {
     TABLE_POLICIES =
         Policies.builder().retention(RETENTION_POLICY).replication(REPLICATION_POLICY).build();
     TABLE_POLICIES_COMPLEX = Policies.builder().retention(RETENTION_POLICY_WITH_PATTERN).build();
+    TABLE_POLICIES_COMPLEX_STRING =
+        "{\n"
+            + "  \"retention\": {\n"
+            + "    \"count\": 3,\n"
+            + "    \"granularity\": \"HOUR\",\n"
+            + "    \"columnPattern\": {\n"
+            + "      \"columnName\": \"name\",\n"
+            + "      \"pattern\": \"'yyyy'\"\n"
+            + "    }\n"
+            + "  },\n"
+            + "  \"sharingEnabled\": false\n"
+            + "}";
     SHARED_TABLE_POLICIES =
         Policies.builder().retention(RETENTION_POLICY).sharingEnabled(true).build();
     TABLE_POLICIES_WITH_EMPTY_PATTERN =


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] 
Currently the display of the policies are in the following format
```
policies                                  
{
  "retention": {
    "count": 180,
    "granularity": "DAY",
    "columnPattern": {
      "columnName": "datepartition",
      "pattern": "\u0027yyyy-MM-dd\u0027"
    }
  },
  "sharingEnabled": true
}
```
we would like to escape the `\u0027` unicode to the single quotation marks to avoid confusion from the users 

This is because during the write pathGson natively escapes the dangerous json characters during writing
https://github.com/google/gson/blob/main/gson/src/main/java/com/google/gson/stream/JsonWriter.java#L199

During the read path returned from iceberg, all UTF-8 encodings will no deserialize this unicode

Using `disableHtmlEscaping` to save the string without the unicode

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output. 
- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
