### PR TITLE
Adds rename support for House Tables

### DIFF
--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/CatalogConstants.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/CatalogConstants.java
@@ -6,6 +6,8 @@ public final class CatalogConstants {
   public static final String SNAPSHOTS_REFS_KEY = "snapshotsRefs";
   public static final String IS_STAGE_CREATE_KEY = "isStageCreate";
   public static final String OPENHOUSE_UUID_KEY = "openhouse.tableUUID";
+  public static final String OPENHOUSE_TABLEID_KEY = "openhouse.tableId";
+  public static final String OPENHOUSE_DATABASEID_KEY = "openhouse.databaseId";
   public static final String INITIAL_VERSION = "INITIAL_VERSION";
   public static final String APPENDED_SNAPSHOTS = "appended_snapshots";
   public static final String STAGED_SNAPSHOTS = "staged_snapshots";

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -128,25 +128,8 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
 
   @Override
   public void renameTable(TableIdentifier from, TableIdentifier to) {
-    try {
-      houseTableRepository
-          .findById(
-              HouseTablePrimaryKey.builder()
-                  .databaseId(from.namespace().toString())
-                  .tableId(from.name())
-                  .build())
-          .ifPresent(
-              houseTable -> {
-                houseTableRepository.rename(
-                    houseTable.getDatabaseId(),
-                    houseTable.getTableId(),
-                    to.namespace().toString(),
-                    to.name());
-              });
-    } catch (HouseTableRepositoryException e) {
-      throw new RuntimeException(
-          String.format("The table %s cannot be renamed due to the server side error:", from), e);
-    }
+    // TODO: Create a table transaction to rename the table and update the metadata atomically
+    throw new UnsupportedOperationException("Rename Tables not implemented yet");
   }
 
   /**

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -128,7 +128,24 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
 
   @Override
   public void renameTable(TableIdentifier from, TableIdentifier to) {
-    throw new UnsupportedOperationException("Rename Tables not implemented yet");
+    try {
+      houseTableRepository
+          .findById(
+              HouseTablePrimaryKey.builder()
+                  .databaseId(from.namespace().toString())
+                  .tableId(from.name())
+                  .build())
+          .ifPresent(
+              houseTable -> {
+                houseTableRepository.rename(
+                    houseTable.getDatabaseId(),
+                    houseTable.getTableId(),
+                    to.namespace().toString(),
+                    to.name());
+              });
+    } catch (HouseTableNotFoundException e) {
+      log.info("House table entry not found {}.{}", from.namespace().toString(), from.name());
+    }
   }
 
   /**

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -20,10 +20,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.iceberg.BaseMetastoreCatalog;
-import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
-import org.apache.iceberg.Transaction;
-import org.apache.iceberg.UpdateProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -131,13 +128,7 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
 
   @Override
   public void renameTable(TableIdentifier from, TableIdentifier to) {
-    Table fromTable = loadTable(from);
-    Transaction transaction = fromTable.newTransaction();
-    UpdateProperties updateProperties = transaction.updateProperties();
-    updateProperties.set(CatalogConstants.OPENHOUSE_TABLEID_KEY, to.name());
-    updateProperties.set(CatalogConstants.OPENHOUSE_DATABASEID_KEY, to.namespace().toString());
-    updateProperties.commit();
-    transaction.commitTransaction();
+    throw new UnsupportedOperationException("Rename Tables not implemented yet");
   }
 
   /**

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -20,7 +20,11 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.iceberg.BaseMetastoreCatalog;
+import org.apache.iceberg.BaseTransaction;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.Transaction;
+import org.apache.iceberg.UpdateProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -129,7 +133,33 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
   @Override
   public void renameTable(TableIdentifier from, TableIdentifier to) {
     // TODO: Create a table transaction to rename the table and update the metadata atomically
-    throw new UnsupportedOperationException("Rename Tables not implemented yet");
+    Table fromTable = loadTable(from);
+    Transaction transaction = fromTable.newTransaction();
+    UpdateProperties updateProperties = transaction.updateProperties();
+    updateProperties.set(CatalogConstants.OPENHOUSE_TABLEID_KEY, to.name());
+    updateProperties.set(CatalogConstants.OPENHOUSE_DATABASEID_KEY, to.namespace().toString());
+    updateProperties.commit();
+    transaction.commitTransaction();
+
+    String newMetadataLocation =
+        ((BaseTransaction.TransactionTable) transaction.table())
+            .operations()
+            .current()
+            .metadataFileLocation();
+
+    try {
+      houseTableRepository.rename(
+          from.namespace().toString(),
+          from.name(),
+          to.namespace().toString(),
+          to.name(),
+          newMetadataLocation);
+    } catch (Exception e) {
+      throw new RuntimeException(
+          String.format(
+              "The table %s cannot be renamed to %s due to the server side error:", from, to),
+          e);
+    }
   }
 
   /**

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -143,8 +143,9 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
                     to.namespace().toString(),
                     to.name());
               });
-    } catch (HouseTableNotFoundException e) {
-      log.info("House table entry not found {}.{}", from.namespace().toString(), from.name());
+    } catch (HouseTableRepositoryException e) {
+      throw new RuntimeException(
+          String.format("The table %s cannot be renamed due to the server side error:", from), e);
     }
   }
 

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -253,7 +253,17 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
           InternalCatalogMetricsConstant.METADATA_UPDATE_LATENCY);
 
       houseTable = houseTableMapper.toHouseTable(updatedMetadata, fileIO);
-      if (!isStageCreate) {
+      if (base != null
+          && !properties
+              .get(CatalogConstants.OPENHOUSE_TABLEID_KEY)
+              .equalsIgnoreCase(this.tableName())) {
+        houseTableRepository.rename(
+            this.tableName(),
+            this.tableIdentifier.namespace().toString(),
+            properties.get(CatalogConstants.OPENHOUSE_TABLEID_KEY),
+            properties.get(CatalogConstants.OPENHOUSE_DATABASEID_KEY),
+            newMetadataLocation);
+      } else if (!isStageCreate) {
         houseTableRepository.save(houseTable);
       } else {
         /**

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -254,14 +254,17 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
 
       houseTable = houseTableMapper.toHouseTable(updatedMetadata, fileIO);
       if (base != null
-          && !properties
-              .get(CatalogConstants.OPENHOUSE_TABLEID_KEY)
-              .equalsIgnoreCase(this.tableName())) {
+          && (!properties
+                  .get(CatalogConstants.OPENHOUSE_TABLEID_KEY)
+                  .equalsIgnoreCase(this.tableIdentifier.name())
+              || !properties
+                  .get(CatalogConstants.OPENHOUSE_DATABASEID_KEY)
+                  .equalsIgnoreCase(this.tableIdentifier.namespace().toString()))) {
         houseTableRepository.rename(
-            this.tableName(),
             this.tableIdentifier.namespace().toString(),
-            properties.get(CatalogConstants.OPENHOUSE_TABLEID_KEY),
+            this.tableIdentifier.name(),
             properties.get(CatalogConstants.OPENHOUSE_DATABASEID_KEY),
+            properties.get(CatalogConstants.OPENHOUSE_TABLEID_KEY),
             newMetadataLocation);
       } else if (!isStageCreate) {
         houseTableRepository.save(houseTable);

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -254,12 +254,14 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
 
       houseTable = houseTableMapper.toHouseTable(updatedMetadata, fileIO);
       if (base != null
-          && (!properties
-                  .get(CatalogConstants.OPENHOUSE_TABLEID_KEY)
-                  .equalsIgnoreCase(this.tableIdentifier.name())
-              || !properties
-                  .get(CatalogConstants.OPENHOUSE_DATABASEID_KEY)
-                  .equalsIgnoreCase(this.tableIdentifier.namespace().toString()))) {
+          && (properties.containsKey(CatalogConstants.OPENHOUSE_TABLEID_KEY)
+                  && !properties
+                      .get(CatalogConstants.OPENHOUSE_TABLEID_KEY)
+                      .equalsIgnoreCase(this.tableIdentifier.name())
+              || properties.containsKey(CatalogConstants.OPENHOUSE_DATABASEID_KEY)
+                  && !properties
+                      .get(CatalogConstants.OPENHOUSE_DATABASEID_KEY)
+                      .equalsIgnoreCase(this.tableIdentifier.namespace().toString()))) {
         houseTableRepository.rename(
             this.tableIdentifier.namespace().toString(),
             this.tableIdentifier.name(),

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepository.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepository.java
@@ -15,5 +15,10 @@ public interface HouseTableRepository extends CrudRepository<HouseTable, HouseTa
 
   List<HouseTable> findAllByDatabaseId(String databaseId);
 
-  void rename(String fromDatabaseId, String fromTableId, String toDatabaseId, String toTableId);
+  void rename(
+      String fromDatabaseId,
+      String fromTableId,
+      String toDatabaseId,
+      String toTableId,
+      String metadataLocation);
 }

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepository.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepository.java
@@ -14,4 +14,6 @@ import org.springframework.stereotype.Repository;
 public interface HouseTableRepository extends CrudRepository<HouseTable, HouseTablePrimaryKey> {
 
   List<HouseTable> findAllByDatabaseId(String databaseId);
+
+  void rename(String fromDatabaseId, String fromTableId, String toDatabaseId, String toTableId);
 }

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepositoryImpl.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepositoryImpl.java
@@ -186,6 +186,18 @@ public class HouseTableRepositoryImpl implements HouseTableRepository {
   }
 
   @Override
+  public void rename(
+      String fromDatabaseId, String fromTableId, String toDatabaseId, String toTableId) {
+    getHtsRetryTemplate(Arrays.asList(IllegalStateException.class))
+        .execute(
+            context ->
+                apiInstance
+                    .renameTable(fromDatabaseId, fromTableId, toDatabaseId, toTableId)
+                    .onErrorResume(e -> handleHtsHttpError(e).then())
+                    .block());
+  }
+
+  @Override
   public <S extends HouseTable> Iterable<S> saveAll(Iterable<S> entities) {
     throw new UnsupportedOperationException("saveAll is not supported.");
   }

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepositoryImpl.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepositoryImpl.java
@@ -187,12 +187,17 @@ public class HouseTableRepositoryImpl implements HouseTableRepository {
 
   @Override
   public void rename(
-      String fromDatabaseId, String fromTableId, String toDatabaseId, String toTableId) {
+      String fromDatabaseId,
+      String fromTableId,
+      String toDatabaseId,
+      String toTableId,
+      String metadataLocation) {
     getHtsRetryTemplate(Arrays.asList(IllegalStateException.class))
         .execute(
             context ->
                 apiInstance
-                    .renameTable(fromDatabaseId, fromTableId, toDatabaseId, toTableId)
+                    .renameTable(
+                        fromDatabaseId, fromTableId, toDatabaseId, toTableId, metadataLocation)
                     .onErrorResume(e -> handleHtsHttpError(e).then())
                     .block());
   }

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepositoryImplTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepositoryImplTest.java
@@ -289,6 +289,47 @@ public class HouseTableRepositoryImplTest {
   }
 
   @Test
+  public void testRepoRename() {
+    mockHtsServer.enqueue(
+        new MockResponse()
+            .setResponseCode(204)
+            .setBody("")
+            .addHeader("Content-Type", "application/json"));
+
+    Assertions.assertDoesNotThrow(
+        () ->
+            htsRepo.rename(
+                HOUSE_TABLE.getDatabaseId(),
+                HOUSE_TABLE.getTableId(),
+                HOUSE_TABLE_SAME_DB.getDatabaseId(),
+                HOUSE_TABLE.getTableId() + "_renamed"));
+  }
+
+  @Test
+  public void testRepoRenameFailsWithExceptions() {
+    HashMap<Integer, Class> map = new HashMap<>();
+    map.put(404, HouseTableNotFoundException.class);
+    map.put(409, HouseTableConcurrentUpdateException.class);
+    map.put(400, HouseTableCallerException.class);
+
+    for (HashMap.Entry<Integer, Class> entry : map.entrySet()) {
+      mockHtsServer.enqueue(
+          new MockResponse()
+              .setResponseCode(entry.getKey())
+              .setBody("")
+              .addHeader("Content-Type", "application/json"));
+      Assertions.assertThrowsExactly(
+          entry.getValue(),
+          () ->
+              htsRepo.rename(
+                  HOUSE_TABLE.getDatabaseId(),
+                  HOUSE_TABLE.getTableId(),
+                  HOUSE_TABLE_SAME_DB.getDatabaseId(),
+                  HOUSE_TABLE.getTableId() + "_renamed"));
+    }
+  }
+
+  @Test
   public void testListOfTablesInDatabase() {
     List<UserTable> tables = new ArrayList<>();
     tables.add(houseTableMapper.toUserTable(HOUSE_TABLE));

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepositoryImplTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepositoryImplTest.java
@@ -302,7 +302,8 @@ public class HouseTableRepositoryImplTest {
                 HOUSE_TABLE.getDatabaseId(),
                 HOUSE_TABLE.getTableId(),
                 HOUSE_TABLE_SAME_DB.getDatabaseId(),
-                HOUSE_TABLE.getTableId() + "_renamed"));
+                HOUSE_TABLE.getTableId() + "_renamed",
+                HOUSE_TABLE.getTableLocation() + "_v2"));
   }
 
   @Test
@@ -325,7 +326,8 @@ public class HouseTableRepositoryImplTest {
                   HOUSE_TABLE.getDatabaseId(),
                   HOUSE_TABLE.getTableId(),
                   HOUSE_TABLE_SAME_DB.getDatabaseId(),
-                  HOUSE_TABLE.getTableId() + "_renamed"));
+                  HOUSE_TABLE.getTableId() + "_renamed",
+                  HOUSE_TABLE.getTableLocation() + "_v2"));
     }
   }
 

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/HouseTablesApiHandler.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/HouseTablesApiHandler.java
@@ -57,4 +57,12 @@ public interface HouseTablesApiHandler<K, V> {
    * @return the row as part of response body that would be returned to the client.
    */
   ApiResponse<EntityResponseBody<V>> putEntity(V entity);
+
+  /**
+   * Function to rename a row in a House Table atomically.
+   *
+   * @param entity The complete entity to be upsert-ed into target House table.
+   * @return the row as part of response body that would be returned to the client.
+   */
+  ApiResponse<Void> renameEntity(K fromKey, K toKey);
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/HouseTablesApiHandler.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/HouseTablesApiHandler.java
@@ -61,8 +61,8 @@ public interface HouseTablesApiHandler<K, V> {
   /**
    * Function to rename a row in a House Table atomically.
    *
-   * @param entity The complete entity to be upsert-ed into target House table.
-   * @return the row as part of response body that would be returned to the client.
+   * @param fromEntity The object to identify the row to rename.
+   * @param toEntity The object to rename the row to.
    */
-  ApiResponse<Void> renameEntity(K fromKey, K toKey);
+  ApiResponse<Void> renameEntity(V fromEntity, V toEntity);
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/OpenHouseJobTableHtsApiHandler.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/OpenHouseJobTableHtsApiHandler.java
@@ -75,4 +75,9 @@ public class OpenHouseJobTableHtsApiHandler implements JobTableHtsApiHandler {
             EntityResponseBody.<Job>builder().entity(jobMapper.toJob(putResult.getFirst())).build())
         .build();
   }
+
+  @Override
+  public ApiResponse<Void> renameEntity(JobKey fromKey, JobKey toKey) {
+    throw new UnsupportedOperationException("Rename toggle status is unsupported");
+  }
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/OpenHouseJobTableHtsApiHandler.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/OpenHouseJobTableHtsApiHandler.java
@@ -77,7 +77,7 @@ public class OpenHouseJobTableHtsApiHandler implements JobTableHtsApiHandler {
   }
 
   @Override
-  public ApiResponse<Void> renameEntity(JobKey fromKey, JobKey toKey) {
-    throw new UnsupportedOperationException("Rename toggle status is unsupported");
+  public ApiResponse<Void> renameEntity(Job fromEntity, Job toEntity) {
+    throw new UnsupportedOperationException("Rename job is unsupported");
   }
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/OpenHouseToggleStatusesApiHandler.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/OpenHouseToggleStatusesApiHandler.java
@@ -53,7 +53,7 @@ public class OpenHouseToggleStatusesApiHandler implements ToggleStatusesApiHandl
   }
 
   @Override
-  public ApiResponse<Void> renameEntity(TableToggleStatusKey fromKey, TableToggleStatusKey toKey) {
+  public ApiResponse<Void> renameEntity(ToggleStatus fromEntity, ToggleStatus toEntity) {
     throw new UnsupportedOperationException("Rename toggle status is unsupported");
   }
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/OpenHouseToggleStatusesApiHandler.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/OpenHouseToggleStatusesApiHandler.java
@@ -51,4 +51,9 @@ public class OpenHouseToggleStatusesApiHandler implements ToggleStatusesApiHandl
   public ApiResponse<EntityResponseBody<ToggleStatus>> putEntity(ToggleStatus entity) {
     throw new UnsupportedOperationException("Update toggle status is unsupported");
   }
+
+  @Override
+  public ApiResponse<Void> renameEntity(TableToggleStatusKey fromKey, TableToggleStatusKey toKey) {
+    throw new UnsupportedOperationException("Rename toggle status is unsupported");
+  }
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/OpenHouseUserTableHtsApiHandler.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/OpenHouseUserTableHtsApiHandler.java
@@ -90,4 +90,15 @@ public class OpenHouseUserTableHtsApiHandler implements UserTableHtsApiHandler {
                 .build())
         .build();
   }
+
+  @Override
+  public ApiResponse<Void> renameEntity(UserTableKey fromUserTable, UserTableKey toUserTable) {
+    userTablesHtsApiValidator.validateRenameEntity(fromUserTable, toUserTable);
+    userTableService.renameUserTable(
+        fromUserTable.getDatabaseId(),
+        fromUserTable.getTableId(),
+        toUserTable.getDatabaseId(),
+        toUserTable.getTableId());
+    return ApiResponse.<Void>builder().httpStatus(HttpStatus.NO_CONTENT).build();
+  }
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/OpenHouseUserTableHtsApiHandler.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/OpenHouseUserTableHtsApiHandler.java
@@ -92,13 +92,24 @@ public class OpenHouseUserTableHtsApiHandler implements UserTableHtsApiHandler {
   }
 
   @Override
-  public ApiResponse<Void> renameEntity(UserTableKey fromUserTable, UserTableKey toUserTable) {
-    userTablesHtsApiValidator.validateRenameEntity(fromUserTable, toUserTable);
+  public ApiResponse<Void> renameEntity(UserTable fromUserTable, UserTable toUserTable) {
+    UserTableKey fromUserTableKey =
+        UserTableKey.builder()
+            .databaseId(fromUserTable.getDatabaseId())
+            .tableId(fromUserTable.getTableId())
+            .build();
+    UserTableKey toUserTableKey =
+        UserTableKey.builder()
+            .databaseId(toUserTable.getDatabaseId())
+            .tableId(toUserTable.getTableId())
+            .build();
+    userTablesHtsApiValidator.validateRenameEntity(fromUserTableKey, toUserTableKey);
     userTableService.renameUserTable(
         fromUserTable.getDatabaseId(),
         fromUserTable.getTableId(),
         toUserTable.getDatabaseId(),
-        toUserTable.getTableId());
+        toUserTable.getTableId(),
+        toUserTable.getMetadataLocation());
     return ApiResponse.<Void>builder().httpStatus(HttpStatus.NO_CONTENT).build();
   }
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/validator/HouseTablesApiValidator.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/validator/HouseTablesApiValidator.java
@@ -38,4 +38,14 @@ public interface HouseTablesApiValidator<K, V> {
    *     request is invalid.
    */
   void validatePutEntity(V entity);
+
+  /**
+   * Function to validate a request to rename an existing row in a House Table to another Key ID.
+   *
+   * @param fromKey The key object to identify the row to rename.
+   * @param toKey The key object to rename the row to.
+   * @throws com.linkedin.openhouse.common.exception.RequestValidationFailureException if the
+   *     request is invalid.
+   */
+  void validateRenameEntity(K fromKey, K toKey);
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/validator/impl/OpenHouseJobTablesHtsApiValidator.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/validator/impl/OpenHouseJobTablesHtsApiValidator.java
@@ -70,4 +70,10 @@ public class OpenHouseJobTablesHtsApiValidator implements HouseTablesApiValidato
     }
     // TODO: Add other validations for Job entity
   }
+
+  @Override
+  public void validateRenameEntity(JobKey fromKey, JobKey toKey) {
+    // No rename operation for jobs
+    throw new UnsupportedOperationException("Rename job is unsupported");
+  }
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/validator/impl/OpenHouseUserTableHtsApiValidator.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/validator/impl/OpenHouseUserTableHtsApiValidator.java
@@ -98,4 +98,10 @@ public class OpenHouseUserTableHtsApiValidator
       throw new RequestValidationFailureException(validationFailures);
     }
   }
+
+  @Override
+  public void validateRenameEntity(UserTableKey fromUserTableKey, UserTableKey toUserTableKey) {
+    validateGetEntity(fromUserTableKey);
+    validateGetEntity(toUserTableKey);
+  }
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/validator/impl/OpenHouseUserTableHtsApiValidator.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/validator/impl/OpenHouseUserTableHtsApiValidator.java
@@ -103,5 +103,23 @@ public class OpenHouseUserTableHtsApiValidator
   public void validateRenameEntity(UserTableKey fromUserTableKey, UserTableKey toUserTableKey) {
     validateGetEntity(fromUserTableKey);
     validateGetEntity(toUserTableKey);
+    List<String> validationFailures = new ArrayList<>();
+    if (fromUserTableKey.getDatabaseId().equals(toUserTableKey.getDatabaseId())
+        && fromUserTableKey.getTableId().equals(toUserTableKey.getTableId())) {
+      validationFailures.add(
+          String.format(
+              "Cannot rename a table to the same current db name and table name: %s",
+              fromUserTableKey));
+    }
+    // Currently do not support cross database rename
+    if (!fromUserTableKey.getDatabaseId().equals(toUserTableKey.getDatabaseId())) {
+      validationFailures.add(
+          String.format(
+              "Cross database rename is not supported: %s to %s",
+              fromUserTableKey, toUserTableKey));
+    }
+    if (!validationFailures.isEmpty()) {
+      throw new RequestValidationFailureException(validationFailures);
+    }
   }
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/validator/impl/OpenHouseUserTableHtsApiValidator.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/validator/impl/OpenHouseUserTableHtsApiValidator.java
@@ -104,15 +104,15 @@ public class OpenHouseUserTableHtsApiValidator
     validateGetEntity(fromUserTableKey);
     validateGetEntity(toUserTableKey);
     List<String> validationFailures = new ArrayList<>();
-    if (fromUserTableKey.getDatabaseId().equals(toUserTableKey.getDatabaseId())
-        && fromUserTableKey.getTableId().equals(toUserTableKey.getTableId())) {
+    if (fromUserTableKey.getDatabaseId().equalsIgnoreCase(toUserTableKey.getDatabaseId())
+        && fromUserTableKey.getTableId().equalsIgnoreCase(toUserTableKey.getTableId())) {
       validationFailures.add(
           String.format(
               "Cannot rename a table to the same current db name and table name: %s",
               fromUserTableKey));
     }
     // Currently do not support cross database rename
-    if (!fromUserTableKey.getDatabaseId().equals(toUserTableKey.getDatabaseId())) {
+    if (!fromUserTableKey.getDatabaseId().equalsIgnoreCase(toUserTableKey.getDatabaseId())) {
       validationFailures.add(
           String.format(
               "Cross database rename is not supported: %s to %s",

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/controller/UserHouseTablesController.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/controller/UserHouseTablesController.java
@@ -34,6 +34,8 @@ public class UserHouseTablesController {
   private static final String HTS_TABLES_QUERY_ENDPOINT = "/hts/tables/query";
   private static final String HTS_TABLES_QUERY_ENDPOINT_V1 = "/v1/hts/tables/query";
 
+  private static final String HTS_TABLES_RENAME_ENDPOINT = "/hts/tables/rename";
+
   @Autowired private UserTableHtsApiHandler tableHtsApiHandler;
 
   @Autowired private UserTablesMapper userTablesMapper;
@@ -167,17 +169,23 @@ public class UserHouseTablesController {
         @ApiResponse(responseCode = "404", description = "User Table PATCH: TBL_DB_NOT_FOUND"),
         @ApiResponse(responseCode = "409", description = "User Table PATCH: CONFLICT")
       })
-  @PatchMapping(value = HTS_TABLES_GENERAL_ENDPOINT)
+  @PatchMapping(value = HTS_TABLES_RENAME_ENDPOINT)
   public ResponseEntity<Void> renameTable(
       @RequestParam(value = "fromDatabaseId") String fromDatabaseId,
       @RequestParam(value = "fromTableId") String fromTableId,
       @RequestParam(value = "toDatabaseId") String toDatabaseId,
-      @RequestParam(value = "toTableId") String toTableId) {
-    UserTableKey fromKey =
-        UserTableKey.builder().databaseId(fromDatabaseId).tableId(fromTableId).build();
-    UserTableKey toKey = UserTableKey.builder().databaseId(toDatabaseId).tableId(toTableId).build();
+      @RequestParam(value = "toTableId") String toTableId,
+      @RequestParam(value = "metadataLocation") String metadataLocation) {
+    UserTable fromUserTable =
+        UserTable.builder().databaseId(fromDatabaseId).tableId(fromTableId).build();
+    UserTable toUserTable =
+        UserTable.builder()
+            .databaseId(toDatabaseId)
+            .tableId(toTableId)
+            .metadataLocation(metadataLocation)
+            .build();
     com.linkedin.openhouse.common.api.spec.ApiResponse<Void> apiResponse =
-        tableHtsApiHandler.renameEntity(fromKey, toKey);
+        tableHtsApiHandler.renameEntity(fromUserTable, toUserTable);
     return new ResponseEntity<>(
         apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
   }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/controller/UserHouseTablesController.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/controller/UserHouseTablesController.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -150,6 +151,33 @@ public class UserHouseTablesController {
           CreateUpdateEntityRequestBody<UserTable> createUpdateTableRequestBody) {
     com.linkedin.openhouse.common.api.spec.ApiResponse<EntityResponseBody<UserTable>> apiResponse =
         tableHtsApiHandler.putEntity(createUpdateTableRequestBody.getEntity());
+    return new ResponseEntity<>(
+        apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
+  }
+
+  @Operation(
+      summary = "Rename a User Table",
+      description =
+          "Update an existing user table, identified by databaseID and tableId, to a new databaseID and tableId.",
+      tags = {"UserTable"})
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "204", description = "User Table PATCH: NO_CONTENT"),
+        @ApiResponse(responseCode = "400", description = "User Table PATCH: BAD_REQUEST"),
+        @ApiResponse(responseCode = "404", description = "User Table PATCH: TBL_DB_NOT_FOUND"),
+        @ApiResponse(responseCode = "409", description = "User Table PATCH: CONFLICT")
+      })
+  @PatchMapping(value = HTS_TABLES_GENERAL_ENDPOINT)
+  public ResponseEntity<Void> renameTable(
+      @RequestParam(value = "fromDatabaseId") String fromDatabaseId,
+      @RequestParam(value = "fromTableId") String fromTableId,
+      @RequestParam(value = "toDatabaseId") String toDatabaseId,
+      @RequestParam(value = "toTableId") String toTableId) {
+    UserTableKey fromKey =
+        UserTableKey.builder().databaseId(fromDatabaseId).tableId(fromTableId).build();
+    UserTableKey toKey = UserTableKey.builder().databaseId(toDatabaseId).tableId(toTableId).build();
+    com.linkedin.openhouse.common.api.spec.ApiResponse<Void> apiResponse =
+        tableHtsApiHandler.renameEntity(fromKey, toKey);
     return new ResponseEntity<>(
         apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
   }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/jdbc/UserTableHtsJdbcRepository.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/jdbc/UserTableHtsJdbcRepository.java
@@ -8,7 +8,9 @@ import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * JDBC-backed {@link HtsRepository} for CRUDing {@link UserTableRow}
@@ -108,4 +110,12 @@ public interface UserTableHtsJdbcRepository
     deleteByDatabaseIdIgnoreCaseAndTableIdIgnoreCase(
         userTableRowPrimaryKey.getDatabaseId(), userTableRowPrimaryKey.getTableId());
   }
+
+  @Modifying
+  @Query(
+      "UPDATE UserTableRow table SET table.tableId = :newTableId WHERE table.databaseId = :databaseId AND table.tableId = :oldTableId")
+  void renameTableId(
+      @Param("databaseId") String databaseId,
+      @Param("oldTableId") String oldTableId,
+      @Param("newTableId") String newTableId);
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/jdbc/UserTableHtsJdbcRepository.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/jdbc/UserTableHtsJdbcRepository.java
@@ -115,9 +115,11 @@ public interface UserTableHtsJdbcRepository
   @Transactional
   @Modifying
   @Query(
-      "UPDATE UserTableRow table SET table.tableId = :newTableId WHERE table.databaseId = :databaseId AND table.tableId = :oldTableId")
+      "UPDATE UserTableRow table SET table.tableId = :newTableId, table.metadataLocation = :metadataLocation WHERE "
+          + "table.databaseId = :databaseId AND table.tableId = :oldTableId")
   void renameTableId(
       @Param("databaseId") String databaseId,
       @Param("oldTableId") String oldTableId,
-      @Param("newTableId") String newTableId);
+      @Param("newTableId") String newTableId,
+      @Param("metadataLocation") String metadataLocation);
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/jdbc/UserTableHtsJdbcRepository.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/jdbc/UserTableHtsJdbcRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * JDBC-backed {@link HtsRepository} for CRUDing {@link UserTableRow}
@@ -111,6 +112,7 @@ public interface UserTableHtsJdbcRepository
         userTableRowPrimaryKey.getDatabaseId(), userTableRowPrimaryKey.getTableId());
   }
 
+  @Transactional
   @Modifying
   @Query(
       "UPDATE UserTableRow table SET table.tableId = :newTableId WHERE table.databaseId = :databaseId AND table.tableId = :oldTableId")

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesService.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesService.java
@@ -52,4 +52,15 @@ public interface UserTablesService {
    *     and update of {@link UserTableDto}.
    */
   Pair<UserTableDto, Boolean> putUserTable(UserTable userTable);
+
+  /**
+   * Rename a {@link UserTable} row in House table.
+   *
+   * @param fromDatabaseId The databaseId of the row to rename.
+   * @param fromTableId The tableId of the row to rename.
+   * @param toDatabaseId The new databaseId of the renamed row.
+   * @param toTableId The new tableId of the renamed row.
+   */
+  void renameUserTable(
+      String fromDatabaseId, String fromTableId, String toDatabaseId, String toTableId);
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesService.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesService.java
@@ -60,7 +60,13 @@ public interface UserTablesService {
    * @param fromTableId The tableId of the row to rename.
    * @param toDatabaseId The new databaseId of the renamed row.
    * @param toTableId The new tableId of the renamed row.
+   * @param metadataLocation The new metadata file of the table with updated table properties for
+   *     updated ids.
    */
   void renameUserTable(
-      String fromDatabaseId, String fromTableId, String toDatabaseId, String toTableId);
+      String fromDatabaseId,
+      String fromTableId,
+      String toDatabaseId,
+      String toTableId,
+      String metadataLocation);
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesServiceImpl.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesServiceImpl.java
@@ -1,6 +1,7 @@
 package com.linkedin.openhouse.housetables.services;
 
 import com.linkedin.openhouse.cluster.metrics.micrometer.MetricsReporter;
+import com.linkedin.openhouse.common.exception.AlreadyExistsException;
 import com.linkedin.openhouse.common.exception.EntityConcurrentModificationException;
 import com.linkedin.openhouse.common.exception.NoSuchUserTableException;
 import com.linkedin.openhouse.common.metrics.MetricsConstant;
@@ -138,7 +139,11 @@ public class UserTablesServiceImpl implements UserTablesService {
       throw new NoSuchUserTableException(fromDatabaseId, fromTableId);
     }
     // Renames user table within the same database
-    htsJdbcRepository.renameTableId(fromDatabaseId, fromTableId, toTableId, metadataLocation);
+    try {
+      htsJdbcRepository.renameTableId(fromDatabaseId, fromTableId, toTableId, metadataLocation);
+    } catch (DataIntegrityViolationException e) {
+      throw new AlreadyExistsException("Table", toTableId);
+    }
   }
 
   @Override

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesServiceImpl.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesServiceImpl.java
@@ -115,6 +115,15 @@ public class UserTablesServiceImpl implements UserTablesService {
     return Pair.of(returnedDto, existingUserTableRow.isPresent());
   }
 
+  /**
+   * Renames a user table within the same database.
+   *
+   * @param fromDatabaseId The databaseId of the row to rename.
+   * @param fromTableId The tableId of the row to rename.
+   * @param toDatabaseId Until rename support across databases is supported, this should be the same
+   *     as fromDatabaseId
+   * @param toTableId The new tableId of the renamed row.
+   */
   @Override
   public void renameUserTable(
       String fromDatabaseId, String fromTableId, String toDatabaseId, String toTableId) {

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesServiceImpl.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesServiceImpl.java
@@ -138,24 +138,7 @@ public class UserTablesServiceImpl implements UserTablesService {
       throw new NoSuchUserTableException(fromDatabaseId, fromTableId);
     }
     // Renames user table within the same database
-    try {
-      htsJdbcRepository.renameTableId(fromDatabaseId, fromTableId, toTableId, metadataLocation);
-    } catch (CommitFailedException
-        | ObjectOptimisticLockingFailureException
-        | DataIntegrityViolationException e) {
-      throw new EntityConcurrentModificationException(
-          String.format(
-              "databaseId : %s, tableId : %s, %s",
-              fromDatabaseId,
-              fromTableId,
-              "Failed to rename user table, it may have been modified/created by other processes."),
-          UserTableRowPrimaryKey.builder()
-              .databaseId(fromDatabaseId)
-              .tableId(fromTableId)
-              .build()
-              .toString(),
-          e);
-    }
+    htsJdbcRepository.renameTableId(fromDatabaseId, fromTableId, toTableId, metadataLocation);
   }
 
   @Override

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesServiceImpl.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesServiceImpl.java
@@ -123,17 +123,23 @@ public class UserTablesServiceImpl implements UserTablesService {
    * @param toDatabaseId Until rename support across databases is supported, this should be the same
    *     as fromDatabaseId
    * @param toTableId The new tableId of the renamed row.
+   * @param metadataLocation The new metadata file of the table with updated table properties that
+   *     match the new tableId
    */
   @Override
   public void renameUserTable(
-      String fromDatabaseId, String fromTableId, String toDatabaseId, String toTableId) {
+      String fromDatabaseId,
+      String fromTableId,
+      String toDatabaseId,
+      String toTableId,
+      String metadataLocation) {
     if (!htsJdbcRepository.existsById(
         UserTableRowPrimaryKey.builder().databaseId(fromDatabaseId).tableId(fromTableId).build())) {
       throw new NoSuchUserTableException(fromDatabaseId, fromTableId);
     }
     // Renames user table within the same database
     try {
-      htsJdbcRepository.renameTableId(fromDatabaseId, fromTableId, toTableId);
+      htsJdbcRepository.renameTableId(fromDatabaseId, fromTableId, toTableId, metadataLocation);
     } catch (CommitFailedException
         | ObjectOptimisticLockingFailureException
         | DataIntegrityViolationException e) {

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesServiceImpl.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesServiceImpl.java
@@ -27,7 +27,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.util.Pair;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @Slf4j
@@ -116,7 +115,6 @@ public class UserTablesServiceImpl implements UserTablesService {
     return Pair.of(returnedDto, existingUserTableRow.isPresent());
   }
 
-  @Transactional // Needed for update query
   @Override
   public void renameUserTable(
       String fromDatabaseId, String fromTableId, String toDatabaseId, String toTableId) {
@@ -132,10 +130,10 @@ public class UserTablesServiceImpl implements UserTablesService {
         | DataIntegrityViolationException e) {
       throw new EntityConcurrentModificationException(
           String.format(
-              "databaseId : %s, tableId : %s, version: %s %s",
+              "databaseId : %s, tableId : %s, %s",
               fromDatabaseId,
               fromTableId,
-              "The requested user table has been modified/created by other processes."),
+              "Failed to rename user table, it may have been modified/created by other processes."),
           UserTableRowPrimaryKey.builder()
               .databaseId(fromDatabaseId)
               .tableId(fromTableId)

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/HtsControllerTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/HtsControllerTest.java
@@ -442,11 +442,12 @@ public class HtsControllerTest {
   @Test
   public void testRenameUserTable() throws Exception {
     mvc.perform(
-            MockMvcRequestBuilders.patch("/hts/tables")
+            MockMvcRequestBuilders.patch("/hts/tables/rename")
                 .param("fromDatabaseId", TEST_DB_ID)
                 .param("fromTableId", TEST_TABLE_ID)
                 .param("toDatabaseId", TEST_DB_ID)
-                .param("toTableId", TEST_TABLE_ID + "_renamed"))
+                .param("toTableId", TEST_TABLE_ID + "_renamed")
+                .param("metadataLocation", "mockMetadataLocation"))
         .andExpect(status().isNoContent())
         .andExpect(content().string(""));
   }
@@ -454,37 +455,41 @@ public class HtsControllerTest {
   @Test
   public void testRenameUserTableFails() throws Exception {
     mvc.perform(
-            MockMvcRequestBuilders.patch("/hts/tables")
+            MockMvcRequestBuilders.patch("/hts/tables/rename")
                 .param("fromDatabaseId", TEST_DB_ID)
                 .param("fromTableId", NON_EXISTED_TABLE)
                 .param("toDatabaseId", TEST_DB_ID)
-                .param("toTableId", TEST_TABLE_ID + "_renamed"))
+                .param("toTableId", TEST_TABLE_ID + "_renamed")
+                .param("metadataLocation", "mockMetadataLocation"))
         .andExpect(status().isNotFound());
 
     // Currently we don't support renaming a table across databases.
     mvc.perform(
-            MockMvcRequestBuilders.patch("/hts/tables")
+            MockMvcRequestBuilders.patch("/hts/tables/rename")
                 .param("fromDatabaseId", TEST_DB_ID)
                 .param("fromTableId", TEST_TABLE_ID)
                 .param("toDatabaseId", TEST_DB_ID + "_renamed")
-                .param("toTableId", TEST_TABLE_ID + "_renamed"))
+                .param("toTableId", TEST_TABLE_ID + "_renamed")
+                .param("metadataLocation", "mockMetadataLocation"))
         .andExpect(status().isBadRequest());
 
     mvc.perform(
-            MockMvcRequestBuilders.patch("/hts/tables")
+            MockMvcRequestBuilders.patch("/hts/tables/rename")
                 .param("fromDatabaseId", TEST_DB_ID)
                 .param("fromTableId", TEST_TABLE_ID)
                 .param("toDatabaseId", TEST_DB_ID)
-                .param("toTableId", TEST_TABLE_ID))
+                .param("toTableId", TEST_TABLE_ID)
+                .param("metadataLocation", "mockMetadataLocation"))
         .andExpect(status().isBadRequest());
 
     htsRepository.save(TEST_TUPLE_2_0.get_userTableRow());
     mvc.perform(
-            MockMvcRequestBuilders.patch("/hts/tables")
+            MockMvcRequestBuilders.patch("/hts/tables/rename")
                 .param("fromDatabaseId", TEST_DB_ID)
                 .param("fromTableId", TEST_TABLE_ID)
                 .param("toDatabaseId", TEST_TUPLE_2_0.getDatabaseId())
-                .param("toTableId", TEST_TUPLE_2_0.getTableId()))
+                .param("toTableId", TEST_TUPLE_2_0.getTableId())
+                .param("metadataLocation", "mockMetadataLocation"))
         .andExpect(status().isConflict());
   }
 }

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/HtsRepositoryTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/HtsRepositoryTest.java
@@ -180,10 +180,12 @@ public class HtsRepositoryTest {
     // verify testTuple1_1 exist first.
     assertThat(htsRepository.existsById(key)).isTrue();
 
+    String newTableMetadata = TEST_TUPLE_1_1.getTableLoc() + "_v2";
     htsRepository.renameTableId(
         TEST_TUPLE_1_1.getDatabaseId(),
         TEST_TUPLE_1_1.getTableId(),
-        TEST_TUPLE_1_1.getTableId() + "_renamed");
+        TEST_TUPLE_1_1.getTableId() + "_renamed",
+        newTableMetadata);
 
     UserTableRow result =
         htsRepository
@@ -193,7 +195,7 @@ public class HtsRepositoryTest {
                     .tableId(TEST_TUPLE_1_1.getTableId() + "_renamed")
                     .build())
             .orElse(UserTableRow.builder().build());
-    assertThat(result.getMetadataLocation()).isEqualTo(TEST_TUPLE_1_1.getTableLoc());
+    assertThat(result.getMetadataLocation()).isEqualTo(newTableMetadata);
 
     // verify testTuple1_1 doesn't exist any more.
     assertThat(htsRepository.existsById(key)).isFalse();

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/HtsRepositoryTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/HtsRepositoryTest.java
@@ -168,4 +168,34 @@ public class HtsRepositoryTest {
     htsRepository.deleteById(
         UserTableRowPrimaryKey.builder().databaseId(TEST_DB_ID).tableId(TEST_TABLE_ID).build());
   }
+
+  @Test
+  public void testRenameUserTable() {
+    htsRepository.save(TEST_TUPLE_1_1.get_userTableRow());
+    UserTableRowPrimaryKey key =
+        UserTableRowPrimaryKey.builder()
+            .tableId(TEST_TUPLE_1_1.getTableId())
+            .databaseId(TEST_TUPLE_1_1.getDatabaseId())
+            .build();
+    // verify testTuple1_1 exist first.
+    assertThat(htsRepository.existsById(key)).isTrue();
+
+    htsRepository.renameTableId(
+        TEST_TUPLE_1_1.getDatabaseId(),
+        TEST_TUPLE_1_1.getTableId(),
+        TEST_TUPLE_1_1.getTableId() + "_renamed");
+
+    UserTableRow result =
+        htsRepository
+            .findById(
+                UserTableRowPrimaryKey.builder()
+                    .databaseId(TEST_TUPLE_1_1.getDatabaseId())
+                    .tableId(TEST_TUPLE_1_1.getTableId() + "_renamed")
+                    .build())
+            .orElse(UserTableRow.builder().build());
+    assertThat(result.getMetadataLocation()).isEqualTo(TEST_TUPLE_1_1.getTableLoc());
+
+    // verify testTuple1_1 doesn't exist any more.
+    assertThat(htsRepository.existsById(key)).isFalse();
+  }
 }

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/UserTablesServiceTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/UserTablesServiceTest.java
@@ -341,12 +341,13 @@ public class UserTablesServiceTest {
   public void testUserTableRename() {
     // testTuple1_0 is one of the table that is created from setup method.
     String newTableName = TEST_TUPLE_1_0.getTableId() + "_newName";
-
+    String newMetadataLocation = TEST_TUPLE_1_0.getTableLoc() + "_new";
     userTablesService.renameUserTable(
         TEST_TUPLE_1_0.getDatabaseId(),
         TEST_TUPLE_1_0.getTableId(),
         TEST_TUPLE_1_0.getDatabaseId(),
-        newTableName);
+        newTableName,
+        newMetadataLocation);
 
     // check if the table is renamed
     UserTableDto result =
@@ -375,7 +376,8 @@ public class UserTablesServiceTest {
               TEST_TUPLE_1_0.getDatabaseId(),
               TEST_TUPLE_1_0.getTableId(),
               TEST_TUPLE_1_0.getDatabaseId(),
-              TEST_TUPLE_2_0.getTableId());
+              TEST_TUPLE_2_0.getTableId(),
+              TEST_TUPLE_2_0.getTableLoc());
         });
 
     Assertions.assertThrows(

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/UserTablesServiceTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/UserTablesServiceTest.java
@@ -3,7 +3,7 @@ package com.linkedin.openhouse.housetables.e2e.usertable;
 import static com.linkedin.openhouse.housetables.model.TestHouseTableModelConstants.*;
 import static org.assertj.core.api.Assertions.*;
 
-import com.linkedin.openhouse.common.exception.EntityConcurrentModificationException;
+import com.linkedin.openhouse.common.exception.AlreadyExistsException;
 import com.linkedin.openhouse.common.exception.NoSuchUserTableException;
 import com.linkedin.openhouse.housetables.api.spec.model.UserTable;
 import com.linkedin.openhouse.housetables.dto.model.UserTableDto;
@@ -354,7 +354,7 @@ public class UserTablesServiceTest {
         userTablesService.getUserTable(TEST_TUPLE_1_0.getDatabaseId(), newTableName);
     assertThat(result.getTableId()).isEqualTo(newTableName);
     assertThat(result.getDatabaseId()).isEqualTo(TEST_TUPLE_1_0.getDatabaseId());
-    assertThat(result.getMetadataLocation()).isEqualTo(TEST_TUPLE_1_0.getTableLoc());
+    assertThat(result.getMetadataLocation()).isEqualTo(newMetadataLocation);
 
     Assertions.assertThrows(
         NoSuchUserTableException.class,
@@ -370,7 +370,7 @@ public class UserTablesServiceTest {
 
     // Expect that the rename will fail as the table already exists
     Assertions.assertThrows(
-        EntityConcurrentModificationException.class,
+        AlreadyExistsException.class,
         () -> {
           userTablesService.renameUserTable(
               TEST_TUPLE_1_0.getDatabaseId(),

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/UserTablesServiceTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/UserTablesServiceTest.java
@@ -336,6 +336,23 @@ public class UserTablesServiceTest {
     assertThat(result.getFirst().getTableVersion()).isEqualTo(modifiedLocation);
   }
 
+  @Test
+  public void testUserTableRename() {
+    // testTuple1_0 is one of the table that is created from setup method.
+    String newTableName = TEST_TUPLE_1_0.getTableId() + "_newName";
+
+    userTablesService.renameUserTable(
+        TEST_TUPLE_1_0.getDatabaseId(),
+        TEST_TUPLE_1_0.getTableId(),
+        TEST_TUPLE_1_0.getDatabaseId(),
+        newTableName);
+
+    // check if the table is renamed
+    UserTableDto result =
+        userTablesService.getUserTable(TEST_TUPLE_1_0.getDatabaseId(), newTableName);
+    assertThat(result.getTableId()).isEqualTo(newTableName);
+  }
+
   private Boolean isUserTableDtoEqual(UserTableDto expected, UserTableDto actual) {
     return expected
         .toBuilder()

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/mock/MockUserTableHtsApiHandler.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/mock/MockUserTableHtsApiHandler.java
@@ -41,4 +41,10 @@ public class MockUserTableHtsApiHandler implements UserTableHtsApiHandler {
         .responseBody(TestHtsApiConstants.TEST_GET_USER_TABLE_RESPONSE_BODY)
         .build();
   }
+
+  @Override
+  public ApiResponse<Void> renameEntity(
+      UserTableKey fromUserTableKey, UserTableKey toUserTableKey) {
+    return ApiResponse.<Void>builder().httpStatus(HttpStatus.NO_CONTENT).build();
+  }
 }

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/mock/MockUserTableHtsApiHandler.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/mock/MockUserTableHtsApiHandler.java
@@ -43,8 +43,7 @@ public class MockUserTableHtsApiHandler implements UserTableHtsApiHandler {
   }
 
   @Override
-  public ApiResponse<Void> renameEntity(
-      UserTableKey fromUserTableKey, UserTableKey toUserTableKey) {
+  public ApiResponse<Void> renameEntity(UserTable fromUserTable, UserTable toUserTable) {
     return ApiResponse.<Void>builder().httpStatus(HttpStatus.NO_CONTENT).build();
   }
 }

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/mock/api/OpenHouseUserTablesValidatorTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/mock/api/OpenHouseUserTablesValidatorTest.java
@@ -112,4 +112,39 @@ public class OpenHouseUserTablesValidatorTest {
         RequestValidationFailureException.class,
         () -> userTablesHtsApiValidator.validateDeleteEntity(userTableKey));
   }
+
+  @Test
+  public void validateRenameEntityCaseInsensitiveSameName() {
+    UserTableKey fromKey = UserTableKey.builder().tableId("testTable").databaseId("testDB").build();
+    UserTableKey toKey = UserTableKey.builder().tableId("TESTTABLE").databaseId("TESTDB").build();
+
+    // Should throw because it's the same table name (case-insensitive)
+    assertThrows(
+        RequestValidationFailureException.class,
+        () -> userTablesHtsApiValidator.validateRenameEntity(fromKey, toKey));
+  }
+
+  @Test
+  public void validateRenameEntityCaseInsensitiveCrossDatabase() {
+    UserTableKey fromKey = UserTableKey.builder().tableId("testTable").databaseId("testDB").build();
+    UserTableKey toKey =
+        UserTableKey.builder().tableId("testTable").databaseId("DIFFERENTDB").build();
+
+    // Should throw because cross-database rename is not supported
+    assertThrows(
+        RequestValidationFailureException.class,
+        () -> userTablesHtsApiValidator.validateRenameEntity(fromKey, toKey));
+  }
+
+  @Test
+  public void validateRenameEntityInvalidInput() {
+    UserTableKey fromKey =
+        UserTableKey.builder().tableId("invalid!table").databaseId("testDB").build();
+    UserTableKey toKey = UserTableKey.builder().tableId("testTable").databaseId("testDB").build();
+
+    // Should throw because of invalid table name format
+    assertThrows(
+        RequestValidationFailureException.class,
+        () -> userTablesHtsApiValidator.validateRenameEntity(fromKey, toKey));
+  }
 }

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/mock/controller/UserHouseTablesControllerTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/mock/controller/UserHouseTablesControllerTest.java
@@ -84,4 +84,18 @@ public class UserHouseTablesControllerTest {
         new ReflectionEquals(SERVICE_AUDIT_EVENT_PUT_TABLE_SUCCESS, EXCLUDE_FIELDS)
             .matches(actualEvent));
   }
+
+  @Test
+  public void testRenameTableRow() throws Exception {
+    mvc.perform(
+            MockMvcRequestBuilders.patch("/hts/tables/rename")
+                .contentType(MediaType.APPLICATION_JSON)
+                .param("fromDatabaseId", TEST_TABLE_ID)
+                .param("fromTableId", TEST_DB_ID)
+                .param("toDatabaseId", "newTableName")
+                .param("toTableId", "newDatabaseName")
+                .param("metadataLocation", "mockMetadataLocation")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNoContent());
+  }
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/HouseTablesH2Repository.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/HouseTablesH2Repository.java
@@ -17,13 +17,18 @@ public interface HouseTablesH2Repository extends HouseTableRepository {
 
   @Override
   default void rename(
-      String fromDatabaseId, String fromTableId, String toDatabaseId, String toTableId) {
+      String fromDatabaseId,
+      String fromTableId,
+      String toDatabaseId,
+      String toTableId,
+      String metadataLocation) {
     HouseTablePrimaryKey fromKey =
         HouseTablePrimaryKey.builder().databaseId(fromDatabaseId).tableId(fromTableId).build();
     this.findById(fromKey)
         .ifPresent(
             houseTable -> {
-              HouseTable renamedTable = houseTable.toBuilder().tableId(toTableId).build();
+              HouseTable renamedTable =
+                  houseTable.toBuilder().tableId(toTableId).tableLocation(metadataLocation).build();
               this.save(renamedTable);
               this.delete(houseTable);
             });

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/HouseTablesH2Repository.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/HouseTablesH2Repository.java
@@ -11,4 +11,11 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 @Primary
-public interface HouseTablesH2Repository extends HouseTableRepository {}
+public interface HouseTablesH2Repository extends HouseTableRepository {
+
+  @Override
+  default void rename(
+      String databaseId, String fromTableId, String toDatabaseId, String toTableId) {
+    // No-op
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/HouseTablesH2Repository.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/HouseTablesH2Repository.java
@@ -1,5 +1,7 @@
 package com.linkedin.openhouse.tables.e2e.h2;
 
+import com.linkedin.openhouse.internal.catalog.model.HouseTable;
+import com.linkedin.openhouse.internal.catalog.model.HouseTablePrimaryKey;
 import com.linkedin.openhouse.internal.catalog.repository.HouseTableRepository;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
@@ -15,7 +17,15 @@ public interface HouseTablesH2Repository extends HouseTableRepository {
 
   @Override
   default void rename(
-      String databaseId, String fromTableId, String toDatabaseId, String toTableId) {
-    // No-op
+      String fromDatabaseId, String fromTableId, String toDatabaseId, String toTableId) {
+    HouseTablePrimaryKey fromKey =
+        HouseTablePrimaryKey.builder().databaseId(fromDatabaseId).tableId(fromTableId).build();
+    this.findById(fromKey)
+        .ifPresent(
+            houseTable -> {
+              HouseTable renamedTable = houseTable.toBuilder().tableId(toTableId).build();
+              this.save(renamedTable);
+              this.delete(houseTable);
+            });
   }
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
@@ -708,6 +708,13 @@ public class RepositoryTest {
     TableIdentifier toTableIdentifier =
         TableIdentifier.of(createdDTO.getDatabaseId(), createdDTO.getTableId() + "_renamed");
     catalog.renameTable(fromTableIdentifier, toTableIdentifier);
+
+    Assertions.assertNotNull(
+        openHouseInternalRepository.findById(
+            TableDtoPrimaryKey.builder()
+                .databaseId(toTableIdentifier.namespace().toString())
+                .tableId(toTableIdentifier.name())
+                .build()));
   }
 
   private TableDtoPrimaryKey getPrimaryKey(TableDto tableDto) {

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
@@ -697,6 +697,19 @@ public class RepositoryTest {
     Assertions.assertFalse(openHouseInternalRepository.existsById(primaryKey));
   }
 
+  @Test
+  public void testRenameTableMetadataUpdate() {
+    /* create the base table */
+    TableDto createdDTO = TABLE_DTO.toBuilder().tableVersion(INITIAL_TABLE_VERSION).build();
+    openHouseInternalRepository.save(createdDTO);
+    /* Using catalog to do update first. */
+    TableIdentifier fromTableIdentifier =
+        TableIdentifier.of(createdDTO.getDatabaseId(), createdDTO.getTableId());
+    TableIdentifier toTableIdentifier =
+        TableIdentifier.of(createdDTO.getDatabaseId(), createdDTO.getTableId() + "_renamed");
+    catalog.renameTable(fromTableIdentifier, toTableIdentifier);
+  }
+
   private TableDtoPrimaryKey getPrimaryKey(TableDto tableDto) {
     return TableDtoPrimaryKey.builder()
         .databaseId(tableDto.getDatabaseId())

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
@@ -697,26 +697,6 @@ public class RepositoryTest {
     Assertions.assertFalse(openHouseInternalRepository.existsById(primaryKey));
   }
 
-  @Test
-  public void testRenameTableMetadataUpdate() {
-    /* create the base table */
-    TableDto createdDTO = TABLE_DTO.toBuilder().tableVersion(INITIAL_TABLE_VERSION).build();
-    openHouseInternalRepository.save(createdDTO);
-    /* Using catalog to do update first. */
-    TableIdentifier fromTableIdentifier =
-        TableIdentifier.of(createdDTO.getDatabaseId(), createdDTO.getTableId());
-    TableIdentifier toTableIdentifier =
-        TableIdentifier.of(createdDTO.getDatabaseId(), createdDTO.getTableId() + "_renamed");
-    catalog.renameTable(fromTableIdentifier, toTableIdentifier);
-
-    Assertions.assertNotNull(
-        openHouseInternalRepository.findById(
-            TableDtoPrimaryKey.builder()
-                .databaseId(toTableIdentifier.namespace().toString())
-                .tableId(toTableIdentifier.name())
-                .build()));
-  }
-
   private TableDtoPrimaryKey getPrimaryKey(TableDto tableDto) {
     return TableDtoPrimaryKey.builder()
         .databaseId(tableDto.getDatabaseId())

--- a/tables-test-fixtures/tables-test-fixtures-iceberg-1.2/src/main/java/com/linkedin/openhouse/tablestest/HouseTablesH2Repository.java
+++ b/tables-test-fixtures/tables-test-fixtures-iceberg-1.2/src/main/java/com/linkedin/openhouse/tablestest/HouseTablesH2Repository.java
@@ -23,4 +23,10 @@ public interface HouseTablesH2Repository extends HouseTableRepository {
     return this.findByDatabaseIdIgnoreCaseAndTableIdIgnoreCase(
         houseTablePrimaryKey.getDatabaseId(), houseTablePrimaryKey.getTableId());
   }
+
+  @Override
+  default void rename(
+      String databaseId, String fromTableId, String toDatabaseId, String toTableId) {
+    // No-op
+  }
 }

--- a/tables-test-fixtures/tables-test-fixtures-iceberg-1.2/src/main/java/com/linkedin/openhouse/tablestest/HouseTablesH2Repository.java
+++ b/tables-test-fixtures/tables-test-fixtures-iceberg-1.2/src/main/java/com/linkedin/openhouse/tablestest/HouseTablesH2Repository.java
@@ -26,7 +26,15 @@ public interface HouseTablesH2Repository extends HouseTableRepository {
 
   @Override
   default void rename(
-      String databaseId, String fromTableId, String toDatabaseId, String toTableId) {
-    // No-op
+      String fromDatabaseId, String fromTableId, String toDatabaseId, String toTableId) {
+    HouseTablePrimaryKey fromKey =
+        HouseTablePrimaryKey.builder().databaseId(fromDatabaseId).tableId(fromTableId).build();
+    this.findById(fromKey)
+        .ifPresent(
+            houseTable -> {
+              HouseTable renamedTable = houseTable.toBuilder().tableId(toTableId).build();
+              this.save(renamedTable);
+              this.delete(houseTable);
+            });
   }
 }

--- a/tables-test-fixtures/tables-test-fixtures-iceberg-1.2/src/main/java/com/linkedin/openhouse/tablestest/HouseTablesH2Repository.java
+++ b/tables-test-fixtures/tables-test-fixtures-iceberg-1.2/src/main/java/com/linkedin/openhouse/tablestest/HouseTablesH2Repository.java
@@ -26,13 +26,18 @@ public interface HouseTablesH2Repository extends HouseTableRepository {
 
   @Override
   default void rename(
-      String fromDatabaseId, String fromTableId, String toDatabaseId, String toTableId) {
+      String fromDatabaseId,
+      String fromTableId,
+      String toDatabaseId,
+      String toTableId,
+      String metadataLocation) {
     HouseTablePrimaryKey fromKey =
         HouseTablePrimaryKey.builder().databaseId(fromDatabaseId).tableId(fromTableId).build();
     this.findById(fromKey)
         .ifPresent(
             houseTable -> {
-              HouseTable renamedTable = houseTable.toBuilder().tableId(toTableId).build();
+              HouseTable renamedTable =
+                  houseTable.toBuilder().tableId(toTableId).tableLocation(metadataLocation).build();
               this.save(renamedTable);
               this.delete(houseTable);
             });


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn) Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

To support renames in Openhouse, House Tables should have the functionality to rename the mysql rows with a database id and table id to another table ID.
This implementation will only support renaming tables within the same database/namespace, not across databases. The API is designed in a way such that renaming across databases may eventually be supported.

This PR is part 1 of multiple PRs needed to support table renames, as the PR is large already. Will add TableService support and integration steps after.

## Changes

- [ ] Client-facing API Changes
- [x] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [x] Documentation
- [x] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [x] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
