### PR TITLE
PR1: Added pagination in the house table layer for get all tables/databases

### DIFF
--- a/services/common/src/main/java/com/linkedin/openhouse/common/metrics/MetricsConstant.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/metrics/MetricsConstant.java
@@ -45,4 +45,14 @@ public final class MetricsConstant {
   public static final String REPO_TABLE_IDS_FIND_ALL_TIME = "repo_table_ids_find_all_time";
   public static final String REPO_TABLES_FIND_ALL_TIME = "repo_tables_find_all_time";
   public static final String HTS_LIST_DATABASES_TIME = "hts_list_databases_time";
+  public static final String HTS_PAGE_DATABASES_TIME = "hts_page_databases_time";
+  public static final String HTS_PAGE_TABLES_TIME = "hts_page_tables_time";
+  public static final String HTS_PAGE_SEARCH_TABLES_TIME = "hts_page_search_tables_time";
+  public static final String HTS_PAGE_SEARCH_TABLES_REQUEST = "hts_page_search_tables_request";
+  public static final String HTS_PAGE_DATABASES_REQUEST = "hts_page_databases_request";
+  public static final String HTS_PAGE_TABLES_REQUEST = "hts_page_tables_request";
+  public static final String HTS_LIST_DATABASES_REQUEST = "hts_list_databases_request";
+  public static final String HTS_LIST_TABLES_REQUEST = "hts_list_tables_request";
+  public static final String HTS_LIST_TABLES_TIME = "hts_list_tables_time";
+  public static final String HTS_SEARCH_TABLES_TIME = "hts_search_tables_time";
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/HouseTablesApiHandler.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/HouseTablesApiHandler.java
@@ -32,6 +32,17 @@ public interface HouseTablesApiHandler<K, V> {
   ApiResponse<GetAllEntityResponseBody<V>> getEntities(V entity);
 
   /**
+   * Function to get paginated rows that fulfills the given entity.
+   *
+   * @param entity The entity serves as a container for predicates.
+   * @param page The page number to be retrieved
+   * @param size The number of entities in the page
+   * @param sortBy The results sorted by a field in the entity. For example, tableId, databaseId
+   * @return Paginated rows that fulfills the predicates expressed through param entity.
+   */
+  ApiResponse<GetAllEntityResponseBody<V>> getEntities(V entity, int page, int size, String sortBy);
+
+  /**
    * Function to Delete a row in a House Table given the key of the row.
    *
    * @param key The key object to identify the row to delete.

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/OpenHouseJobTableHtsApiHandler.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/OpenHouseJobTableHtsApiHandler.java
@@ -52,6 +52,12 @@ public class OpenHouseJobTableHtsApiHandler implements JobTableHtsApiHandler {
   }
 
   @Override
+  public ApiResponse<GetAllEntityResponseBody<Job>> getEntities(
+      Job entity, int page, int size, String sortBy) {
+    throw new UnsupportedOperationException("Get all job is unsupported");
+  }
+
+  @Override
   public ApiResponse<Void> deleteEntity(JobKey key) {
     jobsHTSApiValidator.validateDeleteEntity(key);
     jobsService.deleteJob(key.getJobId());

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/OpenHouseToggleStatusesApiHandler.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/OpenHouseToggleStatusesApiHandler.java
@@ -37,6 +37,12 @@ public class OpenHouseToggleStatusesApiHandler implements ToggleStatusesApiHandl
   }
 
   @Override
+  public ApiResponse<GetAllEntityResponseBody<ToggleStatus>> getEntities(
+      ToggleStatus entity, int page, int size, String sortBy) {
+    throw new UnsupportedOperationException("Get all toggle status is unsupported");
+  }
+
+  @Override
   public ApiResponse<Void> deleteEntity(TableToggleStatusKey key) {
     throw new UnsupportedOperationException("Delete toggle status is unsupported");
   }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/OpenHouseUserTableHtsApiHandler.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/OpenHouseUserTableHtsApiHandler.java
@@ -55,6 +55,22 @@ public class OpenHouseUserTableHtsApiHandler implements UserTableHtsApiHandler {
   }
 
   @Override
+  public ApiResponse<GetAllEntityResponseBody<UserTable>> getEntities(
+      UserTable userTable, int page, int size, String sortBy) {
+    userTablesHtsApiValidator.validateGetEntities(userTable);
+    return ApiResponse.<GetAllEntityResponseBody<UserTable>>builder()
+        .httpStatus(HttpStatus.OK)
+        .responseBody(
+            GetAllEntityResponseBody.<UserTable>builder()
+                .pageResults(
+                    userTableService
+                        .getAllUserTables(userTable, page, size, sortBy)
+                        .map(userTableDto -> userTablesMapper.toUserTable(userTableDto)))
+                .build())
+        .build();
+  }
+
+  @Override
   public ApiResponse<Void> deleteEntity(UserTableKey userTableKey) {
     userTablesHtsApiValidator.validateDeleteEntity(userTableKey);
     userTableService.deleteUserTable(userTableKey.getDatabaseId(), userTableKey.getTableId());

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/spec/response/GetAllEntityResponseBody.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/spec/response/GetAllEntityResponseBody.java
@@ -19,6 +19,11 @@ public class GetAllEntityResponseBody<T> {
       justification = "Value referenced in generated client code.")
   private List<T> results;
 
+  @Schema(description = "Page of user table objects in House table", example = "")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  @SuppressFBWarnings(
+      value = "URF_UNREAD_FIELD",
+      justification = "Value referenced in generated client code.")
   private Page<T> pageResults;
 
   public String toJson() {

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/spec/response/GetAllEntityResponseBody.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/spec/response/GetAllEntityResponseBody.java
@@ -6,6 +6,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.Builder;
+import org.springframework.data.domain.Page;
 
 // TODO: Support pagination
 @Builder
@@ -17,6 +18,8 @@ public class GetAllEntityResponseBody<T> {
       value = "URF_UNREAD_FIELD",
       justification = "Value referenced in generated client code.")
   private List<T> results;
+
+  private Page<T> pageResults;
 
   public String toJson() {
     return new Gson().toJson(this);

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/controller/UserHouseTablesController.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/controller/UserHouseTablesController.java
@@ -31,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserHouseTablesController {
   private static final String HTS_TABLES_GENERAL_ENDPOINT = "/hts/tables";
   private static final String HTS_TABLES_QUERY_ENDPOINT = "/hts/tables/query";
+  private static final String HTS_TABLES_QUERY_ENDPOINT_V1 = "/v1/hts/tables/query";
 
   @Autowired private UserTableHtsApiHandler tableHtsApiHandler;
 
@@ -74,6 +75,29 @@ public class UserHouseTablesController {
       @RequestParam Map<String, String> parameters) {
     com.linkedin.openhouse.common.api.spec.ApiResponse<GetAllEntityResponseBody<UserTable>>
         apiResponse = tableHtsApiHandler.getEntities(userTablesMapper.mapToUserTable(parameters));
+    return new ResponseEntity<>(
+        apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
+  }
+
+  @Operation(
+      summary = "Search User Table by filter.",
+      description =
+          "Returns paginate user tables from house table that fulfills the predicate. "
+              + "For examples, one could provide {databaseId: d1} in the map to query all tables from database d1.",
+      tags = {"UserTable"})
+  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "User Table GET: OK")})
+  @GetMapping(
+      value = HTS_TABLES_QUERY_ENDPOINT_V1,
+      produces = {"application/json"})
+  public ResponseEntity<GetAllEntityResponseBody<UserTable>> getPaginatedUserTables(
+      @RequestParam Map<String, String> parameters,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "50") int size,
+      @RequestParam(defaultValue = "databaseId") String sortBy) {
+    com.linkedin.openhouse.common.api.spec.ApiResponse<GetAllEntityResponseBody<UserTable>>
+        apiResponse =
+            tableHtsApiHandler.getEntities(
+                userTablesMapper.mapToUserTable(parameters), page, size, sortBy);
     return new ResponseEntity<>(
         apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
   }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/dto/model/UserTableDto.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/dto/model/UserTableDto.java
@@ -22,19 +22,4 @@ public class UserTableDto {
   String storageType;
 
   Long creationTime;
-
-  /**
-   * Compare if a given {@link UserTable} matches the current one if all non-null fields are equal.
-   *
-   * @param userTable the object to be examined.
-   * @return true if matched.
-   */
-  public boolean match(UserTableDto userTable) {
-    return Utilities.fieldMatchCaseInsensitive(this.databaseId, userTable.databaseId)
-        && Utilities.fieldMatchCaseInsensitive(this.tableId, userTable.tableId)
-        && Utilities.fieldMatch(this.metadataLocation, userTable.metadataLocation)
-        && Utilities.fieldMatch(this.tableVersion, userTable.tableVersion)
-        && Utilities.fieldMatch(this.storageType, userTable.storageType)
-        && Utilities.fieldMatch(this.creationTime, userTable.creationTime);
-  }
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/HtsRepository.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/HtsRepository.java
@@ -1,10 +1,10 @@
 package com.linkedin.openhouse.housetables.repository;
 
 import com.linkedin.openhouse.housetables.api.spec.model.UserTable;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
 
 /**
  * Interface for repository backed by Iceberg/JDBC for storing and retrieving {@link UserTable} or
  * {@link com.linkedin.openhouse.housetables.api.spec.model.Job} row object.
  */
-public interface HtsRepository<T, ID> extends CrudRepository<T, ID> {}
+public interface HtsRepository<T, ID> extends PagingAndSortingRepository<T, ID> {}

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/iceberg/JobTableHtsRepository.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/iceberg/JobTableHtsRepository.java
@@ -9,12 +9,16 @@ import com.linkedin.openhouse.housetables.repository.HtsRepository;
 import com.linkedin.openhouse.hts.catalog.model.jobtable.JobIcebergRow;
 import com.linkedin.openhouse.hts.catalog.model.jobtable.JobIcebergRowPrimaryKey;
 import com.linkedin.openhouse.hts.catalog.repository.IcebergHtsRepository;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.compress.utils.Lists;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 
 @Deprecated
@@ -49,7 +53,7 @@ public class JobTableHtsRepository implements HtsRepository<JobRow, JobRowPrimar
   }
 
   @Override
-  public Iterable<JobRow> findAll() {
+  public List<JobRow> findAll() {
     return Lists.newArrayList(
             icebergHtsRepository
                 .searchByPartialId(JobIcebergRowPrimaryKey.builder().build())
@@ -91,7 +95,7 @@ public class JobTableHtsRepository implements HtsRepository<JobRow, JobRowPrimar
   }
 
   @Override
-  public Iterable<JobRow> findAllById(Iterable<JobRowPrimaryKey> jobRowPrimaryKeys) {
+  public List<JobRow> findAllById(Iterable<JobRowPrimaryKey> jobRowPrimaryKeys) {
     throw getUnsupportedException();
   }
 
@@ -101,11 +105,21 @@ public class JobTableHtsRepository implements HtsRepository<JobRow, JobRowPrimar
   }
 
   @Override
-  public <S extends JobRow> Iterable<S> saveAll(Iterable<S> entities) {
+  public <S extends JobRow> List<S> saveAll(Iterable<S> entities) {
     throw getUnsupportedException();
   }
 
   private UnsupportedOperationException getUnsupportedException() {
     return new UnsupportedOperationException("Not supported yet");
+  }
+
+  @Override
+  public Iterable<JobRow> findAll(Sort sort) {
+    return null;
+  }
+
+  @Override
+  public Page<JobRow> findAll(Pageable pageable) {
+    return null;
   }
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/iceberg/JobTableHtsRepository.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/iceberg/JobTableHtsRepository.java
@@ -9,7 +9,6 @@ import com.linkedin.openhouse.housetables.repository.HtsRepository;
 import com.linkedin.openhouse.hts.catalog.model.jobtable.JobIcebergRow;
 import com.linkedin.openhouse.hts.catalog.model.jobtable.JobIcebergRowPrimaryKey;
 import com.linkedin.openhouse.hts.catalog.repository.IcebergHtsRepository;
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.compress.utils.Lists;
@@ -53,7 +52,7 @@ public class JobTableHtsRepository implements HtsRepository<JobRow, JobRowPrimar
   }
 
   @Override
-  public List<JobRow> findAll() {
+  public Iterable<JobRow> findAll() {
     return Lists.newArrayList(
             icebergHtsRepository
                 .searchByPartialId(JobIcebergRowPrimaryKey.builder().build())
@@ -95,7 +94,7 @@ public class JobTableHtsRepository implements HtsRepository<JobRow, JobRowPrimar
   }
 
   @Override
-  public List<JobRow> findAllById(Iterable<JobRowPrimaryKey> jobRowPrimaryKeys) {
+  public Iterable<JobRow> findAllById(Iterable<JobRowPrimaryKey> jobRowPrimaryKeys) {
     throw getUnsupportedException();
   }
 
@@ -105,7 +104,7 @@ public class JobTableHtsRepository implements HtsRepository<JobRow, JobRowPrimar
   }
 
   @Override
-  public <S extends JobRow> List<S> saveAll(Iterable<S> entities) {
+  public <S extends JobRow> Iterable<S> saveAll(Iterable<S> entities) {
     throw getUnsupportedException();
   }
 
@@ -115,11 +114,11 @@ public class JobTableHtsRepository implements HtsRepository<JobRow, JobRowPrimar
 
   @Override
   public Iterable<JobRow> findAll(Sort sort) {
-    return null;
+    throw getUnsupportedException();
   }
 
   @Override
   public Page<JobRow> findAll(Pageable pageable) {
-    return null;
+    throw getUnsupportedException();
   }
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/iceberg/UserTableHtsRepository.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/iceberg/UserTableHtsRepository.java
@@ -9,12 +9,16 @@ import com.linkedin.openhouse.housetables.repository.HtsRepository;
 import com.linkedin.openhouse.hts.catalog.model.usertable.UserTableIcebergRow;
 import com.linkedin.openhouse.hts.catalog.model.usertable.UserTableIcebergRowPrimaryKey;
 import com.linkedin.openhouse.hts.catalog.repository.IcebergHtsRepository;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.compress.utils.Lists;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 
 @Deprecated
@@ -78,7 +82,7 @@ public class UserTableHtsRepository implements HtsRepository<UserTableRow, UserT
   }
 
   @Override
-  public Iterable<UserTableRow> findAll() {
+  public List<UserTableRow> findAll() {
     return Lists.newArrayList(
             icebergHtsRepository
                 .searchByPartialId(UserTableIcebergRowPrimaryKey.builder().build())
@@ -90,13 +94,12 @@ public class UserTableHtsRepository implements HtsRepository<UserTableRow, UserT
 
   /* IMPLEMENT AS NEEDED */
   @Override
-  public <S extends UserTableRow> Iterable<S> saveAll(Iterable<S> entities) {
+  public <S extends UserTableRow> List<S> saveAll(Iterable<S> entities) {
     throw getUnsupportedException();
   }
 
   @Override
-  public Iterable<UserTableRow> findAllById(
-      Iterable<UserTableRowPrimaryKey> userTableRowPrimaryKeys) {
+  public List<UserTableRow> findAllById(Iterable<UserTableRowPrimaryKey> userTableRowPrimaryKeys) {
     throw getUnsupportedException();
   }
 
@@ -118,5 +121,14 @@ public class UserTableHtsRepository implements HtsRepository<UserTableRow, UserT
   private UnsupportedOperationException getUnsupportedException() {
     return new UnsupportedOperationException(
         "Only save, findById, existsById, deleteById supported for UserTableHtsRepositoryImpl");
+  }
+
+  public List<UserTableRow> findAll(Sort sort) {
+    throw getUnsupportedException();
+  }
+
+  @Override
+  public Page<UserTableRow> findAll(Pageable pageable) {
+    return null;
   }
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/iceberg/UserTableHtsRepository.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/iceberg/UserTableHtsRepository.java
@@ -9,7 +9,6 @@ import com.linkedin.openhouse.housetables.repository.HtsRepository;
 import com.linkedin.openhouse.hts.catalog.model.usertable.UserTableIcebergRow;
 import com.linkedin.openhouse.hts.catalog.model.usertable.UserTableIcebergRowPrimaryKey;
 import com.linkedin.openhouse.hts.catalog.repository.IcebergHtsRepository;
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.compress.utils.Lists;
@@ -82,7 +81,7 @@ public class UserTableHtsRepository implements HtsRepository<UserTableRow, UserT
   }
 
   @Override
-  public List<UserTableRow> findAll() {
+  public Iterable<UserTableRow> findAll() {
     return Lists.newArrayList(
             icebergHtsRepository
                 .searchByPartialId(UserTableIcebergRowPrimaryKey.builder().build())
@@ -94,12 +93,13 @@ public class UserTableHtsRepository implements HtsRepository<UserTableRow, UserT
 
   /* IMPLEMENT AS NEEDED */
   @Override
-  public <S extends UserTableRow> List<S> saveAll(Iterable<S> entities) {
+  public <S extends UserTableRow> Iterable<S> saveAll(Iterable<S> entities) {
     throw getUnsupportedException();
   }
 
   @Override
-  public List<UserTableRow> findAllById(Iterable<UserTableRowPrimaryKey> userTableRowPrimaryKeys) {
+  public Iterable<UserTableRow> findAllById(
+      Iterable<UserTableRowPrimaryKey> userTableRowPrimaryKeys) {
     throw getUnsupportedException();
   }
 
@@ -123,12 +123,12 @@ public class UserTableHtsRepository implements HtsRepository<UserTableRow, UserT
         "Only save, findById, existsById, deleteById supported for UserTableHtsRepositoryImpl");
   }
 
-  public List<UserTableRow> findAll(Sort sort) {
+  public Iterable<UserTableRow> findAll(Sort sort) {
     throw getUnsupportedException();
   }
 
   @Override
   public Page<UserTableRow> findAll(Pageable pageable) {
-    return null;
+    throw getUnsupportedException();
   }
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/jdbc/UserTableHtsJdbcRepository.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/jdbc/UserTableHtsJdbcRepository.java
@@ -4,8 +4,11 @@ import com.linkedin.openhouse.housetables.config.db.jdbc.JdbcProviderConfigurati
 import com.linkedin.openhouse.housetables.model.UserTableRow;
 import com.linkedin.openhouse.housetables.model.UserTableRowPrimaryKey;
 import com.linkedin.openhouse.housetables.repository.HtsRepository;
+import java.util.List;
 import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 
 /**
@@ -35,12 +38,39 @@ public interface UserTableHtsJdbcRepository
   void deleteByDatabaseIdIgnoreCaseAndTableIdIgnoreCase(String databaseId, String tableId);
 
   @Query("SELECT DISTINCT databaseId FROM UserTableRow")
-  Iterable<String> findAllDistinctDatabaseIds();
+  List<String> findAllDistinctDatabaseIds();
 
-  Iterable<UserTableRow> findAllByDatabaseIdIgnoreCase(String databaseId);
+  List<UserTableRow> findAllByDatabaseIdIgnoreCase(String databaseId);
 
-  Iterable<UserTableRow> findAllByDatabaseIdAndTableIdLikeAllIgnoreCase(
+  List<UserTableRow> findAllByDatabaseIdAndTableIdLikeAllIgnoreCase(
       String databaseId, String tableIdPattern);
+
+  @Query(
+      "SELECT DISTINCT databaseId FROM UserTableRow u where "
+          + "(:databaseId IS NULL OR lower(u.databaseId) = lower(:databaseId))")
+  Page<String> findAllDistinctDatabaseIds(String databaseId, Pageable pageable);
+
+  Page<UserTableRow> findAllByDatabaseIdIgnoreCase(String databaseId, Pageable pageable);
+
+  Page<UserTableRow> findAllByDatabaseIdAndTableIdLikeAllIgnoreCase(
+      String databaseId, String tableIdPattern, Pageable pageable);
+
+  @Query(
+      "select DISTINCT u from UserTableRow u where "
+          + "(:databaseId IS NULL OR lower(u.databaseId) = lower(:databaseId)) AND "
+          + "(:tableId IS NULL OR lower(u.tableId) = lower(:tableId)) AND "
+          + "(:tableVersion IS NULL OR u.version = :tableVersion) AND "
+          + "(:metadataLocation IS NULL OR u.metadataLocation = :metadataLocation) AND "
+          + "(:storageType IS NULL OR u.storageType = :storageType) AND "
+          + "(:creationTime IS NULL OR u.creationTime = :creationTime)")
+  Page<UserTableRow> findAllByFilters(
+      String databaseId,
+      String tableId,
+      String tableVersion,
+      String metadataLocation,
+      String storageType,
+      Long creationTime,
+      Pageable pageable);
 
   /*
    * The following methods are required to maintain the generality of the interface {@link com.linkedin.openhouse.housetables.repository.HtsRepository}

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/jdbc/UserTableHtsJdbcRepository.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/jdbc/UserTableHtsJdbcRepository.java
@@ -4,7 +4,6 @@ import com.linkedin.openhouse.housetables.config.db.jdbc.JdbcProviderConfigurati
 import com.linkedin.openhouse.housetables.model.UserTableRow;
 import com.linkedin.openhouse.housetables.model.UserTableRowPrimaryKey;
 import com.linkedin.openhouse.housetables.repository.HtsRepository;
-import java.util.List;
 import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.data.domain.Page;
@@ -38,11 +37,11 @@ public interface UserTableHtsJdbcRepository
   void deleteByDatabaseIdIgnoreCaseAndTableIdIgnoreCase(String databaseId, String tableId);
 
   @Query("SELECT DISTINCT databaseId FROM UserTableRow")
-  List<String> findAllDistinctDatabaseIds();
+  Iterable<String> findAllDistinctDatabaseIds();
 
-  List<UserTableRow> findAllByDatabaseIdIgnoreCase(String databaseId);
+  Iterable<UserTableRow> findAllByDatabaseIdIgnoreCase(String databaseId);
 
-  List<UserTableRow> findAllByDatabaseIdAndTableIdLikeAllIgnoreCase(
+  Iterable<UserTableRow> findAllByDatabaseIdAndTableIdLikeAllIgnoreCase(
       String databaseId, String tableIdPattern);
 
   @Query(

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/jdbc/UserTableHtsJdbcRepository.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/jdbc/UserTableHtsJdbcRepository.java
@@ -71,6 +71,22 @@ public interface UserTableHtsJdbcRepository
       Long creationTime,
       Pageable pageable);
 
+  @Query(
+      "select DISTINCT u from UserTableRow u where "
+          + "(:databaseId IS NULL OR lower(u.databaseId) = lower(:databaseId)) AND "
+          + "(:tableId IS NULL OR lower(u.tableId) = lower(:tableId)) AND "
+          + "(:tableVersion IS NULL OR u.version = :tableVersion) AND "
+          + "(:metadataLocation IS NULL OR u.metadataLocation = :metadataLocation) AND "
+          + "(:storageType IS NULL OR u.storageType = :storageType) AND "
+          + "(:creationTime IS NULL OR u.creationTime = :creationTime)")
+  Iterable<UserTableRow> findAllByFilters(
+      String databaseId,
+      String tableId,
+      String tableVersion,
+      String metadataLocation,
+      String storageType,
+      Long creationTime);
+
   /*
    * The following methods are required to maintain the generality of the interface {@link com.linkedin.openhouse.housetables.repository.HtsRepository}
    */

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesService.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesService.java
@@ -3,6 +3,7 @@ package com.linkedin.openhouse.housetables.services;
 import com.linkedin.openhouse.housetables.api.spec.model.UserTable;
 import com.linkedin.openhouse.housetables.dto.model.UserTableDto;
 import java.util.List;
+import org.springframework.data.domain.Page;
 import org.springframework.data.util.Pair;
 
 /** Service Interface for Implementing /hts/tables endpoint. */
@@ -24,6 +25,20 @@ public interface UserTablesService {
    * @return list of {@link UserTableDto}s that matches the provided {@link UserTable}
    */
   List<UserTableDto> getAllUserTables(UserTable userTable);
+
+  /**
+   * Given a partially filled {@link UserTable} object, prepare a paginated {@link UserTableDto}s
+   * that matches with the provided {@link UserTable}. See
+   * com.linkedin.openhouse.housetables.dto.model.UserTableDto#match for the definition of match.
+   *
+   * @param userTable
+   * @param page The page number to be retrieved
+   * @param size The number of {@link UserTableDto}s in the specified page
+   * @param sortBy The results sorted by field in {@link UserTable}. For example, tableId,
+   *     databaseId
+   * @return
+   */
+  Page<UserTableDto> getAllUserTables(UserTable userTable, int page, int size, String sortBy);
 
   /** Given a databaseId and tableId, delete the user table entry from the House Table. */
   void deleteUserTable(String databaseId, String tableId);

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesServiceImpl.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesServiceImpl.java
@@ -160,13 +160,6 @@ public class UserTablesServiceImpl implements UserTablesService {
             .findAllByDatabaseIdIgnoreCase(userTable.getDatabaseId(), pageable)
             .map(userTableRow -> userTablesMapper.toUserTableDto(userTableRow));
     return userTableDtoPage;
-    /*return StreamSupport.stream(
-        htsJdbcRepository
-            .findAllByDatabaseIdIgnoreCase(userTable.getDatabaseId(), pageable)
-            .spliterator(),
-        false)
-    .map(userTableRow -> userTablesMapper.toUserTableDto(userTableRow))
-    .collect(Collectors.toList());*/
   }
 
   private List<UserTableDto> listTablesWithPattern(UserTable userTable) {

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesServiceImpl.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesServiceImpl.java
@@ -16,9 +16,14 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.util.Pair;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Component;
@@ -61,6 +66,20 @@ public class UserTablesServiceImpl implements UserTablesService {
       return listTablesWithPattern(userTable);
     } else {
       return searchTables(userTable);
+    }
+  }
+
+  @Override
+  public Page<UserTableDto> getAllUserTables(
+      UserTable userTable, int page, int size, String sortBy) {
+    if (isListDatabases(userTable)) {
+      return listDatabases(page, size, sortBy);
+    } else if (isListTables(userTable)) {
+      return listTables(userTable, page, size, sortBy);
+    } else if (isListTablesWithPattern(userTable)) {
+      return listTablesWithPattern(userTable, page, size, sortBy);
+    } else {
+      return searchTables(userTable, page, size, sortBy);
     }
   }
 
@@ -117,6 +136,13 @@ public class UserTablesServiceImpl implements UserTablesService {
         MetricsConstant.HTS_LIST_DATABASES_TIME);
   }
 
+  private Page<UserTableDto> listDatabases(int page, int size, String sortBy) {
+    Pageable pageable = createPageable(page, size, sortBy, "databaseId");
+    return htsJdbcRepository
+        .findAllDistinctDatabaseIds(null, pageable)
+        .map(databaseId -> UserTableDto.builder().databaseId(databaseId).build());
+  }
+
   private List<UserTableDto> listTables(UserTable userTable) {
     return StreamSupport.stream(
             htsJdbcRepository
@@ -125,6 +151,22 @@ public class UserTablesServiceImpl implements UserTablesService {
             false)
         .map(userTableRow -> userTablesMapper.toUserTableDto(userTableRow))
         .collect(Collectors.toList());
+  }
+
+  private Page<UserTableDto> listTables(UserTable userTable, int page, int size, String sortBy) {
+    Pageable pageable = createPageable(page, size, sortBy, "tableId");
+    Page<UserTableDto> userTableDtoPage =
+        htsJdbcRepository
+            .findAllByDatabaseIdIgnoreCase(userTable.getDatabaseId(), pageable)
+            .map(userTableRow -> userTablesMapper.toUserTableDto(userTableRow));
+    return userTableDtoPage;
+    /*return StreamSupport.stream(
+        htsJdbcRepository
+            .findAllByDatabaseIdIgnoreCase(userTable.getDatabaseId(), pageable)
+            .spliterator(),
+        false)
+    .map(userTableRow -> userTablesMapper.toUserTableDto(userTableRow))
+    .collect(Collectors.toList());*/
   }
 
   private List<UserTableDto> listTablesWithPattern(UserTable userTable) {
@@ -136,6 +178,40 @@ public class UserTablesServiceImpl implements UserTablesService {
             false)
         .map(userTableRow -> userTablesMapper.toUserTableDto(userTableRow))
         .collect(Collectors.toList());
+  }
+
+  private Page<UserTableDto> listTablesWithPattern(
+      UserTable userTable, int page, int size, String sortBy) {
+    Pageable pageable = createPageable(page, size, sortBy, "tableId");
+    return htsJdbcRepository
+        .findAllByDatabaseIdAndTableIdLikeAllIgnoreCase(
+            userTable.getDatabaseId(), userTable.getTableId(), pageable)
+        .map(userTableRow -> userTablesMapper.toUserTableDto(userTableRow));
+  }
+
+  private Page<UserTableDto> searchTables(UserTable userTable, int page, int size, String sortBy) {
+    METRICS_REPORTER.count(MetricsConstant.HTS_GENERAL_SEARCH_REQUEST);
+    Pageable pageable = createPageable(page, size, sortBy, "tableId");
+    log.warn(
+        "Reaching general search for user table which is not expected: {}", userTable.toJson());
+    return htsJdbcRepository
+        .findAllByFilters(
+            userTable.getDatabaseId(),
+            userTable.getTableId(),
+            userTable.getTableVersion(),
+            userTable.getMetadataLocation(),
+            userTable.getStorageType(),
+            userTable.getCreationTime(),
+            pageable)
+        .map(userTableRow -> userTablesMapper.toUserTableDto(userTableRow));
+  }
+
+  private Pageable createPageable(int page, int size, String sortBy, String defaultSortBy) {
+    Sort sort =
+        StringUtils.isEmpty(sortBy)
+            ? Sort.by(defaultSortBy).ascending()
+            : Sort.by(sortBy).ascending();
+    return PageRequest.of(page, size, sort);
   }
 
   private List<UserTableDto> searchTables(UserTable userTable) {

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/UserTablesServiceTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/UserTablesServiceTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
 import org.springframework.data.util.Pair;
 
 @SpringBootTest(classes = SpringH2HtsApplication.class)
@@ -42,7 +43,13 @@ public class UserTablesServiceTest {
     htsRepository.save(testUserTableRow);
     htsRepository.save(TEST_TUPLE_1_0.get_userTableRow());
     htsRepository.save(TEST_TUPLE_2_0.get_userTableRow());
+    htsRepository.save(TEST_TUPLE_3_0.get_userTableRow());
+    htsRepository.save(TEST_TUPLE_4_0.get_userTableRow());
     htsRepository.save(TEST_TUPLE_1_1.get_userTableRow());
+    htsRepository.save(TEST_TUPLE_2_1.get_userTableRow());
+    htsRepository.save(TEST_TUPLE_3_1.get_userTableRow());
+    htsRepository.save(TEST_TUPLE_1_2.get_userTableRow());
+    htsRepository.save(TEST_TUPLE_2_2.get_userTableRow());
 
     // delete candidate
     htsRepository.save(
@@ -108,6 +115,131 @@ public class UserTablesServiceTest {
   }
 
   @Test
+  public void testGetUserTables() {
+    UserTable userTable =
+        UserTable.builder().databaseId(TestHouseTableModelConstants.TEST_DB_ID).build();
+    List<UserTableDto> list = userTablesService.getAllUserTables(userTable);
+    Assertions.assertEquals(5, list.size());
+    Page<UserTableDto> userTableDtoPage0 =
+        userTablesService.getAllUserTables(userTable, 0, 2, "tableId");
+    Assertions.assertEquals(5, userTableDtoPage0.getTotalElements());
+    Assertions.assertEquals(3, userTableDtoPage0.getTotalPages());
+    List<UserTableDto> list0 = userTableDtoPage0.getContent();
+    Assertions.assertEquals(2, list0.size());
+
+    Page<UserTableDto> userTableDtoPage1 =
+        userTablesService.getAllUserTables(userTable, 1, 2, "tableId");
+    Assertions.assertEquals(5, userTableDtoPage1.getTotalElements());
+    Assertions.assertEquals(3, userTableDtoPage1.getTotalPages());
+    List<UserTableDto> list1 = userTableDtoPage1.getContent();
+    Assertions.assertEquals(2, list1.size());
+
+    Page<UserTableDto> userTableDtoPage2 =
+        userTablesService.getAllUserTables(userTable, 2, 2, "tableId");
+    Assertions.assertEquals(5, userTableDtoPage2.getTotalElements());
+    Assertions.assertEquals(3, userTableDtoPage2.getTotalPages());
+    List<UserTableDto> list2 = userTableDtoPage2.getContent();
+    Assertions.assertEquals(1, list2.size());
+  }
+
+  @Test
+  public void testListDatabases() {
+    UserTable userTable = UserTable.builder().build();
+    List<UserTableDto> list = userTablesService.getAllUserTables(userTable);
+    Assertions.assertEquals(5, list.size());
+    Page<UserTableDto> userTableDtoPage0 =
+        userTablesService.getAllUserTables(userTable, 0, 2, "databaseId");
+    Assertions.assertEquals(5, userTableDtoPage0.getTotalElements());
+    Assertions.assertEquals(3, userTableDtoPage0.getTotalPages());
+    List<UserTableDto> list0 = userTableDtoPage0.getContent();
+    Assertions.assertEquals(2, list0.size());
+    for (UserTableDto userTableDto : list0) {
+      Assertions.assertNotNull(userTableDto.getDatabaseId());
+      Assertions.assertNull(userTableDto.getTableId());
+    }
+
+    Page<UserTableDto> userTableDtoPage1 =
+        userTablesService.getAllUserTables(userTable, 1, 2, "databaseId");
+    Assertions.assertEquals(5, userTableDtoPage1.getTotalElements());
+    Assertions.assertEquals(3, userTableDtoPage1.getTotalPages());
+    List<UserTableDto> list1 = userTableDtoPage1.getContent();
+    Assertions.assertEquals(2, list1.size());
+    for (UserTableDto userTableDto : list1) {
+      Assertions.assertNotNull(userTableDto.getDatabaseId());
+      Assertions.assertNull(userTableDto.getTableId());
+    }
+
+    Page<UserTableDto> userTableDtoPage2 =
+        userTablesService.getAllUserTables(userTable, 2, 2, "databaseId");
+    Assertions.assertEquals(5, userTableDtoPage2.getTotalElements());
+    Assertions.assertEquals(3, userTableDtoPage2.getTotalPages());
+    List<UserTableDto> list2 = userTableDtoPage2.getContent();
+    Assertions.assertEquals(1, list2.size());
+    for (UserTableDto userTableDto : list2) {
+      Assertions.assertNotNull(userTableDto.getDatabaseId());
+      Assertions.assertNull(userTableDto.getTableId());
+    }
+  }
+
+  @Test
+  public void testGetUserTablesWithTablePattern() {
+    UserTable userTable =
+        UserTable.builder()
+            .databaseId(TestHouseTableModelConstants.TEST_DB_ID)
+            .tableId("test_table%")
+            .build();
+    List<UserTableDto> list = userTablesService.getAllUserTables(userTable);
+    Assertions.assertEquals(5, list.size());
+    Page<UserTableDto> userTableDtoPage0 =
+        userTablesService.getAllUserTables(userTable, 0, 2, "tableId");
+    Assertions.assertEquals(5, userTableDtoPage0.getTotalElements());
+    Assertions.assertEquals(3, userTableDtoPage0.getTotalPages());
+    List<UserTableDto> list0 = userTableDtoPage0.getContent();
+    Assertions.assertEquals(2, list0.size());
+
+    Page<UserTableDto> userTableDtoPage1 =
+        userTablesService.getAllUserTables(userTable, 1, 2, "tableId");
+    Assertions.assertEquals(5, userTableDtoPage1.getTotalElements());
+    Assertions.assertEquals(3, userTableDtoPage1.getTotalPages());
+    List<UserTableDto> list1 = userTableDtoPage1.getContent();
+    Assertions.assertEquals(2, list1.size());
+
+    Page<UserTableDto> userTableDtoPage2 =
+        userTablesService.getAllUserTables(userTable, 2, 2, "tableId");
+    Assertions.assertEquals(5, userTableDtoPage2.getTotalElements());
+    Assertions.assertEquals(3, userTableDtoPage2.getTotalPages());
+    List<UserTableDto> list2 = userTableDtoPage2.getContent();
+    Assertions.assertEquals(1, list2.size());
+  }
+
+  @Test
+  public void testGetUserTablesWithSearchFilter() {
+    UserTable userTable = UserTable.builder().creationTime(123L).build();
+    List<UserTableDto> list = userTablesService.getAllUserTables(userTable);
+    Assertions.assertEquals(12, list.size());
+    Page<UserTableDto> userTableDtoPage0 =
+        userTablesService.getAllUserTables(userTable, 0, 4, "tableId");
+    Assertions.assertEquals(12, userTableDtoPage0.getTotalElements());
+    Assertions.assertEquals(3, userTableDtoPage0.getTotalPages());
+    List<UserTableDto> list0 = userTableDtoPage0.getContent();
+    Assertions.assertEquals(4, list0.size());
+
+    Page<UserTableDto> userTableDtoPage1 =
+        userTablesService.getAllUserTables(userTable, 1, 4, "tableId");
+    Assertions.assertEquals(12, userTableDtoPage1.getTotalElements());
+    Assertions.assertEquals(3, userTableDtoPage1.getTotalPages());
+    List<UserTableDto> list1 = userTableDtoPage1.getContent();
+    Assertions.assertEquals(4, list1.size());
+
+    Page<UserTableDto> userTableDtoPage2 =
+        userTablesService.getAllUserTables(userTable, 2, 4, "tableId");
+    Assertions.assertEquals(12, userTableDtoPage2.getTotalElements());
+    Assertions.assertEquals(3, userTableDtoPage2.getTotalPages());
+    List<UserTableDto> list2 = userTableDtoPage2.getContent();
+    Assertions.assertEquals(4, list2.size());
+  }
+
+  @Test
   public void testUserTableQuery() {
     List<UserTableDto> results = new ArrayList<>();
     results.add(
@@ -123,6 +255,18 @@ public class UserTablesServiceTest {
             .tableVersion(TEST_TUPLE_2_0.get_userTableDto().getMetadataLocation())
             .build());
     results.add(
+        TEST_TUPLE_3_0
+            .get_userTableDto()
+            .toBuilder()
+            .tableVersion(TEST_TUPLE_3_0.get_userTableDto().getMetadataLocation())
+            .build());
+    results.add(
+        TEST_TUPLE_4_0
+            .get_userTableDto()
+            .toBuilder()
+            .tableVersion(TEST_TUPLE_4_0.get_userTableDto().getMetadataLocation())
+            .build());
+    results.add(
         TEST_USER_TABLE_DTO
             .toBuilder()
             .tableVersion(TEST_USER_TABLE_DTO.getMetadataLocation())
@@ -130,7 +274,7 @@ public class UserTablesServiceTest {
 
     // No filter, should return all tables.
     List<UserTableDto> actual = userTablesService.getAllUserTables(UserTable.builder().build());
-    assertThat(actual.size()).isEqualTo(4);
+    assertThat(actual.size()).isEqualTo(5);
 
     // Only specify the database ID to find all tables under this database.
     actual =
@@ -152,7 +296,7 @@ public class UserTablesServiceTest {
     actual =
         userTablesService.getAllUserTables(
             UserTable.builder().tableId(TEST_TUPLE_2_0.getTableId()).build());
-    assertThat(actual.size()).isEqualTo(1);
+    assertThat(actual.size()).isEqualTo(3);
     assertThat(isUserTableDtoEqual(actual.get(0), TEST_TUPLE_2_0.get_userTableDto())).isTrue();
   }
 

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/mock/MockUserTableHtsApiHandler.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/mock/MockUserTableHtsApiHandler.java
@@ -16,6 +16,12 @@ public class MockUserTableHtsApiHandler implements UserTableHtsApiHandler {
   }
 
   @Override
+  public ApiResponse<GetAllEntityResponseBody<UserTable>> getEntities(
+      UserTable entity, int page, int size, String sortBy) {
+    return null;
+  }
+
+  @Override
   public ApiResponse<Void> deleteEntity(UserTableKey key) {
     return null;
   }

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/model/TestHouseTableModelConstants.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/model/TestHouseTableModelConstants.java
@@ -30,8 +30,20 @@ public final class TestHouseTableModelConstants {
   public static final TestTuple TEST_TUPLE_1_0 = new TestHouseTableModelConstants.TestTuple(1);
   // table2, db0
   public static final TestTuple TEST_TUPLE_2_0 = new TestHouseTableModelConstants.TestTuple(2);
+  // table3, db0
+  public static final TestTuple TEST_TUPLE_3_0 = new TestHouseTableModelConstants.TestTuple(3);
+  // table4, db0
+  public static final TestTuple TEST_TUPLE_4_0 = new TestHouseTableModelConstants.TestTuple(4);
   // table1, db1
   public static final TestTuple TEST_TUPLE_1_1 = new TestHouseTableModelConstants.TestTuple(1, 1);
+  // table2, db1
+  public static final TestTuple TEST_TUPLE_2_1 = new TestHouseTableModelConstants.TestTuple(2, 1);
+  // table3, db1
+  public static final TestTuple TEST_TUPLE_3_1 = new TestHouseTableModelConstants.TestTuple(3, 1);
+  // table1, db2
+  public static final TestTuple TEST_TUPLE_1_2 = new TestHouseTableModelConstants.TestTuple(1, 2);
+  // table2, db2
+  public static final TestTuple TEST_TUPLE_2_2 = new TestHouseTableModelConstants.TestTuple(2, 2);
 
   @Getter
   public static class TestTuple {


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

This PR adds pagination in the house table layer for get all tables/databases. Openhouse data access layer (house tables) uses Spring data JPA repository i.e. [CrudRepository](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/CrudRepository.html). However, CrudRepository does not support pagination and sorting capability. [PagingAndSortingRepository](https://docs.spring.io/spring-data/commons/docs/2.7.0-M4/api/index.html?org/springframework/data/repository/PagingAndSortingRepository.html) which extends [CrudRepository](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/CrudRepository.html) (prior to Spring 3.0) supports pagination. We are currently using spring boot 2.7.8. So by extending all our repositories to [PagingAndSortingRepository](https://docs.spring.io/spring-data/commons/docs/2.7.0-M4/api/index.html?org/springframework/data/repository/PagingAndSortingRepository.html) we don't lose any of the existing behaviours and we gain paging and sorting capability on top of existing JPA repositories. [JpaRepository](https://docs.spring.io/spring-data/jpa/docs/2.7.0/api/index.html?org/springframework/data/jpa/repository/JpaRepository.html) which in turn extends [PagingAndSortingRepository](https://docs.spring.io/spring-data/commons/docs/2.7.0-M4/api/index.html?org/springframework/data/repository/PagingAndSortingRepository.html) and comes with more advanced features which we don't need. So extending [PagingAndSortingRepository](https://docs.spring.io/spring-data/commons/docs/2.7.0-M4/api/index.html?org/springframework/data/repository/PagingAndSortingRepository.html) is the best option for achieving pagination with sorting.

**Backward compatibility:**
We want to keep the existing APIs while pagination is ramped. API signature changes with pagination and so new APIs and methods are added to ensure that existing APIs work as expected.

**Pagination:** 
A new API endpoint `/v1/hts/tables/query` is added for supporting pagination for user tables. The API accepts search parameters and pagination parameters. The pagination parameter includes `page`, `size` and `sortedBy` fields such as `tableId`,`databaseId` etc. Sorting is imported for pagination to work effectively. Unsorted data could lead to invalid results per page. All the pagination parameters have defaults if not provided. Page starts with 0 and the default value for page size is 50. Default sorting is provided on `databaseId`. All sorting order is ascending and sort order is not part of the API parameter. Sort order can be included in future if needed.

Pagination changes include only user tables in this PR. Pagination for jobs and feature toggle APIs are not part of this PR. They can be included in future if needed.

**New HTS API**
A new API called `getPaginatedUserTables` is added in the HTS layer with end point `/v1/hts/tables/query`. This API accepts search parameters and pagination parameters as mentioned above. This API returns a list of tables/databases depending on search parameters and the behaviour is same as exiting `getUserTables` API. The response object remains same as the existing object for existing API i.e. `GetAllEntityResponseBody`. A new parameter called `pageResults` is added to include pagination results. Pagination results are represented by `Page` (`org.springframework.data.domain.Page`). The `pageResults` contains contents (contains search results), pageable (for pagination related metadata), total pages, total elements and some additional parameters such as last to represent if the page is the last page. 

**Next PR:**
The next PR would include pagination changes in the tables layer and internal catalog layer. 


## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Tested using local docker for HTS layer changes for pagination.

**Pagination support for list databases:**
There are 3 databases using existing list databases call

**Existing list databases API call:**
```
% curl -XGET -v 'http://localhost:8001/hts/tables/query' -H 'Content-Type: application/json' | jq

{
  "results": [
    {
      "tableId": null,
      "databaseId": "d1",
      "tableVersion": null,
      "metadataLocation": null,
      "storageType": null,
      "creationTime": null
    },
    {
      "tableId": null,
      "databaseId": "d2",
      "tableVersion": null,
      "metadataLocation": null,
      "storageType": null,
      "creationTime": null
    },
    {
      "tableId": null,
      "databaseId": "d3",
      "tableVersion": null,
      "metadataLocation": null,
      "storageType": null,
      "creationTime": null
    }
  ],
  "pageResults": null
}

```

**List databases API using pagination**
**Query for 1st page:**
```
% curl -XGET -v 'http://localhost:8001/v1/hts/tables/query?page=0&size=2' -H 'Content-Type: application/json' | jq

{
  "results": null,
  "pageResults": {
    "content": [
      {
        "tableId": null,
        "databaseId": "d1",
        "tableVersion": null,
        "metadataLocation": null,
        "storageType": null,
        "creationTime": null
      },
      {
        "tableId": null,
        "databaseId": "d2",
        "tableVersion": null,
        "metadataLocation": null,
        "storageType": null,
        "creationTime": null
      }
    ],
    "pageable": {
      "sort": {
        "empty": false,
        "sorted": true,
        "unsorted": false
      },
      "offset": 0,
      "pageNumber": 0,
      "pageSize": 2,
      "paged": true,
      "unpaged": false
    },
    "last": false,
    "totalPages": 2,
    "totalElements": 3,
    "size": 2,
    "number": 0,
    "sort": {
      "empty": false,
      "sorted": true,
      "unsorted": false
    },
    "first": true,
    "numberOfElements": 2,
    "empty": false
  }
}
```

**Query for 2nd page:**
```
% curl -XGET -v 'http://localhost:8001/v1/hts/tables/query?page=1&size=2' -H 'Content-Type: application/json' | jq

{
  "results": null,
  "pageResults": {
    "content": [
      {
        "tableId": null,
        "databaseId": "d3",
        "tableVersion": null,
        "metadataLocation": null,
        "storageType": null,
        "creationTime": null
      }
    ],
    "pageable": {
      "sort": {
        "empty": false,
        "sorted": true,
        "unsorted": false
      },
      "offset": 2,
      "pageNumber": 1,
      "pageSize": 2,
      "paged": true,
      "unpaged": false
    },
    "last": true,
    "totalPages": 2,
    "totalElements": 3,
    "size": 2,
    "number": 1,
    "sort": {
      "empty": false,
      "sorted": true,
      "unsorted": false
    },
    "first": false,
    "numberOfElements": 1,
    "empty": false
  }
}
```

**Existing list tables API call:**
```
% curl -XGET -v 'http://localhost:8001/hts/tables/query?databaseId=d1' -H 'Content-Type: application/json' | jq

{
  "results": [
    {
      "tableId": "t1",
      "databaseId": "d1",
      "tableVersion": "/data/openhouse/d1/t1-6da57fce-6eba-4471-bc52-4310b46137e8/00000-d6152239-5f89-4f0e-8dd8-f0d27bda9bf7.metadata.json",
      "metadataLocation": "/data/openhouse/d1/t1-6da57fce-6eba-4471-bc52-4310b46137e8/00000-d6152239-5f89-4f0e-8dd8-f0d27bda9bf7.metadata.json",
      "storageType": "hdfs",
      "creationTime": 1747076463360
    },
    {
      "tableId": "t2",
      "databaseId": "d1",
      "tableVersion": "/data/openhouse/d1/t2-6ed48b5e-98c1-46e1-8b73-abf608d9d85a/00000-907448a8-c81a-46e0-993e-161e17970ed3.metadata.json",
      "metadataLocation": "/data/openhouse/d1/t2-6ed48b5e-98c1-46e1-8b73-abf608d9d85a/00000-907448a8-c81a-46e0-993e-161e17970ed3.metadata.json",
      "storageType": "hdfs",
      "creationTime": 1747076490423
    },
    {
      "tableId": "t3",
      "databaseId": "d1",
      "tableVersion": "/data/openhouse/d1/t3-f9a507c6-f3c2-45e2-8cca-f82df7cb8ebb/00000-f9a4a0d5-a5c4-4652-8042-4e234223dbdd.metadata.json",
      "metadataLocation": "/data/openhouse/d1/t3-f9a507c6-f3c2-45e2-8cca-f82df7cb8ebb/00000-f9a4a0d5-a5c4-4652-8042-4e234223dbdd.metadata.json",
      "storageType": "hdfs",
      "creationTime": 1747076511381
    },
    {
      "tableId": "t4",
      "databaseId": "d1",
      "tableVersion": "/data/openhouse/d1/t4-7b32ea67-6bf9-41c9-ba97-92883779a1f2/00000-9aac909b-81ae-4384-a030-63de8d6d2436.metadata.json",
      "metadataLocation": "/data/openhouse/d1/t4-7b32ea67-6bf9-41c9-ba97-92883779a1f2/00000-9aac909b-81ae-4384-a030-63de8d6d2436.metadata.json",
      "storageType": "hdfs",
      "creationTime": 1747076529280
    },
    {
      "tableId": "t5",
      "databaseId": "d1",
      "tableVersion": "/data/openhouse/d1/t5-799ff9e9-518d-4385-befc-36b8c056a688/00000-3f73f6aa-bb87-44fc-94d6-a28ba47b41e0.metadata.json",
      "metadataLocation": "/data/openhouse/d1/t5-799ff9e9-518d-4385-befc-36b8c056a688/00000-3f73f6aa-bb87-44fc-94d6-a28ba47b41e0.metadata.json",
      "storageType": "hdfs",
      "creationTime": 1747076546654
    }
  ],
  "pageResults": null
}
```
**List tables API using pagination**
**Query without specifying pagination params using new API uses default values:**
```
% curl -XGET -v 'http://localhost:8001/v1/hts/tables/query?databaseId=d1' -H 'Content-Type: application/json' | jq

{
  "results": null,
  "pageResults": {
    "content": [
      {
        "tableId": "t1",
        "databaseId": "d1",
        "tableVersion": "/data/openhouse/d1/t1-6da57fce-6eba-4471-bc52-4310b46137e8/00000-d6152239-5f89-4f0e-8dd8-f0d27bda9bf7.metadata.json",
        "metadataLocation": "/data/openhouse/d1/t1-6da57fce-6eba-4471-bc52-4310b46137e8/00000-d6152239-5f89-4f0e-8dd8-f0d27bda9bf7.metadata.json",
        "storageType": "hdfs",
        "creationTime": 1747076463360
      },
      {
        "tableId": "t2",
        "databaseId": "d1",
        "tableVersion": "/data/openhouse/d1/t2-6ed48b5e-98c1-46e1-8b73-abf608d9d85a/00000-907448a8-c81a-46e0-993e-161e17970ed3.metadata.json",
        "metadataLocation": "/data/openhouse/d1/t2-6ed48b5e-98c1-46e1-8b73-abf608d9d85a/00000-907448a8-c81a-46e0-993e-161e17970ed3.metadata.json",
        "storageType": "hdfs",
        "creationTime": 1747076490423
      },
      {
        "tableId": "t3",
        "databaseId": "d1",
        "tableVersion": "/data/openhouse/d1/t3-f9a507c6-f3c2-45e2-8cca-f82df7cb8ebb/00000-f9a4a0d5-a5c4-4652-8042-4e234223dbdd.metadata.json",
        "metadataLocation": "/data/openhouse/d1/t3-f9a507c6-f3c2-45e2-8cca-f82df7cb8ebb/00000-f9a4a0d5-a5c4-4652-8042-4e234223dbdd.metadata.json",
        "storageType": "hdfs",
        "creationTime": 1747076511381
      },
      {
        "tableId": "t4",
        "databaseId": "d1",
        "tableVersion": "/data/openhouse/d1/t4-7b32ea67-6bf9-41c9-ba97-92883779a1f2/00000-9aac909b-81ae-4384-a030-63de8d6d2436.metadata.json",
        "metadataLocation": "/data/openhouse/d1/t4-7b32ea67-6bf9-41c9-ba97-92883779a1f2/00000-9aac909b-81ae-4384-a030-63de8d6d2436.metadata.json",
        "storageType": "hdfs",
        "creationTime": 1747076529280
      },
      {
        "tableId": "t5",
        "databaseId": "d1",
        "tableVersion": "/data/openhouse/d1/t5-799ff9e9-518d-4385-befc-36b8c056a688/00000-3f73f6aa-bb87-44fc-94d6-a28ba47b41e0.metadata.json",
        "metadataLocation": "/data/openhouse/d1/t5-799ff9e9-518d-4385-befc-36b8c056a688/00000-3f73f6aa-bb87-44fc-94d6-a28ba47b41e0.metadata.json",
        "storageType": "hdfs",
        "creationTime": 1747076546654
      }
    ],
    "pageable": {
      "sort": {
        "empty": false,
        "sorted": true,
        "unsorted": false
      },
      "offset": 0,
      "pageNumber": 0,
      "pageSize": 50,
      "paged": true,
      "unpaged": false
    },
    "last": true,
    "totalPages": 1,
    "totalElements": 5,
    "size": 50,
    "number": 0,
    "sort": {
      "empty": false,
      "sorted": true,
      "unsorted": false
    },
    "first": true,
    "numberOfElements": 5,
    "empty": false
  }
}
```

**Query for 1st page:**
```
% curl -XGET -v 'http://localhost:8001/v1/hts/tables/query?databaseId=d1&page=0&size=2' -H 'Content-Type: application/json' | jq

{
  "results": null,
  "pageResults": {
    "content": [
      {
        "tableId": "t1",
        "databaseId": "d1",
        "tableVersion": "/data/openhouse/d1/t1-6da57fce-6eba-4471-bc52-4310b46137e8/00000-d6152239-5f89-4f0e-8dd8-f0d27bda9bf7.metadata.json",
        "metadataLocation": "/data/openhouse/d1/t1-6da57fce-6eba-4471-bc52-4310b46137e8/00000-d6152239-5f89-4f0e-8dd8-f0d27bda9bf7.metadata.json",
        "storageType": "hdfs",
        "creationTime": 1747076463360
      },
      {
        "tableId": "t2",
        "databaseId": "d1",
        "tableVersion": "/data/openhouse/d1/t2-6ed48b5e-98c1-46e1-8b73-abf608d9d85a/00000-907448a8-c81a-46e0-993e-161e17970ed3.metadata.json",
        "metadataLocation": "/data/openhouse/d1/t2-6ed48b5e-98c1-46e1-8b73-abf608d9d85a/00000-907448a8-c81a-46e0-993e-161e17970ed3.metadata.json",
        "storageType": "hdfs",
        "creationTime": 1747076490423
      }
    ],
    "pageable": {
      "sort": {
        "empty": false,
        "sorted": true,
        "unsorted": false
      },
      "offset": 0,
      "pageNumber": 0,
      "pageSize": 2,
      "paged": true,
      "unpaged": false
    },
    "last": false,
    "totalPages": 3,
    "totalElements": 5,
    "size": 2,
    "number": 0,
    "sort": {
      "empty": false,
      "sorted": true,
      "unsorted": false
    },
    "first": true,
    "numberOfElements": 2,
    "empty": false
  }
}
```

**Query for the 2nd page:**
```
% curl -XGET -v 'http://localhost:8001/v1/hts/tables/query?databaseId=d1&page=1&size=2' -H 'Content-Type: application/json' | jq

{
  "results": null,
  "pageResults": {
    "content": [
      {
        "tableId": "t3",
        "databaseId": "d1",
        "tableVersion": "/data/openhouse/d1/t3-f9a507c6-f3c2-45e2-8cca-f82df7cb8ebb/00000-f9a4a0d5-a5c4-4652-8042-4e234223dbdd.metadata.json",
        "metadataLocation": "/data/openhouse/d1/t3-f9a507c6-f3c2-45e2-8cca-f82df7cb8ebb/00000-f9a4a0d5-a5c4-4652-8042-4e234223dbdd.metadata.json",
        "storageType": "hdfs",
        "creationTime": 1747076511381
      },
      {
        "tableId": "t4",
        "databaseId": "d1",
        "tableVersion": "/data/openhouse/d1/t4-7b32ea67-6bf9-41c9-ba97-92883779a1f2/00000-9aac909b-81ae-4384-a030-63de8d6d2436.metadata.json",
        "metadataLocation": "/data/openhouse/d1/t4-7b32ea67-6bf9-41c9-ba97-92883779a1f2/00000-9aac909b-81ae-4384-a030-63de8d6d2436.metadata.json",
        "storageType": "hdfs",
        "creationTime": 1747076529280
      }
    ],
    "pageable": {
      "sort": {
        "empty": false,
        "sorted": true,
        "unsorted": false
      },
      "offset": 2,
      "pageNumber": 1,
      "pageSize": 2,
      "paged": true,
      "unpaged": false
    },
    "last": false,
    "totalPages": 3,
    "totalElements": 5,
    "size": 2,
    "number": 1,
    "sort": {
      "empty": false,
      "sorted": true,
      "unsorted": false
    },
    "first": false,
    "numberOfElements": 2,
    "empty": false
  }
}
```

**Query for the 3rd page:**
```
% curl -XGET -v 'http://localhost:8001/v1/hts/tables/query?databaseId=d1&page=2&size=2' -H 'Content-Type: application/json' | jq

{
  "results": null,
  "pageResults": {
    "content": [
      {
        "tableId": "t5",
        "databaseId": "d1",
        "tableVersion": "/data/openhouse/d1/t5-799ff9e9-518d-4385-befc-36b8c056a688/00000-3f73f6aa-bb87-44fc-94d6-a28ba47b41e0.metadata.json",
        "metadataLocation": "/data/openhouse/d1/t5-799ff9e9-518d-4385-befc-36b8c056a688/00000-3f73f6aa-bb87-44fc-94d6-a28ba47b41e0.metadata.json",
        "storageType": "hdfs",
        "creationTime": 1747076546654
      }
    ],
    "pageable": {
      "sort": {
        "empty": false,
        "sorted": true,
        "unsorted": false
      },
      "offset": 4,
      "pageNumber": 2,
      "pageSize": 2,
      "paged": true,
      "unpaged": false
    },
    "last": true,
    "totalPages": 3,
    "totalElements": 5,
    "size": 2,
    "number": 2,
    "sort": {
      "empty": false,
      "sorted": true,
      "unsorted": false
    },
    "first": false,
    "numberOfElements": 1,
    "empty": false
  }
}
```

**Query for the 4th Page (page results are empty as expected and last page flag is true):** 
```
% curl -XGET -v 'http://localhost:8001/v1/hts/tables/query?databaseId=d1&page=3&size=2' -H 'Content-Type: application/json' | jq

{
  "results": null,
  "pageResults": {
    "content": [],
    "pageable": {
      "sort": {
        "empty": false,
        "sorted": true,
        "unsorted": false
      },
      "offset": 6,
      "pageNumber": 3,
      "pageSize": 2,
      "paged": true,
      "unpaged": false
    },
    "last": true,
    "totalPages": 3,
    "totalElements": 5,
    "size": 2,
    "number": 3,
    "sort": {
      "empty": false,
      "sorted": true,
      "unsorted": false
    },
    "first": false,
    "numberOfElements": 0,
    "empty": true
  }
}
```

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
