### PR TITLE
moving DLO strategy output table to a StrategyDAO for better testing

### DIFF
--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/ddl/AlterTableTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/ddl/AlterTableTest.java
@@ -77,4 +77,90 @@ public class AlterTableTest {
             spark.sql(
                 String.format("ALTER TABLE openhouse.dbUnset.tb1 UNSET TBLPROPERTIES('%s')", key)));
   }
+
+  @Test
+  public void testAlterEncryptedProperty() {
+    // Setup: Create an encrypted table
+    String dbName = "dbEncryptAlter";
+    String tableName = "tbEncryptAlter";
+    TableIdentifier tableIdentifier = TableIdentifier.of(dbName, tableName);
+    String fqtn = String.format("openhouse.%s.%s", dbName, tableName);
+
+    // Mock responses for table creation
+    mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // exists check
+    mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // exists check
+    mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // exists check
+
+    GetTableResponseBody createResponseMock =
+        mockGetTableResponseBody(
+            dbName,
+            tableName,
+            "c1",
+            fqtn,
+            "UUID-Encrypt-Alter",
+            mockTableLocationDefaultSchema(tableIdentifier),
+            "v1",
+            baseSchema,
+            null,
+            null);
+    Map<String, String> encryptedProps = new HashMap<>();
+    encryptedProps.put("encrypted", "true");
+    GetTableResponseBody responseWithEncryption =
+        decorateResponse(createResponseMock, encryptedProps);
+    mockTableService.enqueue(mockResponse(201, responseWithEncryption)); // doCommit for CREATE
+
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id int) USING iceberg TBLPROPERTIES ('encrypted' = 'true')", fqtn));
+
+    // --- Test Case 1: Try to set encrypted to false ---
+    mockTableService.enqueue(mockResponse(200, responseWithEncryption)); // doRefresh for ALTER
+    mockTableService.enqueue(mockResponse(200, responseWithEncryption)); // loadTable in strategy
+
+    UnsupportedOperationException thrownException =
+        Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            () ->
+                spark.sql(
+                    String.format("ALTER TABLE %s SET TBLPROPERTIES('encrypted' = 'false')", fqtn)),
+            "Expected ALTER TABLE setting encrypted=false to fail");
+    Assertions.assertTrue(
+        thrownException.getMessage().contains("Cannot modify or unset the 'encrypted' property"));
+
+    // --- Test Case 2: Try to set another property (should succeed) ---
+    mockTableService.enqueue(mockResponse(200, responseWithEncryption)); // doRefresh for ALTER
+    mockTableService.enqueue(mockResponse(200, responseWithEncryption)); // loadTable in strategy
+
+    // Mock the successful commit response with the new property added
+    Map<String, String> propsWithOther = new HashMap<>(encryptedProps);
+    propsWithOther.put("other_prop", "other_value");
+    GetTableResponseBody responseWithOther = decorateResponse(createResponseMock, propsWithOther);
+    mockTableService.enqueue(mockResponse(200, responseWithOther)); // doCommit for ALTER
+
+    Assertions.assertDoesNotThrow(
+        () ->
+            spark.sql(
+                String.format(
+                    "ALTER TABLE %s SET TBLPROPERTIES('other_prop' = 'other_value')", fqtn)),
+        "Expected ALTER TABLE setting other property to succeed");
+
+    // --- Test Case 3: Try to UNSET the encrypted property ---
+    mockTableService.enqueue(
+        mockResponse(
+            200, responseWithOther)); // doRefresh for UNSET (use state after setting other_prop)
+    mockTableService.enqueue(mockResponse(200, responseWithOther)); // loadTable in strategy
+
+    UnsupportedOperationException thrownExceptionUnset =
+        Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            () -> spark.sql(String.format("ALTER TABLE %s UNSET TBLPROPERTIES('encrypted')", fqtn)),
+            "Expected ALTER TABLE unsetting encrypted property to fail");
+    Assertions.assertTrue(
+        thrownExceptionUnset
+            .getMessage()
+            .contains("Cannot modify or unset the 'encrypted' property"));
+
+    // Optional: Verify the final state if necessary by querying table properties or checking mock
+    // service requests
+  }
 }

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/ddl/CreateTableWithPropsTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/ddl/CreateTableWithPropsTest.java
@@ -43,6 +43,42 @@ public class CreateTableWithPropsTest {
     Assertions.assertDoesNotThrow(
         () ->
             spark.sql(
-                "CREATE TABLE openhouse.dbCreate.tbprop (col1 string, col2 string) USING iceberg"));
+                "CREATE TABLE openhouse.dbCreate.tbprop (col1 string, col2 string) USING iceberg TBLPROPERTIES ('k' = 'v')"));
+  }
+
+  @Test
+  public void testCreateTableWithEncryptionPropSuccessful() {
+    mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // doRefresh()
+    mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // doRefresh()
+    mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // doRefresh()
+
+    GetTableResponseBody mockResponse =
+        mockGetTableResponseBody(
+            "dbEncrypt",
+            "tbEncrypt",
+            "c1",
+            "dbEncrypt.tbEncrypt",
+            "UUID-Encrypt",
+            mockTableLocationDefaultSchema(TableIdentifier.of("dbEncrypt", "tbEncrypt")),
+            "v1",
+            baseSchema,
+            null,
+            null);
+
+    // Expect the 'encrypted' property to be passed to the table service
+    Map<String, String> tblProps = new HashMap<>();
+    tblProps.put("encrypted", "true");
+    GetTableResponseBody responseWithEncryption = decorateResponse(mockResponse, tblProps);
+    mockTableService.enqueue(mockResponse(201, responseWithEncryption)); // doCommit()
+
+    Assertions.assertDoesNotThrow(
+        () ->
+            spark.sql(
+                "CREATE TABLE openhouse.dbEncrypt.tbEncrypt (id int) USING iceberg TBLPROPERTIES ('encrypted' = 'true')"));
+
+    // Optional: Add assertions here to verify the mocked table service received the correct
+    // properties
+    // This would require inspecting the RecordedRequest in the mockTableService,
+    // similar to how other tests might verify request bodies.
   }
 }

--- a/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/OpenhouseDataSourceV2Strategy.scala
+++ b/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/OpenhouseDataSourceV2Strategy.scala
@@ -2,9 +2,10 @@ package com.linkedin.openhouse.spark.sql.execution.datasources.v2
 
 import com.linkedin.openhouse.spark.sql.catalyst.plans.logical.{GrantRevokeStatement, SetColumnPolicyTag, SetHistoryPolicy, SetReplicationPolicy, SetRetentionPolicy, SetSharingPolicy, ShowGrantsStatement, UnSetReplicationPolicy}
 import org.apache.iceberg.spark.{Spark3Util, SparkCatalog, SparkSessionCatalog}
+import org.apache.iceberg.spark.source.SparkTable
 import org.apache.spark.sql.{SparkSession, Strategy}
 import org.apache.spark.sql.catalyst.expressions.PredicateHelper
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.{AlterTableSetPropertiesCommand, AlterTableUnsetPropertiesCommand, LogicalPlan}
 import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
 import org.apache.spark.sql.execution.SparkPlan
 
@@ -12,6 +13,8 @@ import scala.collection.JavaConverters._
 
 /* Strategy to convert a logical plan to physical plans */
 case class OpenhouseDataSourceV2Strategy(spark: SparkSession) extends Strategy with PredicateHelper {
+  private val ENCRYPTED_PROP_KEY = "encrypted"
+
   override def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
     case SetRetentionPolicy(CatalogAndIdentifierExtractor(catalog, ident), granularity, count, colName, colPattern) =>
       SetRetentionPolicyExec(catalog, ident, granularity, count, colName, colPattern) :: Nil
@@ -31,6 +34,37 @@ case class OpenhouseDataSourceV2Strategy(spark: SparkSession) extends Strategy w
 
     case r @ ShowGrantsStatement(resourceType, CatalogAndIdentifierExtractor(catalog, ident)) =>
       ShowGrantsStatementExec(r.output, resourceType, catalog, ident) :: Nil
+
+    case AlterTableSetPropertiesCommand(CatalogAndIdentifierExtractor(catalog, ident), props, isView) if !isView =>
+      catalog.loadTable(ident) match {
+        case iceberg: SparkTable =>
+          val currentProps = iceberg.table().properties()
+          val isCurrentlyEncrypted = currentProps.getOrDefault(ENCRYPTED_PROP_KEY, "false").toBoolean
+          if (isCurrentlyEncrypted && props.contains(ENCRYPTED_PROP_KEY)) {
+            if (!props(ENCRYPTED_PROP_KEY).equalsIgnoreCase("true")) {
+              throw new UnsupportedOperationException(s"Cannot modify or unset the '$ENCRYPTED_PROP_KEY' property for table $ident once set to true.")
+            }
+          }
+          Nil
+        case other =>
+          Nil
+      }
+
+    case AlterTableUnsetPropertiesCommand(CatalogAndIdentifierExtractor(catalog, ident), propKeys, ifExists, isView) if !isView =>
+      catalog.loadTable(ident) match {
+        case iceberg: SparkTable =>
+          val currentProps = iceberg.table().properties()
+          val isCurrentlyEncrypted = currentProps.getOrDefault(ENCRYPTED_PROP_KEY, "false").toBoolean
+          val unsettingEncryption = propKeys.exists(_.equalsIgnoreCase(ENCRYPTED_PROP_KEY))
+
+          if (isCurrentlyEncrypted && unsettingEncryption) {
+            throw new UnsupportedOperationException(s"Cannot modify or unset the '$ENCRYPTED_PROP_KEY' property for table $ident once set to true.")
+          } else {
+            Nil
+          }
+        case other =>
+          Nil
+      }
 
     case _ => Nil
   }


### PR DESCRIPTION
## Summary
**problem:**
CREATE TABLE and INSERT INTO for DLO strategy output is currently not tested. this requires more reliance on docker testing. docker testing is manual so prone to forgetting/incorrectly testing. and delete files cannot be easily tested in docker, ref: https://github.com/linkedin/openhouse/pull/287#issuecomment-2688842448

**solution:**
the `IntegrationTest` infra to create data, test tables, execute DLO strategy, and verify output, already exists, but is in a different module/diff paradigm. already there exists an interface for StrategyDAO, so it is sensible to have both tblprop output and DLO strategy output table under the same interface. this enables shared unittests AND enables testing the DLO strategy output table

**note:** in future PR, I will add delete files to the test table so that we aren't testing against the default value of `0` ref: https://github.com/linkedin/openhouse/pull/287#pullrequestreview-2649071288

## Changes

- [ ] Client-facing API Changes
- [X] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [X] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [X] Manually Tested on local docker setup. Please include commands ran, and their output.
- [X] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.


docker results (the reuqirement to do this will be phased out)
```bash
➜ docker compose -f infra/recipes/docker-compose/oh-hadoop-spark/docker-compose.yml up --build
```
```bash
➜ docker exec -it local.spark-master /bin/bash
bin/spark-shell --packages org.apache.iceberg:iceberg-spark-runtime-3.1_2.12:1.2.0 \
  --jars openhouse-spark-runtime_2.12-*-all.jar  \
  --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,com.linkedin.openhouse.spark.extensions.OpenhouseSparkSessionExtensions   \
  --conf spark.sql.catalog.openhouse=org.apache.iceberg.spark.SparkCatalog   \
  --conf spark.sql.catalog.openhouse.catalog-impl=com.linkedin.openhouse.spark.OpenHouseCatalog     \
  --conf spark.sql.catalog.openhouse.metrics-reporter-impl=com.linkedin.openhouse.javaclient.OpenHouseMetricsReporter    \
  --conf spark.sql.catalog.openhouse.uri=http://openhouse-tables:8080   \
  --conf spark.sql.catalog.openhouse.auth-token=$(cat /var/config/$(whoami).token) \
  --conf spark.sql.catalog.openhouse.cluster=LocalHadoopCluster
```

```scala
spark.sql("use openhouse");
spark.sql("drop table if exists u_openhouse.dlo_run_part")
spark.sql("drop table if exists u_openhouse.dlo_run")
spark.sql("create table u_openhouse.dlo_run_part (ts timestamp, id int, data string) partitioned by (days(ts), id)").show()
spark.sql("create table u_openhouse.dlo_run (ts timestamp, id int, data string)").show()
spark.sql("INSERT INTO u_openhouse.dlo_run (ts, id, data) VALUES (current_timestamp(), 1, 'data'), (current_timestamp(), 2, 'data'), (current_timestamp(), 3, 'data'), (current_timestamp(), 1, 'data'), (current_timestamp(), 2, 'data'), (current_timestamp(), 3, 'data');")
spark.sql("INSERT INTO u_openhouse.dlo_run_part (ts, id, data) VALUES (current_timestamp(), 1, 'data'), (current_timestamp(), 2, 'data'), (current_timestamp(), 3, 'data'), (current_timestamp(), 1, 'data'), (current_timestamp(), 2, 'data'), (current_timestamp(), 3, 'data');")
spark.sql("select content, file_path, file_size_in_bytes, record_count from u_openhouse.dlo_run.files").show(200, false)
spark.sql("select content, file_path, file_size_in_bytes, record_count, partition from u_openhouse.dlo_run_part.files").show(200, false)
spark.sql("show tables in u_openhouse").show(100, false)
```
```bash
docker compose -f infra/recipes/docker-compose/oh-hadoop-spark/docker-compose.yml --profile with_jobs_scheduler run openhouse-jobs-scheduler - --type DATA_LAYOUT_STRATEGY_GENERATION --cluster local --tablesURL http://openhouse-tables:8080 --jobsURL http://openhouse-jobs:8080 --tableMinAgeThresholdHours 0
```

```scala
spark.sql("show tblproperties u_openhouse.dlo_run_part ('write.data-layout.strategies')").show(200, false)
spark.sql("show tblproperties u_openhouse.dlo_run ('write.data-layout.strategies')").show(200, false)
spark.sql("select * from u_openhouse.dlo_strategies").show(80,false)
```

```bash
+----------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|key                         |value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+----------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|write.data-layout.strategies|[{"score":9.999985377015197,"entropy":2.77080843971934816E17,"cost":0.5000007311503093,"gain":5.0,"config":{"targetByteSize":526385152,"minByteSizeRatio":0.75,"maxByteSizeRatio":10.0,"minInputFiles":5,"maxConcurrentFileGroupRewrites":5,"partialProgressEnabled":true,"partialProgressMaxCommits":1,"maxFileGroupSizeBytes":107374182400,"deleteFileThreshold":2147483647},"posDeleteFileCount":0,"eqDeleteFileCount":0,"posDeleteFileBytes":0,"eqDeleteFileBytes":0,"posDeleteRecordCount":0,"eqDeleteRecordCount":0}]|
+----------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+


+----------------------------+----------------------------------------------------------------------------------------+
|key                         |value                                                                                   |
+----------------------------+----------------------------------------------------------------------------------------+
|write.data-layout.strategies|Table openhouse.u_openhouse.dlo_run does not have property: write.data-layout.strategies|
+----------------------------+----------------------------------------------------------------------------------------+


scala> spark.sql("select * from u_openhouse.dlo_strategies").show(80,false)
+------------------------------------+-----------------------+----------------------+------------------------------+----------------------+---------------------+--------------------+---------------------+--------------------+-----------------------+----------------------+
|fqtn                                |timestamp              |estimated_compute_cost|estimated_file_count_reduction|file_size_entropy     |pos_delete_file_count|eq_delete_file_count|pos_delete_file_bytes|eq_delete_file_bytes|pos_delete_record_count|eq_delete_record_count|
+------------------------------------+-----------------------+----------------------+------------------------------+----------------------+---------------------+--------------------+---------------------+--------------------+-----------------------+----------------------+
|u_openhouse.dlo_strategies          |2025-02-27 08:03:54.471|0.5                   |0.0                           |2.7708015546118544E17 |0                    |0                   |0                    |0                   |0                      |0                     |
|u_openhouse.dlo_run_part            |2025-03-07 20:38:47.403|0.500001              |5.0                           |2.77080843971934816E17|0                    |0                   |0                    |0                   |0                      |0                     |
|u_openhouse.dlo_run                 |2025-03-07 20:30:13.376|0.500001              |5.0                           |2.77080843971934816E17|0                    |0                   |0                    |0                   |0                      |0                     |
|u_openhouse.dlo_strategies          |2025-03-07 20:11:26.879|0.500001              |3.0                           |2.77080117298345248E17|0                    |0                   |0                    |0                   |0                      |0                     |
|u_openhouse.dlo_partition_strategies|2025-03-07 20:37:40.361|0.500004              |11.0                          |2.77079862528548448E17|0                    |0                   |0                    |0                   |0                      |0                     |
|u_openhouse.dlo_run                 |2025-02-27 07:11:10.589|0.5                   |3.0                           |2.77080843971934848E17|0                    |0                   |0                    |0                   |0                      |0                     |
|u_openhouse.trino_mor_test_table    |2025-03-07 20:29:48.501|0.500001              |5.0                           |2.77080860114398976E17|0                    |0                   |0                    |0                   |0                      |0                     |
|u_openhouse.dlo_strategies          |2025-03-07 20:38:16.158|0.500003              |8.0                           |2.77080110543083456E17|0                    |0                   |0                    |0                   |0                      |0                     |
|u_openhouse.dlo_strategies          |2025-03-07 20:29:12.733|0.500002              |4.0                           |2.77080115034893824E17|0                    |0                   |0                    |0                   |0                      |0                     |
|u_openhouse.dlo_partition_strategies|2025-02-27 08:03:30.822|0.500001              |1.0                           |2.77079875424947968E17|0                    |0                   |0                    |0                   |0                      |0                     |
|u_openhouse.dlo_run_part            |2025-03-07 20:28:31.053|0.500001              |5.0                           |2.77080843971934816E17|0                    |0                   |0                    |0                   |0                      |0                     |
|u_openhouse.dlo_run                 |2025-02-27 08:03:03.454|0.500001              |5.0                           |2.77080843971934816E17|0                    |0                   |0                    |0                   |0                      |0                     |
+------------------------------------+-----------------------+----------------------+------------------------------+----------------------+---------------------+--------------------+---------------------+--------------------+-----------------------+----------------------+
```


# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.
