### PR TITLE
Refactor persistence strategy for dlo generation

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
@@ -60,7 +60,7 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
     List<DataLayoutStrategy> strategies = strategiesGenerator.generateTableLevelStrategies();
     log.info("Generated {} strategies", strategies.size());
     StrategiesDao dao = StrategiesDaoTableProps.builder().spark(spark).build();
-    dao.save(fqtn, strategies, false);
+    dao.save(fqtn, strategies);
     appendToDloStrategiesTable(spark, outputFqtn, strategies, false, isPartitioned);
   }
 
@@ -70,7 +70,7 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
     List<DataLayoutStrategy> strategies = strategiesGenerator.generatePartitionLevelStrategies();
     log.info("Generated {} strategies", strategies.size());
     StrategiesDao dao = StrategiesDaoTableProps.builder().spark(spark).build();
-    dao.save(fqtn, strategies, true);
+    dao.savePartitionScope(fqtn, strategies);
     appendToDloStrategiesTable(spark, partitionLevelOutputFqtn, strategies, true, true);
   }
 
@@ -103,7 +103,7 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
         } else {
           rows.add(
               String.format(
-                  "('%s', '%b', current_timestamp(), %f, %f, %f, %d, %d, %d, %d, %d, %d)",
+                  "('%s', %b, current_timestamp(), %f, %f, %f, %d, %d, %d, %d, %d, %d)",
                   fqtn,
                   isPartitioned,
                   strategy.getCost(),

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
@@ -9,11 +9,11 @@ import com.linkedin.openhouse.datalayout.strategy.DataLayoutStrategy;
 import com.linkedin.openhouse.jobs.spark.state.StateManager;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.spark.sql.SparkSession;
 
 @Slf4j
@@ -43,21 +43,25 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
             .tableFileStats(tableFileStats)
             .tablePartitionStats(tablePartitionStats)
             .build();
-    runInnerTableScope(spark, strategiesGenerator);
-    runInnerPartitionScope(spark, strategiesGenerator);
+    // Run table scope for unpartitioned table, and run both table and partition scope for
+    // partitioned table
+    boolean isPartitioned = ops.getTable(fqtn).spec() != PartitionSpec.unpartitioned();
+    runInnerTableScope(spark, strategiesGenerator, isPartitioned);
+    if (isPartitioned) {
+      runInnerPartitionScope(spark, strategiesGenerator);
+    }
   }
 
   private void runInnerTableScope(
-      SparkSession spark, OpenHouseDataLayoutStrategyGenerator strategiesGenerator) {
-    log.info("Generating strategies for table {}", fqtn);
+      SparkSession spark,
+      OpenHouseDataLayoutStrategyGenerator strategiesGenerator,
+      boolean isPartitioned) {
+    log.info("Generating table-level strategies for table {}", fqtn);
     List<DataLayoutStrategy> strategies = strategiesGenerator.generateTableLevelStrategies();
-    log.info(
-        "Generated {} strategies {}",
-        strategies.size(),
-        strategies.stream().map(Object::toString).collect(Collectors.joining(", ")));
+    log.info("Generated {} strategies", strategies.size());
     StrategiesDao dao = StrategiesDaoTableProps.builder().spark(spark).build();
-    dao.save(fqtn, strategies);
-    appendToDloStrategiesTable(spark, outputFqtn, strategies, false);
+    dao.save(fqtn, strategies, false);
+    appendToDloStrategiesTable(spark, outputFqtn, strategies, false, isPartitioned);
   }
 
   private void runInnerPartitionScope(
@@ -65,14 +69,17 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
     log.info("Generating partition-level strategies for table {}", fqtn);
     List<DataLayoutStrategy> strategies = strategiesGenerator.generatePartitionLevelStrategies();
     log.info("Generated {} strategies", strategies.size());
-    appendToDloStrategiesTable(spark, partitionLevelOutputFqtn, strategies, true);
+    StrategiesDao dao = StrategiesDaoTableProps.builder().spark(spark).build();
+    dao.save(fqtn, strategies, true);
+    appendToDloStrategiesTable(spark, partitionLevelOutputFqtn, strategies, true, true);
   }
 
-  private void appendToDloStrategiesTable(
+  protected void appendToDloStrategiesTable(
       SparkSession spark,
       String outputFqtn,
       List<DataLayoutStrategy> strategies,
-      boolean isPartitionScope) {
+      boolean isPartitionScope,
+      boolean isPartitioned) {
     if (outputFqtn != null && !strategies.isEmpty()) {
       createTableIfNotExists(spark, outputFqtn, isPartitionScope);
       List<String> rows = new ArrayList<>();
@@ -96,8 +103,9 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
         } else {
           rows.add(
               String.format(
-                  "('%s', current_timestamp(), %f, %f, %f, %d, %d, %d, %d, %d, %d)",
+                  "('%s', '%b', current_timestamp(), %f, %f, %f, %d, %d, %d, %d, %d, %d)",
                   fqtn,
+                  isPartitioned,
                   strategy.getCost(),
                   strategy.getGain(),
                   strategy.getEntropy(),
@@ -143,6 +151,7 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
           String.format(
               "CREATE TABLE IF NOT EXISTS %s ("
                   + "fqtn STRING, "
+                  + "isPartitioned BOOLEAN, "
                   + "timestamp TIMESTAMP, "
                   + "estimated_compute_cost DOUBLE, "
                   + "estimated_file_count_reduction DOUBLE, "

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkAppTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkAppTest.java
@@ -1,0 +1,85 @@
+package com.linkedin.openhouse.jobs.spark;
+
+import com.linkedin.openhouse.tablestest.OpenHouseSparkITest;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DataLayoutStrategyGeneratorSparkAppTest extends OpenHouseSparkITest {
+  @Test
+  public void testPartitionedTable() throws Exception {
+    try (SparkSession spark = getSparkSession()) {
+      // create table
+      String fqtn = "u_openhouse.test_table";
+      spark.sql(
+          "create table openhouse.u_openhouse.test_table (id int, name string) partitioned by (id)");
+      spark.sql("insert into openhouse.u_openhouse.test_table values (1, 'a'), (2, 'b')");
+      // run app
+      Operations ops = Operations.withCatalog(spark, null);
+      DataLayoutStrategyGeneratorSparkApp app =
+          new DataLayoutStrategyGeneratorSparkApp(
+              "test-job-id",
+              null,
+              fqtn,
+              "u_openhouse.dlo_strategies",
+              "u_openhouse.dlo_partition_strategies");
+      app.runInner(ops);
+      // test
+      Assertions.assertEquals(1, spark.sql("select * from u_openhouse.dlo_strategies").count());
+      Assertions.assertEquals(
+          2, spark.sql("select * from u_openhouse.dlo_partition_strategies").count());
+      Assertions.assertTrue(
+          spark
+              .sql("select * from u_openhouse.dlo_strategies")
+              .select("isPartitioned")
+              .first()
+              .getBoolean(0));
+      Assertions.assertNotNull(ops.getTable(fqtn).properties().get("write.data-layout.strategies"));
+      Assertions.assertNotNull(
+          ops.getTable(fqtn).properties().get("write.data-layout.partition-strategies"));
+      // drop table
+      spark.sql("drop table openhouse.u_openhouse.test_table");
+      spark.sql("drop table openhouse.u_openhouse.dlo_strategies");
+      spark.sql("drop table openhouse.u_openhouse.dlo_partition_strategies");
+    }
+  }
+
+  @Test
+  public void testUnPartitionedTable() throws Exception {
+    try (SparkSession spark = getSparkSession()) {
+      // create table
+      String fqtn = "u_openhouse.test_table";
+      spark.sql("create table openhouse.u_openhouse.test_table (id int, name string)");
+      spark.sql("insert into openhouse.u_openhouse.test_table values (1, 'a'), (2, 'b')");
+      // run app
+      Operations ops = Operations.withCatalog(spark, null);
+      DataLayoutStrategyGeneratorSparkApp app =
+          new DataLayoutStrategyGeneratorSparkApp(
+              "test-job-id",
+              null,
+              fqtn,
+              "u_openhouse.dlo_strategies",
+              "u_openhouse.dlo_partition_strategies");
+      app.runInner(ops);
+      // test
+      Assertions.assertEquals(1, spark.sql("select * from u_openhouse.dlo_strategies").count());
+      Assertions.assertThrows(
+          NoSuchTableException.class,
+          () -> spark.sql("select * from u_openhouse.dlo_partition_strategies"));
+      Assertions.assertFalse(
+          spark
+              .sql("select * from u_openhouse.dlo_strategies")
+              .select("isPartitioned")
+              .first()
+              .getBoolean(0));
+      Assertions.assertNotNull(ops.getTable(fqtn).properties().get("write.data-layout.strategies"));
+      Assertions.assertNull(
+          ops.getTable(fqtn).properties().get("write.data-layout.partition-strategies"));
+      // drop table
+      spark.sql("drop table openhouse.u_openhouse.test_table");
+      spark.sql("drop table openhouse.u_openhouse.dlo_strategies");
+      spark.sql("drop table openhouse.u_openhouse.dlo_partition_strategies");
+    }
+  }
+}

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/persistence/StrategiesDao.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/persistence/StrategiesDao.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 /** DAO interface for persisting and loading data layout optimization strategies. */
 public interface StrategiesDao {
-  void save(String fqtn, List<DataLayoutStrategy> strategies);
+  void save(String fqtn, List<DataLayoutStrategy> strategies, boolean isPartitionScope);
 
-  List<DataLayoutStrategy> load(String fqtn);
+  List<DataLayoutStrategy> load(String fqtn, boolean isPartitionScope);
 }

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/persistence/StrategiesDao.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/persistence/StrategiesDao.java
@@ -5,7 +5,11 @@ import java.util.List;
 
 /** DAO interface for persisting and loading data layout optimization strategies. */
 public interface StrategiesDao {
-  void save(String fqtn, List<DataLayoutStrategy> strategies, boolean isPartitionScope);
+  void save(String fqtn, List<DataLayoutStrategy> strategies);
 
-  List<DataLayoutStrategy> load(String fqtn, boolean isPartitionScope);
+  void savePartitionScope(String fqtn, List<DataLayoutStrategy> strategies);
+
+  List<DataLayoutStrategy> load(String fqtn);
+
+  List<DataLayoutStrategy> loadPartitionScope(String fqtn);
 }

--- a/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/e2e/IntegrationTest.java
+++ b/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/e2e/IntegrationTest.java
@@ -34,8 +34,8 @@ public class IntegrationTest extends OpenHouseSparkITest {
       Assertions.assertEquals(10, strategies.size());
 
       StrategiesDao dao = StrategiesDaoTableProps.builder().spark(spark).build();
-      dao.save(testTable, strategies, true);
-      List<DataLayoutStrategy> retrievedStrategies = dao.load(testTable, true);
+      dao.save(testTable, strategies);
+      List<DataLayoutStrategy> retrievedStrategies = dao.load(testTable);
       Assertions.assertEquals(strategies, retrievedStrategies);
     }
   }
@@ -58,8 +58,8 @@ public class IntegrationTest extends OpenHouseSparkITest {
       List<DataLayoutStrategy> strategies = strategyGenerator.generateTableLevelStrategies();
       Assertions.assertEquals(1, strategies.size());
       StrategiesDao dao = StrategiesDaoTableProps.builder().spark(spark).build();
-      dao.save(testTable, strategies, false);
-      List<DataLayoutStrategy> retrievedStrategies = dao.load(testTable, false);
+      dao.savePartitionScope(testTable, strategies);
+      List<DataLayoutStrategy> retrievedStrategies = dao.loadPartitionScope(testTable);
       Assertions.assertEquals(strategies, retrievedStrategies);
     }
   }

--- a/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/e2e/IntegrationTest.java
+++ b/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/e2e/IntegrationTest.java
@@ -34,8 +34,8 @@ public class IntegrationTest extends OpenHouseSparkITest {
       Assertions.assertEquals(10, strategies.size());
 
       StrategiesDao dao = StrategiesDaoTableProps.builder().spark(spark).build();
-      dao.save(testTable, strategies);
-      List<DataLayoutStrategy> retrievedStrategies = dao.load(testTable);
+      dao.save(testTable, strategies, true);
+      List<DataLayoutStrategy> retrievedStrategies = dao.load(testTable, true);
       Assertions.assertEquals(strategies, retrievedStrategies);
     }
   }
@@ -58,8 +58,8 @@ public class IntegrationTest extends OpenHouseSparkITest {
       List<DataLayoutStrategy> strategies = strategyGenerator.generateTableLevelStrategies();
       Assertions.assertEquals(1, strategies.size());
       StrategiesDao dao = StrategiesDaoTableProps.builder().spark(spark).build();
-      dao.save(testTable, strategies);
-      List<DataLayoutStrategy> retrievedStrategies = dao.load(testTable);
+      dao.save(testTable, strategies, false);
+      List<DataLayoutStrategy> retrievedStrategies = dao.load(testTable, false);
       Assertions.assertEquals(strategies, retrievedStrategies);
     }
   }

--- a/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/persistence/StrategiesDaoTablePropsTest.java
+++ b/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/persistence/StrategiesDaoTablePropsTest.java
@@ -20,8 +20,8 @@ public class StrategiesDaoTablePropsTest extends OpenHouseSparkITest {
       // validate up-to 100 strategies can be saved and loaded
       List<DataLayoutStrategy> strategyList = Collections.nCopies(100, strategy);
       StrategiesDao dao = StrategiesDaoTableProps.builder().spark(spark).build();
-      dao.save(testTable, strategyList, false);
-      Assertions.assertEquals(strategyList, dao.load(testTable, false));
+      dao.save(testTable, strategyList);
+      Assertions.assertEquals(strategyList, dao.load(testTable));
     }
   }
 

--- a/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/persistence/StrategiesDaoTablePropsTest.java
+++ b/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/persistence/StrategiesDaoTablePropsTest.java
@@ -20,8 +20,8 @@ public class StrategiesDaoTablePropsTest extends OpenHouseSparkITest {
       // validate up-to 100 strategies can be saved and loaded
       List<DataLayoutStrategy> strategyList = Collections.nCopies(100, strategy);
       StrategiesDao dao = StrategiesDaoTableProps.builder().spark(spark).build();
-      dao.save(testTable, strategyList);
-      Assertions.assertEquals(strategyList, dao.load(testTable));
+      dao.save(testTable, strategyList, false);
+      Assertions.assertEquals(strategyList, dao.load(testTable, false));
     }
   }
 


### PR DESCRIPTION
## Summary
Made following changes:
1. Add `isPartitioned` to the `dlo_strategies` table.
2. Save partition level strategies to table properties.
3. Change the modifier of `appendToDloStrategiesTable` so that the persistence strategy can be overridden.
4. Stop generating partition level strategies for non-partitioned tables.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Added E2E test for DLO generation app logic.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
