### PR TITLE
Extend jobs service to accommodate multiple jobs coordinators

### DIFF
--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/config/JobLaunchConf.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/config/JobLaunchConf.java
@@ -29,4 +29,5 @@ public class JobLaunchConf implements Serializable {
   private String jarPath;
   @Builder.Default private List<String> dependencies = new ArrayList<>();
   @Builder.Default private Map<String, String> sparkProperties = new HashMap<>();
+  private String coordinatorType;
 }

--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/services/JobsRegistry.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/services/JobsRegistry.java
@@ -21,7 +21,7 @@ import lombok.NonNull;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.SerializationUtils;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class JobsRegistry {
   private final String storageUri;
   private final String authTokenPath;
@@ -98,5 +98,12 @@ public class JobsRegistry {
     } catch (IOException e) {
       throw new RuntimeException(String.format("Could not read token file %s", filePath), e);
     }
+  }
+
+  protected String getCoordinatorTypeForJobType(String jobType) {
+    if (!jobLaunchDefaultConfByType.containsKey(jobType)) {
+      throw new JobEngineException(String.format("Job %s is not supported", jobType));
+    }
+    return jobLaunchDefaultConfByType.get(jobType).getCoordinatorType();
   }
 }

--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/services/JobsRegistry.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/services/JobsRegistry.java
@@ -25,7 +25,7 @@ import org.apache.commons.lang3.SerializationUtils;
 public class JobsRegistry {
   private final String storageUri;
   private final String authTokenPath;
-  private final Map<String, JobLaunchConf> jobLaunchDefaultConfByType;
+  protected final Map<String, JobLaunchConf> jobLaunchDefaultConfByType;
 
   public JobLaunchConf createLaunchConf(String jobId, JobConf requestConf) {
     final String type = requestConf.getJobType().name();
@@ -98,12 +98,5 @@ public class JobsRegistry {
     } catch (IOException e) {
       throw new RuntimeException(String.format("Could not read token file %s", filePath), e);
     }
-  }
-
-  protected String getCoordinatorTypeForJobType(String jobType) {
-    if (!jobLaunchDefaultConfByType.containsKey(jobType)) {
-      throw new JobEngineException(String.format("Job %s is not supported", jobType));
-    }
-    return jobLaunchDefaultConfByType.get(jobType).getCoordinatorType();
   }
 }

--- a/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/LivyJobsCoordinatorTest.java
+++ b/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/LivyJobsCoordinatorTest.java
@@ -33,7 +33,8 @@ public class LivyJobsCoordinatorTest {
             Collections.emptyList(),
             "test.jar",
             Collections.emptyList(),
-            Maps.newHashMap());
+            Maps.newHashMap(),
+            "livy");
     responseBody.addProperty("id", testExecutionId);
     ExchangeFunction exchangeFunction =
         request -> {
@@ -58,7 +59,8 @@ public class LivyJobsCoordinatorTest {
             Collections.emptyList(),
             "test.jar",
             Collections.emptyList(),
-            Maps.newHashMap());
+            Maps.newHashMap(),
+            "livy");
     ExchangeFunction exchangeFunction =
         request -> {
           Assertions.assertEquals(HttpMethod.POST, request.method());


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

Extend jobs service to accommodate multiple jobs coordinators.
- Added `coordinatorType` in `JobLaunchConf`.
- Changed the constructor of `JobsRegistry` to be protected.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
