### PR TITLE
Handle queue polling when there is no element

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
@@ -73,7 +73,7 @@ public class JobsScheduler {
   private static final int TABLE_MIN_AGE_THRESHOLD_HOURS_DEFAULT = 72;
   private static final boolean PARALLEL_METADATA_FETCH_MODE_DEFAULT = false;
   private static final int MAX_NUM_CONCURRENT_METADATA_FETCH_THREAD_DEFAULT = 20;
-  private static final int OPERATION_TASK_QUEUE_POLL_TIMEOUT_MINUTES_DEFAULT = 5;
+  private static final int OPERATION_TASK_QUEUE_POLL_TIMEOUT_MINUTES_DEFAULT = 1;
   private static final Map<String, Class<? extends OperationTask>> OPERATIONS_REGISTRY =
       new HashMap<>();
   private static final Meter METER = OtelConfig.getMeter(JobsScheduler.class.getName());
@@ -533,8 +533,10 @@ public class JobsScheduler {
           OperationTask<?> task =
               operationTaskQueue.poll(
                   OPERATION_TASK_QUEUE_POLL_TIMEOUT_MINUTES_DEFAULT, TimeUnit.MINUTES);
-          taskList.add(task);
-          taskFutures.add(executors.submit(task));
+          if (task != null) {
+            taskList.add(task);
+            taskFutures.add(executors.submit(task));
+          }
         } catch (InterruptedException e) {
           log.warn("Interrupted exception while polling from the queue: {}", jobType);
         }


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

Polling blocking queue returns empty element on timeout instead of exception when queue it empty. This issue is already handled in the PR #326. The PR #326 is under review and introduces a complex feature. So adding this quick fix as part of this PR to unblock quick testing. Also updated default queue poll timeout to 1 min.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
