### PR TITLE
Allow primary table setup with custom UUID

### DIFF
--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -183,7 +183,7 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
         && metadata.properties().containsKey(OPENHOUSE_TABLE_TYPE_KEY)) {
       createUpdateTableRequestBody.setTableType(getTableType(base, metadata));
     }
-    // If base table is a replication table, retain the property from base table
+    // If base table is a replicated table, retain the property from base table
     if (base != null && base.properties().containsKey(TBL_IS_REPLICATED_KEY)) {
       Map<String, String> newTblProperties = createUpdateTableRequestBody.getTableProperties();
       newTblProperties.put(TBL_IS_REPLICATED_KEY, base.properties().get(TBL_IS_REPLICATED_KEY));

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -70,6 +70,7 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
   private static final String UPDATED_OPENHOUSE_POLICY_KEY = "updated.openhouse.policy";
   private static final String OPENHOUSE_TABLE_TYPE_KEY = "openhouse.tableType";
   private static final String OPENHOUSE_CLUSTER_ID_KEY = "openhouse.clusterId";
+  private static final String TBL_IS_REPLICATED_KEY = "openhouse.isTableReplicated";
   private static final String POLICIES_KEY = "policies";
   static final String INITIAL_TABLE_VERSION = "INITIAL_VERSION";
 
@@ -181,6 +182,12 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
     if (metadata.properties() != null
         && metadata.properties().containsKey(OPENHOUSE_TABLE_TYPE_KEY)) {
       createUpdateTableRequestBody.setTableType(getTableType(base, metadata));
+    }
+    // If base table is a replication table, retain the property from base table
+    if (base != null && base.properties().containsKey(TBL_IS_REPLICATED_KEY)) {
+      Map<String, String> newTblProperties = createUpdateTableRequestBody.getTableProperties();
+      newTblProperties.put(TBL_IS_REPLICATED_KEY, base.properties().get(TBL_IS_REPLICATED_KEY));
+      createUpdateTableRequestBody.setTableProperties(newTblProperties);
     }
     return createUpdateTableRequestBody;
   }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/TableUUIDGenerator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/TableUUIDGenerator.java
@@ -140,14 +140,14 @@ public class TableUUIDGenerator {
     String tableURI = String.format("%s.%s", databaseId, tableId);
     String dbIdFromProps = extractFromTblPropsIfExists(tableURI, tableProperties, DB_RAW_KEY);
     String tblIdFromProps = extractFromTblPropsIfExists(tableURI, tableProperties, TBL_RAW_KEY);
-    boolean isCreatedForReplication =
+    boolean isTableReplicated =
         Boolean.parseBoolean(
             tableProperties.getOrDefault(OPENHOUSE_NAMESPACE + TBL_IS_REPLICATED_RAW_KEY, "false"));
 
     // validate only when table of type Primary and is not created for replication. CTAS and
     // replication both require
     // UUID to be passed from table Property. To disambiguate, TBL_IS_REPLICATED_RAW_KEY is used.
-    if (TableType.REPLICA_TABLE != tableType && !isCreatedForReplication) {
+    if (TableType.REPLICA_TABLE != tableType && !isTableReplicated) {
       // Extract tableLocation from table properties (openhouse.tableLocation)
       // tableLocation should be the absolute path to the latest metadata file including scheme.
       // Scheme is not present for HDFS and Local storages. See:

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/TableUUIDGenerator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/TableUUIDGenerator.java
@@ -33,6 +33,7 @@ public class TableUUIDGenerator {
   private static final String TBL_RAW_KEY = "tableId";
   private static final String TBL_LOC_RAW_KEY = "tableLocation";
   private static final String TBL_UUID_RAW_KEY = "tableUUID";
+  private static final String TBL_IS_REPLICATED_RAW_KEY = "isTableReplicated";
 
   @Autowired StorageManager storageManager;
 
@@ -139,8 +140,14 @@ public class TableUUIDGenerator {
     String tableURI = String.format("%s.%s", databaseId, tableId);
     String dbIdFromProps = extractFromTblPropsIfExists(tableURI, tableProperties, DB_RAW_KEY);
     String tblIdFromProps = extractFromTblPropsIfExists(tableURI, tableProperties, TBL_RAW_KEY);
+    boolean isCreatedForReplication =
+        Boolean.parseBoolean(
+            tableProperties.getOrDefault(OPENHOUSE_NAMESPACE + TBL_IS_REPLICATED_RAW_KEY, "false"));
 
-    if (TableType.REPLICA_TABLE != tableType) {
+    // validate only when table of type Primary and is not created for replication. CTAS and
+    // replication both require
+    // UUID to be passed from table Property. To disambiguate, TBL_IS_REPLICATED_RAW_KEY is used.
+    if (TableType.REPLICA_TABLE != tableType && !isCreatedForReplication) {
       // Extract tableLocation from table properties (openhouse.tableLocation)
       // tableLocation should be the absolute path to the latest metadata file including scheme.
       // Scheme is not present for HDFS and Local storages. See:


### PR DESCRIPTION
## Summary
To enable replication for Primary -> Primary tables, replication setup process needs to happen which entails creating Primary table with a given UUID. Currently Primary table creation with UUID falls in CTAS bucket and hence checks for table location existence. 

To disambiguate replication requests with CTAS, we expect replication requests to have openhouse. property 'isTableReplicated'. Based on it, table location check is avoided and Primary table with provided UUID is created.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
Unit tests added
Tested on local docker setup
1. Create primary table with given UUID
2. Create Replica table with UUID
<img width="1283" alt="Screenshot 2025-05-28 at 2 44 28 AM" src="https://github.com/user-attachments/assets/7fe581b4-ad39-4a9a-8cdc-95e2e4ef7e84" />
<img width="1335" alt="Screenshot 2025-05-28 at 2 45 33 AM" src="https://github.com/user-attachments/assets/5442b2ce-bac0-44c4-a9b8-62cacdcbee89" />

3. Test CTAS table creation has no regressions

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
