### PR TITLE
Delete lock API with Auth interfaces

### DIFF
--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/TablesApiHandler.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/TablesApiHandler.java
@@ -122,4 +122,15 @@ public interface TablesApiHandler {
       String tableId,
       CreateUpdateLockRequestBody createUpdateLockRequestBody,
       String tableCreatorUpdator);
+
+  /**
+   * Function to Delete a Table lock Resource identified by tableId in a given databaseId
+   *
+   * @param databaseId
+   * @param tableId
+   * @param extractAuthenticatedUserPrincipal
+   * @return empty body on successful delete
+   */
+  ApiResponse<Void> deleteLock(
+      String databaseId, String tableId, String extractAuthenticatedUserPrincipal);
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/impl/OpenHouseTablesApiHandler.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/impl/OpenHouseTablesApiHandler.java
@@ -152,4 +152,12 @@ public class OpenHouseTablesApiHandler implements TablesApiHandler {
     tableService.createLock(databaseId, tableId, createUpdateLockRequestBody, tableCreatorUpdator);
     return ApiResponse.<Void>builder().httpStatus(HttpStatus.CREATED).build();
   }
+
+  @Override
+  public ApiResponse<Void> deleteLock(
+      String databaseId, String tableId, String tableCreatorUpdator) {
+    tablesApiValidator.validateGetTable(databaseId, tableId);
+    tableService.deleteLock(databaseId, tableId, tableCreatorUpdator);
+    return ApiResponse.<Void>builder().httpStatus(HttpStatus.CREATED).build();
+  }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/authorization/Privileges.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/authorization/Privileges.java
@@ -15,6 +15,8 @@ public enum Privileges {
   DELETE_TABLE(Privilege.DELETE_TABLE),
   UPDATE_ACL(Privilege.UPDATE_ACL),
   SYSTEM_ADMIN(Privilege.SYSTEM_ADMIN),
+  LOCK_ADMIN(Privilege.LOCK_ADMIN),
+  UNLOCK_ADMIN(Privilege.UNLOCK_ADMIN),
   SELECT(Privilege.SELECT);
 
   private String privilege;
@@ -39,6 +41,8 @@ public enum Privileges {
     public static final String DELETE_TABLE = "DELETE_TABLE";
     public static final String UPDATE_ACL = "UPDATE_ACL";
     public static final String SYSTEM_ADMIN = "SYSTEM_ADMIN";
+    public static final String LOCK_ADMIN = "LOCK_ADMIN";
+    public static final String UNLOCK_ADMIN = "UNLOCK_ADMIN";
 
     public static final String SELECT = "SELECT";
     private static final Set<String> SUPPORTED_PRIVILEGES =

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/TablesController.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/TablesController.java
@@ -324,4 +324,28 @@ public class TablesController {
     return new ResponseEntity<>(
         apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
   }
+
+  @Operation(
+      summary = "Delete lock on Table",
+      description = "Delete lock on a table identified by databaseId and tableId",
+      tags = {"Table"})
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "204", description = "lock PATCH: NO_CONTENT"),
+        @ApiResponse(responseCode = "400", description = "lock PATCH: BAD_REQUEST"),
+        @ApiResponse(responseCode = "401", description = "lock PATCH: UNAUTHORIZED"),
+        @ApiResponse(responseCode = "403", description = "lock PATCH: FORBIDDEN"),
+        @ApiResponse(responseCode = "404", description = "lock PATCH: TABLE_NOT_FOUND")
+      })
+  @DeleteMapping(
+      value = {"/v1/databases/{databaseId}/tables/{tableId}/lock"},
+      produces = {"application/json"})
+  public ResponseEntity<Void> deleteLock(
+      @Parameter(description = "Database ID", required = true) @PathVariable String databaseId,
+      @Parameter(description = "Table ID", required = true) @PathVariable String tableId) {
+    com.linkedin.openhouse.common.api.spec.ApiResponse<Void> apiResponse =
+        tablesApiHandler.deleteLock(databaseId, tableId, extractAuthenticatedUserPrincipal());
+    return new ResponseEntity<>(
+        apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
+  }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesService.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesService.java
@@ -106,4 +106,14 @@ public interface TablesService {
       String tableId,
       CreateUpdateLockRequestBody createUpdateLockRequestBody,
       String tableCreatorUpdator);
+
+  /**
+   * Delete a table lock represented by databaseId and tableId if actingPrincipal has the right
+   * privilege.
+   *
+   * @param databaseId
+   * @param tableId
+   * @param actingPrincipal
+   */
+  void deleteLock(String databaseId, String tableId, String actingPrincipal);
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/AuthorizationUtils.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/AuthorizationUtils.java
@@ -51,6 +51,31 @@ public class AuthorizationUtils {
   }
 
   /**
+   * Checks if actingPrincipal is authorized to perform lock action on Table.
+   *
+   * @param tableDto
+   * @param actingPrincipal
+   * @param privilege
+   */
+  public void checkTableLockPrivileges(
+      TableDto tableDto, String actingPrincipal, Privileges privilege) {
+    if (tableDto.getTableType().equals(TableType.REPLICA_TABLE)) {
+      String errMsg =
+          String.format(
+              "Lock Operation on Replica table %s.%s is not permitted.",
+              tableDto.getDatabaseId(), tableDto.getTableId());
+      throw new UnsupportedOperationException(errMsg);
+    } else {
+      checkTablePrivilege(tableDto, actingPrincipal, Privileges.LOCK_ADMIN);
+    }
+  }
+
+  public void checkTableUnLockPrivileges(
+      TableDto tableDto, String actingPrincipal, Privileges privilege) {
+    checkTablePrivilege(tableDto, actingPrincipal, Privileges.UNLOCK_ADMIN);
+  }
+
+  /**
    * Throws AccessDeniedException if actingPrincipal is not authorized to act on database denoted by
    * databaseId.
    *

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/MockTablesApiHandler.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/MockTablesApiHandler.java
@@ -210,6 +210,21 @@ public class MockTablesApiHandler implements TablesApiHandler {
     }
   }
 
+  @Override
+  public ApiResponse<Void> deleteLock(
+      String databaseId, String tableId, String extractAuthenticatedUserPrincipal) {
+    switch (databaseId) {
+      case "d204":
+        return ApiResponse.<Void>builder().httpStatus(HttpStatus.NO_CONTENT).build();
+      case "d400":
+        throw new RequestValidationFailureException();
+      case "d404":
+        throw new NoSuchUserTableException(databaseId, tableId);
+      default:
+        return null;
+    }
+  }
+
   private void throwTableException(String tableId) {
     switch (tableId) {
       case "entityconcurrentmodificationexception":


### PR DESCRIPTION
## Summary

Delete Lock API implementation.
```
API:
DELETE  /v1/tables/databases/{databaseId}/tables/{tableId}/lock
```

Effect:
Sets the LockState policy on table to be null effectively unlocking the table for read and writes.
Auth implementations will come in followup PR.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
