### PR TITLE
Fix authorization utils for rename table where permissions on update …

### DIFF
--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
@@ -228,9 +228,12 @@ public class TablesServiceImpl implements TablesService {
               "Table %s.%s is in locked state and cannot be renamed.",
               fromDatabaseId, fromTableId));
     }
-
+    // Rename involves both modifying an existing table and creating a new one
     authorizationUtils.checkDatabasePrivilege(
-        fromDatabaseId, tableCreatorUpdater, Privileges.UPDATE_TABLE_METADATA);
+        fromDatabaseId, tableCreatorUpdater, Privileges.CREATE_TABLE);
+    authorizationUtils.checkTableWritePathPrivileges(
+        existingTableDto.get(), tableCreatorUpdater, Privileges.UPDATE_TABLE_METADATA);
+
     openHouseInternalRepository.rename(
         TableDtoPrimaryKey.builder().databaseId(fromDatabaseId).tableId(fromTableId).build(),
         TableDtoPrimaryKey.builder().databaseId(toDatabaseId).tableId(toTableId).build());


### PR DESCRIPTION
…table metadata should be on the write path

## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

Authorization for a rename table isn't quite accurate to what we are checking today.
Renames act as both creating a new table and updating an existing table.
This PR updates the authorization checks to validate both of these rather than checking update metadata on a db level.

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
