### PR TITLE
OpenHouse server accept client provided schema as-it-is

### DIFF
--- a/apps/spark/src/test/java/com/linkedin/openhouse/catalog/e2e/SparkSchemaEvolutionTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/catalog/e2e/SparkSchemaEvolutionTest.java
@@ -1,0 +1,86 @@
+package com.linkedin.openhouse.catalog.e2e;
+
+import com.linkedin.openhouse.jobs.spark.Operations;
+import com.linkedin.openhouse.tablestest.OpenHouseSparkITest;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SparkSchemaEvolutionTest extends OpenHouseSparkITest {
+
+  @Test
+  void testEndUserSchemaEvolution() throws Exception {
+    SparkSession spark = null;
+    try {
+      spark = getSparkSession();
+      spark.sql("CREATE TABLE openhouse.d1.t1 (name string, id bigint)");
+      spark.sql("INSERT INTO openhouse.d1.t1 VALUES ('Alice', 1)");
+      spark.sql("INSERT INTO openhouse.d1.t1 VALUES ('Bob', 2), ('Charlie', 3)");
+
+      // Inspect the schema object first, establish the baseline
+      Dataset<Row> tableDF = spark.table("openhouse.d1.t1");
+
+      StructType oldSchema = tableDF.schema();
+
+      // Create new dummy dataframe with reordered columns
+      StructType schema =
+          new StructType(
+              new StructField[] {
+                new StructField("dt", DataTypes.StringType, false, Metadata.empty()),
+                new StructField("id", DataTypes.LongType, false, Metadata.empty()),
+                new StructField("name", DataTypes.StringType, false, Metadata.empty())
+              });
+
+      List<Row> data =
+          Arrays.asList(
+              RowFactory.create("2025-04-05", 1L, "John Doe"),
+              RowFactory.create("2025-04-06", 2L, "Jane Smith"));
+
+      // Remember the column ordering here is dt, id, name,
+      // the idea table schema's column ordering will be name, id, dt (as long as dt is at the end,
+      // it should be working)
+      Dataset<Row> dummyDF = spark.createDataFrame(data, schema);
+
+      // Manually evolve to mimic client-side explicit evolution, before a write can be issued
+      Operations operations = Operations.withCatalog(spark, null);
+      Table table = operations.getTable("d1.t1");
+      int colLen = table.schema().columns().size();
+      String lastColName = table.schema().columns().get(colLen - 1).name();
+      table
+          .updateSchema()
+          .unionByNameWith(SparkSchemaUtil.convert(schema))
+          .moveAfter("dt", lastColName)
+          .commit();
+
+      Schema newSchema = operations.getTable("d1.t1").schema();
+      List<Types.NestedField> newSchemaCols = newSchema.columns();
+      Assertions.assertEquals(newSchemaCols.size(), 3);
+      Assertions.assertEquals(newSchemaCols.get(2).name(), "dt");
+
+      // This is necessary to ensure Spark not caching the previous state.
+      spark.sql("REFRESH TABLE openhouse.d1.t1");
+
+      dummyDF.write().mode("append").format("parquet").saveAsTable("openhouse.d1.t1");
+
+      tableDF = spark.table("openhouse.d1.t1");
+      Assertions.assertEquals(tableDF.count(), 5);
+    } finally {
+      if (spark != null) {
+        spark.sql("DROP TABLE openhouse.d1.t1");
+      }
+    }
+  }
+}

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/CatalogConstants.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/CatalogConstants.java
@@ -15,7 +15,7 @@ public final class CatalogConstants {
   /** Used to uniquely identify an update towards a table from user side. */
   public static final String COMMIT_KEY = "commitKey";
 
-  public static final String EVOLVED_SCHEMA_KEY = "evolvedSchema";
+  public static final String EVOLVED_SCHEMA_KEY = "evolved.table.schema";
 
   static final String FEATURE_TOGGLE_STOP_CREATE = "stop_create";
 

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/CatalogConstants.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/CatalogConstants.java
@@ -15,6 +15,8 @@ public final class CatalogConstants {
   /** Used to uniquely identify an update towards a table from user side. */
   public static final String COMMIT_KEY = "commitKey";
 
+  public static final String EVOLVED_SCHEMA_KEY = "EvolvedSchema";
+
   static final String FEATURE_TOGGLE_STOP_CREATE = "stop_create";
 
   static final String CLIENT_TABLE_SCHEMA = "client.table.schema";

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/CatalogConstants.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/CatalogConstants.java
@@ -15,7 +15,7 @@ public final class CatalogConstants {
   /** Used to uniquely identify an update towards a table from user side. */
   public static final String COMMIT_KEY = "commitKey";
 
-  public static final String EVOLVED_SCHEMA_KEY = "EvolvedSchema";
+  public static final String EVOLVED_SCHEMA_KEY = "evolvedSchema";
 
   static final String FEATURE_TOGGLE_STOP_CREATE = "stop_create";
 

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -178,9 +178,6 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
   private TableMetadata rebuildTblMetaWithSchema(TableMetadata newMetadata, String schemaKey) {
     Schema writerSchema = SchemaParser.fromJson(newMetadata.properties().get(schemaKey));
     return TableMetadata.buildFrom(newMetadata)
-        //        .buildFromEmpty()
-        //        .assignUUID()
-        //        .setLocation(newMetadata.location())
         .setCurrentSchema(writerSchema, writerSchema.highestFieldId())
         .addPartitionSpec(
             rebuildPartitionSpec(newMetadata.spec(), newMetadata.schema(), writerSchema))

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -174,6 +174,21 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
     }
   }
 
+  /** An internal helper method to rebuild the {@link TableMetadata} object. */
+  private TableMetadata rebuildTblMetaWithSchema(TableMetadata newMetadata, String schemaKey) {
+    Schema writerSchema = SchemaParser.fromJson(newMetadata.properties().get(schemaKey));
+    return TableMetadata.buildFrom(newMetadata)
+        //        .buildFromEmpty()
+        //        .assignUUID()
+        //        .setLocation(newMetadata.location())
+        .setCurrentSchema(writerSchema, writerSchema.highestFieldId())
+        .addPartitionSpec(
+            rebuildPartitionSpec(newMetadata.spec(), newMetadata.schema(), writerSchema))
+        .addSortOrder(rebuildSortOrder(newMetadata.sortOrder(), writerSchema))
+        .setProperties(newMetadata.properties())
+        .build();
+  }
+
   @SuppressWarnings("checkstyle:MissingSwitchDefault")
   @Override
   protected void doCommit(TableMetadata base, TableMetadata metadata) {
@@ -184,17 +199,11 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
      * object using the client supplied schema by preserving its field-ids.
      */
     if (base == null && metadata.properties().get(CatalogConstants.CLIENT_TABLE_SCHEMA) != null) {
-      Schema clientSchema =
-          SchemaParser.fromJson(metadata.properties().get(CatalogConstants.CLIENT_TABLE_SCHEMA));
-      metadata =
-          TableMetadata.buildFromEmpty()
-              .setLocation(metadata.location())
-              .setCurrentSchema(clientSchema, metadata.lastColumnId())
-              .addPartitionSpec(
-                  rebuildPartitionSpec(metadata.spec(), metadata.schema(), clientSchema))
-              .addSortOrder(rebuildSortOrder(metadata.sortOrder(), clientSchema))
-              .setProperties(metadata.properties())
-              .build();
+      metadata = rebuildTblMetaWithSchema(metadata, CatalogConstants.CLIENT_TABLE_SCHEMA);
+    }
+
+    if (metadata.properties().get(CatalogConstants.EVOLVED_SCHEMA_KEY) != null) {
+      metadata = rebuildTblMetaWithSchema(metadata, CatalogConstants.EVOLVED_SCHEMA_KEY);
     }
 
     int version = currentVersion() + 1;
@@ -220,6 +229,9 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
               getCanonicalFieldName("tableLocation"), CatalogConstants.INITIAL_VERSION));
       properties.put(getCanonicalFieldName("tableLocation"), newMetadataLocation);
 
+      if (properties.containsKey(CatalogConstants.EVOLVED_SCHEMA_KEY)) {
+        properties.remove(CatalogConstants.EVOLVED_SCHEMA_KEY);
+      }
       String serializedSnapshotsToPut = properties.remove(CatalogConstants.SNAPSHOTS_JSON_KEY);
       String serializedSnapshotRefs = properties.remove(CatalogConstants.SNAPSHOTS_REFS_KEY);
       boolean isStageCreate =

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -182,7 +182,6 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
         .addPartitionSpec(
             rebuildPartitionSpec(newMetadata.spec(), newMetadata.schema(), writerSchema))
         .addSortOrder(rebuildSortOrder(newMetadata.sortOrder(), writerSchema))
-        .setProperties(newMetadata.properties())
         .build();
   }
 

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -197,9 +197,7 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
      */
     if (base == null && metadata.properties().get(CatalogConstants.CLIENT_TABLE_SCHEMA) != null) {
       metadata = rebuildTblMetaWithSchema(metadata, CatalogConstants.CLIENT_TABLE_SCHEMA);
-    }
-
-    if (metadata.properties().get(CatalogConstants.EVOLVED_SCHEMA_KEY) != null) {
+    } else if (metadata.properties().get(CatalogConstants.EVOLVED_SCHEMA_KEY) != null) {
       metadata = rebuildTblMetaWithSchema(metadata, CatalogConstants.EVOLVED_SCHEMA_KEY);
     }
 

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/SchemaValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/SchemaValidator.java
@@ -5,11 +5,9 @@ import org.apache.iceberg.Schema;
 
 /**
  * Interface to define schema evolution rules. One should provide implementation of this interface
- * to customize schema evolution rules, e.g. enforcing no column-dropping, no column-reordering,
- * etc.
+ * to customize schema evolution rules, e.g. enforcing no column-dropping.
  */
 public interface SchemaValidator {
-  void validateWriteSchema(
-      Schema oldSchema, Schema newSchema, Schema updatedSchema, String tableUri)
+  void validateWriteSchema(Schema oldSchema, Schema newSchema, String tableUri)
       throws InvalidSchemaEvolutionException, IllegalArgumentException;
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/BaseIcebergSchemaValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/BaseIcebergSchemaValidator.java
@@ -19,10 +19,10 @@ public class BaseIcebergSchemaValidator implements SchemaValidator {
   @Override
   public void validateWriteSchema(Schema oldSchema, Schema newSchema, String tableUri)
       throws InvalidSchemaEvolutionException, IllegalArgumentException {
-    TypeUtil.validateSchema(
-        "OpenHouse Server Schema validation Validation", newSchema, oldSchema, true, false);
     validateFields(oldSchema, newSchema, tableUri);
     enforceDeleteColumnFailure(oldSchema, newSchema, tableUri);
+    TypeUtil.validateSchema(
+        "OpenHouse Server Schema validation Validation", newSchema, oldSchema, true, false);
   }
 
   private void enforceDeleteColumnFailure(Schema oldSchema, Schema newSchema, String tableUri) {

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/BaseIcebergSchemaValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/BaseIcebergSchemaValidator.java
@@ -5,6 +5,7 @@ import com.linkedin.openhouse.tables.repository.SchemaValidator;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.MapDifference;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.springframework.stereotype.Component;
 
@@ -18,6 +19,8 @@ public class BaseIcebergSchemaValidator implements SchemaValidator {
   @Override
   public void validateWriteSchema(Schema oldSchema, Schema newSchema, String tableUri)
       throws InvalidSchemaEvolutionException, IllegalArgumentException {
+    TypeUtil.validateSchema(
+        "OpenHouse Server Schema validation Validation", newSchema, oldSchema, true, false);
     validateFields(oldSchema, newSchema, tableUri);
     enforceDeleteColumnFailure(oldSchema, newSchema, tableUri);
   }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/BaseIcebergSchemaValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/BaseIcebergSchemaValidator.java
@@ -5,7 +5,7 @@ import com.linkedin.openhouse.tables.repository.SchemaValidator;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.MapDifference;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
 import org.springframework.stereotype.Component;
 
 /**
@@ -18,12 +18,8 @@ public class BaseIcebergSchemaValidator implements SchemaValidator {
   @Override
   public void validateWriteSchema(Schema oldSchema, Schema newSchema, String tableUri)
       throws InvalidSchemaEvolutionException, IllegalArgumentException {
-    // TODO: Detect and resolve rename and reorder
-    // This implementation assumes both old and new schemas have field ids internally assigned by
-    // iceberg rather than specified by the users
+    validateFields(oldSchema, newSchema, tableUri);
     enforceDeleteColumnFailure(oldSchema, newSchema, tableUri);
-    TypeUtil.validateWriteSchema(
-        oldSchema, newSchema, /*checkNullability*/ true, /*checkOrdering*/ false);
   }
 
   private void enforceDeleteColumnFailure(Schema oldSchema, Schema newSchema, String tableUri) {
@@ -31,16 +27,52 @@ public class BaseIcebergSchemaValidator implements SchemaValidator {
     MapDifference<Integer, String> diff =
         Maps.difference(oldSchema.idToName(), newSchema.idToName());
 
-    if (diff.entriesOnlyOnLeft().size() != 0) {
+    if (!diff.entriesOnlyOnLeft().isEmpty()) {
       throw new InvalidSchemaEvolutionException(
           tableUri, newSchema.toString(), oldSchema.toString(), "Some columns are dropped");
     }
-    if (diff.entriesDiffering().size() != 0) {
+    if (!diff.entriesDiffering().isEmpty()) {
       throw new InvalidSchemaEvolutionException(
           tableUri,
           newSchema.toString(),
           oldSchema.toString(),
           "Given same id, column name is different");
+    }
+  }
+
+  /**
+   * Since @param newSchema is considered to be the new source-of-truth table schema, OpenHouse just
+   * need to ensure all field-Id are still matching before directly use it to assemble {@link
+   * org.apache.iceberg.TableMetadata}
+   *
+   * <p>Note that Iceberg by itself is case-sensitive by default, the casing info can be lost
+   * through the SQL engine layer. Here OH is honoring the default case sensitivity for column
+   * name-based resolution.
+   *
+   * @param oldSchema existing schema in table catalog
+   * @param newSchema user-provided schema that may contain evolution
+   * @param tableUri tableUri
+   */
+  protected void validateFields(Schema oldSchema, Schema newSchema, String tableUri) {
+    for (Types.NestedField field : oldSchema.columns()) {
+      Types.NestedField columnInNewSchema = newSchema.findField(field.name());
+      if (columnInNewSchema == null) {
+        throw new InvalidSchemaEvolutionException(
+            tableUri,
+            newSchema.toString(),
+            oldSchema.toString(),
+            String.format("Column[%s] not found in newSchema", field.name()));
+      }
+
+      if (columnInNewSchema.fieldId() != field.fieldId()) {
+        throw new InvalidSchemaEvolutionException(
+            tableUri,
+            newSchema.toString(),
+            oldSchema.toString(),
+            String.format(
+                "Internal Error: Column name [%s] in newSchema has a different fieldId",
+                field.name()));
+      }
     }
   }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/BaseIcebergSchemaValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/BaseIcebergSchemaValidator.java
@@ -16,15 +16,14 @@ import org.springframework.stereotype.Component;
 @Component
 public class BaseIcebergSchemaValidator implements SchemaValidator {
   @Override
-  public void validateWriteSchema(
-      Schema oldSchema, Schema newSchema, Schema updatedSchema, String tableUri)
+  public void validateWriteSchema(Schema oldSchema, Schema newSchema, String tableUri)
       throws InvalidSchemaEvolutionException, IllegalArgumentException {
     // TODO: Detect and resolve rename and reorder
     // This implementation assumes both old and new schemas have field ids internally assigned by
     // iceberg rather than specified by the users
     enforceDeleteColumnFailure(oldSchema, newSchema, tableUri);
     TypeUtil.validateWriteSchema(
-        updatedSchema, oldSchema, /*checkNullability*/ true, /*checkOrdering*/ false);
+        newSchema, oldSchema, /*checkNullability*/ true, /*checkOrdering*/ false);
   }
 
   private void enforceDeleteColumnFailure(Schema oldSchema, Schema newSchema, String tableUri) {

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/BaseIcebergSchemaValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/BaseIcebergSchemaValidator.java
@@ -23,7 +23,7 @@ public class BaseIcebergSchemaValidator implements SchemaValidator {
     // iceberg rather than specified by the users
     enforceDeleteColumnFailure(oldSchema, newSchema, tableUri);
     TypeUtil.validateWriteSchema(
-        newSchema, oldSchema, /*checkNullability*/ true, /*checkOrdering*/ false);
+        oldSchema, newSchema, /*checkNullability*/ true, /*checkOrdering*/ false);
   }
 
   private void enforceDeleteColumnFailure(Schema oldSchema, Schema newSchema, String tableUri) {

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -16,6 +16,7 @@ import com.linkedin.openhouse.common.exception.RequestValidationFailureException
 import com.linkedin.openhouse.common.exception.UnsupportedClientOperationException;
 import com.linkedin.openhouse.common.metrics.MetricsConstant;
 import com.linkedin.openhouse.common.schema.IcebergSchemaHelper;
+import com.linkedin.openhouse.internal.catalog.CatalogConstants;
 import com.linkedin.openhouse.internal.catalog.SnapshotsUtil;
 import com.linkedin.openhouse.internal.catalog.fileio.FileIOManager;
 import com.linkedin.openhouse.tables.common.TableType;
@@ -39,11 +40,11 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.UpdateProperties;
-import org.apache.iceberg.UpdateSchema;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -134,10 +135,9 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
       Transaction transaction = table.newTransaction();
       updateEligibilityCheck(table, tableDto);
 
-      boolean schemaUpdated =
-          doUpdateSchemaIfNeeded(transaction, writeSchema, table.schema(), tableDto);
       UpdateProperties updateProperties = transaction.updateProperties();
-
+      boolean schemaUpdated =
+          doUpdateSchemaIfNeeded(writeSchema, table.schema(), tableDto, updateProperties);
       boolean propsUpdated = doUpdateUserPropsIfNeeded(updateProperties, tableDto, table);
       boolean snapshotsUpdated = doUpdateSnapshotsIfNeeded(updateProperties, tableDto);
       boolean policiesUpdated =
@@ -352,21 +352,16 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
     }
   }
 
-  /**
-   * @param transaction
-   * @param writeSchema
-   * @param tableSchema
-   * @param tableDto
-   * @return Whether there are any schema-updates actually materialized.
-   */
+  /** @return Whether there are any schema-updates actually materialized. */
   private boolean doUpdateSchemaIfNeeded(
-      Transaction transaction, Schema writeSchema, Schema tableSchema, TableDto tableDto) {
+      Schema writeSchema,
+      Schema tableSchema,
+      TableDto tableDto,
+      UpdateProperties updateProperties) {
     if (!writeSchema.sameSchema(tableSchema)) {
       try {
-        UpdateSchema update = transaction.updateSchema().unionByNameWith(writeSchema);
-        schemaValidator.validateWriteSchema(
-            tableSchema, writeSchema, update.apply(), tableDto.getTableUri());
-        update.commit();
+        updateProperties.set(CatalogConstants.EVOLVED_SCHEMA_KEY, SchemaParser.toJson(writeSchema));
+        schemaValidator.validateWriteSchema(tableSchema, writeSchema, tableDto.getTableUri());
         return true;
       } catch (Exception e) {
         // TODO: Make upstream change to have explicit SchemaEvolutionFailureException

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -360,8 +360,8 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
       UpdateProperties updateProperties) {
     if (!writeSchema.sameSchema(tableSchema)) {
       try {
-        updateProperties.set(CatalogConstants.EVOLVED_SCHEMA_KEY, SchemaParser.toJson(writeSchema));
         schemaValidator.validateWriteSchema(tableSchema, writeSchema, tableDto.getTableUri());
+        updateProperties.set(CatalogConstants.EVOLVED_SCHEMA_KEY, SchemaParser.toJson(writeSchema));
         return true;
       } catch (Exception e) {
         // TODO: Make upstream change to have explicit SchemaEvolutionFailureException

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
@@ -501,9 +501,7 @@ public class RepositoryTest {
 
     Assertions.assertThrows(
         InvalidSchemaEvolutionException.class,
-        () ->
-            validator.validateWriteSchema(
-                oldSchema, newSchema, update.apply(), createDto.getTableUri()));
+        () -> validator.validateWriteSchema(oldSchema, newSchema, createDto.getTableUri()));
     TableDtoPrimaryKey primaryKey = getPrimaryKey(TABLE_DTO);
     openHouseInternalRepository.deleteById(primaryKey);
     Assertions.assertFalse(openHouseInternalRepository.existsById(primaryKey));
@@ -540,9 +538,7 @@ public class RepositoryTest {
 
     Assertions.assertThrows(
         InvalidSchemaEvolutionException.class,
-        () ->
-            validator.validateWriteSchema(
-                oldSchema, newSchema, update.apply(), createDto.getTableUri()));
+        () -> validator.validateWriteSchema(oldSchema, newSchema, createDto.getTableUri()));
     TableDtoPrimaryKey primaryKey = getPrimaryKey(TABLE_DTO);
     openHouseInternalRepository.deleteById(primaryKey);
     Assertions.assertFalse(openHouseInternalRepository.existsById(primaryKey));
@@ -578,9 +574,7 @@ public class RepositoryTest {
 
     Assertions.assertThrows(
         InvalidSchemaEvolutionException.class,
-        () ->
-            validator.validateWriteSchema(
-                oldSchema, newSchema, update.apply(), createDto.getTableUri()));
+        () -> validator.validateWriteSchema(oldSchema, newSchema, createDto.getTableUri()));
     TableDtoPrimaryKey primaryKey = getPrimaryKey(TABLE_DTO);
     openHouseInternalRepository.deleteById(primaryKey);
     Assertions.assertFalse(openHouseInternalRepository.existsById(primaryKey));
@@ -630,9 +624,7 @@ public class RepositoryTest {
     UpdateSchema update = table.newTransaction().updateSchema().unionByNameWith(newSchema);
     Assertions.assertThrows(
         InvalidSchemaEvolutionException.class,
-        () ->
-            validator.validateWriteSchema(
-                oldSchema, newSchema, update.apply(), createDto.getTableUri()));
+        () -> validator.validateWriteSchema(oldSchema, newSchema, createDto.getTableUri()));
     TableDtoPrimaryKey primaryKey = getPrimaryKey(TABLE_DTO);
     openHouseInternalRepository.deleteById(primaryKey);
     Assertions.assertFalse(openHouseInternalRepository.existsById(primaryKey));

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
@@ -508,6 +508,24 @@ public class RepositoryTest {
   }
 
   @Test
+  void testSchemaEvolutionWithMismatchedFieldId() {
+    Schema oldSchema =
+        new Schema(
+            required(1, "name", Types.StringType.get()),
+            required(2, "count", Types.LongType.get()));
+
+    // negative case: Id being different
+    Schema newSchema =
+        new Schema(
+            required(2, "name", Types.StringType.get()),
+            required(1, "count", Types.LongType.get()));
+
+    Assertions.assertThrows(
+        InvalidSchemaEvolutionException.class,
+        () -> validator.validateWriteSchema(oldSchema, newSchema, "random_uri"));
+  }
+
+  @Test
   void testSchemaEvolutionStruct() {
     Types.StructType leafStructType1 =
         Types.StructType.of(

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesControllerTest.java
@@ -215,45 +215,49 @@ public class TablesControllerTest {
         RequestAndValidateHelper.createTableAndValidateResponse(
             GET_TABLE_RESPONSE_BODY_DIFF_DB, mvc, storageManager);
 
-    String tableLocation = RequestAndValidateHelper.obtainTableLocationFromMvcResult(mvcResultT1d1);
-    String tableSameDbLocation =
-        RequestAndValidateHelper.obtainTableLocationFromMvcResult(mvcResultT2d1);
-    String tableDiffDbLocation =
-        RequestAndValidateHelper.obtainTableLocationFromMvcResult(mvcResultT1d2);
+    try {
+      String tableLocation =
+          RequestAndValidateHelper.obtainTableLocationFromMvcResult(mvcResultT1d1);
+      String tableSameDbLocation =
+          RequestAndValidateHelper.obtainTableLocationFromMvcResult(mvcResultT2d1);
+      String tableDiffDbLocation =
+          RequestAndValidateHelper.obtainTableLocationFromMvcResult(mvcResultT1d2);
 
-    // Sending the same object for update should expect no new object returned and status code being
-    // 200.
-    RequestAndValidateHelper.updateTableAndValidateResponse(
-        mvc,
-        storageManager,
-        buildGetTableResponseBody(mvcResultT1d1),
-        INITIAL_TABLE_VERSION,
-        false);
-    RequestAndValidateHelper.updateTableAndValidateResponse(
-        mvc,
-        storageManager,
-        buildGetTableResponseBody(mvcResultT2d1),
-        INITIAL_TABLE_VERSION,
-        false);
-    RequestAndValidateHelper.updateTableAndValidateResponse(
-        mvc,
-        storageManager,
-        buildGetTableResponseBody(mvcResultT1d2),
-        INITIAL_TABLE_VERSION,
-        false);
+      // Sending the same object for update should expect no new object returned and status code
+      // being
+      // 200.
+      RequestAndValidateHelper.updateTableAndValidateResponse(
+          mvc,
+          storageManager,
+          buildGetTableResponseBody(mvcResultT1d1),
+          INITIAL_TABLE_VERSION,
+          false);
+      RequestAndValidateHelper.updateTableAndValidateResponse(
+          mvc,
+          storageManager,
+          buildGetTableResponseBody(mvcResultT2d1),
+          INITIAL_TABLE_VERSION,
+          false);
+      RequestAndValidateHelper.updateTableAndValidateResponse(
+          mvc,
+          storageManager,
+          buildGetTableResponseBody(mvcResultT1d2),
+          INITIAL_TABLE_VERSION,
+          false);
 
-    // Sending the object with updated schema, expecting version moving ahead.
-    // Creating a container GetTableResponseBody to update schema ONLY
-    RequestAndValidateHelper.updateTableAndValidateResponse(
-        mvc, storageManager, evolveDummySchema(mvcResultT1d1), tableLocation);
-    RequestAndValidateHelper.updateTableAndValidateResponse(
-        mvc, storageManager, evolveDummySchema(mvcResultT2d1), tableSameDbLocation);
-    RequestAndValidateHelper.updateTableAndValidateResponse(
-        mvc, storageManager, evolveDummySchema(mvcResultT1d2), tableDiffDbLocation);
-
-    RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, GET_TABLE_RESPONSE_BODY);
-    RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, GET_TABLE_RESPONSE_BODY_SAME_DB);
-    RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, GET_TABLE_RESPONSE_BODY_DIFF_DB);
+      // Sending the object with updated schema, expecting version moving ahead.
+      // Creating a container GetTableResponseBody to update schema ONLY
+      RequestAndValidateHelper.updateTableAndValidateResponse(
+          mvc, storageManager, evolveDummySchema(mvcResultT1d1), tableLocation);
+      RequestAndValidateHelper.updateTableAndValidateResponse(
+          mvc, storageManager, evolveDummySchema(mvcResultT2d1), tableSameDbLocation);
+      RequestAndValidateHelper.updateTableAndValidateResponse(
+          mvc, storageManager, evolveDummySchema(mvcResultT1d2), tableDiffDbLocation);
+    } finally {
+      RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, GET_TABLE_RESPONSE_BODY);
+      RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, GET_TABLE_RESPONSE_BODY_SAME_DB);
+      RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, GET_TABLE_RESPONSE_BODY_DIFF_DB);
+    }
   }
 
   @Test

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
@@ -353,7 +353,8 @@ public class TablesServiceTest {
         new org.apache.iceberg.Schema(
             Types.NestedField.required(1, "stringId", Types.StringType.get()),
             Types.NestedField.required(2, "timestampCol", Types.TimestampType.withoutZone()),
-            Types.NestedField.required(3, "newCol", Types.StringType.get()));
+            Types.NestedField.optional(
+                3, "newCol", Types.StringType.get())); /* newly added column has to be optional */
     Assertions.assertDoesNotThrow(
         () ->
             tablesService.putTable(


### PR DESCRIPTION
## Summary

Supporting evolution pattern like Schema's Field Ordering for OpenHouse. 
The data flow for the schema evolution is like below: 

1. User-side, which is mostly engine's catalog layer, provided a evolved schema,
2. Such schema gets serialized and passes over the wire. There's a specific segment `schema` in OH's REST API to capture that "newSchema", if there's evolution happening on the client side, 
3. OpenHouse server simply does a `unionByNameWith` operation using Iceberg's Table API. 

Note that this is also how `merge-schema` works in Spark's client side, see https://github.com/apache/iceberg/blob/31e31fd819c846f49d2bd459b8bfadfdc3c2bc3a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java#L172 as a reference. 

On a high level, OpenHouse's internalCatalog simulate the client-side behavior of Iceberg's catalog and "replay" the operation using the high-level Iceberg's Table API, like `UpdateProperties`, `table.updateSchema()` etc. This approach doesn't work well in support column reordering, as OH server side has no direct access to the information about how reordering is conducted on the client side, which is necessary if sticking to the higher level API like `moveBefore` and `moveAfter` exposed by `table.updateSchema()`. 

The new approach here is to
- Trust the `newSchema` provided by client side to the be source-of-truth after simple validation (e.g. Field-id not drifted, no columns being dropped, this behavior can be extended based on specific needs), 
- Use `newSchema` to assemble the new `TableMetadata` object to be persisted as part of commit on the server side, 
- To do so, we use a similar method like snapshot-json, to let service-level constructs `services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java` passing `newSchema` through table properties, and for catalog-level constructs `iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java` deserialize it and process. 




## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done

Adding a new test cases to demonstrate how the client-side resolved schema will be persisted on the server side. 
Other wise, passing all existing schema evolution test cases since the core logic is being changed on the server side as well. 

<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
