### PR TITLE
Generate partition scope DLO strategy and persist to DLO table

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -549,7 +549,8 @@ Build images with jobs scheduler, and run the scheduler separately after all oth
 ```
 docker compose --profile with_jobs_scheduler build
 docker compose --profile with_jobs_scheduler run openhouse-jobs-scheduler - \
-    --type RETENTION --cluster local --tablesURL http://openhouse-tables:8080 --jobsURL http://openhouse-jobs:8080
+    --type RETENTION --cluster local --tablesURL http://openhouse-tables:8080 --jobsURL http://openhouse-jobs:8080 -\
+    --tableMinAgeThresholdHours 0
 ```
 
 > [!NOTE]

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
@@ -80,9 +80,10 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
         if (isPartitionScope) {
           rows.add(
               String.format(
-                  "('%s', '%s', current_timestamp(), %f, %f, %f)",
+                  "('%s', '%s', '%s', current_timestamp(), %f, %f, %f)",
                   fqtn,
                   strategy.getPartitionId(),
+                  strategy.getPartitionColumns(),
                   strategy.getCost(),
                   strategy.getGain(),
                   strategy.getEntropy()));

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
@@ -50,14 +50,14 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
   private void runInnerTableScope(
       SparkSession spark, OpenHouseDataLayoutStrategyGenerator strategiesGenerator) {
     log.info("Generating strategies for table {}", fqtn);
-    List<DataLayoutStrategy> strategies = strategiesGenerator.generate();
+    List<DataLayoutStrategy> strategies = strategiesGenerator.generateTableLevelStrategies();
     log.info(
         "Generated {} strategies {}",
         strategies.size(),
         strategies.stream().map(Object::toString).collect(Collectors.joining(", ")));
     StrategiesDao dao = StrategiesDaoTableProps.builder().spark(spark).build();
     dao.save(fqtn, strategies);
-    appendToDloTable(spark, outputFqtn, strategies, false);
+    appendToDloStrategiesTable(spark, outputFqtn, strategies, false);
   }
 
   private void runInnerPartitionScope(
@@ -65,10 +65,10 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
     log.info("Generating partition-level strategies for table {}", fqtn);
     List<DataLayoutStrategy> strategies = strategiesGenerator.generatePartitionLevelStrategies();
     log.info("Generated {} strategies", strategies.size());
-    appendToDloTable(spark, partitionLevelOutputFqtn, strategies, true);
+    appendToDloStrategiesTable(spark, partitionLevelOutputFqtn, strategies, true);
   }
 
-  private void appendToDloTable(
+  private void appendToDloStrategiesTable(
       SparkSession spark,
       String outputFqtn,
       List<DataLayoutStrategy> strategies,

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
@@ -119,7 +119,16 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
     extraOptions.add(new Option("t", "tableName", true, "Fully-qualified table name"));
     extraOptions.add(
         new Option(
-            "o", "outputTableName", true, "Fully-qualified table name used to store strategies"));
+            "o",
+            "outputTableName",
+            true,
+            "Fully-qualified table name used to store strategies at table level"));
+    extraOptions.add(
+        new Option(
+            "p",
+            "partitionLevelOutputTableName",
+            true,
+            "Fully-qualified table name used to store strategies at partition level"));
     CommandLine cmdLine = createCommandLine(args, extraOptions);
     DataLayoutStrategyGeneratorSparkApp app =
         new DataLayoutStrategyGeneratorSparkApp(

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
@@ -74,7 +74,7 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
       List<DataLayoutStrategy> strategies,
       boolean isPartitionScope) {
     if (outputFqtn != null && !strategies.isEmpty()) {
-      createTableIfNotExists(spark, outputFqtn);
+      createTableIfNotExists(spark, outputFqtn, isPartitionScope);
       List<String> rows = new ArrayList<>();
       for (DataLayoutStrategy strategy : strategies) {
         if (isPartitionScope) {
@@ -101,18 +101,35 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
     }
   }
 
-  private void createTableIfNotExists(SparkSession spark, String outputFqtn) {
-    spark.sql(
-        String.format(
-            "CREATE TABLE IF NOT EXISTS %s ("
-                + "fqtn STRING, "
-                + "timestamp TIMESTAMP, "
-                + "estimated_compute_cost DOUBLE, "
-                + "estimated_file_count_reduction DOUBLE, "
-                + "file_size_entropy DOUBLE "
-                + ") "
-                + "PARTITIONED BY (days(timestamp))",
-            outputFqtn));
+  private void createTableIfNotExists(
+      SparkSession spark, String outputFqtn, boolean isPartitionScope) {
+    if (isPartitionScope) {
+      spark.sql(
+          String.format(
+              "CREATE TABLE IF NOT EXISTS %s ("
+                  + "fqtn STRING, "
+                  + "partition_id STRING, "
+                  + "partition_columns STRING, "
+                  + "timestamp TIMESTAMP, "
+                  + "estimated_compute_cost DOUBLE, "
+                  + "estimated_file_count_reduction DOUBLE, "
+                  + "file_size_entropy DOUBLE "
+                  + ") "
+                  + "PARTITIONED BY (days(timestamp))",
+              outputFqtn));
+    } else {
+      spark.sql(
+          String.format(
+              "CREATE TABLE IF NOT EXISTS %s ("
+                  + "fqtn STRING, "
+                  + "timestamp TIMESTAMP, "
+                  + "estimated_compute_cost DOUBLE, "
+                  + "estimated_file_count_reduction DOUBLE, "
+                  + "file_size_entropy DOUBLE "
+                  + ") "
+                  + "PARTITIONED BY (days(timestamp))",
+              outputFqtn));
+    }
   }
 
   public static void main(String[] args) {

--- a/infra/recipes/docker-compose/oh-hadoop-spark/jobs.yaml
+++ b/infra/recipes/docker-compose/oh-hadoop-spark/jobs.yaml
@@ -62,7 +62,7 @@ jobs:
         <<: *apps-defaults
       - type: DATA_LAYOUT_STRATEGY_GENERATION
         class-name: com.linkedin.openhouse.jobs.spark.DataLayoutStrategyGeneratorSparkApp
-        args: ["--outputTableName", "u_openhouse.dlo_strategies"]
+        args: ["--outputTableName", "u_openhouse.dlo_strategies", "--partitionLevelOutputTableName", "u_openhouse.dlo_partition_strategies"]
         <<: *apps-defaults
       - type: DATA_LAYOUT_STRATEGY_EXECUTION
         class-name: com.linkedin.openhouse.jobs.spark.DataCompactionSparkApp

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/datasource/FileStat.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/datasource/FileStat.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.datalayout.datasource;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,4 +14,5 @@ import lombok.NoArgsConstructor;
 public final class FileStat {
   private String path;
   private long size;
+  private List<String> partitionValues;
 }

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/datasource/TableFileStats.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/datasource/TableFileStats.java
@@ -20,7 +20,7 @@ public class TableFileStats implements DataSource<FileStat> {
   @Override
   public Dataset<FileStat> get() {
     StructType fileSchema =
-        spark.sql(String.format("SELECT * FROM %s.partitions", tableName)).schema();
+        spark.sql(String.format("SELECT * FROM %s.data_files", tableName)).schema();
     try {
       fileSchema.apply("partition");
       return spark

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/datasource/TablePartitionStats.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/datasource/TablePartitionStats.java
@@ -1,6 +1,8 @@
 package com.linkedin.openhouse.datalayout.datasource;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import lombok.Builder;
@@ -30,6 +32,18 @@ public class TablePartitionStats implements DataSource<PartitionStat> {
       return spark
           .sql(String.format("SELECT null, file_count FROM %s.partitions", tableName))
           .map(new TablePartitionStats.PartitionStatMapper(), Encoders.bean(PartitionStat.class));
+    }
+  }
+
+  public List<String> getPartitionColumns() {
+    StructType partitionSchema =
+        spark.sql(String.format("SELECT * FROM %s.partitions", tableName)).schema();
+    try {
+      String[] partitionColumns =
+          ((StructType) partitionSchema.apply("partition").dataType()).fieldNames();
+      return Arrays.asList(partitionColumns);
+    } catch (IllegalArgumentException e) {
+      return Collections.emptyList();
     }
   }
 

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/generator/DataLayoutStrategyGenerator.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/generator/DataLayoutStrategyGenerator.java
@@ -5,4 +5,6 @@ import java.util.List;
 
 public interface DataLayoutStrategyGenerator {
   List<DataLayoutStrategy> generate();
+
+  List<DataLayoutStrategy> generatePartitionLevelStrategies();
 }

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/generator/DataLayoutStrategyGenerator.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/generator/DataLayoutStrategyGenerator.java
@@ -6,5 +6,7 @@ import java.util.List;
 public interface DataLayoutStrategyGenerator {
   List<DataLayoutStrategy> generate();
 
+  List<DataLayoutStrategy> generateTableLevelStrategies();
+
   List<DataLayoutStrategy> generatePartitionLevelStrategies();
 }

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGenerator.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGenerator.java
@@ -42,7 +42,7 @@ public class OpenHouseDataLayoutStrategyGenerator implements DataLayoutStrategyG
 
   /**
    * Generate a list of data layout optimization strategies based on the table file stats and
-   * historic query patterns. For now we only use table-level strategies. TODO: ADD logic to
+   * historic query patterns. For now we only use table-level strategies. TODO: add logic to
    * determine whether to generate table-level or partition-level strategies.
    */
   @Override

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGenerator.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGenerator.java
@@ -59,7 +59,9 @@ public class OpenHouseDataLayoutStrategyGenerator implements DataLayoutStrategyG
     // Retrieve file sizes of all data files.
     Dataset<Long> fileSizes =
         tableFileStats.get().map((MapFunction<FileStat, Long>) FileStat::getSize, Encoders.LONG());
-    Optional<DataLayoutStrategy> strategy = buildDataLayoutStrategy(fileSizes, 1, null);
+    long partitionCount = tablePartitionStats.get().count();
+    Optional<DataLayoutStrategy> strategy =
+        buildDataLayoutStrategy(fileSizes, partitionCount, null);
     return strategy.map(Collections::singletonList).orElse(Collections.emptyList());
   }
 
@@ -85,7 +87,7 @@ public class OpenHouseDataLayoutStrategyGenerator implements DataLayoutStrategyG
                                   .equals(partitionValue))
                   .map((MapFunction<FileStat, Long>) FileStat::getSize, Encoders.LONG());
           Optional<DataLayoutStrategy> strategy =
-              buildDataLayoutStrategy(fileSizes, partitionStatsList.size(), partitionValue);
+              buildDataLayoutStrategy(fileSizes, 1L, partitionValue);
           strategy.ifPresent(strategies::add);
         });
     return strategies;
@@ -103,7 +105,7 @@ public class OpenHouseDataLayoutStrategyGenerator implements DataLayoutStrategyG
    * </ul>
    */
   private Optional<DataLayoutStrategy> buildDataLayoutStrategy(
-      Dataset<Long> fileSizes, int partitionCount, String partitionValue) {
+      Dataset<Long> fileSizes, long partitionCount, String partitionValue) {
     Dataset<Long> filteredSizes =
         fileSizes.filter(
             (FilterFunction<Long>)

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/strategy/DataLayoutStrategy.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/strategy/DataLayoutStrategy.java
@@ -17,4 +17,5 @@ public class DataLayoutStrategy {
   private final DataCompactionConfig config;
   // TODO: support sorting config
   private final String partitionId;
+  private final String partitionColumns;
 }

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/strategy/DataLayoutStrategy.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/strategy/DataLayoutStrategy.java
@@ -16,4 +16,5 @@ public class DataLayoutStrategy {
   private final double gain;
   private final DataCompactionConfig config;
   // TODO: support sorting config
+  private final String partitionId;
 }

--- a/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/e2e/IntegrationTest.java
+++ b/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/e2e/IntegrationTest.java
@@ -30,7 +30,7 @@ public class IntegrationTest extends OpenHouseSparkITest {
               .tableFileStats(tableFileStats)
               .tablePartitionStats(tablePartitionStats)
               .build();
-      List<DataLayoutStrategy> strategies = strategyGenerator.generate();
+      List<DataLayoutStrategy> strategies = strategyGenerator.generateTableLevelStrategies();
       Assertions.assertEquals(1, strategies.size());
       StrategiesDao dao = StrategiesDaoTableProps.builder().spark(spark).build();
       dao.save(testTable, strategies);
@@ -54,7 +54,7 @@ public class IntegrationTest extends OpenHouseSparkITest {
               .tableFileStats(tableFileStats)
               .tablePartitionStats(tablePartitionStats)
               .build();
-      List<DataLayoutStrategy> strategies = strategyGenerator.generate();
+      List<DataLayoutStrategy> strategies = strategyGenerator.generateTableLevelStrategies();
       Assertions.assertEquals(1, strategies.size());
       StrategiesDao dao = StrategiesDaoTableProps.builder().spark(spark).build();
       dao.save(testTable, strategies);

--- a/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGeneratorTest.java
+++ b/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGeneratorTest.java
@@ -43,7 +43,7 @@ public class OpenHouseDataLayoutStrategyGeneratorTest extends OpenHouseSparkITes
               .tableFileStats(tableFileStats)
               .tablePartitionStats(tablePartitionStats)
               .build();
-      List<DataLayoutStrategy> strategies = strategyGenerator.generate();
+      List<DataLayoutStrategy> strategies = strategyGenerator.generateTableLevelStrategies();
       Assertions.assertEquals(1, strategies.size());
       DataLayoutStrategy strategy = strategies.get(0);
       // few groups, expect 1 commit

--- a/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGeneratorTest.java
+++ b/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGeneratorTest.java
@@ -47,6 +47,7 @@ public class OpenHouseDataLayoutStrategyGeneratorTest extends OpenHouseSparkITes
       Assertions.assertEquals(1, strategies.size());
       DataLayoutStrategy strategy = strategies.get(0);
       Assertions.assertNull(strategy.getPartitionId());
+      Assertions.assertNull(strategy.getPartitionColumns());
       // few groups, expect 1 commit
       Assertions.assertEquals(1, strategy.getConfig().getPartialProgressMaxCommits());
       Assertions.assertTrue(strategy.getConfig().isPartialProgressEnabled());
@@ -100,6 +101,7 @@ public class OpenHouseDataLayoutStrategyGeneratorTest extends OpenHouseSparkITes
       Assertions.assertTrue(
           "2025-02-16, data2".equals(strategy.getPartitionId())
               || "2025-02-15, data1".equals(strategy.getPartitionId()));
+      Assertions.assertEquals("ts_day, data", strategy.getPartitionColumns());
       // few groups, expect 1 commit
       Assertions.assertEquals(1, strategy.getConfig().getPartialProgressMaxCommits());
       Assertions.assertTrue(strategy.getConfig().isPartialProgressEnabled());

--- a/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/persistence/StrategiesDaoTablePropsTest.java
+++ b/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/persistence/StrategiesDaoTablePropsTest.java
@@ -21,8 +21,6 @@ public class StrategiesDaoTablePropsTest extends OpenHouseSparkITest {
       List<DataLayoutStrategy> strategyList = Collections.nCopies(100, strategy);
       StrategiesDao dao = StrategiesDaoTableProps.builder().spark(spark).build();
       dao.save(testTable, strategyList);
-      List<DataLayoutStrategy> retrievedStrategies = dao.load(testTable);
-      retrievedStrategies.get(0);
       Assertions.assertEquals(strategyList, dao.load(testTable));
     }
   }

--- a/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/persistence/StrategiesDaoTablePropsTest.java
+++ b/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/persistence/StrategiesDaoTablePropsTest.java
@@ -21,6 +21,8 @@ public class StrategiesDaoTablePropsTest extends OpenHouseSparkITest {
       List<DataLayoutStrategy> strategyList = Collections.nCopies(100, strategy);
       StrategiesDao dao = StrategiesDaoTableProps.builder().spark(spark).build();
       dao.save(testTable, strategyList);
+      List<DataLayoutStrategy> retrievedStrategies = dao.load(testTable);
+      retrievedStrategies.get(0);
       Assertions.assertEquals(strategyList, dao.load(testTable));
     }
   }

--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/services/JobsRegistry.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/services/JobsRegistry.java
@@ -33,10 +33,9 @@ public class JobsRegistry {
       throw new JobEngineException(String.format("Job %s is not supported", type));
     }
     JobLaunchConf extendedRequestConf = createDefaultLaunchConf(requestConf.getJobType());
-    if (MapUtils.isNotEmpty(requestConf.getExecutionConf())) {
-      populateAllSparkProperties(
-          requestConf.getExecutionConf(), extendedRequestConf.getSparkProperties());
-    }
+    // spark conf
+    populateAllSparkProperties(
+        requestConf.getExecutionConf(), extendedRequestConf.getSparkProperties());
     // required arguments
     List<String> extendedArgs =
         new ArrayList<>(Arrays.asList("--jobId", jobId, "--storageURL", storageUri));
@@ -66,7 +65,9 @@ public class JobsRegistry {
     if (authTokenPath != null) {
       sparkProperties.put("spark.sql.catalog.openhouse.auth-token", getToken(authTokenPath));
     }
-    sparkProperties.putAll(executionConf);
+    if (MapUtils.isNotEmpty(executionConf)) {
+      sparkProperties.putAll(executionConf);
+    }
   }
 
   public static JobsRegistry from(JobsProperties properties, Map<String, String> storageProps) {


### PR DESCRIPTION
## Summary
Generate partition scope DLO strategy and persist to the partition-level DLO table. The new DLO table contains 2 new columns: partitionId and partitionColumns. The latter will be used only for analysis purpose and won't be used as filters in the execution app. At this stage, we generate both table-level and partition-level strategies for each table.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Tested on the test cluster. The dlo_partition_strategies table was created and has 1 row for each partition. The file reduction count for each partition is 1, and the partition_id and partition_columns had been correctly set.
```
scala> spark.sql("use openhouse")

scala> spark.sql("create table u_openhouse.dlo_run (ts timestamp, id int, data string) partitioned by (days(ts), id)").show()

scala> spark.sql("insert into u_openhouse.dlo_run values (current_timestamp(), 1, 'data')").show()
scala> spark.sql("insert into u_openhouse.dlo_run values (current_timestamp(), 1, 'data')").show()

scala> spark.sql("insert into u_openhouse.dlo_run values (date_add(current_timestamp(), 1), 1, 'data')").show()
scala> spark.sql("insert into u_openhouse.dlo_run values (date_add(current_timestamp(), 1), 1, 'data')").show()


scala> spark.sql("show tables in u_openhouse").show(100, false)
+-----------+------------------------+-----------+
|namespace  |tableName               |isTemporary|
+-----------+------------------------+-----------+
|u_openhouse|dlo_run                 |false      |
|u_openhouse|dlo_strategies          |false      |
|u_openhouse|dlo_partition_strategies|false      |
+-----------+------------------------+-----------+


scala> spark.sql("select * from u_openhouse.dlo_partition_strategies").show(false)
+-------------------+-------------+-----------------+----------------------+----------------------+------------------------------+----------------------+
|fqtn               |partition_id |partition_columns|timestamp             |estimated_compute_cost|estimated_file_count_reduction|file_size_entropy     |
+-------------------+-------------+-----------------+----------------------+----------------------+------------------------------+----------------------+
|u_openhouse.dlo_run|2025-02-13, 1|ts_day, id       |2025-02-12 10:05:02.08|0.5                   |1.0                           |2.77080845024704256E17|
|u_openhouse.dlo_run|2025-02-12, 1|ts_day, id       |2025-02-12 10:05:02.08|0.5                   |1.0                           |2.77080845024704256E17|
+-------------------+-------------+-----------------+----------------------+----------------------+------------------------------+----------------------+


scala> spark.sql("select * from u_openhouse.dlo_strategies").show(false)
+-------------------+-----------------------+----------------------+------------------------------+----------------------+
|fqtn               |timestamp              |estimated_compute_cost|estimated_file_count_reduction|file_size_entropy     |
+-------------------+-----------------------+----------------------+------------------------------+----------------------+
|u_openhouse.dlo_run|2025-02-12 10:04:07.489|0.5                   |3.0                           |2.77080845024704256E17|
+-------------------+-----------------------+----------------------+------------------------------+----------------------+
```
```
kubectl create job --from=cronjob/jobs-cron-data-layout-strategy-generation dlo-adhoc-test

2025-02-12 10:01:38 INFO  JobsScheduler:155 - Submitting and running 1 jobs based on the job type: DATA_LAYOUT_STRATEGY_GENERATION
2025-02-12 10:01:38 INFO  OperationTask:67 - Launching job for TableMetadata(super=Metadata(creator=openhouse), dbName=u_openhouse, tableName=dlo_run, creationTimeMs=1739347541314, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null)
2025-02-12 10:01:38 INFO  OperationTask:93 - Launched a job with id DATA_LAYOUT_STRATEGY_GENERATION_u_openhouse_dlo_run_a88fffd3-07e7-4a45-bd28-a05e6c17638a for TableMetadata(super=Metadata(creator=openhouse), dbName=u_openhouse, tableName=dlo_run, creationTimeMs=1739347541314, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null)
```

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
