### PR TITLE
Allow extension of preserved key checker to add read-only keys during table creation

### DIFF
--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/PreservedKeyChecker.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/PreservedKeyChecker.java
@@ -28,7 +28,7 @@ public interface PreservedKeyChecker {
    * @param tableDto
    * @return
    */
-  boolean shouldAddKeyDuringTableCreation(String key, TableDto tableDto);
+  boolean allowKeyInCreation(String key, TableDto tableDto);
 
   String describePreservedSpace();
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/PreservedKeyChecker.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/PreservedKeyChecker.java
@@ -20,5 +20,15 @@ public interface PreservedKeyChecker {
     return isKeyPreserved(key);
   }
 
+  /**
+   * Interface for checking which preserved keys to maintain when creating a table with preserved
+   * keys. This is to allow extension of this class for any read-only keys during table creation.
+   *
+   * @param key
+   * @param tableDto
+   * @return
+   */
+  boolean shouldAddKeyDuringTableCreation(String key, TableDto tableDto);
+
   String describePreservedSpace();
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/BasePreservedKeyChecker.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/BasePreservedKeyChecker.java
@@ -41,7 +41,7 @@ public class BasePreservedKeyChecker implements PreservedKeyChecker {
    * @return
    */
   @Override
-  public boolean shouldAddKeyDuringTableCreation(String key, TableDto tableDto) {
+  public boolean allowKeyInCreation(String key, TableDto tableDto) {
     return !isKeyPreservedForTable(key, tableDto);
   }
 

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/BasePreservedKeyChecker.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/BasePreservedKeyChecker.java
@@ -33,6 +33,18 @@ public class BasePreservedKeyChecker implements PreservedKeyChecker {
     return isKeyPreserved(key);
   }
 
+  /**
+   * Prevent any keys with prefix "openhouse." from being added during table creation.
+   *
+   * @param key
+   * @param tableDto
+   * @return
+   */
+  @Override
+  public boolean shouldAddKeyDuringTableCreation(String key, TableDto tableDto) {
+    return !isKeyPreservedForTable(key, tableDto);
+  }
+
   @Override
   public String describePreservedSpace() {
     return "table properties starting with `openhouse.` cannot be modified";

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -284,9 +284,7 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
     // Populate non-preserved keys, mainly user defined properties.
     Map<String, String> propertiesMap =
         tableDto.getTableProperties().entrySet().stream()
-            .filter(
-                entry ->
-                    preservedKeyChecker.shouldAddKeyDuringTableCreation(entry.getKey(), tableDto))
+            .filter(entry -> preservedKeyChecker.allowKeyInCreation(entry.getKey(), tableDto))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     // Populate server reserved properties

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -284,7 +284,9 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
     // Populate non-preserved keys, mainly user defined properties.
     Map<String, String> propertiesMap =
         tableDto.getTableProperties().entrySet().stream()
-            .filter(entry -> !preservedKeyChecker.isKeyPreservedForTable(entry.getKey(), tableDto))
+            .filter(
+                entry ->
+                    preservedKeyChecker.shouldAddKeyDuringTableCreation(entry.getKey(), tableDto))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     // Populate server reserved properties

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
@@ -66,7 +66,7 @@ public class RepositoryTest {
 
   @Autowired SchemaValidator validator;
 
-  @Autowired PreservedKeyChecker preservedKeyChecker;
+  @SpyBean @Autowired PreservedKeyChecker preservedKeyChecker;
 
   @Test
   void extractReservedProps() {
@@ -311,6 +311,7 @@ public class RepositoryTest {
     offensiveMap.put("openhouse.tableId", "random");
     offensiveMap.put("openhouse.tableVersion", "random");
     offensiveMap.put("openhouse.tableLocation", "random");
+    offensiveMap.put("openhouse.keepReadOnlyProp", "true");
     TableDto offensiveDto =
         TABLE_DTO
             .toBuilder()
@@ -318,13 +319,47 @@ public class RepositoryTest {
             .tableProperties(offensiveMap)
             .tableVersion(INITIAL_TABLE_VERSION)
             .build();
-
+    PreservedKeyChecker spyPreservedKeyChecker = Mockito.spy(preservedKeyChecker);
+    // Test extending the preservedKeyChecker enables allowlisting of properties during table
+    // creation
+    Mockito.doReturn(true)
+        .when(spyPreservedKeyChecker)
+        .shouldAddKeyDuringTableCreation(Mockito.eq("openhouse.keepReadOnlyProp"), Mockito.any());
     // Demonstrated the offensive setting doesn't matter.
     TableDto createdDTO = openHouseInternalRepository.save(offensiveDto);
     Assertions.assertEquals(createdDTO.getTableId(), tblName);
+    Map<String, String> createdTableProps = createdDTO.getTableProperties();
+    // Should not be overridden by the user provided value given that these should be filtered on
+    // creation
+    Assertions.assertNotEquals(createdTableProps.get("openhouse.tableVersions"), "random");
+    Assertions.assertNotEquals(createdTableProps.get("openhouse.tableLocation"), "random");
+    Assertions.assertEquals(createdTableProps.get("openhouse.keepReadOnlyProp"), "true");
 
     TableDtoPrimaryKey primaryKey =
         TableDtoPrimaryKey.builder().tableId(tblName).databaseId(TABLE_DTO.getDatabaseId()).build();
+
+    Map<String, String> updatedTableProps = new HashMap<>();
+    updatedTableProps.putAll(createdTableProps);
+    updatedTableProps.put("openhouse.keepReadOnlyProp", "false");
+    TableDto updatedOffensiveDto =
+        TABLE_DTO
+            .toBuilder()
+            .tableId("offensiveMap")
+            .tableProperties(updatedTableProps)
+            .tableVersion(createdDTO.getTableLocation())
+            .build();
+    // Should fail due to updating preserved keys
+    UnsupportedClientOperationException e =
+        Assertions.assertThrows(
+            UnsupportedClientOperationException.class,
+            () -> openHouseInternalRepository.save(updatedOffensiveDto));
+    Assertions.assertTrue(
+        e.getMessage()
+            .startsWith(
+                "Bad tblproperties provided: Can't add, alter or drop table properties due to the restriction: "
+                    + "[table properties starting with `openhouse.` cannot be modified], diff in existing "
+                    + "& provided table properties: {"));
+
     openHouseInternalRepository.deleteById(primaryKey);
     Assertions.assertFalse(openHouseInternalRepository.existsById(primaryKey));
   }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
@@ -324,7 +324,7 @@ public class RepositoryTest {
     // creation
     Mockito.doReturn(true)
         .when(spyPreservedKeyChecker)
-        .shouldAddKeyDuringTableCreation(Mockito.eq("openhouse.keepReadOnlyProp"), Mockito.any());
+        .allowKeyInCreation(Mockito.eq("openhouse.keepReadOnlyProp"), Mockito.any());
     // Demonstrated the offensive setting doesn't matter.
     TableDto createdDTO = openHouseInternalRepository.save(offensiveDto);
     Assertions.assertEquals(createdDTO.getTableId(), tblName);


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn) Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

The `PreservedKeyChecker` will automatically filter any preserved keys when creating an OH table (e.g. `BasePreservedKeyChecker` filters keys prefixed with `openhouse.`), as the expectation is that preserved keys are only written by the OH server.

However, there are some use-cases where it becomes beneficial for users to extend preserved table properties to have read-only table properties that can be defined by users during table creation. This PR does a small change to the PreservedKeyChecker to allow for adding read-only keys only when the table is created.

One usecase is when a user owns a platform of tables which may need an identifier e.g. `openhouse.platform`, which should be set during creation time for any custom handling but we do not want a modification of this key.


## Changes

- [ ] Client-facing API Changes
- [x] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

Added unit tests

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
