### PR TITLE
Support Table History Policy in Snapshot Expiration Job

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableSnapshotsExpirationTask.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableSnapshotsExpirationTask.java
@@ -3,7 +3,9 @@ package com.linkedin.openhouse.jobs.scheduler.tasks;
 import com.linkedin.openhouse.jobs.client.JobsClient;
 import com.linkedin.openhouse.jobs.client.TablesClient;
 import com.linkedin.openhouse.jobs.client.model.JobConf;
+import com.linkedin.openhouse.jobs.util.HistoryConfig;
 import com.linkedin.openhouse.jobs.util.TableMetadata;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -28,10 +30,18 @@ public class TableSnapshotsExpirationTask extends TableOperationTask<TableMetada
 
   @Override
   protected List<String> getArgs() {
-    return Arrays.asList(
-        "--tableName", metadata.fqtn(),
-        "--granularity", "days",
-        "--count", "3");
+    HistoryConfig config = metadata.getHistoryConfig();
+    List<String> jobArgs = new ArrayList<>();
+    if (config.getMaxAge() > 0) {
+      jobArgs.addAll(
+          Arrays.asList(
+              "--maxAge", Integer.toString(config.getMaxAge()),
+              "--granularity", config.getGranularity().getValue()));
+    }
+    if (config.getMinVersions() > 0) {
+      jobArgs.addAll(Arrays.asList("--minVersions", Integer.toString(config.getMinVersions())));
+    }
+    return jobArgs;
   }
 
   @Override

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableSnapshotsExpirationTask.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableSnapshotsExpirationTask.java
@@ -38,8 +38,8 @@ public class TableSnapshotsExpirationTask extends TableOperationTask<TableMetada
               "--maxAge", Integer.toString(config.getMaxAge()),
               "--granularity", config.getGranularity().getValue()));
     }
-    if (config.getMinVersions() > 0) {
-      jobArgs.addAll(Arrays.asList("--minVersions", Integer.toString(config.getMinVersions())));
+    if (config.getVersions() > 0) {
+      jobArgs.addAll(Arrays.asList("--versions", Integer.toString(config.getVersions())));
     }
     return jobArgs;
   }

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -208,9 +208,9 @@ public final class Operations implements AutoCloseable {
 
   /**
    * Expire snapshots on a given {@link Table}. If maxAge is provided, it will expire snapshots
-   * older than maxAge milliseconds. If versions is provided, it will retain the last versions
-   * snapshots. If both are provided, it will prioritize maxAge - only retain up to versions number
-   * of snapshots younger than the maxAge
+   * older than maxAge in granularity timeunit. If versions is provided, it will retain the last
+   * versions snapshots. If both are provided, it will prioritize maxAge; only retain up to versions
+   * number of snapshots younger than the maxAge
    */
   public void expireSnapshots(Table table, int maxAge, String granularity, int versions) {
     ExpireSnapshots expireSnapshotsCommand = table.expireSnapshots().cleanExpiredFiles(false);

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -201,16 +201,17 @@ public final class Operations implements AutoCloseable {
   }
 
   /** Expire snapshots on a given fully-qualified table name. */
-  public void expireSnapshots(String fqtn, long expireBeforeTimestampMs) {
-    expireSnapshots(getTable(fqtn), expireBeforeTimestampMs);
+  public void expireSnapshots(String fqtn, long expireBeforeTimestampMs, int minVersions) {
+    expireSnapshots(getTable(fqtn), expireBeforeTimestampMs, minVersions);
   }
 
   /** Expire snapshots on a given {@link Table}. */
-  public void expireSnapshots(Table table, long expireBeforeTimestampMs) {
+  public void expireSnapshots(Table table, long expireBeforeTimestampMs, int minVersions) {
     table
         .expireSnapshots()
         .cleanExpiredFiles(false)
         .expireOlderThan(expireBeforeTimestampMs)
+        .retainLast(minVersions)
         .commit();
   }
 

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.jobs.spark;
 
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.linkedin.openhouse.common.stats.model.IcebergTableStats;
 import com.linkedin.openhouse.jobs.util.SparkJobUtil;
@@ -223,7 +224,7 @@ public final class Operations implements AutoCloseable {
       log.info("Expiring snapshots for table: {} older than {}ms", table, expireBeforeTimestampMs);
       expireSnapshotsCommand.expireOlderThan(expireBeforeTimestampMs).commit();
     }
-    if (versions > 0) {
+    if (versions > 0 && Iterators.size(table.snapshots().iterator()) > versions) {
       log.info("Expiring snapshots for table: {} retaining last {} versions", table, versions);
       // Note: retainLast keeps the last N snapshots that WOULD be expired, hence expireOlderThan
       // currentTime

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/SnapshotsExpirationSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/SnapshotsExpirationSparkApp.java
@@ -21,9 +21,9 @@ public class SnapshotsExpirationSparkApp extends BaseTableSparkApp {
   private final int versions;
 
   public static class DEFAULT_CONFIGURATION {
-    public static final String MAX_AGE = "3";
+    public static final int MAX_AGE = 3;
     public static final String GRANULARITY = "DAYS";
-    public static final String VERSIONS = "0";
+    public static final int VERSIONS = 0;
   }
 
   private static final String DEFAULT_GRANULARITY = "";
@@ -40,9 +40,9 @@ public class SnapshotsExpirationSparkApp extends BaseTableSparkApp {
       int versions) {
     super(jobId, stateManager, fqtn);
     if (maxAge == 0 && versions == 0) {
-      this.maxAge = Integer.parseInt(DEFAULT_CONFIGURATION.MAX_AGE);
+      this.maxAge = DEFAULT_CONFIGURATION.MAX_AGE;
       this.granularity = DEFAULT_CONFIGURATION.GRANULARITY;
-      this.versions = Integer.parseInt(DEFAULT_CONFIGURATION.VERSIONS);
+      this.versions = DEFAULT_CONFIGURATION.VERSIONS;
     } else {
       this.granularity = granularity;
       this.maxAge = maxAge;

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/SnapshotsExpirationSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/SnapshotsExpirationSparkApp.java
@@ -25,7 +25,8 @@ public class SnapshotsExpirationSparkApp extends BaseTableSparkApp {
 
   private static final String DEFAULT_GRANULARITY = "days";
 
-  private static final String DEFAULT_MIN_VERSIONS = "100";
+  // Default do not define min versions, only retain snapshots based on max age
+  private static final String DEFAULT_MIN_VERSIONS = "0";
 
   public SnapshotsExpirationSparkApp(
       String jobId,

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/HistoryConfig.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/HistoryConfig.java
@@ -6,7 +6,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
-/** Table retention config class. This is app side representation of /tables policies->retention */
+/** History Policy config class. This is app side representation of /tables policies->history */
 @Builder
 @Getter
 @EqualsAndHashCode

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/HistoryConfig.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/HistoryConfig.java
@@ -1,6 +1,6 @@
 package com.linkedin.openhouse.jobs.util;
 
-import com.linkedin.openhouse.tables.client.model.Retention;
+import com.linkedin.openhouse.tables.client.model.History;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -13,6 +13,6 @@ import lombok.ToString;
 @ToString
 public class HistoryConfig {
   private final int maxAge;
-  private final int minVersions;
-  private final Retention.GranularityEnum granularity;
+  private final int versions;
+  private final History.GranularityEnum granularity;
 }

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/HistoryConfig.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/HistoryConfig.java
@@ -1,0 +1,18 @@
+package com.linkedin.openhouse.jobs.util;
+
+import com.linkedin.openhouse.tables.client.model.Retention;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+/** Table retention config class. This is app side representation of /tables policies->retention */
+@Builder
+@Getter
+@EqualsAndHashCode
+@ToString
+public class HistoryConfig {
+  private final int maxAge;
+  private final int minVersions;
+  private final Retention.GranularityEnum granularity;
+}

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableMetadata.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableMetadata.java
@@ -24,6 +24,7 @@ public class TableMetadata extends Metadata {
   protected boolean isClustered;
   @Builder.Default protected @NonNull Map<String, String> jobExecutionProperties = new HashMap<>();
   protected @Nullable RetentionConfig retentionConfig;
+  protected @Nullable HistoryConfig historyConfig;
 
   public String fqtn() {
     return String.format("%s.%s", dbName, tableName);

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -273,7 +273,7 @@ public class OperationsTest extends OpenHouseSparkITest {
 
   @Test
   public void testSnapshotsExpirationMaxAge() throws Exception {
-    final String tableName = "db.test_es_maxage_noop_java";
+    final String tableName = "db.test_es_maxage_java";
     final int numInserts = 3;
     final int maxAge = 0;
     // Not a realistic time setting that is accepted by the SQL, but tests that other snapshots are
@@ -306,7 +306,7 @@ public class OperationsTest extends OpenHouseSparkITest {
 
   @Test
   public void testSnapshotsExpirationMaxAgeNoop() throws Exception {
-    final String tableName = "db.test_es_maxage_java";
+    final String tableName = "db.test_es_maxage_noop_java";
     final int numInserts = 3;
     final int maxAge = 3;
     final String timeGranularity = "DAYS";

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -277,7 +277,7 @@ public class OperationsTest extends OpenHouseSparkITest {
     final int numInserts = 3;
     final int maxAge = 0;
     // Not a realistic time setting that is accepted by the SQL, but tests that other snapshots are
-    // deleted
+    // deleted by the time history policy
     final String timeGranularity = "DAYS";
 
     List<Long> snapshotIds;
@@ -293,7 +293,7 @@ public class OperationsTest extends OpenHouseSparkITest {
       log.info("Loaded table {}, location {}", table.name(), table.location());
 
       ops.expireSnapshots(table, maxAge, timeGranularity, 0);
-      // No snapshots should be cleaned up as they are all within the max age
+      // Only retain the last snapshot
       checkSnapshots(table, snapshotIds.subList(snapshotIds.size() - 1, snapshotIds.size()));
     }
     // restart the app to reload catalog cache

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -275,7 +275,7 @@ public class OperationsTest extends OpenHouseSparkITest {
 
   @Test
   public void testSnapshotsExpirationMaxAge() throws Exception {
-    final String tableName = "db.test_es_java";
+    final String tableName = "db.test_es_maxage_java";
     final int numInserts = 3;
     List<Long> snapshotIds;
     try (Operations ops = Operations.withCatalog(getSparkSession(), meter)) {
@@ -301,7 +301,7 @@ public class OperationsTest extends OpenHouseSparkITest {
 
   @Test
   public void testSnapshotsExpirationMinVersions() throws Exception {
-    final String tableName = "db.test_es_java";
+    final String tableName = "db.test_es_minversions_java";
     final int numInserts = 3;
     List<Long> snapshotIds;
     try (Operations ops = Operations.withCatalog(getSparkSession(), meter)) {


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

Following up from https://github.com/linkedin/openhouse/pull/262 and https://github.com/linkedin/openhouse/pull/259
this PR adds support for snapshot expiration table maintenance job to use the history policies defined.

Most notably snapshot expiration will follow the settings of `maxAge`, `granularity`, and `versions` as follows:
1. If maxAge is provided, it will expire snapshots older than maxAge in granularity timeunit. 
2. If versions is provided, it will retain the last versions snapshots regardless of their age.
3. If both are provided, it will prioritize maxAge; only retain up to versions number of snapshots younger than the maxAge. This is done by pruning the snapshots older than maxAge, and then running a second expiration to keeping N versions after that. 

Note: If versions are defined and there are less than N versions in the history, then there were not enough commits (within that timespan if defined). Snapshot expiration will always keep at least 1 version.

The default behavior of snapshot expiration job will remain the same, keep snapshots within the last 3 days.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
