### PR TITLE
Adding table properties to signal replication run state

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
@@ -2,6 +2,7 @@ package com.linkedin.openhouse.jobs.client;
 
 import com.linkedin.openhouse.datalayout.persistence.StrategiesDaoTableProps;
 import com.linkedin.openhouse.datalayout.strategy.DataLayoutStrategy;
+import com.linkedin.openhouse.jobs.util.AppConstants;
 import com.linkedin.openhouse.jobs.util.DatabaseTableFilter;
 import com.linkedin.openhouse.jobs.util.DirectoryMetadata;
 import com.linkedin.openhouse.jobs.util.ReplicationConfig;
@@ -113,9 +114,16 @@ public class TablesClient {
                     .cluster(rc.getDestination())
                     .tableOwner(response.getTableCreator())
                     .schedule(rc.getCronSchedule())
+                    .enableSetup(
+                        getTableProperty(
+                            AppConstants.REPLICATION_SETUP_KEY, response.getTableProperties()))
                     .build()));
     // since replicationConfigList is initialized, it cannot be null.
     return Optional.of(replicationConfigList);
+  }
+
+  protected String getTableProperty(String propertyName, Map<String, String> tblProperties) {
+    return tblProperties.getOrDefault(propertyName, null);
   }
 
   protected GetTableResponseBody getTable(TableMetadata tableMetadata) {

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/AppConstants.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/AppConstants.java
@@ -47,6 +47,7 @@ public final class AppConstants {
   public static final String JOB_ID = "job_id";
   public static final String QUEUED_TIME = "queued_time";
   public static final String DATABASE_NAME = "database_name";
+  public static final String REPLICATION_SETUP_KEY = "replication.enableSetup";
 
   private AppConstants() {}
 }

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/ReplicationConfig.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/ReplicationConfig.java
@@ -14,4 +14,5 @@ public class ReplicationConfig {
   private final String schedule;
   private final String tableOwner;
   private final String cluster;
+  private final String enableSetup;
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/InternalRepositoryUtils.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/InternalRepositoryUtils.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.UpdateProperties;
 public final class InternalRepositoryUtils {
 
   protected static final String POLICIES_KEY = "policies";
+  protected static final String REPLICATION_SETUP_KEY = "replication.enableSetup";
 
   private static final Set<String> EXCLUDE_PROPERTIES_LIST =
       new HashSet<>(Collections.singletonList(POLICIES_KEY));

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -18,6 +18,7 @@ import com.linkedin.openhouse.common.metrics.MetricsConstant;
 import com.linkedin.openhouse.common.schema.IcebergSchemaHelper;
 import com.linkedin.openhouse.internal.catalog.SnapshotsUtil;
 import com.linkedin.openhouse.internal.catalog.fileio.FileIOManager;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.Policies;
 import com.linkedin.openhouse.tables.common.TableType;
 import com.linkedin.openhouse.tables.dto.mapper.TablesMapper;
 import com.linkedin.openhouse.tables.dto.mapper.iceberg.PartitionSpecMapper;
@@ -31,6 +32,7 @@ import com.linkedin.openhouse.tables.repository.SchemaValidator;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -136,10 +138,16 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
           doUpdateSchemaIfNeeded(transaction, writeSchema, table.schema(), tableDto);
       UpdateProperties updateProperties = transaction.updateProperties();
 
+      // check if replicationPolicy has any change. update property replication.setupNeeded
+      // accordingly
+      if (checkIfReplicationPolicyUpdated(table.properties(), tableDto.getPolicies())) {
+        updateProperties.set(REPLICATION_SETUP_KEY, "true");
+      }
       boolean propsUpdated = doUpdateUserPropsIfNeeded(updateProperties, tableDto, table);
       boolean snapshotsUpdated = doUpdateSnapshotsIfNeeded(updateProperties, tableDto);
       boolean policiesUpdated =
           doUpdatePoliciesIfNeeded(updateProperties, tableDto, table.properties());
+
       // TODO remove tableTypeAdded after all existing tables have been back-filled to have a
       // tableType
       boolean tableTypeAdded = checkIfTableTypeAdded(updateProperties, table.properties());
@@ -158,6 +166,25 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
     }
     return convertToTableDto(
         table, fileIOManager, partitionSpecMapper, policiesMapper, tableTypeMapper);
+  }
+
+  private boolean checkIfReplicationPolicyUpdated(
+      Map<String, String> existingTableProps, Policies policyFromTableDTO) {
+    String existingPolicies = existingTableProps.getOrDefault(POLICIES_KEY, "");
+    // If both are empty or null, no update
+    if (existingPolicies.isEmpty() && policyFromTableDTO == null) {
+      return false;
+    }
+    // If existing policies exist and policyFromTableDTO is not null, compare replication
+    if (!existingPolicies.isEmpty() && policyFromTableDTO != null) {
+      Policies existingPoliciesObj =
+          new GsonBuilder().create().fromJson(existingPolicies, Policies.class);
+      return !Objects.equals(
+          existingPoliciesObj.getReplication(), policyFromTableDTO.getReplication());
+    }
+    // If existing policies are empty but policyFromTableDTO is not null, update needed if
+    // replication is set
+    return existingPolicies.isEmpty() && policyFromTableDTO.getReplication() != null;
   }
 
   private boolean skipEligibilityCheck(
@@ -298,6 +325,9 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
     // Populate policies
     String policiesString = policiesMapper.toPoliciesJsonString(tableDto);
     propertiesMap.put(InternalRepositoryUtils.POLICIES_KEY, policiesString);
+    if (tableDto.getPolicies() != null && tableDto.getPolicies().getReplication() != null) {
+      propertiesMap.put(REPLICATION_SETUP_KEY, "true");
+    }
 
     if (!CollectionUtils.isEmpty(tableDto.getJsonSnapshots())) {
       meterRegistry.counter(MetricsConstant.REPO_TABLE_CREATED_WITH_DATA_CTR).increment();

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
@@ -13,6 +13,7 @@ import com.linkedin.openhouse.internal.catalog.model.HouseTable;
 import com.linkedin.openhouse.internal.catalog.model.HouseTablePrimaryKey;
 import com.linkedin.openhouse.internal.catalog.repository.HouseTableRepository;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.ClusteringColumn;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.ReplicationConfig;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.TimePartitionSpec;
 import com.linkedin.openhouse.tables.common.TableType;
 import com.linkedin.openhouse.tables.model.TableDto;
@@ -24,6 +25,7 @@ import com.linkedin.openhouse.tables.repository.SchemaValidator;
 import com.linkedin.openhouse.tables.repository.impl.InternalRepositoryUtils;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -440,6 +442,81 @@ public class RepositoryTest {
       openHouseInternalRepository.deleteById(primaryKey);
       Assertions.assertFalse(openHouseInternalRepository.existsById(primaryKey));
     }
+  }
+
+  @Test
+  public void testCreateTableWithReplicationProperty() {
+    String replicationKey = "replication.enableSetup";
+    TableDto tableDTO =
+        TABLE_DTO
+            .toBuilder()
+            .policies(TABLE_POLICIES.toBuilder().replication(null).build())
+            .tableVersion(INITIAL_TABLE_VERSION)
+            .build();
+
+    TableDto createdDTO = openHouseInternalRepository.save(tableDTO);
+    Assertions.assertFalse(createdDTO.getTableProperties().containsKey(replicationKey));
+
+    TableDtoPrimaryKey primaryKey =
+        TableDtoPrimaryKey.builder()
+            .tableId(TABLE_DTO.getTableId())
+            .databaseId(TABLE_DTO.getDatabaseId())
+            .build();
+    openHouseInternalRepository.deleteById(primaryKey);
+
+    // create table with some replication config and assert that tblProperty has key
+    TableDto tableDTOWithReplicationPolicy =
+        TABLE_DTO.toBuilder().policies(TABLE_POLICIES).tableVersion(INITIAL_TABLE_VERSION).build();
+
+    TableDto createdDTOWithReplicationPolicy =
+        openHouseInternalRepository.save(tableDTOWithReplicationPolicy);
+    Assertions.assertTrue(createdDTOWithReplicationPolicy.getTableProperties().containsKey());
+    Assertions.assertTrue(
+        Boolean.parseBoolean(
+            createdDTOWithReplicationPolicy.getTableProperties().get(replicationKey)));
+
+    Map<String, String> modifiedProperties =
+        new HashMap<>(createdDTOWithReplicationPolicy.getTableProperties());
+    modifiedProperties.put(replicationKey, "false");
+
+    // update tblProperty, setting to false
+    TableDto tableDTOWithTblProperties =
+        createdDTOWithReplicationPolicy
+            .toBuilder()
+            .tableType(TableType.PRIMARY_TABLE)
+            .tableVersion(createdDTOWithReplicationPolicy.getTableLocation())
+            .tableProperties(modifiedProperties)
+            .build();
+
+    TableDto createdDTOWithTblProps = openHouseInternalRepository.save(tableDTOWithTblProperties);
+    Assertions.assertTrue(createdDTOWithTblProps.getTableProperties().containsKey(replicationKey));
+    Assertions.assertFalse(
+        Boolean.parseBoolean(createdDTOWithTblProps.getTableProperties().get(replicationKey)));
+
+    // Update replication policy and assert that tblProperty values is set back to true
+    ArrayList<ReplicationConfig> configs = new ArrayList<>();
+    configs.add(ReplicationConfig.builder().destination("CLUSTER1").interval("15H").build());
+    TableDto tableDTOWithUpdatedReplicationPolicy =
+        createdDTOWithTblProps
+            .toBuilder()
+            .tableVersion(createdDTOWithTblProps.getTableLocation())
+            .policies(
+                TABLE_POLICIES
+                    .toBuilder()
+                    .replication(REPLICATION_POLICY.toBuilder().config(configs).build())
+                    .build())
+            .build();
+
+    TableDto createdDTOWithUpdatedReplicationPolicy =
+        openHouseInternalRepository.save(tableDTOWithUpdatedReplicationPolicy);
+    Assertions.assertTrue(
+        createdDTOWithUpdatedReplicationPolicy.getTableProperties().containsKey("replicationKey"));
+    Assertions.assertTrue(
+        Boolean.parseBoolean(
+            createdDTOWithUpdatedReplicationPolicy.getTableProperties().get(replicationKey)));
+
+    openHouseInternalRepository.deleteById(primaryKey);
+    Assertions.assertFalse(openHouseInternalRepository.existsById(primaryKey));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Adding a property in tblProperties to indicate replication run state for a table based on replicationConfig addition/update.
Property: replication.enableSetup
Cases:
1. Table Created without replication Policy - replication.enableSetup is not added.
2. Table Created with replication Policy - replication.enableSetup is added. Values is set to `true`
3. Table is updated with a new value for replication policy -  replication.enableSetup is added. Value is set to `true`
4. Table is updated without changes to replication policy -  no changes to replication.enableSetup property

Based on boolean value of the property, replication job is triggered only when needed, ie. when policy is added or updated.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
Unit tests added.
Local Docker system tests in progress

<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
