### PR TITLE
Adding jvm-gc / hikaricp metrics in HTS for parity to /tables

### DIFF
--- a/services/housetables/src/main/resources/application.properties
+++ b/services/housetables/src/main/resources/application.properties
@@ -14,3 +14,7 @@ management.endpoint.prometheus.enabled=true
 management.endpoint.beans.enabled=true
 management.metrics.web.server.request.autotime.percentiles=0.5,0.75,0.9,0.95,0.99
 management.metrics.distribution.percentiles-histogram.http.server.requests=true
+management.metrics.distribution.percentiles-histogram.jvm.gc.pause=true
+management.metrics.distribution.percentiles-histogram.hikaricp.connections.acquire=true
+management.metrics.distribution.percentiles-histogram.hikaricp.connections.usage=true
+management.metrics.distribution.percentiles-histogram.hikaricp.connections.creation=true


### PR DESCRIPTION
## Summary

This PR just adds a few metrics (provided in springboot) for enriched metrics to collect for HTS. 

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->
`./gradlew :services:housetables:bootRun` works fine. 

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
