### PR TITLE
Fix bug for the new job column EngineType

### DIFF
--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/api/spec/response/JobResponseBody.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/api/spec/response/JobResponseBody.java
@@ -74,6 +74,10 @@ public class JobResponseBody {
   @Nullable
   private String executionId;
 
+  @Schema(description = "Engine type that job submitted to", example = "LIVY")
+  @Nullable
+  private String engineType;
+
   public String toJson() {
     return new Gson().toJson(this);
   }


### PR DESCRIPTION
## Summary

Fix bug for the new job column `EngineType`. Didn't add this field in `JobResponseBody`.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Create a job
```
curl -XPOST localhost:8002/jobs 

{
  "jobName": "job1",
  "clusterId": "openhouse",
  "jobConf": {
    "jobType": "DATA_COMPACTION"
  }
}
```
Get the job with the following response body where `engineType` is included.
```
{
    "jobId": "job1_7c6e7fc6-1b86-4bb9-b25e-928f6fb76faa",
    "jobName": "job1",
    "clusterId": "openhouse",
    "state": "FAILED",
    "creationTimeMs": 1746049651021,
    "startTimeMs": 1746049708292,
    "finishTimeMs": 1746049769920,
    "lastUpdateTimeMs": 1746049651021,
    "jobConf": {
        "jobType": "DATA_COMPACTION",
        "proxyUser": null,
        "executionConf": {},
        "args": []
    },
    "executionId": "0",
    "engineType": "LIVY"
}
```

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
