### PR TITLE
Preserve database case in table properties after rename operation

### DIFF
--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -132,15 +132,22 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
 
   @Override
   public void renameTable(TableIdentifier from, TableIdentifier to) {
-    TableIdentifier fromTableId = TableIdentifier.of(from.namespace().toString(), from.name());
-    Table fromTable = loadTable(fromTableId);
+    Table fromTable = loadTable(from);
     String tableClusterId = fromTable.properties().get(CatalogConstants.OPENHOUSE_CLUSTERID_KEY);
+
+    // Preserve existing case if databases are the same
+    String toDatabaseName =
+        from.namespace().toString().equalsIgnoreCase(from.namespace().toString())
+            ? from.namespace().toString()
+            : to.namespace().toString();
+
     TableUri tableUri =
         TableUri.builder()
             .clusterId(tableClusterId)
-            .databaseId(to.namespace().toString())
+            .databaseId(toDatabaseName)
             .tableId(to.name())
             .build();
+
     Transaction transaction = fromTable.newTransaction();
     UpdateProperties updateProperties = transaction.updateProperties();
     log.info(
@@ -148,11 +155,11 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
         CatalogConstants.OPENHOUSE_TABLEID_KEY,
         to.name(),
         CatalogConstants.OPENHOUSE_DATABASEID_KEY,
-        to.namespace().toString(),
+        toDatabaseName,
         CatalogConstants.OPENHOUSE_TABLEURI_KEY,
         tableUri.toString());
     updateProperties.set(CatalogConstants.OPENHOUSE_TABLEID_KEY, to.name());
-    updateProperties.set(CatalogConstants.OPENHOUSE_DATABASEID_KEY, to.namespace().toString());
+    updateProperties.set(CatalogConstants.OPENHOUSE_DATABASEID_KEY, toDatabaseName);
     updateProperties.set(CatalogConstants.OPENHOUSE_TABLEURI_KEY, tableUri.toString());
     updateProperties.commit();
     transaction.commitTransaction();

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -137,7 +137,7 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
 
     // Preserve existing case if databases are the same
     String toDatabaseName =
-        from.namespace().toString().equalsIgnoreCase(from.namespace().toString())
+        from.namespace().toString().equalsIgnoreCase(to.namespace().toString())
             ? from.namespace().toString()
             : to.namespace().toString();
 

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/HouseTablesH2Repository.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/HouseTablesH2Repository.java
@@ -28,7 +28,12 @@ public interface HouseTablesH2Repository extends HouseTableRepository {
         .ifPresent(
             houseTable -> {
               HouseTable renamedTable =
-                  houseTable.toBuilder().tableId(toTableId).tableLocation(metadataLocation).build();
+                  houseTable
+                      .toBuilder()
+                      .databaseId(toDatabaseId)
+                      .tableId(toTableId)
+                      .tableLocation(metadataLocation)
+                      .build();
               this.save(renamedTable);
               this.delete(houseTable);
             });


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

When renaming a table, OH is case insensitive on reads, and case preserving on writes.
When a rename occurs across the same database, we want to preserve the original casing on the database even if the renamed table has a different casing for consistency.

This is handled properly on HTS side but needs to propagate to the table properties as well.

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
