### PR TITLE
BugFix: CTAS doesnt allow custom UUID for Replica Table

### DIFF
--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/TableUUIDGenerator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/TableUUIDGenerator.java
@@ -139,18 +139,21 @@ public class TableUUIDGenerator {
     String tableURI = String.format("%s.%s", databaseId, tableId);
     String dbIdFromProps = extractFromTblPropsIfExists(tableURI, tableProperties, DB_RAW_KEY);
     String tblIdFromProps = extractFromTblPropsIfExists(tableURI, tableProperties, TBL_RAW_KEY);
-    // Extract tableLocation from table properties (openhouse.tableLocation)
-    // tableLocation should be the absolute path to the latest metadata file including scheme.
-    // Scheme is not present for HDFS and Local storages. See:
-    // https://github.com/linkedin/openhouse/issues/121
-    String tableLocation = extractFromTblPropsIfExists(tableURI, tableProperties, TBL_LOC_RAW_KEY);
-    Storage storage = storageManager.getStorageFromPath(tableLocation);
 
-    if (TableType.REPLICA_TABLE != tableType
-        && !storage.isPathValid(tableLocation, dbIdFromProps, tblIdFromProps, tableUUIDProperty)) {
-      log.error("Previous tableLocation: {} doesn't exist", tableLocation);
-      throw new RequestValidationFailureException(
-          String.format("Provided snapshot is invalid for %s.%s", dbIdFromProps, tblIdFromProps));
+    if (TableType.REPLICA_TABLE != tableType) {
+      // Extract tableLocation from table properties (openhouse.tableLocation)
+      // tableLocation should be the absolute path to the latest metadata file including scheme.
+      // Scheme is not present for HDFS and Local storages. See:
+      // https://github.com/linkedin/openhouse/issues/121
+      String tableLocation =
+          extractFromTblPropsIfExists(tableURI, tableProperties, TBL_LOC_RAW_KEY);
+      Storage storage = storageManager.getStorageFromPath(tableLocation);
+
+      if (!storage.isPathValid(tableLocation, dbIdFromProps, tblIdFromProps, tableUUIDProperty)) {
+        log.error("Previous tableLocation: {} doesn't exist", tableLocation);
+        throw new RequestValidationFailureException(
+            String.format("Provided snapshot is invalid for %s.%s", dbIdFromProps, tblIdFromProps));
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

ReplicaTableSetupJob is failing past https://github.com/linkedin/openhouse/commit/b301c4bae819818b183b1227c1ea172f4e75f7b9

The reason is "openhouse.tableLocation" is a must field for `createTable`/`putSnapshot` call (for both REPLICA  and PRIMARY table)

This workflow has been tested for CTAS statements in both prod/docker, but ReplicaTableSetup is failing.

In this PR we change the regressive behavior back for REPLICA table where tableLocation would not be needed.

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

## Changes

- [ ] Client-facing API Changes
- [X] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [X] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
