### PR TITLE
Fix multiple instances of tables and jobs client creation issue

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTaskFactory.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTaskFactory.java
@@ -1,9 +1,7 @@
 package com.linkedin.openhouse.jobs.scheduler.tasks;
 
 import com.linkedin.openhouse.jobs.client.JobsClient;
-import com.linkedin.openhouse.jobs.client.JobsClientFactory;
 import com.linkedin.openhouse.jobs.client.TablesClient;
-import com.linkedin.openhouse.jobs.client.TablesClientFactory;
 import com.linkedin.openhouse.jobs.util.Metadata;
 import java.lang.reflect.InvocationTargetException;
 import lombok.AllArgsConstructor;
@@ -12,8 +10,8 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public class OperationTaskFactory<T extends OperationTask<?>> {
   private Class<T> cls;
-  private JobsClientFactory jobsClientFactory;
-  private TablesClientFactory tablesClientFactory;
+  private JobsClient jobsClient;
+  private TablesClient tablesClient;
   private long pollIntervalMs;
   private long timeoutMs;
 
@@ -22,11 +20,6 @@ public class OperationTaskFactory<T extends OperationTask<?>> {
           IllegalAccessException, IllegalStateException {
     return cls.getDeclaredConstructor(
             JobsClient.class, TablesClient.class, metadata.getClass(), long.class, long.class)
-        .newInstance(
-            jobsClientFactory.create(),
-            tablesClientFactory.create(),
-            metadata,
-            pollIntervalMs,
-            timeoutMs);
+        .newInstance(jobsClient, tablesClient, metadata, pollIntervalMs, timeoutMs);
   }
 }

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/scheduler/JobsSchedulerTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/scheduler/JobsSchedulerTest.java
@@ -32,14 +32,13 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mockito;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@Disabled(
-    "The jobs scheduler test class is disabled as it takes time to run. Enable it to test jobs scheduler locally")
+/*@Disabled(
+"The jobs scheduler test class is disabled as it takes time to run. Enable it to test jobs scheduler locally")*/
 public class JobsSchedulerTest {
 
   private TablesClient tablesClient;
@@ -91,28 +90,16 @@ public class JobsSchedulerTest {
     jobsClientFactory = Mockito.mock(JobsClientFactory.class);
     tasksFactorySnapshotExpiration =
         new OperationTaskFactory<>(
-            operationTaskClsSnapshotExpiration,
-            jobsClientFactory,
-            tablesClientFactory,
-            60000L,
-            60000L);
+            operationTaskClsSnapshotExpiration, jobsClient, tablesClient, 60000L, 60000L);
     tasksFactoryRetention =
         new OperationTaskFactory<>(
-            operationTaskClsRetention, jobsClientFactory, tablesClientFactory, 60000L, 60000L);
+            operationTaskClsRetention, jobsClient, tablesClient, 60000L, 60000L);
     tasksFactoryStatsCollection =
         new OperationTaskFactory<>(
-            operationTaskClsStatsCollection,
-            jobsClientFactory,
-            tablesClientFactory,
-            60000L,
-            60000L);
+            operationTaskClsStatsCollection, jobsClient, tablesClient, 60000L, 60000L);
     tasksFactoryOrphanFileDeletion =
         new OperationTaskFactory<>(
-            operationTaskClsOrphanFileDeletion,
-            jobsClientFactory,
-            tablesClientFactory,
-            60000L,
-            60000L);
+            operationTaskClsOrphanFileDeletion, jobsClient, tablesClient, 60000L, 60000L);
     for (int i = 0; i < dbCount; i++) {
       databases.add("db" + i);
     }
@@ -136,7 +123,8 @@ public class JobsSchedulerTest {
             jobExecutors,
             statusExecutors,
             tasksFactorySnapshotExpiration,
-            tablesClientFactory.create(),
+            tablesClient,
+            jobsClient,
             operationTaskManagerSnapshotExpiration,
             jobInfoManagerSnapshotExpiration);
     jobsSchedulerOrphanFileDeletion =
@@ -144,7 +132,8 @@ public class JobsSchedulerTest {
             jobExecutors,
             statusExecutors,
             tasksFactoryOrphanFileDeletion,
-            tablesClientFactory.create(),
+            tablesClient,
+            jobsClient,
             operationTaskManagerOrphanFileDeletion,
             jobInfoManagerOrphanFileDeletion);
     operationTasksBuilderSnapshotExpiration =

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/scheduler/JobsSchedulerTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/scheduler/JobsSchedulerTest.java
@@ -32,13 +32,14 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mockito;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-/*@Disabled(
-"The jobs scheduler test class is disabled as it takes time to run. Enable it to test jobs scheduler locally")*/
+@Disabled(
+    "The jobs scheduler test class is disabled as it takes time to run. Enable it to test jobs scheduler locally")
 public class JobsSchedulerTest {
 
   private TablesClient tablesClient;

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilderTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilderTest.java
@@ -74,28 +74,16 @@ public class OperationTasksBuilderTest {
     JobsClientFactory jobsClientFactory = Mockito.mock(JobsClientFactory.class);
     tasksFactorySnapshotExpiration =
         new OperationTaskFactory<>(
-            operationTaskClsSnapshotExpiration,
-            jobsClientFactory,
-            tablesClientFactory,
-            60000L,
-            60000L);
+            operationTaskClsSnapshotExpiration, jobsClient, tablesClient, 60000L, 60000L);
     tasksFactoryRetention =
         new OperationTaskFactory<>(
-            operationTaskClsRetention, jobsClientFactory, tablesClientFactory, 60000L, 60000L);
+            operationTaskClsRetention, jobsClient, tablesClient, 60000L, 60000L);
     tasksFactoryStatsCollection =
         new OperationTaskFactory<>(
-            operationTaskClsStatsCollection,
-            jobsClientFactory,
-            tablesClientFactory,
-            60000L,
-            60000L);
+            operationTaskClsStatsCollection, jobsClient, tablesClient, 60000L, 60000L);
     tasksFactoryOrphanFileDeletion =
         new OperationTaskFactory<>(
-            operationTaskClsOrphanFileDeletion,
-            jobsClientFactory,
-            tablesClientFactory,
-            60000L,
-            60000L);
+            operationTaskClsOrphanFileDeletion, jobsClient, tablesClient, 60000L, 60000L);
     operationTaskManagerSnapshotExpiration =
         new OperationTaskManager(JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION);
     operationTaskManagerOrphanFileDeletion =


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

In the existing codebase for every operation task creation (every job submission thread) a new TablesClient and JobsClient instances are created. That results multiple such clients creation and effectively not taking the advantage of http connection pooling. Instead default connection pool (pool size is 500) is created for each new client created which will effectively exhaust all the resources on the client side. One job submission thread makes just one call to job service to launch job so JobClient with pool size of 500 is waster of resources. This is a major issue and was unnoticed so far due to the nature of sequential submit which slows down over a period of time and sequential/low connection usage. We often times get netty issues in the job scheduler logs such a resource exhaustion, netty closing connection etc. when we adjust parallelism or regular cadence execution, but the actual root cause was not noticed so far. 
In the new multi-mode operation model, jobs submission frequency is higher and submission and status check happens in parallel and hence more connection usage. So with the multi mode operation started seeing more connection issues, more frequent DNS lookup failures after couple of hours of execution. Eventually netty starts closing the connections and netty runs out of resources. So the fix done here is to use single instance of TablesClient and JobsClient with connection pooling.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
