### PR TITLE
Add SQL support for World Readable Tables

### DIFF
--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/SetWorldReadablePolicyStatementTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/SetWorldReadablePolicyStatementTest.java
@@ -1,0 +1,142 @@
+package com.linkedin.openhouse.spark.statementtest;
+
+import com.google.common.collect.Lists;
+import com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseParseException;
+import java.nio.file.Files;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.execution.ExplainMode;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class SetWorldReadablePolicyStatementTest {
+
+  private static SparkSession spark = null;
+
+  @Test
+  public void testPolicySuccess() {
+    Dataset<Row> df = spark.sql("ALTER TABLE openhouse.db.table SET POLICY (WORLD_READABLE=TRUE)");
+    assert isPlanValid(df, "openhouse", "db.table", "TRUE");
+
+    Dataset<Row> df1 =
+        spark.sql("ALTER TABLE openhouse.db.table SET POLICY (WORLD_READABLE=FALSE)");
+    assert isPlanValid(df1, "openhouse", "db.table", "FALSE");
+  }
+
+  @Test
+  public void testPolicyAfterUseCatalog() {
+    spark.sql("use openhouse").show();
+    Dataset<Row> df = spark.sql("ALTER TABLE db.table SET policy (WORLD_READABLE=TRUE)");
+    assert isPlanValid(df, "openhouse", "db.table", "TRUE");
+  }
+
+  @Test
+  public void testPolicyAfterUseCatalogAndDatabase() {
+    spark.sql("use openhouse.db").show();
+    Dataset<Row> df = spark.sql("ALTER TABLE table SET policy (WORLD_READABLE=TRUE)");
+    assert isPlanValid(df, "openhouse", "db.table", "TRUE");
+  }
+
+  @Test
+  public void testPolicyWithQuotedTableIdentifier() {
+    Dataset<Row> df =
+        spark.sql("ALTER TABLE openhouse.`db`.`table` SET policy (WORLD_READABLE=TRUE)");
+    assert isPlanValid(df, "openhouse", "db.table", "TRUE");
+  }
+
+  @Test
+  public void testPolicyIdentifierWithLeadingDigits() {
+    Dataset<Row> df = spark.sql("ALTER TABLE openhouse.0_.0_ SET policy (WORLD_READABLE=TRUE)");
+    assert isPlanValid(df, "openhouse", "0_.0_", "TRUE");
+  }
+
+  @Test
+  public void testWorldReadableWithMultiLineComments() {
+    List<String> statementsWithComments =
+        Lists.newArrayList(
+            "/* bracketed comment */  ALTER TABLE openhouse.`db`.`table` SET policy (WORLD_READABLE=TRUE)",
+            "/**/  ALTER TABLE openhouse.`db`.`table` SET policy (WORLD_READABLE=TRUE)",
+            "-- single line comment \n ALTER TABLE openhouse.`db`.`table` SET policy (WORLD_READABLE=TRUE)",
+            "-- multiple \n-- single line \n-- comments \n ALTER TABLE openhouse.`db`.`table` SET policy (WORLD_READABLE=TRUE)",
+            "/* select * from multiline_comment \n where x like '%sql%'; */ ALTER TABLE openhouse.`db`.`table` SET policy (WORLD_READABLE=TRUE)",
+            "/* {\"app\": \"dbt\", \"dbt_version\": \"1.0.1\", \"profile_name\": \"profile1\", \"target_name\": \"dev\", "
+                + "\"node_id\": \"model.profile1.stg_users\"} \n*/ ALTER TABLE openhouse.`db`.`table` SET policy (WORLD_READABLE=TRUE)",
+            "/* Some multi-line comment \n"
+                + "*/ ALTER /* inline comment */ TABLE openhouse.`db`.`table` SET policy (WORLD_READABLE=TRUE) -- ending comment",
+            "ALTER -- a line ending comment\n"
+                + "TABLE openhouse.`db`.`table` SET policy (WORLD_READABLE=TRUE)");
+    for (String statement : statementsWithComments) {
+      assert isPlanValid(spark.sql(statement), "openhouse", "db.table", "TRUE");
+    }
+  }
+
+  @Test
+  public void testPolicyInvalidSyntax() {
+    Assertions.assertThrows(
+        OpenhouseParseException.class,
+        () -> spark.sql("ALTER TABLE openhouse.db.table SET policy (WORLD_READABLE=TRU)").show());
+  }
+
+  @SneakyThrows
+  @BeforeAll
+  public void setupSpark() {
+    Path unittest = new Path(Files.createTempDirectory("unittest").toString());
+    spark =
+        SparkSession.builder()
+            .master("local[2]")
+            .config(
+                "spark.sql.extensions",
+                ("org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,"
+                    + "com.linkedin.openhouse.spark.extensions.OpenhouseSparkSessionExtensions"))
+            .config("spark.sql.catalog.openhouse", "org.apache.iceberg.spark.SparkCatalog")
+            .config("spark.sql.catalog.openhouse.type", "hadoop")
+            .config("spark.sql.catalog.openhouse.warehouse", unittest.toString())
+            .getOrCreate();
+  }
+
+  @BeforeEach
+  public void setup() {
+    spark
+        .sql(
+            "CREATE TABLE openhouse.db.table (id bigint, data string, `openhouse.tableId` string) USING iceberg")
+        .show();
+    spark
+        .sql(
+            "CREATE TABLE openhouse.0_.0_ (id bigint, 0_ string, `openhouse.tableId` string) USING iceberg")
+        .show();
+    spark
+        .sql("ALTER TABLE openhouse.db.table SET TBLPROPERTIES ('openhouse.tableId' = 'tableid')")
+        .show();
+    spark
+        .sql("ALTER TABLE openhouse.0_.0_ SET TBLPROPERTIES ('openhouse.tableId' = 'tableid')")
+        .show();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    spark.sql("DROP TABLE openhouse.db.table").show();
+    spark.sql("DROP TABLE openhouse.0_.0_").show();
+  }
+
+  @AfterAll
+  public void tearDownSpark() {
+    spark.close();
+  }
+
+  @SneakyThrows
+  private boolean isPlanValid(
+      Dataset<Row> dataframe, String catalogName, String dbTable, String isWorldReadable) {
+    String queryStr = dataframe.queryExecution().explainString(ExplainMode.fromString("simple"));
+    return queryStr.contains(isWorldReadable) && queryStr.contains(dbTable);
+  }
+}

--- a/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/antlr/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensions.g4
+++ b/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/antlr/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensions.g4
@@ -26,6 +26,7 @@ statement
   : ALTER TABLE multipartIdentifier SET POLICY '(' retentionPolicy (columnRetentionPolicy)? ')'        #setRetentionPolicy
   | ALTER TABLE multipartIdentifier SET POLICY '(' replicationPolicy ')'                               #setReplicationPolicy
   | ALTER TABLE multipartIdentifier SET POLICY '(' sharingPolicy ')'                                   #setSharingPolicy
+  | ALTER TABLE multipartIdentifier SET POLICY '(' worldReadablePolicy ')'                             #setWorldReadablePolicy
   | ALTER TABLE multipartIdentifier SET POLICY '(' historyPolicy ')'                                   #setHistoryPolicy
   | ALTER TABLE multipartIdentifier MODIFY columnNameClause SET columnPolicy                           #setColumnPolicyTag
   | GRANT privilege ON grantableResource TO principal                                                  #grantStatement
@@ -66,7 +67,7 @@ quotedIdentifier
     ;
 
 nonReserved
-    : ALTER | TABLE | SET | POLICY | RETENTION | SHARING | REPLICATION | HISTORY
+    : ALTER | TABLE | SET | POLICY | RETENTION | SHARING | REPLICATION | HISTORY | WORLD_READABLE
     | GRANT | REVOKE | ON | TO | SHOW | GRANTS | PATTERN | WHERE | COLUMN
     ;
 
@@ -160,11 +161,15 @@ historyPolicy
     ;
 
 maxAge
-    : MAX_AGE'='duration
+    : MAX_AGE '=' duration
     ;
 
 versions
-    : VERSIONS'='POSITIVE_INTEGER
+    : VERSIONS '=' POSITIVE_INTEGER
+    ;
+
+worldReadablePolicy
+    : WORLD_READABLE '=' BOOLEAN
     ;
 
 ALTER: 'ALTER';
@@ -175,6 +180,7 @@ RETENTION: 'RETENTION';
 REPLICATION: 'REPLICATION';
 HISTORY: 'HISTORY';
 SHARING: 'SHARING';
+WORLD_READABLE: 'WORLD_READABLE';
 GRANT: 'GRANT';
 REVOKE: 'REVOKE';
 ON: 'ON';

--- a/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensionsAstBuilder.scala
+++ b/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensionsAstBuilder.scala
@@ -2,7 +2,7 @@ package com.linkedin.openhouse.spark.sql.catalyst.parser.extensions
 
 import com.linkedin.openhouse.spark.sql.catalyst.enums.GrantableResourceTypes
 import com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseSqlExtensionsParser._
-import com.linkedin.openhouse.spark.sql.catalyst.plans.logical.{GrantRevokeStatement, SetColumnPolicyTag, SetHistoryPolicy, SetReplicationPolicy, SetRetentionPolicy, SetSharingPolicy, ShowGrantsStatement}
+import com.linkedin.openhouse.spark.sql.catalyst.plans.logical.{GrantRevokeStatement, SetColumnPolicyTag, SetHistoryPolicy, SetReplicationPolicy, SetRetentionPolicy, SetSharingPolicy, SetWorldReadablePolicy, ShowGrantsStatement}
 import com.linkedin.openhouse.spark.sql.catalyst.enums.GrantableResourceTypes.GrantableResourceType
 import com.linkedin.openhouse.gen.tables.client.model.TimePartitionSpec
 import org.antlr.v4.runtime.tree.ParseTree
@@ -184,6 +184,16 @@ class OpenhouseSqlExtensionsAstBuilder (delegate: ParserInterface) extends Openh
 
   override def visitVersions(ctx: VersionsContext): Integer = {
     ctx.POSITIVE_INTEGER().getText.toInt
+  }
+
+  override def visitSetWorldReadablePolicy(ctx: SetWorldReadablePolicyContext): SetWorldReadablePolicy = {
+    val tableName = typedVisit[Seq[String]](ctx.multipartIdentifier)
+    val isWorldReadable = typedVisit[String](ctx.worldReadablePolicy())
+    SetWorldReadablePolicy(tableName, isWorldReadable)
+  }
+
+  override def visitWorldReadablePolicy(ctx: WorldReadablePolicyContext): String = {
+    ctx.BOOLEAN().getText
   }
 
   private def toBuffer[T](list: java.util.List[T]) = list.asScala

--- a/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/plans/logical/SetWorldReadablePolicy.scala
+++ b/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/plans/logical/SetWorldReadablePolicy.scala
@@ -1,0 +1,9 @@
+package com.linkedin.openhouse.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.plans.logical.Command
+
+case class SetWorldReadablePolicy(tableName: Seq[String], isWorldReadable: String) extends Command {
+  override def simpleString(maxFields: Int): String = {
+    s"SetWorldReadablePolicy: ${tableName} ${isWorldReadable}"
+  }
+}

--- a/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/OpenhouseDataSourceV2Strategy.scala
+++ b/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/OpenhouseDataSourceV2Strategy.scala
@@ -1,6 +1,7 @@
 package com.linkedin.openhouse.spark.sql.execution.datasources.v2
 
-import com.linkedin.openhouse.spark.sql.catalyst.plans.logical.{GrantRevokeStatement, SetColumnPolicyTag, SetReplicationPolicy, SetRetentionPolicy, SetSharingPolicy, SetHistoryPolicy, ShowGrantsStatement}
+import com.linkedin.openhouse.spark.sql.catalyst.plans.logical.{GrantRevokeStatement, SetColumnPolicyTag, SetReplicationPolicy,
+  SetRetentionPolicy, SetSharingPolicy, SetHistoryPolicy, ShowGrantsStatement, SetWorldReadablePolicy}
 import org.apache.iceberg.spark.{Spark3Util, SparkCatalog, SparkSessionCatalog}
 import org.apache.spark.sql.{SparkSession, Strategy}
 import org.apache.spark.sql.catalyst.expressions.PredicateHelper
@@ -21,6 +22,8 @@ case class OpenhouseDataSourceV2Strategy(spark: SparkSession) extends Strategy w
       SetHistoryPolicyExec(catalog, ident, granularity, maxAge, versions) :: Nil
     case SetSharingPolicy(CatalogAndIdentifierExtractor(catalog, ident), sharing) =>
       SetSharingPolicyExec(catalog, ident, sharing) :: Nil
+    case SetWorldReadablePolicy(CatalogAndIdentifierExtractor(catalog, ident), worldReadable) =>
+      SetWorldReadablePolicyExec(catalog, ident, worldReadable) :: Nil
     case SetColumnPolicyTag(CatalogAndIdentifierExtractor(catalog, ident), policyTag, cols) =>
       SetColumnPolicyTagExec(catalog, ident, policyTag, cols) :: Nil
 

--- a/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/SetWorldReadablePolicyExec.scala
+++ b/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/SetWorldReadablePolicyExec.scala
@@ -1,0 +1,36 @@
+package com.linkedin.openhouse.spark.sql.execution.datasources.v2
+
+import org.apache.iceberg.spark.source.SparkTable
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
+import org.apache.spark.sql.execution.datasources.v2.V2CommandExec
+
+case class SetWorldReadablePolicyExec(
+  catalog: TableCatalog,
+  ident: Identifier,
+  worldReadable: String) extends V2CommandExec {
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override protected def run(): Seq[InternalRow] = {
+    catalog.loadTable(ident) match {
+      case iceberg: SparkTable if iceberg.table().properties().containsKey("openhouse.tableId") =>
+        val key = "updated.openhouse.policy"
+        val value = s"""{"world_readable": ${worldReadable}}"""
+
+        iceberg.table().updateProperties()
+          .set(key, value)
+          .commit()
+
+      case table =>
+        throw new UnsupportedOperationException(s"Cannot set world readable policy for non-Openhouse table: $table")
+    }
+
+    Nil
+  }
+
+  override def simpleString(maxFields: Int): String = {
+    s"SetWorldReadablePolicyExec: ${catalog} ${ident} ${worldReadable}"
+  }
+}

--- a/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/plans/logical/SetWorldReadablePolicy.scala
+++ b/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/plans/logical/SetWorldReadablePolicy.scala
@@ -1,0 +1,9 @@
+package com.linkedin.openhouse.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.plans.logical.LeafCommand
+
+case class SetWorldReadablePolicy(tableName: Seq[String], isWorldReadable: String) extends LeafCommand {
+  override def simpleString(maxFields: Int): String = {
+    s"SetWorldReadablePolicy: ${tableName} ${isWorldReadable}"
+  }
+}

--- a/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/SetWorldReadablePolicyExec.scala
+++ b/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/SetWorldReadablePolicyExec.scala
@@ -1,0 +1,36 @@
+package com.linkedin.openhouse.spark.sql.execution.datasources.v2
+
+import org.apache.iceberg.spark.source.SparkTable
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
+import org.apache.spark.sql.execution.datasources.v2.LeafV2CommandExec
+
+case class SetWorldReadablePolicyExec(
+  catalog: TableCatalog,
+  ident: Identifier,
+  isWorldReadable: String) extends LeafV2CommandExec {
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override protected def run(): Seq[InternalRow] = {
+    catalog.loadTable(ident) match {
+      case iceberg: SparkTable if iceberg.table().properties().containsKey("openhouse.tableId") =>
+        val key = "updated.openhouse.policy"
+        val value = s"""{"world_readable": ${isWorldReadable}}"""
+
+        iceberg.table().updateProperties()
+          .set(key, value)
+          .commit()
+
+      case table =>
+        throw new UnsupportedOperationException(s"Cannot set world readable policy for non-Openhouse table: $table")
+    }
+
+    Nil
+  }
+
+  override def simpleString(maxFields: Int): String = {
+    s"SetWorldReadablePolicyExec: ${catalog} ${ident} ${isWorldReadable}"
+  }
+}


### PR DESCRIPTION
## Summary

We want to support globally readable tables in OpenHouse. This is to support a number of usecases where the existing sharable table model is not scalable for.

This policy will run independently of sharable tables, and the presumption is that we will not allow tables that were set as sharable to be globally readable. 

The SQL syntax will be `ALTER TABLE table SET policy (WORLD_READABLE=TRUE)`

where WORLD_READABLE can be set as true or false, if true then it can be read by any user.

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

## Changes

- [x] Client-facing API Changes
- [x] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

Unit tests

Tested with local docker

```
scala> spark.sql("ALTER TABLE openhouse.db.tb SET POLICY ( WORLD_READABLE=TRUE )").show
ANTLR Tool version 4.7.1 used for code generation does not match the current runtime version 4.8ANTLR Tool version 4.7.1 used for code generation does not match the current runtime version 4.8++
||
++
++


scala> spark.sql("ALTER TABLE openhouse.db.tb SET POLICY ( WORLD_READABLE=FALSE )").show
++
||
++
++

```

Also tested negative and edge cases:

```
 spark.sql("ALTER TABLE openhouse.db.tb SET POLICY ( WORLD_READABLE=FALE )").show
com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseParseException: mismatched input 'FALE' expecting {'.', 'SET'}; line 1 pos 56
  at com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseParseErrorListener$.syntaxError(OpenhouseSparkSqlExtensionsParser.scala:123)
  at org.antlr.v4.runtime.ProxyErrorListener.syntaxError(ProxyErrorListener.java:41)
  at org.antlr.v4.runtime.Parser.notifyErrorListeners(Parser.java:544)
  at org.antlr.v4.runtime.DefaultErrorStrategy.reportInputMismatch(DefaultErrorStrategy.java:327)
  at org.antlr.v4.runtime.DefaultErrorStrategy.reportError(DefaultErrorStrategy.java:139)
  at com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseSqlExtensionsParser.worldReadablePolicy(OpenhouseSqlExtensionsParser.java:2179)
  at com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseSqlExtensionsParser.statement(OpenhouseSqlExtensionsParser.java:519)
  at com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseSqlExtensionsParser.singleStatement(OpenhouseSqlExtensionsParser.java:150)
  at com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseSparkSqlExtensionsParser.$anonfun$parsePlan$1(OpenhouseSparkSqlExtensionsParser.scala:22)
  at com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseSparkSqlExtensionsParser.parse(OpenhouseSparkSqlExtensionsParser.scala:89)
  at com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseSparkSqlExtensionsParser.parsePlan(OpenhouseSparkSqlExtensionsParser.scala:22)
  at org.apache.spark.sql.SparkSession.$anonfun$sql$2(SparkSession.scala:613)
  at org.apache.spark.sql.catalyst.QueryPlanningTracker.measurePhase(QueryPlanningTracker.scala:111)
  at org.apache.spark.sql.SparkSession.$anonfun$sql$1(SparkSession.scala:613)
  at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:772)
  at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:610)
  ... 47 elided

scala> spark.sql("ALTER TABLE openhouse.db.tb SET POLICY ( WORLD_READABE=FALSE )").show
com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseParseException: no viable alternative at input 'ALTER TABLE openhouse.db.tb SET POLICY ( WORLD_READABE'; line 1 pos 41
  at com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseParseErrorListener$.syntaxError(OpenhouseSparkSqlExtensionsParser.scala:123)
  at org.antlr.v4.runtime.ProxyErrorListener.syntaxError(ProxyErrorListener.java:41)
  at org.antlr.v4.runtime.Parser.notifyErrorListeners(Parser.java:544)
  at org.antlr.v4.runtime.DefaultErrorStrategy.reportNoViableAlternative(DefaultErrorStrategy.java:310)
  at org.antlr.v4.runtime.DefaultErrorStrategy.reportError(DefaultErrorStrategy.java:136)
  at com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseSqlExtensionsParser.statement(OpenhouseSqlExtensionsParser.java:620)
  at com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseSqlExtensionsParser.singleStatement(OpenhouseSqlExtensionsParser.java:150)
  at com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseSparkSqlExtensionsParser.$anonfun$parsePlan$1(OpenhouseSparkSqlExtensionsParser.scala:22)
  at com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseSparkSqlExtensionsParser.parse(OpenhouseSparkSqlExtensionsParser.scala:89)
  at com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseSparkSqlExtensionsParser.parsePlan(OpenhouseSparkSqlExtensionsParser.scala:22)
  at org.apache.spark.sql.SparkSession.$anonfun$sql$2(SparkSession.scala:613)
  at org.apache.spark.sql.catalyst.QueryPlanningTracker.measurePhase(QueryPlanningTracker.scala:111)
  at org.apache.spark.sql.SparkSession.$anonfun$sql$1(SparkSession.scala:613)
  at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:772)
  at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:610)
  ... 47 elided

scala> spark.sql("ALTER TABLE openhouse.db.tb SET POLICY ( world_readable=FALSE )").show
++
||
++
++


```

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
