### PR TITLE
Consider WebClientRequestException as a CSUE

### DIFF
--- a/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
@@ -108,8 +108,7 @@ public class OpenHouseTableOperationsTest {
     when(mockTableApi.updateTableV1(anyString(), anyString(), any()))
         .thenReturn(Mono.error(mock(WebClientRequestException.class)));
     Assertions.assertThrows(
-        WebClientWithMessageException.class,
-        () -> openHouseTableOperations.doCommit(base, metadata));
+        CommitStateUnknownException.class, () -> openHouseTableOperations.doCommit(base, metadata));
     when(mockTableApi.updateTableV1(anyString(), anyString(), any()))
         .thenReturn(Mono.error(mock(WebClientResponseException.class)));
     Assertions.assertThrows(

--- a/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
@@ -9,6 +9,7 @@ import com.linkedin.openhouse.gen.tables.client.model.Policies;
 import com.linkedin.openhouse.gen.tables.client.model.PolicyTag;
 import com.linkedin.openhouse.gen.tables.client.model.Retention;
 import com.linkedin.openhouse.javaclient.exception.WebClientWithMessageException;
+import com.linkedin.openhouse.relocated.org.springframework.http.HttpStatus;
 import com.linkedin.openhouse.relocated.org.springframework.web.reactive.function.client.WebClientRequestException;
 import com.linkedin.openhouse.relocated.org.springframework.web.reactive.function.client.WebClientResponseException;
 import com.linkedin.openhouse.relocated.reactor.core.publisher.Mono;
@@ -109,11 +110,20 @@ public class OpenHouseTableOperationsTest {
         .thenReturn(Mono.error(mock(WebClientRequestException.class)));
     Assertions.assertThrows(
         CommitStateUnknownException.class, () -> openHouseTableOperations.doCommit(base, metadata));
+    WebClientResponseException exception40x =
+        mock(WebClientResponseException.MethodNotAllowed.class);
+    when(exception40x.getStatusCode()).thenReturn(HttpStatus.METHOD_NOT_ALLOWED);
     when(mockTableApi.updateTableV1(anyString(), anyString(), any()))
-        .thenReturn(Mono.error(mock(WebClientResponseException.class)));
+        .thenReturn(Mono.error(exception40x));
     Assertions.assertThrows(
         WebClientWithMessageException.class,
         () -> openHouseTableOperations.doCommit(base, metadata));
+    WebClientResponseException exception50x = mock(WebClientResponseException.BadGateway.class);
+    when(exception50x.getStatusCode()).thenReturn(HttpStatus.BAD_GATEWAY);
+    when(mockTableApi.updateTableV1(anyString(), anyString(), any()))
+        .thenReturn(Mono.error(exception50x));
+    Assertions.assertThrows(
+        CommitStateUnknownException.class, () -> openHouseTableOperations.doCommit(base, metadata));
   }
 
   @Test

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -299,7 +299,8 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
       return Mono.error(
           new BadRequestException(
               casted, casted.getStatusCode().value() + " , " + casted.getResponseBodyAsString()));
-    } else if (e instanceof WebClientResponseException) {
+    } else if (e instanceof WebClientResponseException
+        && ((WebClientResponseException) e).getStatusCode().is4xxClientError()) {
       return Mono.error(new WebClientResponseWithMessageException((WebClientResponseException) e));
     } else {
       /**

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -306,8 +306,13 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
        * This serves as a catch-all for any unexpected exceptions that could occur during doCommit,
        * (i.e) exceptions that are not WebClientResponseException. This is a conservative approach
        * to skip any unexpected cleanup that could occur when a commit aborts at the caller, thus
-       * avoiding any potential data loss.
+       * avoiding any potential data loss. {@link WebClientRequestException} is caught here.
        */
+      log.error(
+          String.format(
+              "Unexpected exception occurred during doCommit: %s, with stacktrace: ",
+              e.getClass().getSimpleName()),
+          e);
       return Mono.error(new CommitStateUnknownException(e));
     }
   }

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -301,8 +301,6 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
               casted, casted.getStatusCode().value() + " , " + casted.getResponseBodyAsString()));
     } else if (e instanceof WebClientResponseException) {
       return Mono.error(new WebClientResponseWithMessageException((WebClientResponseException) e));
-    } else if (e instanceof WebClientRequestException) {
-      return Mono.error(new WebClientRequestWithMessageException((WebClientRequestException) e));
     } else {
       /**
        * This serves as a catch-all for any unexpected exceptions that could occur during doCommit,


### PR DESCRIPTION
## Summary
Network cutoff between Client and Server surface as WebClientRequestException.

Following situation can arise:
- Client makes a docommit() call that succeeds
- Server responds success
- Network cuts off
- Client gets WebClientRequestException
- Client deletes snapshots and added data

The state of the table can end up corrupted.

## Details
### When is WebClientRequestException Thrown
WebClientRequestException is thrown only **if something goes wrong before response (even if failure) is completely received** see the [code block here](https://github.com/spring-projects/spring-framework/blob/5e939ccb4ba26243e765dd37f37eda90f90292d8/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/ExchangeFunctions.java#L106): 
```
return this.connector
		.connect(httpMethod, url, httpRequest -> clientRequest.writeTo(httpRequest, this.strategies))
		.doOnRequest(n -> logRequest(clientRequest))
		.doOnCancel(() -> logger.debug(clientRequest.logPrefix() + "Cancel signal (to close connection)"))
		.onErrorResume(WebClientUtils.WRAP_EXCEPTION_PREDICATE, t -> wrapException(t, clientRequest))     ====> this code throws WebClientRequestException.
		.map(httpResponse -> {
			String logPrefix = getLogPrefix(clientRequest, httpResponse);
			logResponse(httpResponse, logPrefix);
			return new DefaultClientResponse(
					httpResponse, this.strategies, logPrefix, httpMethod.name() + " " + url,
					() -> createRequest(clientRequest));
		});
```
^ This means the request could've been processed.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [X] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
