### PR TITLE
Remove dlo partition strategies from table properties

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkApp.java
@@ -74,7 +74,7 @@ public class DataLayoutStrategyGeneratorSparkApp extends BaseTableSparkApp {
     List<DataLayoutStrategy> strategies = strategiesGenerator.generatePartitionLevelStrategies();
     log.info("Generated {} strategies for table {}", strategies.size(), fqtn);
     StrategiesDao dao = StrategiesDaoTableProps.builder().spark(spark).build();
-    dao.savePartitionScope(fqtn, strategies);
+    dao.deletePartitionScope(fqtn);
     appendToDloStrategiesTable(spark, partitionLevelOutputFqtn, strategies, true, true);
   }
 

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkAppTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/DataLayoutStrategyGeneratorSparkAppTest.java
@@ -1,9 +1,6 @@
 package com.linkedin.openhouse.jobs.spark;
 
-import com.linkedin.openhouse.datalayout.persistence.StrategiesDaoTableProps;
-import com.linkedin.openhouse.datalayout.strategy.DataLayoutStrategy;
 import com.linkedin.openhouse.tablestest.OpenHouseSparkITest;
-import java.util.List;
 import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.Assertions;
@@ -38,10 +35,8 @@ public class DataLayoutStrategyGeneratorSparkAppTest extends OpenHouseSparkITest
               .first()
               .getBoolean(0));
       Assertions.assertNotNull(ops.getTable(fqtn).properties().get("write.data-layout.strategies"));
-      List<DataLayoutStrategy> strategies =
-          StrategiesDaoTableProps.deserializeList(
-              ops.getTable(fqtn).properties().get("write.data-layout.partition-strategies"));
-      Assertions.assertEquals(2, strategies.size());
+      Assertions.assertNull(
+          ops.getTable(fqtn).properties().get("write.data-layout.partition-strategies"));
     }
   }
 

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/persistence/StrategiesDao.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/persistence/StrategiesDao.java
@@ -12,4 +12,8 @@ public interface StrategiesDao {
   List<DataLayoutStrategy> load(String fqtn);
 
   List<DataLayoutStrategy> loadPartitionScope(String fqtn);
+
+  void delete(String fqtn);
+
+  void deletePartitionScope(String fqtn);
 }

--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/persistence/StrategiesDaoTableProps.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/persistence/StrategiesDaoTableProps.java
@@ -72,6 +72,24 @@ public class StrategiesDaoTableProps implements StrategiesDao {
     return deserializeList(propValue);
   }
 
+  @Override
+  public void delete(String fqtn) {
+    log.info("Deleting strategies for table {}", fqtn);
+    spark.sql(
+        String.format(
+            "ALTER TABLE %s UNSET TBLPROPERTIES ('%s')",
+            fqtn, DATA_LAYOUT_STRATEGIES_PROPERTY_KEY));
+  }
+
+  @Override
+  public void deletePartitionScope(String fqtn) {
+    log.info("Deleting partition level strategies for table {}", fqtn);
+    spark.sql(
+        String.format(
+            "ALTER TABLE %s UNSET TBLPROPERTIES ('%s')",
+            fqtn, DATA_LAYOUT_STRATEGIES_PARTITION_PROPERTY_KEY));
+  }
+
   public static String serialize(List<DataLayoutStrategy> strategies) {
     Gson gson = new GsonBuilder().create();
     Type type = new TypeToken<ArrayList<DataLayoutStrategy>>() {}.getType();

--- a/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/persistence/StrategiesDaoTablePropsTest.java
+++ b/libs/datalayout/src/test/java/com/linkedin/openhouse/datalayout/persistence/StrategiesDaoTablePropsTest.java
@@ -18,10 +18,34 @@ public class StrategiesDaoTablePropsTest extends OpenHouseSparkITest {
       DataLayoutStrategy strategy =
           DataLayoutStrategy.builder().config(DataCompactionConfig.builder().build()).build();
       // validate up-to 100 strategies can be saved and loaded
-      List<DataLayoutStrategy> strategyList = Collections.nCopies(100, strategy);
+      List<DataLayoutStrategy> strategyList = Collections.nCopies(2, strategy);
       StrategiesDao dao = StrategiesDaoTableProps.builder().spark(spark).build();
       dao.save(testTable, strategyList);
+      dao.savePartitionScope(testTable, strategyList);
       Assertions.assertEquals(strategyList, dao.load(testTable));
+      Assertions.assertEquals(strategyList, dao.loadPartitionScope(testTable));
+      // validate delete
+      dao.delete(testTable);
+      dao.deletePartitionScope(testTable);
+      Assertions.assertEquals(
+          0,
+          spark
+              .sql(String.format("SHOW TBLPROPERTIES %s", testTable))
+              .filter(
+                  String.format(
+                      "key='%s'", StrategiesDaoTableProps.DATA_LAYOUT_STRATEGIES_PROPERTY_KEY))
+              .collectAsList()
+              .size());
+      Assertions.assertEquals(
+          0,
+          spark
+              .sql(String.format("SHOW TBLPROPERTIES %s", testTable))
+              .filter(
+                  String.format(
+                      "key='%s'",
+                      StrategiesDaoTableProps.DATA_LAYOUT_STRATEGIES_PARTITION_PROPERTY_KEY))
+              .collectAsList()
+              .size());
     }
   }
 


### PR DESCRIPTION
## Summary

Remove dlo partition strategies from table properties to avoid making metadata.json too big to block reads.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
