### PR TITLE
PR1 (nullability bug): test structure prior to feature change

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,8 +82,17 @@ allprojects {
       testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:" + junit_version
     }
 
-    tasks.withType(Test) {
+    tasks.withType(Test).configureEach {
       useJUnitPlatform()
+
+      testLogging {
+        events "passed" //, "started", "skipped", "failed"
+        // showStandardStreams = true
+      }
+
+      // beforeTest { descriptor ->
+      //     logger.lifecycle("Running test: ${descriptor.className}.${descriptor.name}")
+      // }
     }
 
     spotless {

--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,8 @@ allprojects {
       useJUnitPlatform()
 
       testLogging {
-        events "passed" //, "started", "skipped", "failed"
+        // use these options for analyzing results: --console=plain > output.log 2>&1
+        events "passed", "skipped", "failed" //, "started"
         // showStandardStreams = true
       }
 

--- a/build.gradle
+++ b/build.gradle
@@ -91,9 +91,9 @@ allprojects {
         // showStandardStreams = true
       }
 
-      // beforeTest { descriptor ->
-      //     logger.lifecycle("Running test: ${descriptor.className}.${descriptor.name}")
-      // }
+       beforeTest { descriptor ->
+           logger.lifecycle("Running test: ${descriptor.className}.${descriptor.name}")
+       }
     }
 
     spotless {

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/build.gradle
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/build.gradle
@@ -47,24 +47,29 @@ task statementTest(type: Test) {
   filter {
     includeTestsMatching 'com.linkedin.openhouse.spark.statementtest.*'
   }
-  if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
-    jvmArgs \
-        '--add-opens=java.base/java.nio=ALL-UNNAMED',
-        '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED'
+  jvmArgs \
+      '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED'
+}
+
+task catalogTest(type: Test) {
+  filter {
+    includeTestsMatching 'com.linkedin.openhouse.spark.catalogtest.*'
   }
+  jvmArgs \
+      '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED'
 }
 
 test {
   filter {
     excludeTestsMatching 'com.linkedin.openhouse.spark.statementtest.*'
+    excludeTestsMatching 'com.linkedin.openhouse.spark.catalogtest.*'
   }
-  if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
-    jvmArgs \
-        '--add-opens=java.base/java.nio=ALL-UNNAMED',
-        '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED',
-        '--add-opens=java.base/sun.util.calendar=ALL-UNNAMED',
-        '--add-exports=java.base/sun.util.calendar=ALL-UNNAMED'
-  }
+  jvmArgs \
+      '--add-opens=java.base/java.nio=ALL-UNNAMED',
+      '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED',
+      '--add-opens=java.base/sun.util.calendar=ALL-UNNAMED',
+      '--add-exports=java.base/sun.util.calendar=ALL-UNNAMED'
 }
 
 test.dependsOn statementTest
+statementTest.dependsOn catalogTest

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/build.gradle
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/build.gradle
@@ -47,16 +47,22 @@ task statementTest(type: Test) {
   filter {
     includeTestsMatching 'com.linkedin.openhouse.spark.statementtest.*'
   }
-  jvmArgs \
-      '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED'
+  if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
+    jvmArgs \
+        '--add-opens=java.base/java.nio=ALL-UNNAMED',
+        '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED'
+  }
 }
 
 task catalogTest(type: Test) {
   filter {
     includeTestsMatching 'com.linkedin.openhouse.spark.catalogtest.*'
   }
-  jvmArgs \
-      '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED'
+  if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
+    jvmArgs \
+        '--add-opens=java.base/java.nio=ALL-UNNAMED',
+        '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED'
+  }
 }
 
 test {
@@ -64,11 +70,13 @@ test {
     excludeTestsMatching 'com.linkedin.openhouse.spark.statementtest.*'
     excludeTestsMatching 'com.linkedin.openhouse.spark.catalogtest.*'
   }
-  jvmArgs \
-      '--add-opens=java.base/java.nio=ALL-UNNAMED',
-      '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED',
-      '--add-opens=java.base/sun.util.calendar=ALL-UNNAMED',
-      '--add-exports=java.base/sun.util.calendar=ALL-UNNAMED'
+  if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
+    jvmArgs \
+        '--add-opens=java.base/java.nio=ALL-UNNAMED',
+        '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED',
+        '--add-opens=java.base/sun.util.calendar=ALL-UNNAMED',
+        '--add-exports=java.base/sun.util.calendar=ALL-UNNAMED'
+  }
 }
 
 test.dependsOn statementTest

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/build.gradle
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/build.gradle
@@ -54,21 +54,9 @@ task statementTest(type: Test) {
   }
 }
 
-task catalogTest(type: Test) {
-  filter {
-    includeTestsMatching 'com.linkedin.openhouse.spark.catalogtest.*'
-  }
-  if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
-    jvmArgs \
-        '--add-opens=java.base/java.nio=ALL-UNNAMED',
-        '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED'
-  }
-}
-
 test {
   filter {
     excludeTestsMatching 'com.linkedin.openhouse.spark.statementtest.*'
-    excludeTestsMatching 'com.linkedin.openhouse.spark.catalogtest.*'
   }
   if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
     jvmArgs \
@@ -80,4 +68,3 @@ test {
 }
 
 test.dependsOn statementTest
-statementTest.dependsOn catalogTest

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/CTASNonNullTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/CTASNonNullTest.java
@@ -10,8 +10,7 @@ import org.junit.jupiter.api.Test;
 public class CTASNonNullTest extends OpenHouseSparkITest {
   @Test
   public void testCTASPreservesNonNull() throws Exception {
-    SparkSession.Builder builder = getBuilder();
-    try (SparkSession spark = createSparkSession(builder)) {
+    try (SparkSession spark = getSparkSession()) {
       // Create source table with NOT NULL column
       spark.sql(
           "CREATE TABLE openhouse.ctasNonNull.test_table (id INT NOT NULL, name STRING NOT NULL, value DOUBLE NOT NULL)");

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/CTASNonNullTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/CTASNonNullTest.java
@@ -1,0 +1,41 @@
+package com.linkedin.openhouse.spark.catalogtest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.linkedin.openhouse.tablestest.OpenHouseSparkITest;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+public class CTASNonNullTest extends OpenHouseSparkITest {
+  @Test
+  public void testCTASPreservesNonNull() throws Exception {
+    SparkSession.Builder builder = getBuilder();
+    try (SparkSession spark = createSparkSession(builder)) {
+      // Create source table with NOT NULL column
+      spark.sql(
+          "CREATE TABLE openhouse.ctasNonNull.test_table (id INT NOT NULL, name STRING NOT NULL, value DOUBLE NOT NULL)");
+      // Create target table using CTAS, OpenHouse catalog
+      spark.sql(
+          "CREATE TABLE openhouse.ctasNonNull.test_tableCtas USING iceberg AS SELECT * FROM openhouse.ctasNonNull.test_table");
+
+      // Get schemas for both tables
+      StructType sourceSchema = spark.table("openhouse.ctasNonNull.test_table").schema();
+      StructType targetSchema = spark.table("openhouse.ctasNonNull.test_tableCtas").schema();
+
+      // Verify spark catalogs have correct classes configured
+      assertEquals(
+          "org.apache.iceberg.spark.SparkCatalog", spark.conf().get("spark.sql.catalog.openhouse"));
+
+      // Verify id column is preserved in good catalog, not preserved in bad catalog
+      assertFalse(sourceSchema.apply("id").nullable(), "Source table id column should be required");
+      assertTrue(
+          targetSchema.apply("id").nullable(),
+          "Target table id column required should not be preserved -- due to 1) the CTAS non-nullable preservation is off by default and 2) OS spark3.1 catalyst connector lack of support for non-null CTAS");
+
+      // Clean up
+      spark.sql("DROP TABLE openhouse.ctasNonNull.test_table");
+      spark.sql("DROP TABLE openhouse.ctasNonNull.test_tableCtas");
+    }
+  }
+}

--- a/integrations/spark/spark-3.5/openhouse-spark-itest/build.gradle
+++ b/integrations/spark/spark-3.5/openhouse-spark-itest/build.gradle
@@ -60,9 +60,18 @@ task statementTest(type: Test) {
       '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED'
 }
 
+task catalogTest(type: Test) {
+  filter {
+    includeTestsMatching 'com.linkedin.openhouse.spark.catalogtest.*'
+  }
+  jvmArgs \
+      '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED'
+}
+
 test {
   filter {
     excludeTestsMatching 'com.linkedin.openhouse.spark.statementtest.*'
+    excludeTestsMatching 'com.linkedin.openhouse.spark.catalogtest.*'
   }
   jvmArgs \
       '--add-opens=java.base/java.nio=ALL-UNNAMED',
@@ -72,3 +81,4 @@ test {
 }
 
 test.dependsOn statementTest
+statementTest.dependsOn catalogTest

--- a/integrations/spark/spark-3.5/openhouse-spark-itest/build.gradle
+++ b/integrations/spark/spark-3.5/openhouse-spark-itest/build.gradle
@@ -60,18 +60,9 @@ task statementTest(type: Test) {
       '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED'
 }
 
-task catalogTest(type: Test) {
-  filter {
-    includeTestsMatching 'com.linkedin.openhouse.spark.catalogtest.*'
-  }
-  jvmArgs \
-      '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED'
-}
-
 test {
   filter {
     excludeTestsMatching 'com.linkedin.openhouse.spark.statementtest.*'
-    excludeTestsMatching 'com.linkedin.openhouse.spark.catalogtest.*'
   }
   jvmArgs \
       '--add-opens=java.base/java.nio=ALL-UNNAMED',
@@ -81,4 +72,3 @@ test {
 }
 
 test.dependsOn statementTest
-statementTest.dependsOn catalogTest

--- a/integrations/spark/spark-3.5/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/CTASNonNullTestSpark3_5.java
+++ b/integrations/spark/spark-3.5/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/CTASNonNullTestSpark3_5.java
@@ -1,0 +1,41 @@
+package com.linkedin.openhouse.spark.catalogtest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.linkedin.openhouse.tablestest.OpenHouseSparkITest;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+public class CTASNonNullTestSpark3_5 extends OpenHouseSparkITest {
+  @Test
+  public void testCTASPreservesNonNull() throws Exception {
+    SparkSession.Builder builder = getBuilder();
+    try (SparkSession spark = createSparkSession(builder)) {
+      // Create source table with NOT NULL column
+      spark.sql(
+          "CREATE TABLE openhouse.ctasNonNull.test_table (id INT NOT NULL, name STRING NOT NULL, value DOUBLE NOT NULL)");
+      // Create target table using CTAS, OpenHouse catalog
+      spark.sql(
+          "CREATE TABLE openhouse.ctasNonNull.test_tableCtas USING iceberg AS SELECT * FROM openhouse.ctasNonNull.test_table");
+
+      // Get schemas for both tables
+      StructType sourceSchema = spark.table("openhouse.ctasNonNull.test_table").schema();
+      StructType targetSchema = spark.table("openhouse.ctasNonNull.test_tableCtas").schema();
+
+      // Verify spark catalogs have correct classes configured
+      assertEquals(
+          "org.apache.iceberg.spark.SparkCatalog", spark.conf().get("spark.sql.catalog.openhouse"));
+
+      // Verify id column is preserved in good catalog, not preserved in bad catalog
+      assertFalse(sourceSchema.apply("id").nullable(), "Source table id column should be required");
+      assertTrue(
+          targetSchema.apply("id").nullable(),
+          "Target table id column required should not be preserved -- due to 1) the CTAS non-nullable preservation is off by default and 2) OS spark3.1 catalyst connector lack of support for non-null CTAS");
+
+      // Clean up
+      spark.sql("DROP TABLE openhouse.ctasNonNull.test_table");
+      spark.sql("DROP TABLE openhouse.ctasNonNull.test_tableCtas");
+    }
+  }
+}

--- a/integrations/spark/spark-3.5/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/CTASNonNullTestSpark3_5.java
+++ b/integrations/spark/spark-3.5/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/CTASNonNullTestSpark3_5.java
@@ -10,8 +10,7 @@ import org.junit.jupiter.api.Test;
 public class CTASNonNullTestSpark3_5 extends OpenHouseSparkITest {
   @Test
   public void testCTASPreservesNonNull() throws Exception {
-    SparkSession.Builder builder = getBuilder();
-    try (SparkSession spark = createSparkSession(builder)) {
+    try (SparkSession spark = getSparkSession()) {
       // Create source table with NOT NULL column
       spark.sql(
           "CREATE TABLE openhouse.ctasNonNull.test_table (id INT NOT NULL, name STRING NOT NULL, value DOUBLE NOT NULL)");

--- a/tables-test-fixtures/tables-test-fixtures-iceberg-1.2/src/main/java/com/linkedin/openhouse/tablestest/TestSparkSessionUtil.java
+++ b/tables-test-fixtures/tables-test-fixtures-iceberg-1.2/src/main/java/com/linkedin/openhouse/tablestest/TestSparkSessionUtil.java
@@ -37,7 +37,7 @@ public final class TestSparkSessionUtil {
     builder
         .config(
             String.format("spark.sql.catalog.%s", catalogName),
-            "com.linkedin.openhouse.spark.SparkCatalog")
+            "org.apache.iceberg.spark.SparkCatalog")
         .config(
             String.format("spark.sql.catalog.%s.catalog-impl", catalogName),
             "com.linkedin.openhouse.spark.OpenHouseCatalog")


### PR DESCRIPTION
## Summary
problem: 
1. OpenHouseITest does not expose public methods to configure the spark catalog to non-default settings. in [PR2](https://github.com/linkedin/openhouse/pull/288/files), i must add non-default settings when using OpenHouseITest
2. there isn't a CTAS test already for spark with catalog integration (although there is one for spark and catalog but without being integrated). in [PR2](https://github.com/linkedin/openhouse/pull/288/files), I will update the existing CTAS to isolate and validate a before/after of my change.

solution: we refactor openhouseitest to allow for a builder to be returned and configurable, and then add a new CTAS test for existing behavior

PR2 after PR1 is merged will look like this: https://github.com/cbb330/openhouse/pull/5/files

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [X] Refactoring
- [ ] Documentation
- [X] Tests

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [X] Added new tests for the changes made.
- [X] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

