### PR TITLE
Add timeout for queued tasks

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
@@ -159,7 +159,7 @@ public class JobsScheduler {
                 cmdLine.getOptionValue("taskPollIntervalMs"),
                 OperationTask.POLL_INTERVAL_MS_DEFAULT),
             NumberUtils.toLong(
-                cmdLine.getOptionValue("taskTimeoutMs"), OperationTask.TIMEOUT_MS_DEFAULT));
+                cmdLine.getOptionValue("taskTimeoutMs"), OperationTask.QUEUED_TIMEOUT_MS_DEFAULT));
     ThreadPoolExecutor jobExecutors = null;
     ThreadPoolExecutor statusExecutors = null;
     if (isMultiOperationMode(cmdLine)) {

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
@@ -159,7 +159,8 @@ public class JobsScheduler {
                 cmdLine.getOptionValue("taskPollIntervalMs"),
                 OperationTask.POLL_INTERVAL_MS_DEFAULT),
             NumberUtils.toLong(
-                cmdLine.getOptionValue("taskTimeoutMs"), OperationTask.QUEUED_TIMEOUT_MS_DEFAULT));
+                cmdLine.getOptionValue("taskQueuedTimeoutMs"),
+                OperationTask.QUEUED_TIMEOUT_MS_DEFAULT));
     ThreadPoolExecutor jobExecutors = null;
     ThreadPoolExecutor statusExecutors = null;
     if (isMultiOperationMode(cmdLine)) {
@@ -491,7 +492,7 @@ public class JobsScheduler {
         Option.builder(null)
             .required(false)
             .hasArg()
-            .longOpt("taskTimeoutMs")
+            .longOpt("taskQueuedTimeoutMs")
             .desc("Timeout in milliseconds for an individual task")
             .build());
     // TODO: move these to ODD specific config

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
@@ -160,7 +160,9 @@ public class JobsScheduler {
                 OperationTask.POLL_INTERVAL_MS_DEFAULT),
             NumberUtils.toLong(
                 cmdLine.getOptionValue("taskQueuedTimeoutMs"),
-                OperationTask.QUEUED_TIMEOUT_MS_DEFAULT));
+                OperationTask.QUEUED_TIMEOUT_MS_DEFAULT),
+            NumberUtils.toLong(
+                cmdLine.getOptionValue("taskTimeoutMs"), OperationTask.TASK_TIMEOUT_MS_DEFAULT));
     ThreadPoolExecutor jobExecutors = null;
     ThreadPoolExecutor statusExecutors = null;
     if (isMultiOperationMode(cmdLine)) {
@@ -357,11 +359,13 @@ public class JobsScheduler {
     }
 
     log.info(
-        "Finishing scheduler for job type {}, tasks stats: {} created, {} succeeded,"
-            + " {} cancelled (timeout), {} failed, {} skipped (no state)",
+        "Finishing scheduler for job type {}, tasks stats: {} created, {} succeeded, {} running, {} queued"
+            + " {} cancelled (scheduler timeout), {} failed, {} skipped (no state)",
         jobType,
         taskList.size(),
         jobStateCountMap.get(JobState.SUCCEEDED),
+        jobStateCountMap.get(JobState.RUNNING),
+        jobStateCountMap.get(JobState.QUEUED),
         jobStateCountMap.get(JobState.CANCELLED),
         jobStateCountMap.get(JobState.FAILED),
         jobStateCountMap.get(JobState.SKIPPED));
@@ -385,10 +389,14 @@ public class JobsScheduler {
     LongCounter failedJobCounter = METER.counterBuilder(AppConstants.FAILED_JOB_COUNT).build();
     LongCounter cancelledJobCounter =
         METER.counterBuilder(AppConstants.CANCELLED_JOB_COUNT).build();
+    LongCounter runningJobCounter = METER.counterBuilder(AppConstants.RUNNING_JOB_COUNT).build();
+    LongCounter queuedJobCounter = METER.counterBuilder(AppConstants.QUEUED_JOB_COUNT).build();
     Attributes attributes = Attributes.of(AttributeKey.stringKey(AppConstants.TYPE), taskType);
     successfulJobCounter.add(jobStateCountMap.get(JobState.SUCCEEDED), attributes);
     failedJobCounter.add(jobStateCountMap.get(JobState.FAILED), attributes);
     cancelledJobCounter.add(jobStateCountMap.get(JobState.CANCELLED), attributes);
+    runningJobCounter.add(jobStateCountMap.get(JobState.RUNNING), attributes);
+    queuedJobCounter.add(jobStateCountMap.get(JobState.QUEUED), attributes);
     METER
         .gaugeBuilder(AppConstants.RUN_DURATION_SCHEDULER)
         .ofLongs()
@@ -493,7 +501,14 @@ public class JobsScheduler {
             .required(false)
             .hasArg()
             .longOpt("taskQueuedTimeoutMs")
-            .desc("Timeout in milliseconds for an individual task")
+            .desc("Timeout in milliseconds for an individual task in queued state")
+            .build());
+    options.addOption(
+        Option.builder(null)
+            .required(false)
+            .hasArg()
+            .longOpt("taskTimeoutMs")
+            .desc("Timeout in milliseconds for an individual task to poll jobs status")
             .build());
     // TODO: move these to ODD specific config
     options.addOption(
@@ -1035,15 +1050,18 @@ public class JobsScheduler {
           executors.getQueue().clear();
         }
         log.warn(
-            "Attempting to cancel job for {} because of timeout of {} hours", task, tasksWaitHours);
+            "Attempting to cancel task for {} because of timeout of {} hours",
+            task,
+            tasksWaitHours);
         if (taskFuture.cancel(true)) {
-          log.warn("Cancelled job for {} because of timeout of {} hours", task, tasksWaitHours);
+          log.warn("Cancelled task for {} because of timeout of {} hours", task, tasksWaitHours);
         }
       } finally {
         if (!skipStateCountUpdate) {
           if (jobState.isPresent()) {
             jobStateCountMap.put(jobState.get(), jobStateCountMap.get(jobState.get()) + 1);
           } else if (taskFuture.isCancelled()) {
+            // Even though the jobs are reported as cancelled, they might be queued or running.
             jobStateCountMap.put(JobState.CANCELLED, jobStateCountMap.get(JobState.CANCELLED) + 1);
           } else {
             // Jobs that are skipped due to replica or missing retention policy, etc.

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTaskFactory.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTaskFactory.java
@@ -13,13 +13,20 @@ public class OperationTaskFactory<T extends OperationTask<?>> {
   private JobsClient jobsClient;
   private TablesClient tablesClient;
   private long pollIntervalMs;
-  private long timeoutMs;
+  private long queuedTimeoutMs;
+  private long taskTimeoutMs;
 
   public <S extends Metadata> T create(S metadata)
       throws NoSuchMethodException, InvocationTargetException, InstantiationException,
           IllegalAccessException, IllegalStateException {
     return cls.getDeclaredConstructor(
-            JobsClient.class, TablesClient.class, metadata.getClass(), long.class, long.class)
-        .newInstance(jobsClient, tablesClient, metadata, pollIntervalMs, timeoutMs);
+            JobsClient.class,
+            TablesClient.class,
+            metadata.getClass(),
+            long.class,
+            long.class,
+            long.class)
+        .newInstance(
+            jobsClient, tablesClient, metadata, pollIntervalMs, queuedTimeoutMs, taskTimeoutMs);
   }
 }

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OrphanTableDirectoryDeletionTask.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OrphanTableDirectoryDeletionTask.java
@@ -17,8 +17,9 @@ public class OrphanTableDirectoryDeletionTask extends TableDirectoryOperationTas
       TablesClient tablesClient,
       DirectoryMetadata metadata,
       long pollIntervalMs,
-      long timeoutMs) {
-    super(jobsClient, tablesClient, metadata, pollIntervalMs, timeoutMs);
+      long queuedTimeoutMs,
+      long taskTimeoutMs) {
+    super(jobsClient, tablesClient, metadata, pollIntervalMs, queuedTimeoutMs, taskTimeoutMs);
   }
 
   public OrphanTableDirectoryDeletionTask(

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableDataCompactionTask.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableDataCompactionTask.java
@@ -22,8 +22,9 @@ public class TableDataCompactionTask extends TableOperationTask<TableMetadata> {
       TablesClient tablesClient,
       TableMetadata metadata,
       long pollIntervalMs,
-      long timeoutMs) {
-    super(jobsClient, tablesClient, metadata, pollIntervalMs, timeoutMs);
+      long queuedTimeoutMs,
+      long taskTimeoutMs) {
+    super(jobsClient, tablesClient, metadata, pollIntervalMs, queuedTimeoutMs, taskTimeoutMs);
   }
 
   public TableDataCompactionTask(

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableDataLayoutStrategyExecutionTask.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableDataLayoutStrategyExecutionTask.java
@@ -20,8 +20,9 @@ public class TableDataLayoutStrategyExecutionTask
       TablesClient tablesClient,
       TableDataLayoutMetadata metadata,
       long pollIntervalMs,
-      long timeoutMs) {
-    super(jobsClient, tablesClient, metadata, pollIntervalMs, timeoutMs);
+      long queuedTimeoutMs,
+      long taskTimeoutMs) {
+    super(jobsClient, tablesClient, metadata, pollIntervalMs, queuedTimeoutMs, taskTimeoutMs);
   }
 
   public TableDataLayoutStrategyExecutionTask(

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableDataLayoutStrategyGenerationTask.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableDataLayoutStrategyGenerationTask.java
@@ -17,8 +17,9 @@ public class TableDataLayoutStrategyGenerationTask extends TableOperationTask<Ta
       TablesClient tablesClient,
       TableMetadata metadata,
       long pollIntervalMs,
-      long timeoutMs) {
-    super(jobsClient, tablesClient, metadata, pollIntervalMs, timeoutMs);
+      long queuedTimeoutMs,
+      long taskTimeoutMs) {
+    super(jobsClient, tablesClient, metadata, pollIntervalMs, queuedTimeoutMs, taskTimeoutMs);
   }
 
   public TableDataLayoutStrategyGenerationTask(

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableDirectoryOperationTask.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableDirectoryOperationTask.java
@@ -18,8 +18,9 @@ public abstract class TableDirectoryOperationTask extends OperationTask<Director
       TablesClient tablesClient,
       DirectoryMetadata metadata,
       long pollIntervalMs,
-      long timeoutMs) {
-    super(jobsClient, tablesClient, metadata, pollIntervalMs, timeoutMs);
+      long queuedTimeoutMs,
+      long taskTimeoutMs) {
+    super(jobsClient, tablesClient, metadata, pollIntervalMs, queuedTimeoutMs, taskTimeoutMs);
   }
 
   public TableDirectoryOperationTask(

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableOperationTask.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableOperationTask.java
@@ -21,8 +21,9 @@ public abstract class TableOperationTask<T extends TableMetadata> extends Operat
       TablesClient tablesClient,
       T metadata,
       long pollIntervalMs,
-      long timeoutMs) {
-    super(jobsClient, tablesClient, metadata, pollIntervalMs, timeoutMs);
+      long queuedTimeoutMs,
+      long taskTimeoutMs) {
+    super(jobsClient, tablesClient, metadata, pollIntervalMs, queuedTimeoutMs, taskTimeoutMs);
   }
 
   protected TableOperationTask(JobsClient jobsClient, TablesClient tablesClient, T metadata) {

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableOrphanFilesDeletionTask.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableOrphanFilesDeletionTask.java
@@ -22,8 +22,9 @@ public class TableOrphanFilesDeletionTask extends TableOperationTask<TableMetada
       TablesClient tablesClient,
       TableMetadata metadata,
       long pollIntervalMs,
-      long timeoutMs) {
-    super(jobsClient, tablesClient, metadata, pollIntervalMs, timeoutMs);
+      long queuedTimeoutMs,
+      long taskTimeoutMs) {
+    super(jobsClient, tablesClient, metadata, pollIntervalMs, queuedTimeoutMs, taskTimeoutMs);
   }
 
   public TableOrphanFilesDeletionTask(

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableRetentionTask.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableRetentionTask.java
@@ -20,8 +20,9 @@ public class TableRetentionTask extends TableOperationTask<TableMetadata> {
       TablesClient tablesClient,
       TableMetadata metadata,
       long pollIntervalMs,
-      long timeoutMs) {
-    super(jobsClient, tablesClient, metadata, pollIntervalMs, timeoutMs);
+      long queuedTimeoutMs,
+      long taskTimeoutMs) {
+    super(jobsClient, tablesClient, metadata, pollIntervalMs, queuedTimeoutMs, taskTimeoutMs);
   }
 
   public TableRetentionTask(

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableSnapshotsExpirationTask.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableSnapshotsExpirationTask.java
@@ -24,8 +24,9 @@ public class TableSnapshotsExpirationTask extends TableOperationTask<TableMetada
       TablesClient tablesClient,
       TableMetadata metadata,
       long pollIntervalMs,
-      long timeoutMs) {
-    super(jobsClient, tablesClient, metadata, pollIntervalMs, timeoutMs);
+      long queuedTimeoutMs,
+      long taskTimeoutMs) {
+    super(jobsClient, tablesClient, metadata, pollIntervalMs, queuedTimeoutMs, taskTimeoutMs);
   }
 
   public TableSnapshotsExpirationTask(

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableStagedFilesDeletionTask.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableStagedFilesDeletionTask.java
@@ -17,8 +17,9 @@ public class TableStagedFilesDeletionTask extends TableOperationTask<TableMetada
       TablesClient tablesClient,
       TableMetadata metadata,
       long pollIntervalMs,
-      long timeoutMs) {
-    super(jobsClient, tablesClient, metadata, pollIntervalMs, timeoutMs);
+      long queuedTimeoutMs,
+      long taskTimeoutMs) {
+    super(jobsClient, tablesClient, metadata, pollIntervalMs, queuedTimeoutMs, taskTimeoutMs);
   }
 
   public TableStagedFilesDeletionTask(

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableStatsCollectionTask.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/TableStatsCollectionTask.java
@@ -18,8 +18,9 @@ public class TableStatsCollectionTask extends TableOperationTask<TableMetadata> 
       TablesClient tablesClient,
       TableMetadata metadata,
       long pollIntervalMs,
-      long timeoutMs) {
-    super(jobsClient, tablesClient, metadata, pollIntervalMs, timeoutMs);
+      long queuedTimeoutMs,
+      long taskTimeoutMs) {
+    super(jobsClient, tablesClient, metadata, pollIntervalMs, queuedTimeoutMs, taskTimeoutMs);
   }
 
   public TableStatsCollectionTask(

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/AppConstants.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/AppConstants.java
@@ -38,6 +38,8 @@ public final class AppConstants {
   public static final String SUCCESSFUL_JOB_COUNT = "succeeded_job_count";
   public static final String FAILED_JOB_COUNT = "failed_job_count";
   public static final String CANCELLED_JOB_COUNT = "cancelled_job_count";
+  public static final String RUNNING_JOB_COUNT = "running_job_count";
+  public static final String QUEUED_JOB_COUNT = "queued_job_count";
 
   public static final String JOBS_CLIENT_INITIALIZATION_ERROR = "jobs_client_initialization_error";
 

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/scheduler/JobsSchedulerTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/scheduler/JobsSchedulerTest.java
@@ -91,16 +91,16 @@ public class JobsSchedulerTest {
     jobsClientFactory = Mockito.mock(JobsClientFactory.class);
     tasksFactorySnapshotExpiration =
         new OperationTaskFactory<>(
-            operationTaskClsSnapshotExpiration, jobsClient, tablesClient, 60000L, 60000L);
+            operationTaskClsSnapshotExpiration, jobsClient, tablesClient, 60000L, 60000L, 120000L);
     tasksFactoryRetention =
         new OperationTaskFactory<>(
-            operationTaskClsRetention, jobsClient, tablesClient, 60000L, 60000L);
+            operationTaskClsRetention, jobsClient, tablesClient, 60000L, 60000L, 120000L);
     tasksFactoryStatsCollection =
         new OperationTaskFactory<>(
-            operationTaskClsStatsCollection, jobsClient, tablesClient, 60000L, 60000L);
+            operationTaskClsStatsCollection, jobsClient, tablesClient, 60000L, 60000L, 120000L);
     tasksFactoryOrphanFileDeletion =
         new OperationTaskFactory<>(
-            operationTaskClsOrphanFileDeletion, jobsClient, tablesClient, 60000L, 60000L);
+            operationTaskClsOrphanFileDeletion, jobsClient, tablesClient, 60000L, 60000L, 120000L);
     for (int i = 0; i < dbCount; i++) {
       databases.add("db" + i);
     }

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilderTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilderTest.java
@@ -74,16 +74,16 @@ public class OperationTasksBuilderTest {
     JobsClientFactory jobsClientFactory = Mockito.mock(JobsClientFactory.class);
     tasksFactorySnapshotExpiration =
         new OperationTaskFactory<>(
-            operationTaskClsSnapshotExpiration, jobsClient, tablesClient, 60000L, 60000L);
+            operationTaskClsSnapshotExpiration, jobsClient, tablesClient, 60000L, 60000L, 120000L);
     tasksFactoryRetention =
         new OperationTaskFactory<>(
-            operationTaskClsRetention, jobsClient, tablesClient, 60000L, 60000L);
+            operationTaskClsRetention, jobsClient, tablesClient, 60000L, 60000L, 120000L);
     tasksFactoryStatsCollection =
         new OperationTaskFactory<>(
-            operationTaskClsStatsCollection, jobsClient, tablesClient, 60000L, 60000L);
+            operationTaskClsStatsCollection, jobsClient, tablesClient, 60000L, 60000L, 120000L);
     tasksFactoryOrphanFileDeletion =
         new OperationTaskFactory<>(
-            operationTaskClsOrphanFileDeletion, jobsClient, tablesClient, 60000L, 60000L);
+            operationTaskClsOrphanFileDeletion, jobsClient, tablesClient, 60000L, 60000L, 120000L);
     operationTaskManagerSnapshotExpiration =
         new OperationTaskManager(JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION);
     operationTaskManagerOrphanFileDeletion =


### PR DESCRIPTION
## Summary
In the past, we kept the queued tasks for 3 hours. This PR reduced it to 10 minutes, and renames variables to prevent confusions. The reason behind the change is that, we found most of the queued tasks are not due to engine-side queuing, but due to an issue we called "orphan tasks". The root cause is that user apps are never launched because of out-of-quota issue in the user space, and so the state will never be updated resulting in thread spinning for 3 hours. This type of launch failure ends in minutes, but we want to make the killing mechanism more generic, so I'm setting the timeout to be 10 minutes. For running jobs, we will keep them running even after they hit the SLA of the scheduler, but only let Task exit status polling. This will prevent the waste of parallelism and also increase the job success rate. For more info, check this [doc](https://docs.google.com/document/d/1uJWIfYchhTNquFFrO9XVXr9CDOZJjIgvD2b3isJOZDI/edit?tab=t.0#heading=h.ki3l4jeu6j04).

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [ ] Tests

1. Stop cancelling queued or running jobs. Instead, only let Task exit status polling. Note, even the scheduler will only cancel the task instead of the submitted jobs after timeout. That being said, the SOT of `jobState` will only be mysql. The log and metrics reported by the scheduler only reflects the snapshot when it is killed.
2. Added a new parameter `queuedTimeoutMs`, so need to update the constructors for all Tasks.

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [x] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Will verify the results in prod.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
