### PR TITLE
Generate delete file statistics for DLO strategy

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
@@ -80,7 +80,7 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
         if (isPartitionScope) {
           rows.add(
               String.format(
-                  "('%s', '%s', '%s', current_timestamp(), %f, %f, %f, %d, %d, %d, %d)",
+                  "('%s', '%s', '%s', current_timestamp(), %f, %f, %f, %d, %d, %d, %d, %d, %d)",
                   fqtn,
                   strategy.getPartitionId(),
                   strategy.getPartitionColumns(),
@@ -90,11 +90,13 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
                   strategy.getPosDeleteFileCount(),
                   strategy.getEqDeleteFileCount(),
                   strategy.getPosDeleteFileBytes(),
-                  strategy.getEqDeleteFileBytes()));
+                  strategy.getEqDeleteFileBytes(),
+                  strategy.getPosDeleteRecordCount(),
+                  strategy.getEqDeleteRecordCount()));
         } else {
           rows.add(
               String.format(
-                  "('%s', current_timestamp(), %f, %f, %f, %d, %d, %d, %d)",
+                  "('%s', current_timestamp(), %f, %f, %f, %d, %d, %d, %d, %d, %d)",
                   fqtn,
                   strategy.getCost(),
                   strategy.getGain(),
@@ -102,7 +104,9 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
                   strategy.getPosDeleteFileCount(),
                   strategy.getEqDeleteFileCount(),
                   strategy.getPosDeleteFileBytes(),
-                  strategy.getEqDeleteFileBytes()));
+                  strategy.getEqDeleteFileBytes(),
+                  strategy.getPosDeleteRecordCount(),
+                  strategy.getEqDeleteRecordCount()));
         }
       }
       String strategiesInsertStmt =
@@ -128,7 +132,9 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
                   + "pos_delete_file_count LONG, "
                   + "eq_delete_file_count LONG, "
                   + "pos_delete_file_bytes LONG, "
-                  + "eq_delete_file_bytes LONG"
+                  + "eq_delete_file_bytes LONG,"
+                  + "pos_delete_record_count LONG, "
+                  + "eq_delete_record_count LONG"
                   + ") "
                   + "PARTITIONED BY (days(timestamp))",
               outputFqtn));
@@ -144,7 +150,9 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
                   + "pos_delete_file_count LONG, "
                   + "eq_delete_file_count LONG, "
                   + "pos_delete_file_bytes LONG, "
-                  + "eq_delete_file_bytes LONG "
+                  + "eq_delete_file_bytes LONG,"
+                  + "pos_delete_record_count LONG, "
+                  + "eq_delete_record_count LONG"
                   + ") "
                   + "PARTITIONED BY (days(timestamp))",
               outputFqtn));

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
@@ -80,18 +80,29 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
         if (isPartitionScope) {
           rows.add(
               String.format(
-                  "('%s', '%s', '%s', current_timestamp(), %f, %f, %f)",
+                  "('%s', '%s', '%s', current_timestamp(), %f, %f, %f, %d, %d, %d, %d)",
                   fqtn,
                   strategy.getPartitionId(),
                   strategy.getPartitionColumns(),
                   strategy.getCost(),
                   strategy.getGain(),
-                  strategy.getEntropy()));
+                  strategy.getEntropy(),
+                  strategy.getPosDeleteFileCount(),
+                  strategy.getEqDeleteFileCount(),
+                  strategy.getPosDeleteFileBytes(),
+                  strategy.getEqDeleteFileBytes()));
         } else {
           rows.add(
               String.format(
-                  "('%s', current_timestamp(), %f, %f, %f)",
-                  fqtn, strategy.getCost(), strategy.getGain(), strategy.getEntropy()));
+                  "('%s', current_timestamp(), %f, %f, %f, %d, %d, %d, %d)",
+                  fqtn,
+                  strategy.getCost(),
+                  strategy.getGain(),
+                  strategy.getEntropy(),
+                  strategy.getPosDeleteFileCount(),
+                  strategy.getEqDeleteFileCount(),
+                  strategy.getPosDeleteFileBytes(),
+                  strategy.getEqDeleteFileBytes()));
         }
       }
       String strategiesInsertStmt =
@@ -113,7 +124,11 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
                   + "timestamp TIMESTAMP, "
                   + "estimated_compute_cost DOUBLE, "
                   + "estimated_file_count_reduction DOUBLE, "
-                  + "file_size_entropy DOUBLE "
+                  + "file_size_entropy DOUBLE, "
+                  + "pos_delete_file_count LONG, "
+                  + "eq_delete_file_count LONG, "
+                  + "pos_delete_file_bytes LONG, "
+                  + "eq_delete_file_bytes LONG"
                   + ") "
                   + "PARTITIONED BY (days(timestamp))",
               outputFqtn));
@@ -125,7 +140,11 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
                   + "timestamp TIMESTAMP, "
                   + "estimated_compute_cost DOUBLE, "
                   + "estimated_file_count_reduction DOUBLE, "
-                  + "file_size_entropy DOUBLE "
+                  + "file_size_entropy DOUBLE, "
+                  + "pos_delete_file_count LONG, "
+                  + "eq_delete_file_count LONG, "
+                  + "pos_delete_file_bytes LONG, "
+                  + "eq_delete_file_bytes LONG "
                   + ") "
                   + "PARTITIONED BY (days(timestamp))",
               outputFqtn));

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/datasource/FileStat.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/datasource/FileStat.java
@@ -16,5 +16,6 @@ public final class FileStat {
   private FileContent content;
   private String path;
   private long sizeInBytes;
+  private long recordCount;
   private List<String> partitionValues;
 }

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/datasource/FileStat.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/datasource/FileStat.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.iceberg.FileContent;
 
 /** Represents the statistics of a file. */
 @Data
@@ -12,7 +13,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public final class FileStat {
+  private FileContent content;
   private String path;
-  private long size;
+  private long sizeInBytes;
   private List<String> partitionValues;
 }

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/datasource/TableFileStats.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/datasource/TableFileStats.java
@@ -27,14 +27,14 @@ public class TableFileStats implements DataSource<FileStat> {
       return spark
           .sql(
               String.format(
-                  "SELECT content, file_path, file_size_in_bytes, partition FROM %s.data_files",
+                  "SELECT content, file_path, file_size_in_bytes, record_count, partition FROM %s.data_files",
                   tableName))
           .map(new FileStatMapper(), Encoders.bean(FileStat.class));
     } catch (IllegalArgumentException e) {
       return spark
           .sql(
               String.format(
-                  "SELECT content, file_path, file_size_in_bytes, null FROM %s.data_files",
+                  "SELECT content, file_path, file_size_in_bytes, record_count, null FROM %s.data_files",
                   tableName))
           .map(new FileStatMapper(), Encoders.bean(FileStat.class));
     }
@@ -44,7 +44,7 @@ public class TableFileStats implements DataSource<FileStat> {
     @Override
     public FileStat call(Row row) {
       List<String> partitionValues = new ArrayList<>();
-      Row partition = row.getStruct(3);
+      Row partition = row.getStruct(4);
       if (partition != null) {
         for (int i = 0; i < partition.size(); i++) {
           partitionValues.add(Objects.toString(partition.get(i)));
@@ -54,6 +54,7 @@ public class TableFileStats implements DataSource<FileStat> {
           .content(fromId(row.getInt(0)))
           .path(row.getString(1))
           .sizeInBytes(row.getLong(2))
+          .recordCount(row.getLong(3))
           .partitionValues(partitionValues)
           .build();
     }

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/strategy/DataLayoutStrategy.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/strategy/DataLayoutStrategy.java
@@ -18,4 +18,8 @@ public class DataLayoutStrategy {
   // TODO: support sorting config
   private final String partitionId;
   private final String partitionColumns;
+  private final long posDeleteFileCount;
+  private final long eqDeleteFileCount;
+  private final long posDeleteFileBytes;
+  private final long eqDeleteFileBytes;
 }

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/strategy/DataLayoutStrategy.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/strategy/DataLayoutStrategy.java
@@ -22,4 +22,6 @@ public class DataLayoutStrategy {
   private final long eqDeleteFileCount;
   private final long posDeleteFileBytes;
   private final long eqDeleteFileBytes;
+  private final long posDeleteRecordCount;
+  private final long eqDeleteRecordCount;
 }

--- a/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/datasource/TableFileStatsTest.java
+++ b/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/datasource/TableFileStatsTest.java
@@ -26,7 +26,7 @@ public class TableFileStatsTest extends OpenHouseSparkITest {
           TableFileStats.builder().spark(spark).tableName(testTable).build();
       Map<String, Long> stats =
           tableFileStats.get().collectAsList().stream()
-              .collect(Collectors.toMap(FileStat::getPath, FileStat::getSize));
+              .collect(Collectors.toMap(FileStat::getPath, FileStat::getSizeInBytes));
       FileSystem fs = FileSystem.get(spark.sparkContext().hadoopConfiguration());
       Path tableDirectory =
           new Path(
@@ -77,7 +77,7 @@ public class TableFileStatsTest extends OpenHouseSparkITest {
         String idPartitionValue = fileStat.getPartitionValues().get(1);
         String folder = "data" + "/ts_day=" + tsPartitionValue + "/id=" + idPartitionValue;
         FileStatus fileStatus = fs.listStatus(new Path(tableDirectory, folder))[0];
-        Assertions.assertEquals(fileStatus.getLen(), fileStat.getSize());
+        Assertions.assertEquals(fileStatus.getLen(), fileStat.getSizeInBytes());
       }
     }
   }

--- a/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/e2e/IntegrationTest.java
+++ b/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/e2e/IntegrationTest.java
@@ -30,8 +30,9 @@ public class IntegrationTest extends OpenHouseSparkITest {
               .tableFileStats(tableFileStats)
               .tablePartitionStats(tablePartitionStats)
               .build();
-      List<DataLayoutStrategy> strategies = strategyGenerator.generateTableLevelStrategies();
-      Assertions.assertEquals(1, strategies.size());
+      List<DataLayoutStrategy> strategies = strategyGenerator.generatePartitionLevelStrategies();
+      Assertions.assertEquals(10, strategies.size());
+
       StrategiesDao dao = StrategiesDaoTableProps.builder().spark(spark).build();
       dao.save(testTable, strategies);
       List<DataLayoutStrategy> retrievedStrategies = dao.load(testTable);

--- a/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGeneratorTest.java
+++ b/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGeneratorTest.java
@@ -50,8 +50,11 @@ public class OpenHouseDataLayoutStrategyGeneratorTest extends OpenHouseSparkITes
       Assertions.assertNull(strategy.getPartitionColumns());
       // few groups, expect 1 commit
       Assertions.assertEquals(1, strategy.getConfig().getPartialProgressMaxCommits());
+      Assertions.assertEquals(
+          0, strategy.getPosDeleteFileCount(), "Table should have 0 position delete files");
+      Assertions.assertEquals(
+          0, strategy.getEqDeleteFileCount(), "Table should have 0 equality delete files");
       Assertions.assertTrue(strategy.getConfig().isPartialProgressEnabled());
-
       Assertions.assertTrue(
           strategy.getGain() == 5, "Gain for 6 files compaction in 2 partitions should be 5");
       Assertions.assertTrue(
@@ -105,6 +108,10 @@ public class OpenHouseDataLayoutStrategyGeneratorTest extends OpenHouseSparkITes
       // few groups, expect 1 commit
       Assertions.assertEquals(1, strategy.getConfig().getPartialProgressMaxCommits());
       Assertions.assertTrue(strategy.getConfig().isPartialProgressEnabled());
+      Assertions.assertEquals(
+          0, strategy.getPosDeleteFileCount(), "Table should have 0 position delete files");
+      Assertions.assertEquals(
+          0, strategy.getEqDeleteFileCount(), "Table should have 0 equality delete files");
       Assertions.assertTrue(
           strategy.getGain() == 2, "Gain for 3 files compaction in 1 partitions should be 2");
       Assertions.assertTrue(

--- a/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGeneratorTest.java
+++ b/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGeneratorTest.java
@@ -112,6 +112,10 @@ public class OpenHouseDataLayoutStrategyGeneratorTest extends OpenHouseSparkITes
           0, strategy.getPosDeleteFileCount(), "Table should have 0 position delete files");
       Assertions.assertEquals(
           0, strategy.getEqDeleteFileCount(), "Table should have 0 equality delete files");
+      Assertions.assertEquals(
+          0, strategy.getPosDeleteRecordCount(), "Table should have 0 position records");
+      Assertions.assertEquals(
+          0, strategy.getEqDeleteRecordCount(), "Table should have 0 equality records");
       Assertions.assertTrue(
           strategy.getGain() == 2, "Gain for 3 files compaction in 1 partitions should be 2");
       Assertions.assertTrue(


### PR DESCRIPTION
## Summary
**problem**: delete files are accumulating across tables due to trino default write behavior for UPDATE/MERGE/DELET statements

**solution**: 
1. (this PR) - record delete file count/size per table and persist to table ✅ 
2. let the DLO strategy execute for many days to accumulate data 🕐 
3. analyze the optimization algorithm and update the model to discover and act on tables who would benefit most from compacting their delete files 🕐 
4. (future PR) - codify the algorithm updates into DLO strategy 🕐 

**outcome**: databases accumulating delete files will be discovered and compacted appropriately to prevent degraded query impact


✨ **bonus content** ✨  :

I noticed there is a gap in DLO testing because manual validation must be done to verify the final form and contents of the DLO table, e.g. https://github.com/linkedin/openhouse/pull/284

so:
1. will a functional test into IntegrationTest by moving the DLO output table logic into StrategiesDAOInternal with save/load methods, and validated DLO finishes and outputs a table with contents and shape as expected 🕐 
2. will add an acceptance test in internal app to validate schema is evolved correctly on the actual tables 🕐 

this will help automate the testing for future changes and prevent bad changes from occuring due to validation being manually done

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [X] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

## Testing Done

- [X] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [x] Some other form of testing like staging or soak time in production. Please explain.

tested in local docker: 
setup commands
```bash
➜ docker compose -f infra/recipes/docker-compose/oh-hadoop-spark/docker-compose.yml up --build
➜ docker exec -it local.spark-master /bin/bash
bin/spark-shell --packages org.apache.iceberg:iceberg-spark-runtime-3.1_2.12:1.2.0 \
  --jars openhouse-spark-runtime_2.12-*-all.jar  \
  --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,com.linkedin.openhouse.spark.extensions.OpenhouseSparkSessionExtensions   \
  --conf spark.sql.catalog.openhouse=org.apache.iceberg.spark.SparkCatalog   \
  --conf spark.sql.catalog.openhouse.catalog-impl=com.linkedin.openhouse.spark.OpenHouseCatalog     \
  --conf spark.sql.catalog.openhouse.metrics-reporter-impl=com.linkedin.openhouse.javaclient.OpenHouseMetricsReporter    \
  --conf spark.sql.catalog.openhouse.uri=http://openhouse-tables:8080   \
  --conf spark.sql.catalog.openhouse.auth-token=$(cat /var/config/$(whoami).token) \
  --conf spark.sql.catalog.openhouse.cluster=LocalHadoopCluster
spark.sql("use openhouse");
spark.sql("drop table if exists u_openhouse.dlo_run_pre")
spark.sql("drop table if exists u_openhouse.dlo_run")

spark.sql("create table u_openhouse.dlo_run (ts timestamp, id int, data string) partitioned by (days(ts), id)").show()
spark.sql("INSERT INTO u_openhouse.dlo_run (ts, id, data) VALUES (current_timestamp(), 1, 'data'), (current_timestamp(), 2, 'data'), (current_timestamp(), 3, 'data'), (current_timestamp(), 1, 'data'), (current_timestamp(), 2, 'data'), (current_timestamp(), 3, 'data');")


spark.sql("select content, file_path, file_size_in_bytes, record_count, partition from u_openhouse.dlo_run.files").show(200, false)

spark.sql("show tables in u_openhouse").show(100, false)
docker compose -f infra/recipes/docker-compose/oh-hadoop-spark/docker-compose.yml --profile with_jobs_scheduler run openhouse-jobs-scheduler - --type DATA_LAYOUT_STRATEGY_GENERATION --cluster local --tablesURL http://openhouse-tables:8080 --jobsURL http://openhouse-jobs:8080 --tableMinAgeThresholdHours 0

spark.sql("show tblproperties u_openhouse.dlo_run ('write.data-layout.strategies')").show(200, false)
spark.sql("select * from u_openhouse.dlo_strategies").show(80,false)
```bash


```bash
scala> spark.sql("show tblproperties u_openhouse.dlo_run ('write.data-layout.strategies')").show(200, false)
+----------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|key                         |value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+----------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|write.data-layout.strategies|[{"score":9.999985377015197,"entropy":2.77080843971934816E17,"cost":0.5000007311503093,"gain":5.0,"config":{"targetByteSize":526385152,"minByteSizeRatio":0.75,"maxByteSizeRatio":10.0,"minInputFiles":5,"maxConcurrentFileGroupRewrites":5,"partialProgressEnabled":true,"partialProgressMaxCommits":1,"maxFileGroupSizeBytes":107374182400,"deleteFileThreshold":2147483647},"posDeleteFileCount":0,"eqDeleteFileCount":0,"posDeleteFileBytes":0,"eqDeleteFileBytes":0,"posDeleteRecordCount":0,"eqDeleteRecordCount":0}]|
+----------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+


scala> spark.sql("select * from u_openhouse.dlo_strategies").show(80,false)
+------------------------------------+-----------------------+----------------------+------------------------------+----------------------+---------------------+--------------------+---------------------+--------------------+-----------------------+----------------------+
|fqtn                                |timestamp              |estimated_compute_cost|estimated_file_count_reduction|file_size_entropy     |pos_delete_file_count|eq_delete_file_count|pos_delete_file_bytes|eq_delete_file_bytes|pos_delete_record_count|eq_delete_record_count|
+------------------------------------+-----------------------+----------------------+------------------------------+----------------------+---------------------+--------------------+---------------------+--------------------+-----------------------+----------------------+
|u_openhouse.dlo_partition_strategies|2025-02-27 08:03:30.822|0.500001              |1.0                           |2.77079875424947968E17|0                    |0                   |0                    |0                   |0                      |0                     |
|u_openhouse.dlo_run                 |2025-02-27 07:11:10.589|0.5                   |3.0                           |2.77080843971934848E17|0                    |0                   |0                    |0                   |0                      |0                     |
|u_openhouse.dlo_run                 |2025-02-27 08:03:03.454|0.500001              |5.0                           |2.77080843971934816E17|0                    |0                   |0                    |0                   |0                      |0                     |
|u_openhouse.dlo_strategies          |2025-02-27 08:03:54.471|0.5                   |0.0                           |2.7708015546118544E17 |0                    |0                   |0                    |0                   |0                      |0                     |
+------------------------------------+-----------------------+----------------------+------------------------------+----------------------+---------------------+--------------------+---------------------+--------------------+-----------------------+----------------------+
```

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.
