### PR TITLE
Set spark.driver.host to localhost in integration tests

### DIFF
--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/SparkTestBase.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/SparkTestBase.java
@@ -35,6 +35,7 @@ public class SparkTestBase
       spark =
           SparkSession.builder()
               .master("local[2]")
+              .config("spark.driver.host", "localhost")
               .config(
                   "spark.sql.extensions",
                   ("org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,"

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/GrantRevokeStatementTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/GrantRevokeStatementTest.java
@@ -383,6 +383,7 @@ public class GrantRevokeStatementTest {
     spark =
         SparkSession.builder()
             .master("local[2]")
+            .config("spark.driver.host", "localhost")
             .config(
                 "spark.sql.extensions",
                 ("org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,"

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/SetColumnPolicyTagStatementTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/SetColumnPolicyTagStatementTest.java
@@ -32,6 +32,7 @@ public class SetColumnPolicyTagStatementTest {
     spark =
         SparkSession.builder()
             .master("local[2]")
+            .config("spark.driver.host", "localhost")
             .config(
                 "spark.sql.extensions",
                 ("org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,"

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/SetHistoryPolicyStatementTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/SetHistoryPolicyStatementTest.java
@@ -28,6 +28,7 @@ public class SetHistoryPolicyStatementTest {
     spark =
         SparkSession.builder()
             .master("local[2]")
+            .config("spark.driver.host", "localhost")
             .config(
                 "spark.sql.extensions",
                 ("org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,"

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/SetSharingPolicyStatementTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/SetSharingPolicyStatementTest.java
@@ -98,6 +98,7 @@ public class SetSharingPolicyStatementTest {
     spark =
         SparkSession.builder()
             .master("local[2]")
+            .config("spark.driver.host", "localhost")
             .config(
                 "spark.sql.extensions",
                 ("org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,"

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/SetTablePolicyStatementTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/SetTablePolicyStatementTest.java
@@ -28,6 +28,7 @@ public class SetTablePolicyStatementTest {
     spark =
         SparkSession.builder()
             .master("local[2]")
+            .config("spark.driver.host", "localhost")
             .config(
                 "spark.sql.extensions",
                 ("org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,"

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/SetTableReplicationPolicyStatementTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/SetTableReplicationPolicyStatementTest.java
@@ -31,6 +31,7 @@ public class SetTableReplicationPolicyStatementTest {
     spark =
         SparkSession.builder()
             .master("local[2]")
+            .config("spark.driver.host", "localhost")
             .config(
                 "spark.sql.extensions",
                 ("org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,"


### PR DESCRIPTION
## Summary
Started getting binding failure because hostname has changed from 127.0.0.1 to some internal network ip.
`spark.driver.bindAddress` defaults to `{spark.driver.host}`.
It's a common practice to set driver host to localhost in tests.

```
Can't assign requested address: Service 'sparkDriver' failed after 16 retries (on a random free port)! Consider explicitly setting the appropriate binding address for the service 'sparkDriver' (for example spark.driver.bindAddress for SparkDriver) to the correct binding address.
java.net.BindException: Can't assign requested address: Service 'sparkDriver' failed after 16 retries (on a random free port)! Consider explicitly setting the appropriate binding address for the service 'sparkDriver' (for example spark.driver.bindAddress for SparkDriver) to the correct binding address.
```

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
