### PR TITLE
Added new retention column to setup retention for job_row table

### DIFF
--- a/iceberg/openhouse/htscatalog/src/main/java/com/linkedin/openhouse/hts/catalog/model/jobtable/JobIcebergRow.java
+++ b/iceberg/openhouse/htscatalog/src/main/java/com/linkedin/openhouse/hts/catalog/model/jobtable/JobIcebergRow.java
@@ -36,6 +36,8 @@ public class JobIcebergRow implements IcebergRow {
 
   private String executionId;
 
+  private Long retentionTimeSec;
+
   @Override
   public Schema getSchema() {
     return new Schema(
@@ -50,7 +52,8 @@ public class JobIcebergRow implements IcebergRow {
         Types.NestedField.optional(9, "lastUpdateTimeMs", Types.LongType.get()),
         Types.NestedField.optional(10, "jobConf", Types.StringType.get()),
         Types.NestedField.optional(11, "heartbeatTimeMs", Types.LongType.get()),
-        Types.NestedField.optional(12, "executionId", Types.StringType.get()));
+        Types.NestedField.optional(12, "executionId", Types.StringType.get()),
+        Types.NestedField.optional(13, "retentionTimeSec", Types.LongType.get()));
   }
 
   @Override
@@ -68,6 +71,7 @@ public class JobIcebergRow implements IcebergRow {
     genericRecord.setField("jobConf", jobConf);
     genericRecord.setField("heartbeatTimeMs", heartbeatTimeMs);
     genericRecord.setField("executionId", executionId);
+    genericRecord.setField("retentionTimeSec", retentionTimeSec);
     return genericRecord;
   }
 

--- a/iceberg/openhouse/htscatalog/src/main/java/com/linkedin/openhouse/hts/catalog/model/jobtable/JobIcebergRowPrimaryKey.java
+++ b/iceberg/openhouse/htscatalog/src/main/java/com/linkedin/openhouse/hts/catalog/model/jobtable/JobIcebergRowPrimaryKey.java
@@ -49,6 +49,7 @@ public class JobIcebergRowPrimaryKey implements IcebergRowPrimaryKey {
         .jobConf((String) record.getField("jobConf"))
         .heartbeatTimeMs((Long) record.getField("heartbeatTimeMs"))
         .executionId((String) record.getField("executionId"))
+        .retentionTimeSec((Long) record.getField("retentionTimeSec"))
         .build();
   }
 }

--- a/iceberg/openhouse/htscatalog/src/test/java/com/linkedin/openhouse/hts/catalog/mock/api/TestJobIcebergRow.java
+++ b/iceberg/openhouse/htscatalog/src/test/java/com/linkedin/openhouse/hts/catalog/mock/api/TestJobIcebergRow.java
@@ -29,6 +29,7 @@ public class TestJobIcebergRow {
             .lastUpdateTimeMs(1651017746000L)
             .heartbeatTimeMs(1651017746000L)
             .executionId("1")
+            .retentionTimeSec(1745908497L)
             .build();
   }
 
@@ -58,7 +59,8 @@ public class TestJobIcebergRow {
                     "lastUpdateTimeMs",
                     "jobConf",
                     "heartbeatTimeMs",
-                    "executionId")));
+                    "executionId",
+                    "retentionTimeSec")));
   }
 
   @Test
@@ -74,6 +76,7 @@ public class TestJobIcebergRow {
     Assertions.assertEquals(jobIcebergRow.getRecord().getField("lastUpdateTimeMs"), 1651017746000L);
     Assertions.assertEquals(jobIcebergRow.getRecord().getField("heartbeatTimeMs"), 1651017746000L);
     Assertions.assertEquals(jobIcebergRow.getRecord().getField("executionId"), "1");
+    Assertions.assertEquals(jobIcebergRow.getRecord().getField("retentionTimeSec"), 1745908497L);
   }
 
   @Test

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/spec/model/Job.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/spec/model/Job.java
@@ -80,4 +80,11 @@ public class Job {
   @Schema(description = "Engine type that job submitted to", example = "LIVY")
   @JsonProperty(value = "engineType")
   private String engineType;
+
+  @Schema(
+      description =
+          "Job retention time in seconds. This is used to retain job based defined retention period",
+      example = "1745908497")
+  @JsonProperty(value = "retentionTimeSec")
+  private Long retentionTimeSec;
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/dto/model/JobDto.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/dto/model/JobDto.java
@@ -33,6 +33,8 @@ public class JobDto {
 
   String engineType;
 
+  Long retentionTimeSec;
+
   /**
    * Compare if a given {@link JobDto} matches the current one if all non-null fields are equal.
    *
@@ -52,6 +54,7 @@ public class JobDto {
         && Utilities.fieldMatch(this.jobConf, jobDto.jobConf)
         && Utilities.fieldMatch(this.heartbeatTimeMs, jobDto.heartbeatTimeMs)
         && Utilities.fieldMatch(this.executionId, jobDto.executionId)
-        && Utilities.fieldMatch(this.engineType, jobDto.engineType);
+        && Utilities.fieldMatch(this.engineType, jobDto.engineType)
+        && Utilities.fieldMatch(this.retentionTimeSec, jobDto.retentionTimeSec);
   }
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/model/JobRow.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/model/JobRow.java
@@ -45,4 +45,6 @@ public class JobRow {
   String executionId;
 
   String engineType;
+
+  Long retentionTimeSec;
 }

--- a/services/housetables/src/main/resources/schema.sql
+++ b/services/housetables/src/main/resources/schema.sql
@@ -28,6 +28,7 @@ CREATE TABLE IF NOT EXISTS job_row (
     execution_id            VARCHAR (128),
     engine_type             VARCHAR (128),
     ETL_TS                  datetime(6)      DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    retention_time_sec      BIGINT ,
     PRIMARY KEY (job_id)
     );
 

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/job/JobControllerTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/job/JobControllerTest.java
@@ -50,6 +50,7 @@ public class JobControllerTest {
           .heartbeatTimeMs(1651017746000L)
           .executionId("1")
           .engineType("LIVY")
+          .retentionTimeSec(1745908497L)
           .build();
 
   @Autowired HtsRepository<JobRow, JobRowPrimaryKey> htsRepository;

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/job/JobRepositoryTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/job/JobRepositoryTest.java
@@ -35,6 +35,7 @@ public class JobRepositoryTest {
           .heartbeatTimeMs(1651017746000L)
           .executionId("1")
           .engineType("LIVY")
+          .retentionTimeSec(1745908497L)
           .build();
 
   @Autowired HtsRepository<JobRow, JobRowPrimaryKey> htsRepository;

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/job/JobServiceTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/job/JobServiceTest.java
@@ -40,6 +40,7 @@ public class JobServiceTest {
           .heartbeatTimeMs(1651017746000L)
           .executionId("1")
           .engineType("LIVY")
+          .retentionTimeSec(1745908497L)
           .build();
   private final JobRow testJobRow2 = testJobRow.toBuilder().jobId("id2").state("X").build();
   private final JobRow testJobRow3 = testJobRow.toBuilder().jobId("id3").state("X").build();

--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/model/JobDto.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/model/JobDto.java
@@ -47,4 +47,7 @@ public class JobDto {
   // job execution engine job identifier
   private String executionId;
   private String engineType;
+
+  // Used for data retention
+  private long retentionTimeSec;
 }

--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/services/JobsServiceImpl.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/services/JobsServiceImpl.java
@@ -11,6 +11,7 @@ import com.linkedin.openhouse.jobs.dto.mapper.JobsMapper;
 import com.linkedin.openhouse.jobs.model.JobDto;
 import com.linkedin.openhouse.jobs.model.JobDtoPrimaryKey;
 import com.linkedin.openhouse.jobs.repository.JobsInternalRepository;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,6 +53,7 @@ public class JobsServiceImpl implements JobsService {
             .lastUpdateTimeMs(timestamp)
             .state(JobState.QUEUED)
             .engineType(jobLaunchConf.getEngineType())
+            .retentionTimeSec(Instant.now().getEpochSecond())
             .build();
     jobDto = mapper.toJobDto(jobDto, createJobRequestBody);
     repository.save(jobDto);

--- a/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobModelConstants.java
+++ b/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobModelConstants.java
@@ -20,6 +20,7 @@ public final class JobModelConstants {
         .lastUpdateTimeMs(1651017746000L)
         .heartbeatTimeMs(1651017746000L)
         .executionId("1")
+        .retentionTimeSec(1745908497L)
         .state(JobState.SUCCEEDED);
   }
 

--- a/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsMapperTest.java
+++ b/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/JobsMapperTest.java
@@ -65,7 +65,7 @@ public class JobsMapperTest {
         .state(job.getState())
         .jobConf(job.getJobConf())
         .executionId(job.getExecutionId())
-        // internal heartbeatTimeMs and sessionId are omitted
+        // internal heartbeatTimeMs, sessionId and retentionTimeSec are omitted
         .build();
   }
 
@@ -89,6 +89,7 @@ public class JobsMapperTest {
         .finishTimeMs(jobDto.getFinishTimeMs())
         .lastUpdateTimeMs(jobDto.getLastUpdateTimeMs())
         .heartbeatTimeMs(jobDto.getHeartbeatTimeMs())
-        .executionId(jobDto.getExecutionId());
+        .executionId(jobDto.getExecutionId())
+        .retentionTimeSec(jobDto.getRetentionTimeSec());
   }
 }


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

Openhouse `job_row` table requires periodic manual clean up as internal maintenance jobs are growing with more tables being onboarded. So it is essential to setup retention on mysql table so that automatic retention policy is applied. The internal mysql team manages retention pipeline based on partition key defined on a specific column format. None of the existing column supports the required format. Hence, the best option is to add a new column rather than modifying the existing columns. This PR adds `retention_time_sec` column (aka `retentionTimeSec` field in the entity) to `job_row` table which is populated with unix timestamp (epoch in sec) while creating job entry.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done

Updated the unit test to accomodate new column addition.
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Manually tested the changes on local docker. The new field retention_time_sec is populated once create job API is invoked. 

Create job: 
```
anath1@anath1-mn4233 oh-hadoop-spark % curl -XPOST -v 'http://localhost:8002/jobs/' -H 'Content-Type: application/json' -d '{
   "jobName":"test_retention_job",
   "clusterId":"my_cluster",
   "jobConf":{
      "jobType":"RETENTION",
      "table":"db.tb"
   }
}'
```
Mysql entries:
```
mysql> select * from job_row;
+----------------------------------------------------------+--------+---------+---------------------+------------+------------------+---------------+----------------+---------------------+------------------------------------------------------+-------------------+--------------+----------------------------+--------------------+
| job_id                                                   | state  | version | job_name            | cluster_id | creation_time_ms | start_time_ms | finish_time_ms | last_update_time_ms | job_conf                                             | heartbeat_time_ms | execution_id | ETL_TS                     | retention_time_sec |
+----------------------------------------------------------+--------+---------+---------------------+------------+------------------+---------------+----------------+---------------------+------------------------------------------------------+-------------------+--------------+----------------------------+--------------------+
| test_retention_job_922b689d-85f6-4a61-bf2c-25f47fddb436  | QUEUED |       1 | test_retention_job  | my_cluster |    1746133943203 |             0 |              0 |       1746133943203 | {"jobType":"RETENTION","executionConf":{},"args":[]} |                 0 | NULL         | 2025-05-01 21:12:23.452135 |         1746133943 |
```

Get job works. Here is the response:

```
anath1@anath1-mn4233 oh-hadoop-spark % curl -XGET 'http://localhost:8002/jobs/test_retention_job_922b689d-85f6-4a61-bf2c-25f47fddb436' | jq 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   336    0   336    0     0  11996      0 --:--:-- --:--:-- --:--:-- 12444
{
  "jobId": "test_retention_job_922b689d-85f6-4a61-bf2c-25f47fddb436",
  "jobName": "test_retention_job",
  "clusterId": "my_cluster",
  "state": "QUEUED",
  "creationTimeMs": 1746133943203,
  "startTimeMs": 0,
  "finishTimeMs": 0,
  "lastUpdateTimeMs": 1746133943203,
  "jobConf": {
    "jobType": "RETENTION",
    "proxyUser": null,
    "executionConf": {},
    "args": []
  },
  "executionId": null
}

```
Please note that get job response would not contain the new field `retention_time_sec` as this is internal.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
