### PR TITLE
Extend autocomp to unpartitioned tables

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -550,7 +550,7 @@ Build images with jobs scheduler, and run the scheduler separately after all oth
 docker compose --profile with_jobs_scheduler build
 docker compose --profile with_jobs_scheduler run openhouse-jobs-scheduler - \
     --type RETENTION --cluster local --tablesURL http://openhouse-tables:8080 --jobsURL http://openhouse-jobs:8080 -\
-    --tableMinAgeThresholdHours 0
+    --tableMinAgeThresholdHours 0 --taskPollIntervalMs 5000
 ```
 
 > [!NOTE]

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
@@ -81,6 +81,9 @@ public class OperationTasksBuilder {
     List<DataLayoutStrategy> strategies =
         tableDataLayoutMetadataList.stream()
             .map(TableDataLayoutMetadata::getDataLayoutStrategy)
+            // filter out strategies with no gain/file count reduction
+            // or discounted to 0, e.g. frequently overwritten un-partitioned tables
+            .filter(s -> s.getGain() * (1.0 - s.getFileCountReductionDiscount()) >= 1.0)
             .collect(Collectors.toList());
     DataLayoutStrategyScorer scorer =
         new SimpleWeightedSumDataLayoutStrategyScorer(

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
@@ -83,7 +83,7 @@ public class OperationTasksBuilder {
             .map(TableDataLayoutMetadata::getDataLayoutStrategy)
             // filter out strategies with no gain/file count reduction
             // or discounted to 0, e.g. frequently overwritten un-partitioned tables
-            .filter(s -> s.getGain() * (1.0 - s.getFileCountReductionDiscount()) >= 1.0)
+            .filter(s -> s.getGain() * (1.0 - s.getFileCountReductionPenalty()) >= 1.0)
             .collect(Collectors.toList());
     DataLayoutStrategyScorer scorer =
         new SimpleWeightedSumDataLayoutStrategyScorer(

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
@@ -75,7 +75,7 @@ public class OperationTasksBuilder {
     // filter out non-primary and non-clustered/time-partitioned tables before ranking
     tableDataLayoutMetadataList =
         tableDataLayoutMetadataList.stream()
-            .filter(m -> m.isPrimary() && (m.isClustered() || m.isTimePartitioned()))
+            .filter(TableMetadata::isPrimary)
             .collect(Collectors.toList());
     log.info("Fetched metadata for {} data layout strategies", tableDataLayoutMetadataList.size());
     List<DataLayoutStrategy> strategies =

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableDataLayoutStrategyExecutionTask.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableDataLayoutStrategyExecutionTask.java
@@ -62,6 +62,6 @@ public class TableDataLayoutStrategyExecutionTask
 
   @Override
   protected boolean shouldRun() {
-    return metadata.isPrimary() && (metadata.isTimePartitioned() || metadata.isClustered());
+    return metadata.isPrimary();
   }
 }

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
@@ -91,7 +91,7 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
         if (isPartitionScope) {
           rows.add(
               String.format(
-                  "('%s', '%s', '%s', current_timestamp(), %f, %f, %f, %d, %d, %d, %d, %d, %d)",
+                  "('%s', '%s', '%s', current_timestamp(), %f, %f, %f, %d, %d, %d, %d, %d, %d, %f)",
                   fqtn,
                   strategy.getPartitionId(),
                   strategy.getPartitionColumns(),
@@ -103,11 +103,12 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
                   strategy.getPosDeleteFileBytes(),
                   strategy.getEqDeleteFileBytes(),
                   strategy.getPosDeleteRecordCount(),
-                  strategy.getEqDeleteRecordCount()));
+                  strategy.getEqDeleteRecordCount(),
+                  strategy.getFileCountReductionPenalty()));
         } else {
           rows.add(
               String.format(
-                  "('%s', current_timestamp(), %f, %f, %f, %d, %d, %d, %d, %d, %d, %b)",
+                  "('%s', current_timestamp(), %f, %f, %f, %d, %d, %d, %d, %d, %d, %b, %f)",
                   fqtn,
                   strategy.getCost(),
                   strategy.getGain(),
@@ -118,7 +119,8 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
                   strategy.getEqDeleteFileBytes(),
                   strategy.getPosDeleteRecordCount(),
                   strategy.getEqDeleteRecordCount(),
-                  isPartitioned));
+                  isPartitioned,
+                  strategy.getFileCountReductionPenalty()));
         }
       }
       String strategiesInsertStmt =
@@ -146,7 +148,8 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
                   + "pos_delete_file_bytes LONG, "
                   + "eq_delete_file_bytes LONG,"
                   + "pos_delete_record_count LONG, "
-                  + "eq_delete_record_count LONG"
+                  + "eq_delete_record_count LONG, "
+                  + "file_count_reduction_penalty DOUBLE"
                   + ") "
                   + "PARTITIONED BY (days(timestamp))",
               outputFqtn));
@@ -165,7 +168,8 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
                   + "eq_delete_file_bytes LONG,"
                   + "pos_delete_record_count LONG, "
                   + "eq_delete_record_count LONG, "
-                  + "isPartitioned BOOLEAN"
+                  + "isPartitioned BOOLEAN, "
+                  + "file_count_reduction_penalty DOUBLE"
                   + ") "
                   + "PARTITIONED BY (days(timestamp))",
               outputFqtn));

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
@@ -2,6 +2,7 @@ package com.linkedin.openhouse.jobs.spark;
 
 import com.linkedin.openhouse.datalayout.datasource.TableFileStats;
 import com.linkedin.openhouse.datalayout.datasource.TablePartitionStats;
+import com.linkedin.openhouse.datalayout.datasource.TableSnapshotStats;
 import com.linkedin.openhouse.datalayout.generator.OpenHouseDataLayoutStrategyGenerator;
 import com.linkedin.openhouse.datalayout.persistence.StrategiesDao;
 import com.linkedin.openhouse.datalayout.persistence.StrategiesDaoTableProps;
@@ -37,10 +38,13 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
     TableFileStats tableFileStats = TableFileStats.builder().tableName(fqtn).spark(spark).build();
     TablePartitionStats tablePartitionStats =
         TablePartitionStats.builder().tableName(fqtn).spark(spark).build();
+    TableSnapshotStats tableSnapshotStats =
+        TableSnapshotStats.builder().tableName(fqtn).spark(spark).build();
     OpenHouseDataLayoutStrategyGenerator strategiesGenerator =
         OpenHouseDataLayoutStrategyGenerator.builder()
             .tableFileStats(tableFileStats)
             .tablePartitionStats(tablePartitionStats)
+            .tableSnapshotStats(tableSnapshotStats)
             .build();
     // Run table scope for unpartitioned table, and run both table and partition scope for
     // partitioned table

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
@@ -40,15 +40,16 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
         TablePartitionStats.builder().tableName(fqtn).spark(spark).build();
     TableSnapshotStats tableSnapshotStats =
         TableSnapshotStats.builder().tableName(fqtn).spark(spark).build();
+    boolean isPartitioned = ops.getTable(fqtn).spec().isPartitioned();
     OpenHouseDataLayoutStrategyGenerator strategiesGenerator =
         OpenHouseDataLayoutStrategyGenerator.builder()
             .tableFileStats(tableFileStats)
             .tablePartitionStats(tablePartitionStats)
             .tableSnapshotStats(tableSnapshotStats)
+            .partitioned(isPartitioned)
             .build();
     // Run table scope for unpartitioned table, and run both table and partition scope for
     // partitioned table
-    boolean isPartitioned = ops.getTable(fqtn).spec().isPartitioned();
     runInnerTableScope(spark, strategiesGenerator, isPartitioned);
     if (isPartitioned) {
       runInnerPartitionScope(spark, strategiesGenerator);

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/datasource/SnapshotStat.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/datasource/SnapshotStat.java
@@ -1,0 +1,16 @@
+package com.linkedin.openhouse.datalayout.datasource;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SnapshotStat {
+  long committedAt;
+  long snapshotId;
+  String operation;
+}

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/datasource/TableSnapshotStats.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/datasource/TableSnapshotStats.java
@@ -1,0 +1,34 @@
+package com.linkedin.openhouse.datalayout.datasource;
+
+import lombok.Builder;
+import org.apache.spark.api.java.function.MapFunction;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+@Builder
+public class TableSnapshotStats implements DataSource<SnapshotStat> {
+  private final SparkSession spark;
+  private final String tableName;
+
+  @Override
+  public Dataset<SnapshotStat> get() {
+    return spark
+        .sql(
+            String.format(
+                "SELECT committed_at, snapshot_id, operation FROM %s.snapshots", tableName))
+        .map(new TableSnapshotStats.SnapshotStatMapper(), Encoders.bean(SnapshotStat.class));
+  }
+
+  static class SnapshotStatMapper implements MapFunction<Row, SnapshotStat> {
+    @Override
+    public SnapshotStat call(Row row) {
+      return SnapshotStat.builder()
+          .committedAt(row.getTimestamp(0).getTime())
+          .snapshotId(row.getLong(1))
+          .operation(row.getString(2))
+          .build();
+    }
+  }
+}

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGenerator.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGenerator.java
@@ -45,6 +45,7 @@ public class OpenHouseDataLayoutStrategyGenerator implements DataLayoutStrategyG
   private final TableFileStats tableFileStats;
   private final TablePartitionStats tablePartitionStats;
   private final TableSnapshotStats tableSnapshotStats;
+  private final boolean partitioned;
 
   /**
    * Generate a list of data layout optimization strategies based on the table file stats and
@@ -148,7 +149,7 @@ public class OpenHouseDataLayoutStrategyGenerator implements DataLayoutStrategyG
 
     // don't discount for partitioned tables
     double fileCountReductionDiscount = 0.0;
-    if (partitionValues == null) {
+    if (!partitioned) {
       fileCountReductionDiscount =
           computeFileCountReductionDiscount(tableSnapshotStats.get(), LAST_SNAPSHOT_LOOKBACK_DAYS);
     }

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGenerator.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGenerator.java
@@ -148,10 +148,10 @@ public class OpenHouseDataLayoutStrategyGenerator implements DataLayoutStrategyG
     double reducedFileCountPerComputeGbHr = reducedFileCount / computeGbHr;
 
     // don't discount for partitioned tables
-    double fileCountReductionDiscount = 0.0;
+    double fileCountReductionPenalty = 0.0;
     if (!partitioned) {
-      fileCountReductionDiscount =
-          computeFileCountReductionDiscount(tableSnapshotStats.get(), LAST_SNAPSHOT_LOOKBACK_DAYS);
+      fileCountReductionPenalty =
+          computeFileCountReductionPenalty(tableSnapshotStats.get(), LAST_SNAPSHOT_LOOKBACK_DAYS);
     }
 
     DataCompactionConfig config = buildDataCompactionConfig(rewriteFileBytes, partitionCount);
@@ -173,7 +173,7 @@ public class OpenHouseDataLayoutStrategyGenerator implements DataLayoutStrategyG
             .eqDeleteFileCount(eqDeleteStats._2())
             .posDeleteRecordCount(posDeleteStats._3())
             .eqDeleteRecordCount(eqDeleteStats._3())
-            .fileCountReductionDiscount(fileCountReductionDiscount)
+            .fileCountReductionPenalty(fileCountReductionPenalty)
             .build());
   }
 
@@ -208,7 +208,7 @@ public class OpenHouseDataLayoutStrategyGenerator implements DataLayoutStrategyG
         .build();
   }
 
-  private double computeFileCountReductionDiscount(
+  private double computeFileCountReductionPenalty(
       Dataset<SnapshotStat> snapshotStats, int lookbackDays) {
     long snapshotCount =
         snapshotStats

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/ranker/SimpleWeightedSumDataLayoutStrategyScorer.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/ranker/SimpleWeightedSumDataLayoutStrategyScorer.java
@@ -81,7 +81,6 @@ public class SimpleWeightedSumDataLayoutStrategyScorer implements DataLayoutStra
   }
 
   private double discountedGain(DataLayoutStrategy dataLayoutStrategy) {
-    return dataLayoutStrategy.getGain()
-        * (1.0 - dataLayoutStrategy.getFileCountReductionDiscount());
+    return dataLayoutStrategy.getGain() * (1.0 - dataLayoutStrategy.getFileCountReductionPenalty());
   }
 }

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/ranker/SimpleWeightedSumDataLayoutStrategyScorer.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/ranker/SimpleWeightedSumDataLayoutStrategyScorer.java
@@ -40,16 +40,10 @@ public class SimpleWeightedSumDataLayoutStrategyScorer implements DataLayoutStra
 
     for (DataLayoutStrategy dataLayoutStrategy : dataLayoutStrategies) {
       double normalizedCost = minMaxNormalize(dataLayoutStrategy.getCost(), minCost, maxCost);
-      double normalizedGain = minMaxNormalize(dataLayoutStrategy.getGain(), minGain, maxGain);
+      double normalizedGain = minMaxNormalize(discountedGain(dataLayoutStrategy), minGain, maxGain);
       ScoredDataLayoutStrategy normalizedDataLayoutStrategy =
           ScoredDataLayoutStrategy.builder()
-              .dataLayoutStrategy(
-                  DataLayoutStrategy.builder()
-                      .config(dataLayoutStrategy.getConfig())
-                      .entropy(dataLayoutStrategy.getEntropy())
-                      .cost(dataLayoutStrategy.getCost())
-                      .gain(dataLayoutStrategy.getGain())
-                      .build())
+              .dataLayoutStrategy(dataLayoutStrategy)
               .normalizedComputeCost(normalizedCost)
               .normalizedFileCountReduction(normalizedGain)
               .score(
@@ -78,10 +72,15 @@ public class SimpleWeightedSumDataLayoutStrategyScorer implements DataLayoutStra
   }
 
   private double minGain(List<DataLayoutStrategy> dataLayoutStrategies) {
-    return dataLayoutStrategies.stream().mapToDouble(DataLayoutStrategy::getGain).min().orElse(0);
+    return dataLayoutStrategies.stream().mapToDouble(this::discountedGain).min().orElse(0);
   }
 
   private double maxGain(List<DataLayoutStrategy> dataLayoutStrategies) {
-    return dataLayoutStrategies.stream().mapToDouble(DataLayoutStrategy::getGain).max().orElse(0);
+    return dataLayoutStrategies.stream().mapToDouble(this::discountedGain).max().orElse(0);
+  }
+
+  private double discountedGain(DataLayoutStrategy dataLayoutStrategy) {
+    return dataLayoutStrategy.getGain()
+        * (1.0 - dataLayoutStrategy.getFileCountReductionDiscount());
   }
 }

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/ranker/SimpleWeightedSumDataLayoutStrategyScorer.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/ranker/SimpleWeightedSumDataLayoutStrategyScorer.java
@@ -40,7 +40,8 @@ public class SimpleWeightedSumDataLayoutStrategyScorer implements DataLayoutStra
 
     for (DataLayoutStrategy dataLayoutStrategy : dataLayoutStrategies) {
       double normalizedCost = minMaxNormalize(dataLayoutStrategy.getCost(), minCost, maxCost);
-      double normalizedGain = minMaxNormalize(discountedGain(dataLayoutStrategy), minGain, maxGain);
+      double discountedGain = discountedGain(dataLayoutStrategy);
+      double normalizedGain = minMaxNormalize(discountedGain, minGain, maxGain);
       ScoredDataLayoutStrategy normalizedDataLayoutStrategy =
           ScoredDataLayoutStrategy.builder()
               .dataLayoutStrategy(dataLayoutStrategy)

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/strategy/DataLayoutStrategy.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/strategy/DataLayoutStrategy.java
@@ -24,5 +24,5 @@ public class DataLayoutStrategy {
   private final long eqDeleteFileBytes;
   private final long posDeleteRecordCount;
   private final long eqDeleteRecordCount;
-  private final double fileCountReductionDiscount;
+  private final double fileCountReductionPenalty;
 }

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/strategy/DataLayoutStrategy.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/strategy/DataLayoutStrategy.java
@@ -24,4 +24,5 @@ public class DataLayoutStrategy {
   private final long eqDeleteFileBytes;
   private final long posDeleteRecordCount;
   private final long eqDeleteRecordCount;
+  private final double fileCountReductionDiscount;
 }

--- a/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/datasource/TableSnapshotStatsTest.java
+++ b/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/datasource/TableSnapshotStatsTest.java
@@ -1,0 +1,32 @@
+package com.linkedin.openhouse.datalayout.datasource;
+
+import com.linkedin.openhouse.tablestest.OpenHouseSparkITest;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TableSnapshotStatsTest extends OpenHouseSparkITest {
+  @Test
+  public void testTableSnapshotStats() throws Exception {
+    final String testTable = "db.test_table_snapshot_stats";
+    try (SparkSession spark = getSparkSession()) {
+      spark.sql("USE openhouse");
+      spark.sql(String.format("CREATE TABLE %s (id INT, data STRING)", testTable));
+      spark.sql(String.format("INSERT INTO %s VALUES (0, '0')", testTable));
+      spark.sql(String.format("INSERT INTO %s VALUES (1, '1')", testTable));
+      TableSnapshotStats tableSnapshotStats =
+          TableSnapshotStats.builder().spark(spark).tableName(testTable).build();
+      List<SnapshotStat> stats = tableSnapshotStats.get().collectAsList();
+      Assertions.assertEquals(2, stats.size());
+      for (SnapshotStat stat : stats) {
+        Assertions.assertEquals("append", stat.operation);
+        // verify that parsed committed timestamp is within 10 seconds of current time
+        Assertions.assertTrue(
+            System.currentTimeMillis() - TimeUnit.SECONDS.toMillis(10) <= stat.committedAt
+                && stat.committedAt <= System.currentTimeMillis());
+      }
+    }
+  }
+}

--- a/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/e2e/IntegrationTest.java
+++ b/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/e2e/IntegrationTest.java
@@ -2,6 +2,7 @@ package com.linkedin.openhouse.datalayout.e2e;
 
 import com.linkedin.openhouse.datalayout.datasource.TableFileStats;
 import com.linkedin.openhouse.datalayout.datasource.TablePartitionStats;
+import com.linkedin.openhouse.datalayout.datasource.TableSnapshotStats;
 import com.linkedin.openhouse.datalayout.generator.OpenHouseDataLayoutStrategyGenerator;
 import com.linkedin.openhouse.datalayout.persistence.StrategiesDao;
 import com.linkedin.openhouse.datalayout.persistence.StrategiesDaoTableProps;
@@ -25,10 +26,13 @@ public class IntegrationTest extends OpenHouseSparkITest {
           TableFileStats.builder().tableName(testTable).spark(spark).build();
       TablePartitionStats tablePartitionStats =
           TablePartitionStats.builder().tableName(testTable).spark(spark).build();
+      TableSnapshotStats tableSnapshotStats =
+          TableSnapshotStats.builder().tableName(testTable).spark(spark).build();
       OpenHouseDataLayoutStrategyGenerator strategyGenerator =
           OpenHouseDataLayoutStrategyGenerator.builder()
               .tableFileStats(tableFileStats)
               .tablePartitionStats(tablePartitionStats)
+              .tableSnapshotStats(tableSnapshotStats)
               .build();
       List<DataLayoutStrategy> strategies = strategyGenerator.generatePartitionLevelStrategies();
       Assertions.assertEquals(10, strategies.size());
@@ -50,10 +54,13 @@ public class IntegrationTest extends OpenHouseSparkITest {
           TableFileStats.builder().tableName(testTable).spark(spark).build();
       TablePartitionStats tablePartitionStats =
           TablePartitionStats.builder().tableName(testTable).spark(spark).build();
+      TableSnapshotStats tableSnapshotStats =
+          TableSnapshotStats.builder().tableName(testTable).spark(spark).build();
       OpenHouseDataLayoutStrategyGenerator strategyGenerator =
           OpenHouseDataLayoutStrategyGenerator.builder()
               .tableFileStats(tableFileStats)
               .tablePartitionStats(tablePartitionStats)
+              .tableSnapshotStats(tableSnapshotStats)
               .build();
       List<DataLayoutStrategy> strategies = strategyGenerator.generateTableLevelStrategies();
       Assertions.assertEquals(1, strategies.size());

--- a/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGeneratorTest.java
+++ b/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGeneratorTest.java
@@ -12,8 +12,8 @@ import org.junit.jupiter.api.Test;
 
 public class OpenHouseDataLayoutStrategyGeneratorTest extends OpenHouseSparkITest {
   @Test
-  void testTableLevelStrategySanityCheck() throws Exception {
-    final String testTable = "db.test_table_sanity_check";
+  void testTableLevelStrategyPartitioned() throws Exception {
+    final String testTable = "db.test_table_sanity_check_partitioned";
     try (SparkSession spark = getSparkSession()) {
       spark.sql("USE openhouse");
       spark.sql(
@@ -46,12 +46,14 @@ public class OpenHouseDataLayoutStrategyGeneratorTest extends OpenHouseSparkITes
               .tableFileStats(tableFileStats)
               .tablePartitionStats(tablePartitionStats)
               .tableSnapshotStats(tableSnapshotStats)
+              .partitioned(true)
               .build();
       List<DataLayoutStrategy> strategies = strategyGenerator.generateTableLevelStrategies();
       Assertions.assertEquals(1, strategies.size());
       DataLayoutStrategy strategy = strategies.get(0);
       Assertions.assertNull(strategy.getPartitionId());
       Assertions.assertNull(strategy.getPartitionColumns());
+      Assertions.assertEquals(0.0, strategy.getFileCountReductionPenalty());
       // few groups, expect 1 commit
       Assertions.assertEquals(1, strategy.getConfig().getPartialProgressMaxCommits());
       Assertions.assertEquals(
@@ -59,8 +61,8 @@ public class OpenHouseDataLayoutStrategyGeneratorTest extends OpenHouseSparkITes
       Assertions.assertEquals(
           0, strategy.getEqDeleteFileCount(), "Table should have 0 equality delete files");
       Assertions.assertTrue(strategy.getConfig().isPartialProgressEnabled());
-      Assertions.assertTrue(
-          strategy.getGain() == 5, "Gain for 6 files compaction in 2 partitions should be 5");
+      Assertions.assertEquals(
+          5, strategy.getGain(), "Gain for 6 files compaction in 2 partitions should be 5");
       Assertions.assertTrue(
           strategy.getCost() < 1.0, "Cost for 6 files compaction should be negligible");
       Assertions.assertTrue(
@@ -69,7 +71,53 @@ public class OpenHouseDataLayoutStrategyGeneratorTest extends OpenHouseSparkITes
   }
 
   @Test
-  void testPartitionLevelStrategySanityCheck() throws Exception {
+  void testTableLevelStrategy() throws Exception {
+    final String testTable = "db.test_table_sanity_check";
+    try (SparkSession spark = getSparkSession()) {
+      spark.sql("USE openhouse");
+      spark.sql(String.format("create table %s (id int, data string, ts timestamp)", testTable));
+
+      for (int i = 0; i < 3; ++i) {
+        spark.sql(
+            String.format("insert into %s values (0, 'data', current_timestamp())", testTable));
+      }
+
+      TableFileStats tableFileStats =
+          TableFileStats.builder().tableName(testTable).spark(spark).build();
+      TablePartitionStats tablePartitionStats =
+          TablePartitionStats.builder().tableName(testTable).spark(spark).build();
+      TableSnapshotStats tableSnapshotStats =
+          TableSnapshotStats.builder().tableName(testTable).spark(spark).build();
+      OpenHouseDataLayoutStrategyGenerator strategyGenerator =
+          OpenHouseDataLayoutStrategyGenerator.builder()
+              .tableFileStats(tableFileStats)
+              .tablePartitionStats(tablePartitionStats)
+              .tableSnapshotStats(tableSnapshotStats)
+              .build();
+      List<DataLayoutStrategy> strategies = strategyGenerator.generateTableLevelStrategies();
+      Assertions.assertEquals(1, strategies.size());
+      DataLayoutStrategy strategy = strategies.get(0);
+      Assertions.assertNull(strategy.getPartitionId());
+      Assertions.assertNull(strategy.getPartitionColumns());
+      // the un-partitioned table is penalized 100% due to recent updates
+      Assertions.assertEquals(1.0, strategy.getFileCountReductionPenalty());
+      // few groups, expect 1 commit
+      Assertions.assertEquals(1, strategy.getConfig().getPartialProgressMaxCommits());
+      Assertions.assertEquals(
+          0, strategy.getPosDeleteFileCount(), "Table should have 0 position delete files");
+      Assertions.assertEquals(
+          0, strategy.getEqDeleteFileCount(), "Table should have 0 equality delete files");
+      Assertions.assertTrue(strategy.getConfig().isPartialProgressEnabled());
+      Assertions.assertEquals(2, strategy.getGain(), "Gain for 3 files compaction should be 2");
+      Assertions.assertTrue(
+          strategy.getCost() < 1.0, "Cost for 6 files compaction should be negligible");
+      Assertions.assertTrue(
+          strategy.getScore() < 10.0, "Score for 6 files compaction should be negligible");
+    }
+  }
+
+  @Test
+  void testPartitionLevelStrategy() throws Exception {
     final String testTable = "db_partition.test_table_sanity_check";
     try (SparkSession spark = getSparkSession()) {
       spark.sql("USE openhouse");
@@ -104,6 +152,7 @@ public class OpenHouseDataLayoutStrategyGeneratorTest extends OpenHouseSparkITes
               .tableFileStats(tableFileStats)
               .tablePartitionStats(tablePartitionStats)
               .tableSnapshotStats(tableSnapshotStats)
+              .partitioned(true)
               .build();
       List<DataLayoutStrategy> strategies = strategyGenerator.generatePartitionLevelStrategies();
       Assertions.assertEquals(2, strategies.size());
@@ -113,6 +162,7 @@ public class OpenHouseDataLayoutStrategyGeneratorTest extends OpenHouseSparkITes
           "2025-02-16, data2".equals(strategy.getPartitionId())
               || "2025-02-15, data1".equals(strategy.getPartitionId()));
       Assertions.assertEquals("ts_day, data", strategy.getPartitionColumns());
+      Assertions.assertEquals(0.0, strategy.getFileCountReductionPenalty());
       // few groups, expect 1 commit
       Assertions.assertEquals(1, strategy.getConfig().getPartialProgressMaxCommits());
       Assertions.assertTrue(strategy.getConfig().isPartialProgressEnabled());
@@ -124,8 +174,8 @@ public class OpenHouseDataLayoutStrategyGeneratorTest extends OpenHouseSparkITes
           0, strategy.getPosDeleteRecordCount(), "Table should have 0 position records");
       Assertions.assertEquals(
           0, strategy.getEqDeleteRecordCount(), "Table should have 0 equality records");
-      Assertions.assertTrue(
-          strategy.getGain() == 2, "Gain for 3 files compaction in 1 partitions should be 2");
+      Assertions.assertEquals(
+          2, strategy.getGain(), "Gain for 3 files compaction in 1 partitions should be 2");
       Assertions.assertTrue(
           strategy.getCost() < 1.0, "Cost for 3 files compaction should be negligible");
       Assertions.assertTrue(

--- a/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGeneratorTest.java
+++ b/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGeneratorTest.java
@@ -2,6 +2,7 @@ package com.linkedin.openhouse.datalayout.generator;
 
 import com.linkedin.openhouse.datalayout.datasource.TableFileStats;
 import com.linkedin.openhouse.datalayout.datasource.TablePartitionStats;
+import com.linkedin.openhouse.datalayout.datasource.TableSnapshotStats;
 import com.linkedin.openhouse.datalayout.strategy.DataLayoutStrategy;
 import com.linkedin.openhouse.tablestest.OpenHouseSparkITest;
 import java.util.List;
@@ -38,10 +39,13 @@ public class OpenHouseDataLayoutStrategyGeneratorTest extends OpenHouseSparkITes
           TableFileStats.builder().tableName(testTable).spark(spark).build();
       TablePartitionStats tablePartitionStats =
           TablePartitionStats.builder().tableName(testTable).spark(spark).build();
+      TableSnapshotStats tableSnapshotStats =
+          TableSnapshotStats.builder().tableName(testTable).spark(spark).build();
       OpenHouseDataLayoutStrategyGenerator strategyGenerator =
           OpenHouseDataLayoutStrategyGenerator.builder()
               .tableFileStats(tableFileStats)
               .tablePartitionStats(tablePartitionStats)
+              .tableSnapshotStats(tableSnapshotStats)
               .build();
       List<DataLayoutStrategy> strategies = strategyGenerator.generateTableLevelStrategies();
       Assertions.assertEquals(1, strategies.size());
@@ -92,10 +96,14 @@ public class OpenHouseDataLayoutStrategyGeneratorTest extends OpenHouseSparkITes
           TableFileStats.builder().tableName(testTable).spark(spark).build();
       TablePartitionStats tablePartitionStats =
           TablePartitionStats.builder().tableName(testTable).spark(spark).build();
+      TableSnapshotStats tableSnapshotStats =
+          TableSnapshotStats.builder().tableName(testTable).spark(spark).build();
+
       OpenHouseDataLayoutStrategyGenerator strategyGenerator =
           OpenHouseDataLayoutStrategyGenerator.builder()
               .tableFileStats(tableFileStats)
               .tablePartitionStats(tablePartitionStats)
+              .tableSnapshotStats(tableSnapshotStats)
               .build();
       List<DataLayoutStrategy> strategies = strategyGenerator.generatePartitionLevelStrategies();
       Assertions.assertEquals(2, strategies.size());


### PR DESCRIPTION
## Summary
Currently, jobs scheduler filters out unpartitioned tables when scheduling compaction jobs. After analyzing existing data at LinkedIn, we have realized that essentially all of the unpartitioned tables that are good candidates for compaction don't get updated frequently (for 1 week at least), and most of the tables that get updated at least once in the past are not good candidates due to high percent of files being replaced. There are very few exceptions.

This PR is based on this observation of production data that we can actually get most of the benefits by implementing a very simple heuristic: if an unpartitioned table didn't have data updates in the past 7 days, then include in scoring/ranking. The way it's implemented is we introduce a new trait: file count reduction discount, a ratio from 0 to 1. In the current implementation it's either 0 or 1, in the future it's like to be a function of ratio of files removed from the table, something we requires further exploration especially for partitioned tables, e.g. to actually exclude those that shouldn't be compacted due to high rate of file replacement.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

### Generate strategies
```
$ docker compose --profile with_jobs_scheduler run openhouse-jobs-scheduler - --type DATA_LAYOUT_STRATEGY_GENERATION --cluster local --tablesURL http://openhouse-tables:8080 --jobsURL http://openhouse-jobs:8080 --tableMinAgeThresholdHours 0 --taskPollIntervalMs 5000
...
2025-03-24 01:56:51 INFO  OperationTasksBuilder:47 - Fetched metadata for 2 tables
2025-03-24 01:56:51 INFO  OperationTasksBuilder:134 - Found metadata TableMetadata(super=Metadata(creator=openhouse), dbName=u_openhouse, tableName=partitioned, creationTimeMs=1742775684319, isPrimary=true, isTimePartitioned=true, isClustered=false, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null)
2025-03-24 01:56:51 INFO  OperationTasksBuilder:134 - Found metadata TableMetadata(super=Metadata(creator=openhouse), dbName=u_openhouse, tableName=unpartitioned, creationTimeMs=1742775710428, isPrimary=true, isTimePartitioned=false, isClustered=false, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null)
2025-03-24 01:56:51 INFO  JobsScheduler:162 - Submitting and running 2 jobs based on the job type: DATA_LAYOUT_STRATEGY_GENERATION
...
2025-03-24 01:56:52 INFO  OperationTask:110 - Launched a job with id DATA_LAYOUT_STRATEGY_GENERATION_u_openhouse_unpartitioned_cbbe8521-d5b0-4d59-aea9-f4277c194086 for TableMetadata(super=Metadata(creator=openhouse), dbName=u_openhouse, tableName=unpartitioned, creationTimeMs=1742775710428, isPrimary=true, isTimePartitioned=false, isClustered=false, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null)
2025-03-24 01:56:52 INFO  OperationTask:110 - Launched a job with id DATA_LAYOUT_STRATEGY_GENERATION_u_openhouse_partitioned_5164b948-7bfa-42ae-9536-4aa76844df5f for TableMetadata(super=Metadata(creator=openhouse), dbName=u_openhouse, tableName=partitioned, creationTimeMs=1742775684319, isPrimary=true, isTimePartitioned=true, isClustered=false, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null)
...
2025-03-24 01:57:48 INFO  OperationTask:156 - Finished job for entity TableMetadata(super=Metadata(creator=openhouse), dbName=u_openhouse, tableName=partitioned, creationTimeMs=1742775684319, isPrimary=true, isTimePartitioned=true, isClustered=false, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null): JobId DATA_LAYOUT_STRATEGY_GENERATION_u_openhouse_partitioned_5164b948-7bfa-42ae-9536-4aa76844df5f, executionId 5, runTime 52478, queuedTime 13841, state SUCCEEDED
2025-03-24 01:58:08 INFO  OperationTask:156 - Finished job for entity TableMetadata(super=Metadata(creator=openhouse), dbName=u_openhouse, tableName=unpartitioned, creationTimeMs=1742775710428, isPrimary=true, isTimePartitioned=false, isClustered=false, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null): JobId DATA_LAYOUT_STRATEGY_GENERATION_u_openhouse_unpartitioned_cbbe8521-d5b0-4d59-aea9-f4277c194086, executionId 4, runTime 75778, queuedTime 13486, state SUCCEEDED
2025-03-24 01:58:08 INFO  JobsScheduler:205 - Finishing scheduler for job type DATA_LAYOUT_STRATEGY_GENERATION, tasks stats: 2 created, 2 succeeded, 0 cancelled (timeout), 0 failed, 0 skipped (no state)
```
### Run compactions
Partitioned table is compacted, unpartitioned table is filtered out due to discounting = 1
```
$ docker compose --profile with_jobs_scheduler run openhouse-jobs-scheduler - --type DATA_LAYOUT_STRATEGY_EXECUTION --cluster local --tablesURL http://openhouse-tables:8080 --jobsURL http://openhouse-jobs:8080 --tableMinAgeThresholdHours 0 --taskPollIntervalMs 5000
...
2025-03-24 03:15:51 INFO  OperationTasksBuilder:80 - Fetched metadata for 2 data layout strategies
2025-03-24 03:15:51 INFO  OperationTasksBuilder:98 - Max compute cost budget: 1000.0, max strategies count: 10
2025-03-24 03:15:51 INFO  OperationTasksBuilder:105 - Selected 1 strategies
2025-03-24 03:15:51 INFO  OperationTasksBuilder:118 - Total estimated compute cost: 0.500000950495402, total estimated reduced file count: 9.0
2025-03-24 03:15:51 INFO  OperationTasksBuilder:137 - Found metadata TableDataLayoutMetadata(super=TableMetadata(super=Metadata(creator=openhouse), dbName=u_openhouse, tableName=partitioned, creationTimeMs=1742775684319, isPrimary=true, isTimePartitioned=true, isClustered=false, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), dataLayoutStrategy=DataLayoutStrategy(score=17.999965782230575, entropy=2.770809505122068E17, cost=0.500000950495402, gain=9.0, config=DataCompactionConfig(targetByteSize=526385152, minByteSizeRatio=0.75, maxByteSizeRatio=10.0, minInputFiles=5, maxConcurrentFileGroupRewrites=5, partialProgressEnabled=true, partialProgressMaxCommits=1, maxFileGroupSizeBytes=107374182400, deleteFileThreshold=2147483647), partitionId=null, partitionColumns=null, posDeleteFileCount=0, eqDeleteFileCount=0, posDeleteFileBytes=0, eqDeleteFileBytes=0, posDeleteRecordCount=0, eqDeleteRecordCount=0, fileCountReductionDiscount=0.0))
2025-03-24 03:15:57 INFO  OperationTask:110 - Launched a job with id DATA_LAYOUT_STRATEGY_EXECUTION_u_openhouse_partitioned_673b4ca2-58d7-41be-a9a3-1aafcd5d2faf for TableDataLayoutMetadata(super=TableMetadata(super=Metadata(creator=openhouse), dbName=u_openhouse, tableName=partitioned, creationTimeMs=1742775684319, isPrimary=true, isTimePartitioned=true, isClustered=false, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), dataLayoutStrategy=DataLayoutStrategy(score=17.999965782230575, entropy=2.770809505122068E17, cost=0.500000950495402, gain=9.0, config=DataCompactionConfig(targetByteSize=526385152, minByteSizeRatio=0.75, maxByteSizeRatio=10.0, minInputFiles=5, maxConcurrentFileGroupRewrites=5, partialProgressEnabled=true, partialProgressMaxCommits=1, maxFileGroupSizeBytes=107374182400, deleteFileThreshold=2147483647), partitionId=null, partitionColumns=null, posDeleteFileCount=0, eqDeleteFileCount=0, posDeleteFileBytes=0, eqDeleteFileBytes=0, posDeleteRecordCount=0, eqDeleteRecordCount=0, fileCountReductionDiscount=0.0))
2025-03-24 03:16:33 INFO  OperationTask:156 - Finished job for entity TableDataLayoutMetadata(super=TableMetadata(super=Metadata(creator=openhouse), dbName=u_openhouse, tableName=partitioned, creationTimeMs=1742775684319, isPrimary=true, isTimePartitioned=true, isClustered=false, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), dataLayoutStrategy=DataLayoutStrategy(score=17.999965782230575, entropy=2.770809505122068E17, cost=0.500000950495402, gain=9.0, config=DataCompactionConfig(targetByteSize=526385152, minByteSizeRatio=0.75, maxByteSizeRatio=10.0, minInputFiles=5, maxConcurrentFileGroupRewrites=5, partialProgressEnabled=true, partialProgressMaxCommits=1, maxFileGroupSizeBytes=107374182400, deleteFileThreshold=2147483647), partitionId=null, partitionColumns=null, posDeleteFileCount=0, eqDeleteFileCount=0, posDeleteFileBytes=0, eqDeleteFileBytes=0, posDeleteRecordCount=0, eqDeleteRecordCount=0, fileCountReductionDiscount=0.0)): JobId DATA_LAYOUT_STRATEGY_EXECUTION_u_openhouse_partitioned_673b4ca2-58d7-41be-a9a3-1aafcd5d2faf, executionId 0, runTime 38922, queuedTime 18571, state SUCCEEDED
2025-03-24 03:16:33 INFO  JobsScheduler:205 - Finishing scheduler for job type DATA_LAYOUT_STRATEGY_EXECUTION, tasks stats: 1 created, 1 succeeded, 0 cancelled (timeout), 0 failed, 0 skipped (no state)
```
# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
