### PR TITLE
Fix bug in data layout strategy selection

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
@@ -4,10 +4,9 @@ import com.linkedin.openhouse.datalayout.ranker.DataLayoutCandidateSelector;
 import com.linkedin.openhouse.datalayout.ranker.DataLayoutStrategyScorer;
 import com.linkedin.openhouse.datalayout.ranker.GreedyMaxBudgetCandidateSelector;
 import com.linkedin.openhouse.datalayout.ranker.SimpleWeightedSumDataLayoutStrategyScorer;
-import com.linkedin.openhouse.datalayout.strategy.DataLayoutStrategy;
-import com.linkedin.openhouse.datalayout.strategy.ScoredDataLayoutStrategy;
 import com.linkedin.openhouse.jobs.client.TablesClient;
 import com.linkedin.openhouse.jobs.client.model.JobConf;
+import com.linkedin.openhouse.jobs.util.DataLayoutUtil;
 import com.linkedin.openhouse.jobs.util.DirectoryMetadata;
 import com.linkedin.openhouse.jobs.util.Metadata;
 import com.linkedin.openhouse.jobs.util.TableDataLayoutMetadata;
@@ -72,23 +71,9 @@ public class OperationTasksBuilder {
       JobConf.JobTypeEnum jobType, Properties properties, Meter meter) {
     List<TableDataLayoutMetadata> tableDataLayoutMetadataList =
         tablesClient.getTableDataLayoutMetadataList();
-    // filter out non-primary and non-clustered/time-partitioned tables before ranking
-    tableDataLayoutMetadataList =
-        tableDataLayoutMetadataList.stream()
-            .filter(TableMetadata::isPrimary)
-            .collect(Collectors.toList());
-    log.info("Fetched metadata for {} data layout strategies", tableDataLayoutMetadataList.size());
-    List<DataLayoutStrategy> strategies =
-        tableDataLayoutMetadataList.stream()
-            .map(TableDataLayoutMetadata::getDataLayoutStrategy)
-            // filter out strategies with no gain/file count reduction
-            // or discounted to 0, e.g. frequently overwritten un-partitioned tables
-            .filter(s -> s.getGain() * (1.0 - s.getFileCountReductionPenalty()) >= 1.0)
-            .collect(Collectors.toList());
     DataLayoutStrategyScorer scorer =
         new SimpleWeightedSumDataLayoutStrategyScorer(
             COMPACTION_GAIN_WEIGHT_DEFAULT, COMPUTE_COST_WEIGHT_DEFAULT);
-    List<ScoredDataLayoutStrategy> scoredStrategies = scorer.scoreDataLayoutStrategies(strategies);
     double maxComputeCost =
         NumberUtils.toDouble(
             properties.getProperty(MAX_COST_BUDGET_GB_HRS), MAX_COST_BUDGET_GB_HRS_DEFAULT);
@@ -101,12 +86,9 @@ public class OperationTasksBuilder {
         maxStrategiesCount);
     DataLayoutCandidateSelector candidateSelector =
         new GreedyMaxBudgetCandidateSelector(maxComputeCost, maxStrategiesCount);
-    List<Integer> selectedStrategyIndices = candidateSelector.select(scoredStrategies);
-    log.info("Selected {} strategies", selectedStrategyIndices.size());
     List<TableDataLayoutMetadata> selectedTableDataLayoutMetadataList =
-        selectedStrategyIndices.stream()
-            .map(tableDataLayoutMetadataList::get)
-            .collect(Collectors.toList());
+        DataLayoutUtil.selectStrategies(scorer, candidateSelector, tableDataLayoutMetadataList);
+    log.info("Selected {} strategies", selectedTableDataLayoutMetadataList.size());
     double totalComputeCost =
         selectedTableDataLayoutMetadataList.stream()
             .map(m -> m.getDataLayoutStrategy().getCost())

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
@@ -89,6 +89,9 @@ public class OperationTasksBuilder {
     List<TableDataLayoutMetadata> selectedTableDataLayoutMetadataList =
         DataLayoutUtil.selectStrategies(scorer, candidateSelector, tableDataLayoutMetadataList);
     log.info("Selected {} strategies", selectedTableDataLayoutMetadataList.size());
+    for (TableDataLayoutMetadata metadata : selectedTableDataLayoutMetadataList) {
+      log.info("Selected metadata {}", metadata);
+    }
     double totalComputeCost =
         selectedTableDataLayoutMetadataList.stream()
             .map(m -> m.getDataLayoutStrategy().getCost())

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/DataLayoutUtil.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/DataLayoutUtil.java
@@ -1,0 +1,48 @@
+package com.linkedin.openhouse.jobs.util;
+
+import com.linkedin.openhouse.datalayout.ranker.DataLayoutCandidateSelector;
+import com.linkedin.openhouse.datalayout.ranker.DataLayoutStrategyScorer;
+import com.linkedin.openhouse.datalayout.strategy.DataLayoutStrategy;
+import com.linkedin.openhouse.datalayout.strategy.ScoredDataLayoutStrategy;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public final class DataLayoutUtil {
+  private DataLayoutUtil() {
+    // private method of static utility class
+  }
+
+  public static List<TableDataLayoutMetadata> selectStrategies(
+      DataLayoutStrategyScorer scorer,
+      DataLayoutCandidateSelector selector,
+      List<TableDataLayoutMetadata> tableDataLayoutMetadataList) {
+    // filter out non-primary tables
+    tableDataLayoutMetadataList =
+        tableDataLayoutMetadataList.stream()
+            .filter(TableMetadata::isPrimary)
+            .collect(Collectors.toList());
+    log.info("Fetched metadata for {} data layout strategies", tableDataLayoutMetadataList.size());
+    tableDataLayoutMetadataList =
+        tableDataLayoutMetadataList.stream()
+            // filter out strategies with no gain/file count reduction
+            // or discounted to 0, e.g. frequently overwritten un-partitioned tables
+            .filter(
+                m ->
+                    m.getDataLayoutStrategy().getGain()
+                            * (1.0 - m.getDataLayoutStrategy().getFileCountReductionPenalty())
+                        >= 1.0)
+            .collect(Collectors.toList());
+    log.info("Filtered metadata for {} data layout strategies", tableDataLayoutMetadataList.size());
+    List<DataLayoutStrategy> strategies =
+        tableDataLayoutMetadataList.stream()
+            .map(TableDataLayoutMetadata::getDataLayoutStrategy)
+            .collect(Collectors.toList());
+    List<ScoredDataLayoutStrategy> scoredStrategies = scorer.scoreDataLayoutStrategies(strategies);
+    List<Integer> selectedStrategyIndices = selector.select(scoredStrategies);
+    return selectedStrategyIndices.stream()
+        .map(tableDataLayoutMetadataList::get)
+        .collect(Collectors.toList());
+  }
+}

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableDataLayoutMetadata.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableDataLayoutMetadata.java
@@ -3,6 +3,7 @@ package com.linkedin.openhouse.jobs.util;
 import com.linkedin.openhouse.datalayout.strategy.DataLayoutStrategy;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
@@ -11,5 +12,5 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class TableDataLayoutMetadata extends TableMetadata {
-  protected DataLayoutStrategy dataLayoutStrategy;
+  @NonNull protected DataLayoutStrategy dataLayoutStrategy;
 }

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/util/DataLayoutUtilTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/util/DataLayoutUtilTest.java
@@ -1,0 +1,83 @@
+package com.linkedin.openhouse.jobs.util;
+
+import com.linkedin.openhouse.datalayout.ranker.DataLayoutCandidateSelector;
+import com.linkedin.openhouse.datalayout.ranker.DataLayoutStrategyScorer;
+import com.linkedin.openhouse.datalayout.ranker.GreedyMaxBudgetCandidateSelector;
+import com.linkedin.openhouse.datalayout.ranker.SimpleWeightedSumDataLayoutStrategyScorer;
+import com.linkedin.openhouse.datalayout.strategy.DataLayoutStrategy;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DataLayoutUtilTest {
+  private static final double GAIN_WEIGHT = 0.7;
+  private static final double COST_WEIGHT = 0.3;
+
+  @Test
+  void testSelectStrategies() {
+    List<TableDataLayoutMetadata> tableDataLayoutMetadataList =
+        Arrays.asList(
+            TableDataLayoutMetadata.builder()
+                .dataLayoutStrategy(
+                    // large gain, but all discounted to 0 due to penalty, should be filtered out
+                    DataLayoutStrategy.builder()
+                        .gain(10000)
+                        .cost(10)
+                        .fileCountReductionPenalty(1.0)
+                        .build())
+                .dbName("db")
+                .tableName("table1")
+                .isPrimary(true)
+                .build(),
+            TableDataLayoutMetadata.builder()
+                .dataLayoutStrategy(
+                    DataLayoutStrategy.builder()
+                        .gain(1000)
+                        .cost(100)
+                        .fileCountReductionPenalty(0.0)
+                        .build())
+                .dbName("db")
+                .tableName("table2")
+                // not primary, should be filtered out
+                .isPrimary(false)
+                .build(),
+            TableDataLayoutMetadata.builder()
+                .dataLayoutStrategy(
+                    // small gain, but not discounted to 0, should be selected
+                    DataLayoutStrategy.builder()
+                        .gain(10)
+                        .cost(10)
+                        .fileCountReductionPenalty(0.0)
+                        .build())
+                .dbName("db")
+                .tableName("table3")
+                .isPrimary(true)
+                .build(),
+            TableDataLayoutMetadata.builder()
+                .dataLayoutStrategy(
+                    // medium gain and cost, should be selected
+                    DataLayoutStrategy.builder()
+                        .gain(1000)
+                        .cost(100)
+                        .fileCountReductionPenalty(0.0)
+                        .build())
+                .dbName("db")
+                .tableName("table4")
+                .isPrimary(true)
+                .build());
+    DataLayoutStrategyScorer scorer =
+        new SimpleWeightedSumDataLayoutStrategyScorer(GAIN_WEIGHT, COST_WEIGHT);
+    double maxComputeCost = 1e6; // infinite
+    int maxStrategiesCount = 1000; // infinite
+    DataLayoutCandidateSelector candidateSelector =
+        new GreedyMaxBudgetCandidateSelector(maxComputeCost, maxStrategiesCount);
+    List<TableDataLayoutMetadata> selectedTableDataLayoutMetadataList =
+        DataLayoutUtil.selectStrategies(scorer, candidateSelector, tableDataLayoutMetadataList);
+    Assertions.assertEquals(2, selectedTableDataLayoutMetadataList.size());
+    List<String> expectedTableNames = Arrays.asList("table3", "table4");
+    for (TableDataLayoutMetadata tableDataLayoutMetadata : selectedTableDataLayoutMetadataList) {
+      Assertions.assertTrue(expectedTableNames.contains(tableDataLayoutMetadata.getTableName()));
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Previously, strategies with low gain were filtered out, and the remaining strategies were used for selection. The selected indices were used on the original larger list. So, suboptimal strategies were incorrectly picked, and some good candidates were missed out.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
