### PR TITLE
Passing correct tableType for table commit operations for Replication use cases

### DIFF
--- a/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
@@ -347,6 +347,38 @@ public class OpenHouseTableOperationsTest {
   }
 
   @Test
+  public void testTableTypeForReplicationFlow() {
+    Map<String, String> baseProps = new HashMap<>();
+    Map<String, String> metaDataProps = new HashMap<>();
+    baseProps.put("openhouse.tableType", "REPLICA_TABLE");
+    baseProps.put("openhouse.clusterId", "cluster1");
+    baseProps.put(
+        "openhouse.policy",
+        "{\"replication\":{\"config\":[{\"destination\":\"a\", \"interval\":\"1D\"}, {\"destination\":\"aa\", \"interval\":\"2D\"}]}}");
+
+    TableMetadata base = mock(TableMetadata.class);
+    metaDataProps.put("openhouse.tableType", "PRIMARY_TABLE");
+    metaDataProps.put("openhouse.clusterId", "cluster2");
+    metaDataProps.put(
+        "openhouse.policy",
+        "{\"replication\":{\"config\":[{\"destination\":\"a\", \"interval\":\"1D\"}, {\"destination\":\"aa\", \"interval\":\"2D\"}]}}");
+    TableMetadata metadata = mock(TableMetadata.class);
+
+    when(base.properties()).thenReturn(baseProps);
+    Schema schema = new Schema();
+    when(base.schema()).thenReturn(schema);
+
+    when(metadata.properties()).thenReturn(metaDataProps);
+    OpenHouseTableOperations openHouseTableOperations = mock(OpenHouseTableOperations.class);
+
+    when(openHouseTableOperations.getTableType(base, metadata)).thenCallRealMethod();
+    CreateUpdateTableRequestBody.TableTypeEnum tableType =
+        openHouseTableOperations.getTableType(base, metadata);
+
+    Assertions.assertEquals(tableType, CreateUpdateTableRequestBody.TableTypeEnum.REPLICA_TABLE);
+  }
+
+  @Test
   public void testPoliciesHistoryInMetadataNoUpdate() {
     Map<String, String> props = new HashMap<>();
     props.put(

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -69,6 +69,7 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
 
   private static final String UPDATED_OPENHOUSE_POLICY_KEY = "updated.openhouse.policy";
   private static final String OPENHOUSE_TABLE_TYPE_KEY = "openhouse.tableType";
+  private static final String OPENHOUSE_CLUSTER_ID_KEY = "openhouse.clusterId";
   private static final String POLICIES_KEY = "policies";
   static final String INITIAL_TABLE_VERSION = "INITIAL_VERSION";
 
@@ -166,11 +167,36 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
     // set tableType from incoming metadata to createUpdateTableRequestBody
     if (metadata.properties() != null
         && metadata.properties().containsKey(OPENHOUSE_TABLE_TYPE_KEY)) {
-      createUpdateTableRequestBody.setTableType(
-          CreateUpdateTableRequestBody.TableTypeEnum.valueOf(
-              metadata.properties().get(OPENHOUSE_TABLE_TYPE_KEY)));
+      createUpdateTableRequestBody.setTableType(getTableType(base, metadata));
     }
     return createUpdateTableRequestBody;
+  }
+
+  // If request is coming from replication process, createUpdateTableRequestBody.tableType should be
+  // REPLICA_TABLE
+  // Replication process requests are identified based on difference between table types and
+  // cluster_id between base,
+  // metadata
+  @VisibleForTesting
+  CreateUpdateTableRequestBody.TableTypeEnum getTableType(
+      TableMetadata base, TableMetadata metadata) {
+    if (base != null) {
+      CreateUpdateTableRequestBody.TableTypeEnum baseTableType =
+          CreateUpdateTableRequestBody.TableTypeEnum.valueOf(
+              base.properties().get(OPENHOUSE_TABLE_TYPE_KEY));
+      CreateUpdateTableRequestBody.TableTypeEnum metadataTableType =
+          CreateUpdateTableRequestBody.TableTypeEnum.valueOf(
+              metadata.properties().get(OPENHOUSE_TABLE_TYPE_KEY));
+      if (baseTableType == CreateUpdateTableRequestBody.TableTypeEnum.REPLICA_TABLE
+          && metadataTableType == CreateUpdateTableRequestBody.TableTypeEnum.PRIMARY_TABLE
+          && !base.properties()
+              .get(OPENHOUSE_CLUSTER_ID_KEY)
+              .equals(metadata.properties().get(OPENHOUSE_CLUSTER_ID_KEY))) {
+        return baseTableType;
+      }
+    }
+    return CreateUpdateTableRequestBody.TableTypeEnum.valueOf(
+        metadata.properties().get(OPENHOUSE_TABLE_TYPE_KEY));
   }
 
   @VisibleForTesting

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -172,11 +172,11 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
     return createUpdateTableRequestBody;
   }
 
-  // If request is coming from replication process, createUpdateTableRequestBody.tableType should be
-  // REPLICA_TABLE
-  // Replication process requests are identified based on difference between table types and
-  // cluster_id between base,
-  // metadata
+  /**
+   * If request is coming from replication process, createUpdateTableRequestBody.tableType should be
+   * REPLICA_TABLE Replication process requests are identified based on difference between table
+   * types and cluster_id between base, metadata
+   */
   @VisibleForTesting
   CreateUpdateTableRequestBody.TableTypeEnum getTableType(
       TableMetadata base, TableMetadata metadata) {
@@ -187,6 +187,7 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
       CreateUpdateTableRequestBody.TableTypeEnum metadataTableType =
           CreateUpdateTableRequestBody.TableTypeEnum.valueOf(
               metadata.properties().get(OPENHOUSE_TABLE_TYPE_KEY));
+      // check if commit request is from replication case
       if (baseTableType == CreateUpdateTableRequestBody.TableTypeEnum.REPLICA_TABLE
           && metadataTableType == CreateUpdateTableRequestBody.TableTypeEnum.PRIMARY_TABLE
           && !base.properties()


### PR DESCRIPTION
## Summary

For replication commits `doCommit(base, metadata), createUpdateTableRequest.tableType gets populated as PRIMARY_TABLE, coming from metadata. This makes the request object wrong and any processing done based in that can fail. 
One such failure is at validation layer for replication configs.

Fix: Add base.tableType to createUpdateTableRequest as tableType when commit is coming from replication flow.
Replication flow is identified based on:
base.tableType == replica and metadata.tableType == primary
and base.clusterId != metadata.clusterId
## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
