### PR TITLE
Adding permissions spec for a Locked table

### DIFF
--- a/services/common/src/main/java/com/linkedin/openhouse/common/exception/UnsupportedClientOperationException.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/exception/UnsupportedClientOperationException.java
@@ -20,6 +20,6 @@ public class UnsupportedClientOperationException extends RuntimeException {
     GRANT_ON_UNSHARED_TABLES,
     ALTER_TABLE_TYPE,
     GRANT_ON_LOCKED_TABLES,
-    DELETE_LOCKED_TABLE
+    LOCKED_TABLE_OPERATION
   }
 }

--- a/services/common/src/main/java/com/linkedin/openhouse/common/exception/UnsupportedClientOperationException.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/exception/UnsupportedClientOperationException.java
@@ -18,6 +18,8 @@ public class UnsupportedClientOperationException extends RuntimeException {
     ALTER_RESERVED_TBLPROPS,
     ALTER_RESERVED_ROLES,
     GRANT_ON_UNSHARED_TABLES,
-    ALTER_TABLE_TYPE
+    ALTER_TABLE_TYPE,
+    GRANT_ON_LOCKED_TABLES,
+    DELETE_LOCKED_TABLE
   }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/authorization/Privileges.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/authorization/Privileges.java
@@ -16,7 +16,7 @@ public enum Privileges {
   UPDATE_ACL(Privilege.UPDATE_ACL),
   SYSTEM_ADMIN(Privilege.SYSTEM_ADMIN),
   LOCK_ADMIN(Privilege.LOCK_ADMIN),
-  UNLOCK_ADMIN(Privilege.UNLOCK_ADMIN),
+  LOCK_WRITER(Privilege.LOCK_WRITER),
   SELECT(Privilege.SELECT);
 
   private String privilege;
@@ -42,7 +42,7 @@ public enum Privileges {
     public static final String UPDATE_ACL = "UPDATE_ACL";
     public static final String SYSTEM_ADMIN = "SYSTEM_ADMIN";
     public static final String LOCK_ADMIN = "LOCK_ADMIN";
-    public static final String UNLOCK_ADMIN = "UNLOCK_ADMIN";
+    public static final String LOCK_WRITER = "LOCK_WRITER";
 
     public static final String SELECT = "SELECT";
     private static final Set<String> SUPPORTED_PRIVILEGES =

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/authorization/Privileges.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/authorization/Privileges.java
@@ -16,7 +16,6 @@ public enum Privileges {
   UPDATE_ACL(Privilege.UPDATE_ACL),
   SYSTEM_ADMIN(Privilege.SYSTEM_ADMIN),
   LOCK_ADMIN(Privilege.LOCK_ADMIN),
-  LOCK_WRITER(Privilege.LOCK_WRITER),
   SELECT(Privilege.SELECT);
 
   private String privilege;

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/authorization/Privileges.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/authorization/Privileges.java
@@ -41,7 +41,6 @@ public enum Privileges {
     public static final String UPDATE_ACL = "UPDATE_ACL";
     public static final String SYSTEM_ADMIN = "SYSTEM_ADMIN";
     public static final String LOCK_ADMIN = "LOCK_ADMIN";
-    public static final String LOCK_WRITER = "LOCK_WRITER";
 
     public static final String SELECT = "SELECT";
     private static final Set<String> SUPPORTED_PRIVILEGES =

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/IcebergSnapshotsServiceImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/IcebergSnapshotsServiceImpl.java
@@ -66,7 +66,7 @@ public class IcebergSnapshotsServiceImpl implements IcebergSnapshotsService {
 
     if (tableDto.isPresent()) {
       if (isTableLocked(tableDto.get())) {
-        authorizationUtils.checkLockTableWritePathPrivileges(
+        authorizationUtils.checkLockTablePrivilege(
             tableDto.get(), tableCreatorUpdater, Privileges.LOCK_WRITER);
       }
       authorizationUtils.checkTableWritePathPrivileges(

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/IcebergSnapshotsServiceImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/IcebergSnapshotsServiceImpl.java
@@ -3,6 +3,7 @@ package com.linkedin.openhouse.tables.services;
 import com.linkedin.openhouse.common.api.spec.TableUri;
 import com.linkedin.openhouse.common.exception.EntityConcurrentModificationException;
 import com.linkedin.openhouse.common.exception.RequestValidationFailureException;
+import com.linkedin.openhouse.common.exception.UnsupportedClientOperationException;
 import com.linkedin.openhouse.tables.api.spec.v0.request.IcebergSnapshotsRequestBody;
 import com.linkedin.openhouse.tables.authorization.Privileges;
 import com.linkedin.openhouse.tables.dto.mapper.TablesMapper;
@@ -66,8 +67,10 @@ public class IcebergSnapshotsServiceImpl implements IcebergSnapshotsService {
 
     if (tableDto.isPresent()) {
       if (isTableLocked(tableDto.get())) {
-        authorizationUtils.checkLockTablePrivilege(
-            tableDto.get(), tableCreatorUpdater, Privileges.LOCK_WRITER);
+        throw new UnsupportedClientOperationException(
+            UnsupportedClientOperationException.Operation.LOCKED_TABLE_OPERATION,
+            String.format(
+                "Table %s.%s is in locked state and cannot be written to", databaseId, tableId));
       }
       authorizationUtils.checkTableWritePathPrivileges(
           tableDto.get(), tableCreatorUpdater, Privileges.UPDATE_TABLE_METADATA);

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/IcebergSnapshotsServiceImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/IcebergSnapshotsServiceImpl.java
@@ -66,7 +66,7 @@ public class IcebergSnapshotsServiceImpl implements IcebergSnapshotsService {
 
     if (tableDto.isPresent()) {
       if (isTableLocked(tableDto.get())) {
-        authorizationUtils.checkTableLockPrivileges(
+        authorizationUtils.checkLockTableWritePathPrivileges(
             tableDto.get(), tableCreatorUpdater, Privileges.LOCK_WRITER);
       }
       authorizationUtils.checkTableWritePathPrivileges(

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/IcebergSnapshotsServiceImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/IcebergSnapshotsServiceImpl.java
@@ -65,6 +65,10 @@ public class IcebergSnapshotsServiceImpl implements IcebergSnapshotsService {
             icebergSnapshotRequestBody);
 
     if (tableDto.isPresent()) {
+      if (isTableLocked(tableDto.get())) {
+        authorizationUtils.checkTableLockPrivileges(
+            tableDto.get(), tableCreatorUpdater, Privileges.LOCK_WRITER);
+      }
       authorizationUtils.checkTableWritePathPrivileges(
           tableDto.get(), tableCreatorUpdater, Privileges.UPDATE_TABLE_METADATA);
     } else {
@@ -92,5 +96,11 @@ public class IcebergSnapshotsServiceImpl implements IcebergSnapshotsService {
               "The requested table has been modified/created by other processes."),
           ce);
     }
+  }
+
+  private boolean isTableLocked(TableDto tableDto) {
+    return tableDto.getPolicies() != null
+        && tableDto.getPolicies().getLockState() != null
+        && tableDto.getPolicies().getLockState().isLocked();
   }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
@@ -193,7 +193,8 @@ public class TablesServiceImpl implements TablesService {
     if (isTableLocked(tableDto.get())) {
       throw new UnsupportedClientOperationException(
           UnsupportedClientOperationException.Operation.DELETE_LOCKED_TABLE,
-          String.format("Table %s.%s is in locked state. Cannot be deleted", databaseId, tableId));
+          String.format(
+              "Table %s.%s is in locked state and cannot be deleted", databaseId, tableId));
     }
     authorizationUtils.checkTableWritePathPrivileges(
         tableDto.get(), actingPrincipal, Privileges.DELETE_TABLE);
@@ -225,7 +226,9 @@ public class TablesServiceImpl implements TablesService {
         if (isTableLocked(tableDto)) {
           throw new UnsupportedClientOperationException(
               UnsupportedClientOperationException.Operation.GRANT_ON_LOCKED_TABLES,
-              String.format("%s.%s is not a shared table", databaseId, tableId));
+              String.format(
+                  "%s.%s is in locked state and grants are not allowed for sharing",
+                  databaseId, tableId));
         }
         authorizationHandler.grantRole(
             role, granteePrincipal, expirationEpochTimeSeconds, properties, tableDto);

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
@@ -60,7 +60,7 @@ public class TablesServiceImpl implements TablesService {
             .orElseThrow(() -> new NoSuchUserTableException(databaseId, tableId));
     // Restricts reading table to users with lock admin Privileges
     if (isTableLocked(tableDto)) {
-      authorizationUtils.checkTablePrivilege(tableDto, actingPrincipal, Privileges.LOCK_ADMIN);
+      authorizationUtils.checkLockTablePrivilege(tableDto, actingPrincipal, Privileges.LOCK_ADMIN);
     }
     authorizationUtils.checkTablePrivilege(
         tableDto, actingPrincipal, Privileges.GET_TABLE_METADATA);
@@ -94,7 +94,7 @@ public class TablesServiceImpl implements TablesService {
       }
       checkIfLockPoliciesUpdated(tableDto.get(), createUpdateTableRequestBody);
       if (isTableLocked(tableDto.get())) {
-        authorizationUtils.checkTablePrivilege(
+        authorizationUtils.checkLockTablePrivilege(
             tableDto.get(), tableCreatorUpdater, Privileges.LOCK_ADMIN);
       }
       authorizationUtils.checkTableWritePathPrivileges(
@@ -272,7 +272,7 @@ public class TablesServiceImpl implements TablesService {
         openHouseInternalRepository
             .findById(TableDtoPrimaryKey.builder().databaseId(databaseId).tableId(tableId).build())
             .orElseThrow(() -> new NoSuchUserTableException(databaseId, tableId));
-    authorizationUtils.checkTableLockPrivileges(
+    authorizationUtils.checkLockTableWritePathPrivileges(
         tableDto, tableCreatorUpdater, Privileges.LOCK_ADMIN);
     // lock state from incoming request
     LockState lockState =
@@ -315,7 +315,10 @@ public class TablesServiceImpl implements TablesService {
         openHouseInternalRepository
             .findById(TableDtoPrimaryKey.builder().databaseId(databaseId).tableId(tableId).build())
             .orElseThrow(() -> new NoSuchUserTableException(databaseId, tableId));
-    authorizationUtils.checkTableLockPrivileges(tableDto, actingPrincipal, Privileges.LOCK_ADMIN);
+    authorizationUtils.checkLockTableWritePathPrivileges(
+        tableDto, actingPrincipal, Privileges.LOCK_ADMIN);
+    authorizationUtils.checkTableWritePathPrivileges(
+        tableDto, actingPrincipal, Privileges.UPDATE_TABLE_METADATA);
     Policies policies = tableDto.getPolicies();
     if (policies != null && policies.getLockState() != null && policies.getLockState().isLocked()) {
       Policies policiesToSave;

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/AuthorizationUtils.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/AuthorizationUtils.java
@@ -26,16 +26,29 @@ public class AuthorizationUtils {
    * @param privilege
    */
   public void checkTablePrivilege(TableDto tableDto, String actingPrincipal, Privileges privilege) {
-    String lockErrorSuffix = "";
-    if (Privileges.LOCK_ADMIN.toString().equals(privilege.getPrivilege())
-        || Privileges.LOCK_WRITER.toString().equals(privilege.getPrivilege())) {
-      lockErrorSuffix = " to act on table in locked state";
-    }
     if (!authorizationHandler.checkAccessDecision(actingPrincipal, tableDto, privilege)) {
       throw new AccessDeniedException(
           String.format(
-              "Operation on table %s.%s failed as user %s is unauthorized%s",
-              tableDto.getDatabaseId(), tableDto.getTableId(), actingPrincipal, lockErrorSuffix));
+              "Operation on table %s.%s failed as user %s is unauthorized",
+              tableDto.getDatabaseId(), tableDto.getTableId(), actingPrincipal));
+    }
+  }
+
+  /**
+   * * Throws AccessDeniedException if actingPrincipal is not authorized to act on a Locked table
+   * denoted by tableId.
+   *
+   * @param tableDto
+   * @param actingPrincipal
+   * @param privilege
+   */
+  public void checkLockTablePrivilege(
+      TableDto tableDto, String actingPrincipal, Privileges privilege) {
+    if (!authorizationHandler.checkAccessDecision(actingPrincipal, tableDto, privilege)) {
+      throw new AccessDeniedException(
+          String.format(
+              "Operation on table %s.%s failed as user %s is unauthorized to act on Locked table",
+              tableDto.getDatabaseId(), tableDto.getTableId(), actingPrincipal));
     }
   }
 
@@ -56,13 +69,13 @@ public class AuthorizationUtils {
   }
 
   /**
-   * Checks if actingPrincipal is authorized to perform lock/unlock action on Table.
+   * Checks if actingPrincipal is authorized to perform write action on locked Table.
    *
    * @param tableDto
    * @param actingPrincipal
    * @param privilege
    */
-  public void checkTableLockPrivileges(
+  public void checkLockTableWritePathPrivileges(
       TableDto tableDto, String actingPrincipal, Privileges privilege) {
     if (TableType.REPLICA_TABLE.equals(tableDto.getTableType())) {
       String errMsg =

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/AuthorizationUtils.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/AuthorizationUtils.java
@@ -27,8 +27,8 @@ public class AuthorizationUtils {
    */
   public void checkTablePrivilege(TableDto tableDto, String actingPrincipal, Privileges privilege) {
     String lockErrorSuffix = "";
-    if (privilege.getPrivilege().equals(Privileges.LOCK_ADMIN.toString())
-        || privilege.getPrivilege().equals(Privileges.LOCK_WRITER.toString())) {
+    if (Privileges.LOCK_ADMIN.toString().equals(privilege.getPrivilege())
+        || Privileges.LOCK_WRITER.toString().equals(privilege.getPrivilege())) {
       lockErrorSuffix = " to act on table in locked state";
     }
     if (!authorizationHandler.checkAccessDecision(actingPrincipal, tableDto, privilege)) {

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/AuthorizationUtils.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/AuthorizationUtils.java
@@ -69,26 +69,6 @@ public class AuthorizationUtils {
   }
 
   /**
-   * Checks if actingPrincipal is authorized to perform write action on locked Table.
-   *
-   * @param tableDto
-   * @param actingPrincipal
-   * @param privilege
-   */
-  public void checkLockTableWritePathPrivileges(
-      TableDto tableDto, String actingPrincipal, Privileges privilege) {
-    if (TableType.REPLICA_TABLE.equals(tableDto.getTableType())) {
-      String errMsg =
-          String.format(
-              "Lock/UnLock Operation on Replica table %s.%s is not permitted.",
-              tableDto.getDatabaseId(), tableDto.getTableId());
-      throw new UnsupportedOperationException(errMsg);
-    } else {
-      checkTablePrivilege(tableDto, actingPrincipal, privilege);
-    }
-  }
-
-  /**
    * Throws AccessDeniedException if actingPrincipal is not authorized to act on database denoted by
    * databaseId.
    *

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/AuthorizationUtils.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/AuthorizationUtils.java
@@ -26,11 +26,16 @@ public class AuthorizationUtils {
    * @param privilege
    */
   public void checkTablePrivilege(TableDto tableDto, String actingPrincipal, Privileges privilege) {
+    String lockErrorSuffix = "";
+    if (privilege.getPrivilege().equals(Privileges.LOCK_ADMIN.toString())
+        || privilege.getPrivilege().equals(Privileges.LOCK_WRITER.toString())) {
+      lockErrorSuffix = " to act on table in locked state";
+    }
     if (!authorizationHandler.checkAccessDecision(actingPrincipal, tableDto, privilege)) {
       throw new AccessDeniedException(
           String.format(
-              "Operation on table %s.%s failed as user %s is unauthorized",
-              tableDto.getDatabaseId(), tableDto.getTableId(), actingPrincipal));
+              "Operation on table %s.%s failed as user %s is unauthorized%s",
+              tableDto.getDatabaseId(), tableDto.getTableId(), actingPrincipal, lockErrorSuffix));
     }
   }
 

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RequestAndValidateHelper.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RequestAndValidateHelper.java
@@ -284,6 +284,19 @@ public final class RequestAndValidateHelper {
         .andExpect(content().string(""));
   }
 
+  static void deleteLockOnTableAndValidate(MockMvc mvc, GetTableResponseBody getTableResponseBody)
+      throws Exception {
+    mvc.perform(
+            MockMvcRequestBuilders.delete(
+                String.format(
+                    ValidationUtilities.CURRENT_MAJOR_VERSION_PREFIX
+                        + "/databases/%s/tables/%s/lock",
+                    getTableResponseBody.getDatabaseId(),
+                    getTableResponseBody.getTableId())))
+        .andExpect(status().isNoContent())
+        .andExpect(content().string(""));
+  }
+
   static MvcResult putSnapshotsAndValidateResponse(
       Catalog catalog,
       MockMvc mvc,

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesControllerTest.java
@@ -1326,6 +1326,7 @@ public class TablesControllerTest {
         JsonPath.read(mvcResult.getResponse().getContentAsString(), "$.policies");
     Assertions.assertEquals(updatedPolicies.get("lockState").get("locked"), true);
     Assertions.assertNotNull(updatedPolicies.get("lockState").get("creationTime"));
+    RequestAndValidateHelper.deleteLockOnTableAndValidate(mvc, GET_TABLE_RESPONSE_BODY);
     RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, GET_TABLE_RESPONSE_BODY);
   }
 

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
@@ -651,7 +651,7 @@ public class TablesServiceTest {
     TableDto result1 =
         tablesService.getTable(TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER);
     Assertions.assertTrue(result1.getPolicies().getLockState().isLocked());
-
+    tablesService.deleteLock(tableDtoCopy.getDatabaseId(), tableDtoCopy.getTableId(), TEST_USER);
     Assertions.assertDoesNotThrow(
         () ->
             tablesService.deleteTable(
@@ -683,5 +683,41 @@ public class TablesServiceTest {
         () ->
             tablesService.deleteTable(
                 tableDtoCopy.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER));
+  }
+
+  @Test
+  public void testFailedOpsOnLockTable() {
+    TableDto tableDtoCopy = TABLE_DTO.toBuilder().build();
+    verifyPutTableRequest(tableDtoCopy, null, true);
+    tablesService.createLock(
+        tableDtoCopy.getDatabaseId(),
+        tableDtoCopy.getTableId(),
+        CreateUpdateLockRequestBody.builder().locked(true).expirationInDays(4).build(),
+        TEST_USER);
+    TableDto result =
+        tablesService.getTable(TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER);
+    Assertions.assertTrue(result.getPolicies().getLockState().isLocked());
+    // assert delete on locked table throws UnsupportedOperationException
+    Assertions.assertThrows(
+        UnsupportedClientOperationException.class,
+        () ->
+            tablesService.deleteTable(
+                tableDtoCopy.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER));
+
+    // assert delete on locked table throws UnsupportedOperationException
+    UpdateAclPoliciesRequestBody updateAclPoliciesRequestBody =
+        UpdateAclPoliciesRequestBody.builder()
+            .role("AclEditor")
+            .principal("DUMMY_USER")
+            .operation(UpdateAclPoliciesRequestBody.Operation.GRANT)
+            .build();
+    Assertions.assertThrows(
+        UnsupportedClientOperationException.class,
+        () ->
+            tablesService.updateAclPolicies(
+                tableDtoCopy.getDatabaseId(),
+                TABLE_DTO.getTableId(),
+                updateAclPoliciesRequestBody,
+                TEST_USER));
   }
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
@@ -719,5 +719,10 @@ public class TablesServiceTest {
                 TABLE_DTO.getTableId(),
                 updateAclPoliciesRequestBody,
                 TEST_USER));
+    tablesService.deleteLock(tableDtoCopy.getDatabaseId(), tableDtoCopy.getTableId(), TEST_USER);
+    Assertions.assertDoesNotThrow(
+        () ->
+            tablesService.deleteTable(
+                tableDtoCopy.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER));
   }
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
@@ -698,13 +698,6 @@ public class TablesServiceTest {
         tablesService.getTable(TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER);
     Assertions.assertTrue(result.getPolicies().getLockState().isLocked());
     // assert delete on locked table throws UnsupportedOperationException
-    Assertions.assertThrows(
-        UnsupportedClientOperationException.class,
-        () ->
-            tablesService.deleteTable(
-                tableDtoCopy.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER));
-
-    // assert delete on locked table throws UnsupportedOperationException
     UpdateAclPoliciesRequestBody updateAclPoliciesRequestBody =
         UpdateAclPoliciesRequestBody.builder()
             .role("AclEditor")

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/RequestConstants.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/RequestConstants.java
@@ -4,6 +4,8 @@ import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateLockRequest
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.IcebergSnapshotsRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.UpdateAclPoliciesRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.LockState;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.Policies;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAclPoliciesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllDatabasesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllTablesResponseBody;
@@ -94,6 +96,20 @@ public final class RequestConstants {
           .baseTableVersion("v1")
           .jsonSnapshots(Collections.singletonList(TEST_ICEBERG_SNAPSHOT_JSON))
           .createUpdateTableRequestBody(TEST_CREATE_TABLE_REQUEST_BODY)
+          .build();
+
+  public static final IcebergSnapshotsRequestBody TEST_ICEBERG_SNAPSHOTS_REQUEST_BODY_FOR_LOCKED =
+      IcebergSnapshotsRequestBody.builder()
+          .baseTableVersion("v1")
+          .jsonSnapshots(Collections.singletonList(TEST_ICEBERG_SNAPSHOT_JSON))
+          .createUpdateTableRequestBody(
+              TEST_CREATE_TABLE_REQUEST_BODY
+                  .toBuilder()
+                  .policies(
+                      Policies.builder()
+                          .lockState(LockState.builder().locked(true).build())
+                          .build())
+                  .build())
           .build();
 
   public static final IcebergSnapshotsRequestBody

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/service/IcebergSnapshotsServiceTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/service/IcebergSnapshotsServiceTest.java
@@ -4,6 +4,7 @@ import static com.linkedin.openhouse.tables.mock.RequestConstants.*;
 
 import com.linkedin.openhouse.common.exception.EntityConcurrentModificationException;
 import com.linkedin.openhouse.common.exception.RequestValidationFailureException;
+import com.linkedin.openhouse.common.exception.UnsupportedClientOperationException;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.IcebergSnapshotsRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.LockState;
@@ -168,7 +169,7 @@ public class IcebergSnapshotsServiceTest {
   }
 
   @Test
-  public void testTableUpdatedForLockedTable() {
+  public void testTableUpdatedForLockedTableThrowsException() {
     final IcebergSnapshotsRequestBody requestBody = TEST_ICEBERG_SNAPSHOTS_REQUEST_BODY_FOR_LOCKED;
     final String dbId = requestBody.getCreateUpdateTableRequestBody().getDatabaseId();
     final String tableId = requestBody.getCreateUpdateTableRequestBody().getTableId();
@@ -191,11 +192,9 @@ public class IcebergSnapshotsServiceTest {
     Mockito.when(mockRepository.findById(key)).thenReturn(Optional.of(tableDto));
     Mockito.when(mockRepository.save(tableDtoArgumentCaptor.capture())).thenReturn(tableDto);
 
-    Pair<TableDto, Boolean> result = service.putIcebergSnapshots(dbId, tableId, requestBody, null);
-    Assertions.assertEquals(tableDto, result.getFirst(), "Returned DTO must be the mock value");
-    Assertions.assertFalse(result.getSecond(), "Table must be found in repository");
-
-    verifyCalls(key, TEST_TABLE_CREATOR, requestBody.getCreateUpdateTableRequestBody());
+    Assertions.assertThrows(
+        UnsupportedClientOperationException.class,
+        () -> service.putIcebergSnapshots(dbId, tableId, requestBody, null));
   }
 
   private void verifyCalls(


### PR DESCRIPTION
## Summary
Lock API adds to policy object field to indicate that the table is in locked State. 
A table can be locked/unlocked by only a limited set of users: system admin (Openhouse) and table Admin. 

When a table is locked write data/metadata will be blocked for all users.

New Privilege Have been added to implement distinct permission for lock and unlock. LOCK_ADMIN incorporating
System User + Table admin

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
