### PR TITLE
Refactor policy validators to inherit an interface for future policies

### DIFF
--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/HistoryPolicySpecValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/HistoryPolicySpecValidator.java
@@ -1,6 +1,7 @@
 package com.linkedin.openhouse.tables.api.validator.impl;
 
 import com.linkedin.openhouse.common.api.spec.TableUri;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.History;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.TimePartitionSpec;
 import lombok.extern.slf4j.Slf4j;
@@ -8,12 +9,14 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-public class HistoryPolicySpecValidator {
+public class HistoryPolicySpecValidator extends PolicySpecValidator {
 
   private String failureMessage = "";
   private String errorField = "";
 
-  protected boolean validate(History history, TableUri tableUri) {
+  public boolean validate(
+      CreateUpdateTableRequestBody createUpdateTableRequestBody, TableUri tableUri) {
+    History history = createUpdateTableRequestBody.getPolicies().getHistory();
     if (history != null) {
       if (history.getMaxAge() <= 0 && history.getVersions() <= 0) {
         failureMessage =

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/HistoryPolicySpecValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/HistoryPolicySpecValidator.java
@@ -11,9 +11,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class HistoryPolicySpecValidator extends PolicySpecValidator {
 
-  private String failureMessage = "";
-  private String errorField = "";
-
   public boolean validate(
       CreateUpdateTableRequestBody createUpdateTableRequestBody, TableUri tableUri) {
     History history = createUpdateTableRequestBody.getPolicies().getHistory();
@@ -88,13 +85,5 @@ public class HistoryPolicySpecValidator extends PolicySpecValidator {
     }
     int versions = history.getVersions();
     return versions >= 2 && versions <= 100;
-  }
-
-  public String getMessage() {
-    return failureMessage;
-  }
-
-  public String getField() {
-    return errorField;
   }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/PolicySpecValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/PolicySpecValidator.java
@@ -1,0 +1,22 @@
+package com.linkedin.openhouse.tables.api.validator.impl;
+
+import com.linkedin.openhouse.common.api.spec.TableUri;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
+
+public abstract class PolicySpecValidator {
+
+  protected String failureMessage = "";
+
+  protected String errorField = "";
+
+  public abstract boolean validate(
+      CreateUpdateTableRequestBody createUpdateTableRequestBody, TableUri tableUri);
+
+  public String getField() {
+    return errorField;
+  }
+
+  public String getMessage() {
+    return failureMessage;
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/ReplicationConfigValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/ReplicationConfigValidator.java
@@ -1,6 +1,7 @@
 package com.linkedin.openhouse.tables.api.validator.impl;
 
 import com.linkedin.openhouse.common.api.spec.TableUri;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.Replication;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -11,11 +12,13 @@ import org.springframework.stereotype.Component;
  */
 @Slf4j
 @Component
-public class ReplicationConfigValidator {
+public class ReplicationConfigValidator extends PolicySpecValidator {
   private String failureMessage = "";
   private String errorField = "";
 
-  public boolean validate(Replication replication, TableUri tableUri) {
+  public boolean validate(
+      CreateUpdateTableRequestBody createUpdateTableRequestBody, TableUri tableUri) {
+    Replication replication = createUpdateTableRequestBody.getPolicies().getReplication();
     if (replication != null) {
       log.info(String.format("Table: %s replication: %s\n", tableUri, replication));
     }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/ReplicationConfigValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/ReplicationConfigValidator.java
@@ -13,9 +13,6 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 public class ReplicationConfigValidator extends PolicySpecValidator {
-  private String failureMessage = "";
-  private String errorField = "";
-
   public boolean validate(
       CreateUpdateTableRequestBody createUpdateTableRequestBody, TableUri tableUri) {
     Replication replication = createUpdateTableRequestBody.getPolicies().getReplication();
@@ -23,13 +20,5 @@ public class ReplicationConfigValidator extends PolicySpecValidator {
       log.info(String.format("Table: %s replication: %s\n", tableUri, replication));
     }
     return true;
-  }
-
-  public String getMessage() {
-    return failureMessage;
-  }
-
-  public String getField() {
-    return errorField;
   }
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/api/validator/impl/HistoryPolicySpecValidatorTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/api/validator/impl/HistoryPolicySpecValidatorTest.java
@@ -1,7 +1,9 @@
 package com.linkedin.openhouse.tables.api.validator.impl;
 
 import com.linkedin.openhouse.common.api.spec.TableUri;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.History;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.Policies;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.TimePartitionSpec;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,13 +23,16 @@ public class HistoryPolicySpecValidatorTest {
   void testValidateRejectsUnstructuredmaxAge() {
     History historyWithNoGranularity = History.builder().maxAge(1).build();
 
-    Assertions.assertFalse(this.validator.validate(historyWithNoGranularity, tableUri));
+    Assertions.assertFalse(
+        this.validator.validate(
+            createRequestBodyWithHistoryPolicy(historyWithNoGranularity), tableUri));
     Assertions.assertTrue(this.validator.getMessage().contains("Incorrect maxAge specified"));
 
     History historyWithNomaxAge =
         History.builder().granularity(TimePartitionSpec.Granularity.DAY).versions(3).build();
 
-    Assertions.assertFalse(this.validator.validate(historyWithNomaxAge, tableUri));
+    Assertions.assertFalse(
+        this.validator.validate(createRequestBodyWithHistoryPolicy(historyWithNomaxAge), tableUri));
     Assertions.assertTrue(this.validator.getMessage().contains("Incorrect maxAge specified"));
   }
 
@@ -35,7 +40,8 @@ public class HistoryPolicySpecValidatorTest {
   void testValidateDefineNonNullRetentionPolicies() {
     History history = History.builder().build();
 
-    Assertions.assertFalse(this.validator.validate(history, tableUri));
+    Assertions.assertFalse(
+        this.validator.validate(createRequestBodyWithHistoryPolicy(history), tableUri));
     Assertions.assertTrue(
         this.validator
             .getMessage()
@@ -51,21 +57,28 @@ public class HistoryPolicySpecValidatorTest {
             .granularity(TimePartitionSpec.Granularity.DAY)
             .versions(10)
             .build();
-    Assertions.assertFalse(this.validator.validate(historyDaysExceeded, tableUri));
+    Assertions.assertFalse(
+        this.validator.validate(createRequestBodyWithHistoryPolicy(historyDaysExceeded), tableUri));
 
     // Exceed days in hours
     History historyHoursExceeded =
         History.builder().maxAge(100).granularity(TimePartitionSpec.Granularity.HOUR).build();
-    Assertions.assertFalse(this.validator.validate(historyHoursExceeded, tableUri));
+    Assertions.assertFalse(
+        this.validator.validate(
+            createRequestBodyWithHistoryPolicy(historyHoursExceeded), tableUri));
 
     // Exceed Granularity
     History historyGranularityExceeded =
         History.builder().maxAge(2).granularity(TimePartitionSpec.Granularity.MONTH).build();
-    Assertions.assertFalse(this.validator.validate(historyGranularityExceeded, tableUri));
+    Assertions.assertFalse(
+        this.validator.validate(
+            createRequestBodyWithHistoryPolicy(historyGranularityExceeded), tableUri));
 
     // Exceed version count
     History historyCountExceeded = History.builder().versions(1000).build();
-    Assertions.assertFalse(this.validator.validate(historyCountExceeded, tableUri));
+    Assertions.assertFalse(
+        this.validator.validate(
+            createRequestBodyWithHistoryPolicy(historyCountExceeded), tableUri));
 
     // Exceed both policies
     History historyBothExceeded =
@@ -74,7 +87,8 @@ public class HistoryPolicySpecValidatorTest {
             .granularity(TimePartitionSpec.Granularity.HOUR)
             .versions(1000)
             .build();
-    Assertions.assertFalse(this.validator.validate(historyBothExceeded, tableUri));
+    Assertions.assertFalse(
+        this.validator.validate(createRequestBodyWithHistoryPolicy(historyBothExceeded), tableUri));
     Assertions.assertTrue(this.validator.getMessage().contains("must be between"));
   }
 
@@ -83,16 +97,19 @@ public class HistoryPolicySpecValidatorTest {
     // Less than minimum number of hours
     History historyHoursMin =
         History.builder().maxAge(1).granularity(TimePartitionSpec.Granularity.HOUR).build();
-    Assertions.assertFalse(this.validator.validate(historyHoursMin, tableUri));
+    Assertions.assertFalse(
+        this.validator.validate(createRequestBodyWithHistoryPolicy(historyHoursMin), tableUri));
 
     // Less than 2 versions
     History historyVersionsMin = History.builder().versions(1).build();
-    Assertions.assertFalse(this.validator.validate(historyVersionsMin, tableUri));
+    Assertions.assertFalse(
+        this.validator.validate(createRequestBodyWithHistoryPolicy(historyVersionsMin), tableUri));
 
     // Less than minimum number of days
     History historyDaysMin =
         History.builder().maxAge(0).granularity(TimePartitionSpec.Granularity.DAY).build();
-    Assertions.assertFalse(this.validator.validate(historyDaysMin, tableUri));
+    Assertions.assertFalse(
+        this.validator.validate(createRequestBodyWithHistoryPolicy(historyDaysMin), tableUri));
 
     // Less than both policies
     History historyPolicyMin =
@@ -101,7 +118,8 @@ public class HistoryPolicySpecValidatorTest {
             .granularity(TimePartitionSpec.Granularity.HOUR)
             .versions(1)
             .build();
-    Assertions.assertFalse(this.validator.validate(historyPolicyMin, tableUri));
+    Assertions.assertFalse(
+        this.validator.validate(createRequestBodyWithHistoryPolicy(historyPolicyMin), tableUri));
     Assertions.assertTrue(this.validator.getMessage().contains("must be between"));
   }
 
@@ -110,14 +128,17 @@ public class HistoryPolicySpecValidatorTest {
     // Only define maxAge
     History history =
         History.builder().maxAge(36).granularity(TimePartitionSpec.Granularity.HOUR).build();
-    Assertions.assertTrue(this.validator.validate(history, tableUri));
+    Assertions.assertTrue(
+        this.validator.validate(createRequestBodyWithHistoryPolicy(history), tableUri));
 
     history = History.builder().versions(50).build();
-    Assertions.assertTrue(this.validator.validate(history, tableUri));
+    Assertions.assertTrue(
+        this.validator.validate(createRequestBodyWithHistoryPolicy(history), tableUri));
 
     // Only define versions
     history = History.builder().versions(10).build();
-    Assertions.assertTrue(this.validator.validate(history, tableUri));
+    Assertions.assertTrue(
+        this.validator.validate(createRequestBodyWithHistoryPolicy(history), tableUri));
 
     // Define both maxAge and version count
     history =
@@ -126,6 +147,12 @@ public class HistoryPolicySpecValidatorTest {
             .granularity(TimePartitionSpec.Granularity.DAY)
             .versions(10)
             .build();
-    Assertions.assertTrue(this.validator.validate(history, tableUri));
+    Assertions.assertTrue(
+        this.validator.validate(createRequestBodyWithHistoryPolicy(history), tableUri));
+  }
+
+  private CreateUpdateTableRequestBody createRequestBodyWithHistoryPolicy(History history) {
+    Policies historyPolicies = Policies.builder().history(history).build();
+    return CreateUpdateTableRequestBody.builder().policies(historyPolicies).build();
   }
 }


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

As Openhouse begins to support more policies, it becomes beneficial to have all the validators follow a common interface, defined by `PolicySpecValidator`. It takes in the entire request sent for the Create/Update table request since some policies may be dependent on other properties of the table.

This PR performs a small refactor to have these classes share the same base class, and future policy definitions to follow this pattern.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
