### PR TITLE
Enable parallel metadata fetch for DLO-exec app

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
@@ -37,6 +37,9 @@ import org.apache.arrow.util.VisibleForTesting;
 import org.apache.hadoop.fs.Path;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.support.RetryTemplate;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 /**
  * A read-only client for interacting with /tables service. Supports limited operations necessary
@@ -50,7 +53,7 @@ public class TablesClient {
   private final RetryTemplate retryTemplate;
   private final TableApi tableApi;
   private final DatabaseApi databaseApi;
-  private final DatabaseTableFilter databaseFilter;
+  private final DatabaseTableFilter databaseTableFilter;
   @VisibleForTesting private final StorageClient storageClient;
 
   public Optional<RetentionConfig> getTableRetention(TableMetadata tableMetadata) {
@@ -140,7 +143,7 @@ public class TablesClient {
    * @return
    */
   public boolean applyDatabaseFilter(String dbName) {
-    return databaseFilter.applyDatabaseName(dbName);
+    return databaseTableFilter.applyDatabaseName(dbName);
   }
 
   /**
@@ -150,7 +153,7 @@ public class TablesClient {
    * @return
    */
   public boolean applyTableMetadataFilter(TableMetadata tableMetadata) {
-    return databaseFilter.apply(tableMetadata);
+    return databaseTableFilter.apply(tableMetadata);
   }
 
   /**
@@ -183,7 +186,7 @@ public class TablesClient {
   public List<TableMetadata> getTableMetadataList() {
     List<TableMetadata> tableMetadataList = new ArrayList<>();
     for (String dbName : getDatabases()) {
-      if (databaseFilter.applyDatabaseName(dbName)) {
+      if (databaseTableFilter.applyDatabaseName(dbName)) {
         tableMetadataList.addAll(
             RetryUtil.executeWithRetry(
                 retryTemplate,
@@ -202,7 +205,7 @@ public class TablesClient {
                           .flatMap(
                               shallowResponseBody ->
                                   mapTableResponseToTableMetadata(shallowResponseBody)
-                                      .filter(databaseFilter::apply)
+                                      .filter(databaseTableFilter::apply)
                                       .map(Stream::of)
                                       .orElseGet(Stream::empty))
                           .collect(Collectors.toList());
@@ -216,7 +219,7 @@ public class TablesClient {
   public List<TableDataLayoutMetadata> getTableDataLayoutMetadataList() {
     List<TableDataLayoutMetadata> tableDataLayoutMetadataList = new ArrayList<>();
     for (String dbName : getDatabases()) {
-      if (databaseFilter.applyDatabaseName(dbName)) {
+      if (databaseTableFilter.applyDatabaseName(dbName)) {
         tableDataLayoutMetadataList.addAll(
             RetryUtil.executeWithRetry(
                 retryTemplate,
@@ -236,7 +239,7 @@ public class TablesClient {
                               shallowResponseBody ->
                                   mapTableResponseToTableDataLayoutMetadataList(shallowResponseBody)
                                       .stream()
-                                      .filter(databaseFilter::apply))
+                                      .filter(databaseTableFilter::apply))
                           .collect(Collectors.toList());
                     },
                 Collections.emptyList()));
@@ -253,7 +256,7 @@ public class TablesClient {
    */
   public Set<String> getTableNamesForDbName(String dbName) {
     Set<String> tableNames = new HashSet<>();
-    if (databaseFilter.applyDatabaseName(dbName)) {
+    if (databaseTableFilter.applyDatabaseName(dbName)) {
       tableNames.addAll(
           RetryUtil.executeWithRetry(
               retryTemplate,
@@ -270,7 +273,7 @@ public class TablesClient {
                         .map(Collection::stream)
                         .orElseGet(Stream::empty)
                         .map(this::mapTableResponseToTableDirectoryName)
-                        .filter(databaseFilter::applyTableDirectoryPath)
+                        .filter(databaseTableFilter::applyTableDirectoryPath)
                         .collect(Collectors.toSet());
                   },
               Collections.emptySet()));
@@ -306,7 +309,7 @@ public class TablesClient {
     // we use getDatabases interface to avoid accidentally deleting essential directories on the
     // database level
     for (String dbName : getDatabases()) {
-      if (databaseFilter.applyDatabaseName(dbName)) {
+      if (databaseTableFilter.applyDatabaseName(dbName)) {
         Path dbPath = new Path(storageClient.getRootPath(), dbName);
         orphanTableDirectories.addAll(getOrphanTableDirectories(dbPath));
       }
@@ -357,8 +360,8 @@ public class TablesClient {
             .isClustered(tableResponseBody.getClustering() != null)
             .retentionConfig(getTableRetention(tableResponseBody).orElse(null))
             .replicationConfig(getTableReplication(tableResponseBody).orElse(null))
-            .jobExecutionProperties(getJobExecutionProperties(tableResponseBody));
-    builder.creationTimeMs(Objects.requireNonNull(tableResponseBody.getCreationTime()));
+            .jobExecutionProperties(getJobExecutionProperties(tableResponseBody))
+            .creationTimeMs(Objects.requireNonNull(tableResponseBody.getCreationTime()));
     return Optional.of(builder.build());
   }
 
@@ -386,8 +389,8 @@ public class TablesClient {
             .isTimePartitioned(tableResponseBody.getTimePartitioning() != null)
             .isClustered(tableResponseBody.getClustering() != null)
             .retentionConfig(getTableRetention(tableResponseBody).orElse(null))
-            .jobExecutionProperties(getJobExecutionProperties(tableResponseBody));
-    builder.creationTimeMs(Objects.requireNonNull(tableResponseBody.getCreationTime()));
+            .jobExecutionProperties(getJobExecutionProperties(tableResponseBody))
+            .creationTimeMs(Objects.requireNonNull(tableResponseBody.getCreationTime()));
     List<TableDataLayoutMetadata> result = new ArrayList<>();
     for (DataLayoutStrategy strategy : getDataLayoutStrategies(tableResponseBody)) {
       result.add(builder.dataLayoutStrategy(strategy).build());
@@ -431,5 +434,108 @@ public class TablesClient {
             .build();
     String location = getTable(metadata).getTableLocation();
     return new Path(Objects.requireNonNull(location)).getParent().getName();
+  }
+
+  // Below are asynchronous methods
+  /**
+   * Fetch all tables for the given database asynchronously using Mono.
+   *
+   * @param database
+   * @return Mono<List<GetTableResponseBody>>
+   */
+  public Mono<List<GetTableResponseBody>> getAllTablesAsync(String database) {
+    return Mono.fromCallable(
+            () -> {
+              GetAllTablesResponseBody allTablesResponseBody = getAllTables(database);
+              log.debug("Got all tables: {} for database {}", allTablesResponseBody, database);
+              if (allTablesResponseBody == null) {
+                return Collections.<GetTableResponseBody>emptyList();
+              }
+              return allTablesResponseBody.getResults();
+            })
+        .onErrorResume(
+            ex -> {
+              log.error("Error while fetching tables for database {}", database, ex);
+              return Mono.just(Collections.emptyList());
+            })
+        .subscribeOn(
+            Schedulers.boundedElastic()); // Offload the blocking call to boundedElastic scheduler
+  }
+
+  /**
+   * Fetch table metadata for a table asynchronously using Mono.
+   *
+   * @param getTableResponseBody
+   * @return Mono<TableMetadata>
+   */
+  public Mono<TableMetadata> getTableMetadataAsync(GetTableResponseBody getTableResponseBody) {
+    return Mono.fromCallable(() -> mapTableResponseToTableMetadata(getTableResponseBody))
+        .flatMap(
+            optionalTableMetadata -> {
+              if (optionalTableMetadata.isPresent()) {
+                log.debug("Got table metadata for : {}", optionalTableMetadata.get());
+                return Mono.just(optionalTableMetadata.get());
+              } else {
+                return Mono.empty();
+              }
+            })
+        .onErrorResume(
+            ex -> {
+              log.error("Error while fetching table metadata for : {}", getTableResponseBody, ex);
+              return Mono.empty();
+            })
+        .subscribeOn(
+            Schedulers.boundedElastic()); // Offload the blocking call to boundedElastic scheduler
+  }
+
+  /**
+   * Fetch table data layout metadata for a table asynchronously using Mono.
+   *
+   * @param getTableResponseBody
+   * @return Mono<TableMetadata>
+   */
+  public Mono<List<TableDataLayoutMetadata>> getTableDataLayoutMetadataListAsync(
+      GetTableResponseBody getTableResponseBody) {
+    return Mono.fromCallable(
+            () -> mapTableResponseToTableDataLayoutMetadataList(getTableResponseBody))
+        .flatMap(
+            tableDataLayoutMetadataList -> {
+              if (!tableDataLayoutMetadataList.isEmpty()) {
+                log.debug("Got table data layout metadata for : {}", tableDataLayoutMetadataList);
+                return Mono.just(tableDataLayoutMetadataList);
+              } else {
+                return Mono.empty();
+              }
+            })
+        .onErrorResume(
+            ex -> {
+              log.error(
+                  "Error while fetching table data layout metadata for : {}",
+                  getTableResponseBody,
+                  ex);
+              return Mono.empty();
+            })
+        .subscribeOn(
+            Schedulers.boundedElastic()); // Offload the blocking call to boundedElastic scheduler
+  }
+
+  public List<TableDataLayoutMetadata> getTableDataLayoutMetadataListInParallel(
+      int numParallelMetadataFetch) {
+    return Flux.fromIterable(getDatabases())
+        .parallel(numParallelMetadataFetch)
+        .runOn(Schedulers.boundedElastic())
+        .filter(databaseTableFilter::applyDatabaseName)
+        .flatMap(
+            database ->
+                getAllTablesAsync(database)
+                    .flatMapMany(Flux::fromIterable)
+                    .parallel(numParallelMetadataFetch)
+                    .runOn(Schedulers.boundedElastic())
+                    .flatMap(this::getTableDataLayoutMetadataListAsync)
+                    .flatMap(Flux::fromIterable)
+                    .filter(databaseTableFilter::apply))
+        .sequential()
+        .collectList()
+        .block();
   }
 }

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
@@ -335,6 +335,7 @@ public class TablesClient {
         Collections.emptyList());
   }
 
+  @VisibleForTesting
   public Optional<TableMetadata> mapTableResponseToTableMetadata(
       GetTableResponseBody shallowResponseBody) {
     GetTableResponseBody tableResponseBody =
@@ -365,7 +366,8 @@ public class TablesClient {
     return Optional.of(builder.build());
   }
 
-  protected List<TableDataLayoutMetadata> mapTableResponseToTableDataLayoutMetadataList(
+  @VisibleForTesting
+  public List<TableDataLayoutMetadata> mapTableResponseToTableDataLayoutMetadataList(
       GetTableResponseBody shallowResponseBody) {
     GetTableResponseBody tableResponseBody =
         getTable(shallowResponseBody.getDatabaseId(), shallowResponseBody.getTableId());
@@ -492,7 +494,7 @@ public class TablesClient {
    * Fetch table data layout metadata for a table asynchronously using Mono.
    *
    * @param getTableResponseBody
-   * @return Mono<TableMetadata>
+   * @return Mono<List<TableDataLayoutMetadata>
    */
   public Mono<List<TableDataLayoutMetadata>> getTableDataLayoutMetadataListAsync(
       GetTableResponseBody getTableResponseBody) {

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TablesClient.java
@@ -521,6 +521,12 @@ public class TablesClient {
             Schedulers.boundedElastic()); // Offload the blocking call to boundedElastic scheduler
   }
 
+  /**
+   * Fetch table data layout metadata for all tables in parallel using Flux.
+   *
+   * @param numParallelMetadataFetch
+   * @return List<TableDataLayoutMetadata>
+   */
   public List<TableDataLayoutMetadata> getTableDataLayoutMetadataListInParallel(
       int numParallelMetadataFetch) {
     return Flux.fromIterable(getDatabases())

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
@@ -46,6 +46,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.cli.BasicParser;
 import org.apache.commons.cli.CommandLine;
@@ -113,17 +115,28 @@ public class JobsScheduler {
   private static final String SUPPORTED_OPERATIONS_STRING =
       String.join(",", OPERATIONS_REGISTRY.keySet());
 
-  protected final ThreadPoolExecutor jobExecutors;
-  protected final ThreadPoolExecutor statusExecutors;
+  @Getter(AccessLevel.PROTECTED)
+  private final ThreadPoolExecutor jobExecutors;
+
+  @Getter(AccessLevel.PROTECTED)
+  private final ThreadPoolExecutor statusExecutors;
+
   protected final OperationTaskFactory<? extends OperationTask> taskFactory;
   private final TablesClient tablesClient;
   private final JobsClient jobsClient;
   private AtomicBoolean jobLaunchTasksSubmissionCompleted = new AtomicBoolean(false);
   private AtomicBoolean jobStatusTasksSubmissionCompleted = new AtomicBoolean(false);
-  protected final OperationTaskManager operationTaskManager;
-  protected final JobInfoManager jobInfoManager;
-  protected final OperationTasksBuilder tasksBuilder;
-  protected Map<JobState, Integer> jobStateCountMap = new ConcurrentHashMap<>();
+
+  @Getter(AccessLevel.PROTECTED)
+  private final OperationTaskManager operationTaskManager;
+
+  private final JobInfoManager jobInfoManager;
+
+  @Getter(AccessLevel.PROTECTED)
+  private final OperationTasksBuilder tasksBuilder;
+
+  @Getter(AccessLevel.PROTECTED)
+  private Map<JobState, Integer> jobStateCountMap = new ConcurrentHashMap<>();
 
   public JobsScheduler(
       ThreadPoolExecutor jobExecutors,

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
@@ -50,8 +50,8 @@ public class OperationTasksBuilder {
   protected final TablesClient tablesClient;
 
   private final int numParallelMetadataFetch;
-  private final OperationTaskManager operationTaskManager;
-  private final JobInfoManager jobInfoManager;
+  protected final OperationTaskManager operationTaskManager;
+  protected final JobInfoManager jobInfoManager;
 
   private List<OperationTask<?>> prepareTableOperationTaskList(
       JobConf.JobTypeEnum jobType, OperationMode operationMode) {

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
@@ -46,10 +46,10 @@ public class OperationTasksBuilder {
 
   private final int numParallelMetadataFetch;
 
-  @Getter(AccessLevel.PUBLIC)
+  @Getter(AccessLevel.PROTECTED)
   private final OperationTaskManager operationTaskManager;
 
-  @Getter(AccessLevel.PUBLIC)
+  @Getter(AccessLevel.PROTECTED)
   private final JobInfoManager jobInfoManager;
 
   private List<OperationTask<?>> prepareTableOperationTaskList(
@@ -244,6 +244,7 @@ public class OperationTasksBuilder {
       Meter meter,
       OperationMode operationMode) {
     if (jobType == JobConf.JobTypeEnum.DATA_LAYOUT_STRATEGY_EXECUTION) {
+      // DLO execution job needs to fetch all table metadata before submission
       buildDataLayoutOperationTaskListInParallel(jobType, properties, meter, operationMode);
     } else {
       buildOperationTaskListInParallelInternal(jobType, operationMode);
@@ -329,7 +330,6 @@ public class OperationTasksBuilder {
                 Optional<OperationTask<?>> optionalOperationTask =
                     processMetadata(tableDataLayoutMetadata, jobType, operationMode);
                 if (optionalOperationTask.isPresent()) {
-                  // Put tableMetadata into operation task manager
                   operationTaskManager.addData(optionalOperationTask.get());
                 }
               } catch (InterruptedException e) {

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
@@ -12,11 +12,8 @@ import com.linkedin.openhouse.jobs.util.DirectoryMetadata;
 import com.linkedin.openhouse.jobs.util.Metadata;
 import com.linkedin.openhouse.jobs.util.TableDataLayoutMetadata;
 import com.linkedin.openhouse.jobs.util.TableMetadata;
-import com.linkedin.openhouse.tables.client.model.GetAllTablesResponseBody;
-import com.linkedin.openhouse.tables.client.model.GetTableResponseBody;
 import io.opentelemetry.api.metrics.Meter;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
@@ -27,7 +24,6 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.math.NumberUtils;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 /**
@@ -44,14 +40,17 @@ public class OperationTasksBuilder {
   private static final double MAX_COST_BUDGET_GB_HRS_DEFAULT = 1000.0;
   private static final int MAX_STRATEGIES_COUNT_DEFAULT = 10;
 
-  @Getter(AccessLevel.NONE)
   private final OperationTaskFactory<? extends OperationTask<?>> taskFactory;
 
   protected final TablesClient tablesClient;
 
   private final int numParallelMetadataFetch;
-  protected final OperationTaskManager operationTaskManager;
-  protected final JobInfoManager jobInfoManager;
+
+  @Getter(AccessLevel.PUBLIC)
+  private final OperationTaskManager operationTaskManager;
+
+  @Getter(AccessLevel.PUBLIC)
+  private final JobInfoManager jobInfoManager;
 
   private List<OperationTask<?>> prepareTableOperationTaskList(
       JobConf.JobTypeEnum jobType, OperationMode operationMode) {
@@ -88,6 +87,16 @@ public class OperationTasksBuilder {
       OperationMode operationMode) {
     List<TableDataLayoutMetadata> tableDataLayoutMetadataList =
         tablesClient.getTableDataLayoutMetadataList();
+    List<TableDataLayoutMetadata> selectedTableDataLayoutMetadataList =
+        rankAndSelectFromTableDataLayoutMetadataList(
+            tableDataLayoutMetadataList, properties, meter);
+    return processMetadataList(selectedTableDataLayoutMetadataList, jobType, operationMode);
+  }
+
+  private List<TableDataLayoutMetadata> rankAndSelectFromTableDataLayoutMetadataList(
+      List<TableDataLayoutMetadata> tableDataLayoutMetadataList,
+      Properties properties,
+      Meter meter) {
     DataLayoutStrategyScorer scorer =
         new SimpleWeightedSumDataLayoutStrategyScorer(
             COMPACTION_GAIN_WEIGHT_DEFAULT, COMPUTE_COST_WEIGHT_DEFAULT);
@@ -129,7 +138,7 @@ public class OperationTasksBuilder {
         .counterBuilder("data_layout_optimization_estimated_reduced_file_count")
         .build()
         .add((long) totalReducedFileCount);
-    return processMetadataList(selectedTableDataLayoutMetadataList, jobType, operationMode);
+    return selectedTableDataLayoutMetadataList;
   }
 
   private List<OperationTask<?>> processMetadataList(
@@ -149,7 +158,7 @@ public class OperationTasksBuilder {
   }
 
   @VisibleForTesting
-  protected Optional<OperationTask<?>> processMetadata(
+  public Optional<OperationTask<?>> processMetadata(
       Metadata metadata, JobConf.JobTypeEnum jobType, OperationMode operationMode) {
     try {
       OperationTask<?> task = taskFactory.create(metadata);
@@ -229,6 +238,18 @@ public class OperationTasksBuilder {
     }
   }
 
+  public void buildOperationTaskListInParallel(
+      JobConf.JobTypeEnum jobType,
+      Properties properties,
+      Meter meter,
+      OperationMode operationMode) {
+    if (jobType == JobConf.JobTypeEnum.DATA_LAYOUT_STRATEGY_EXECUTION) {
+      buildDataLayoutOperationTaskListInParallel(jobType, properties, meter, operationMode);
+    } else {
+      buildOperationTaskListInParallelInternal(jobType, operationMode);
+    }
+  }
+
   /**
    * Uses Flux to iterate the databases list in parallel. For each database, list tables
    * asynchronously(using Mono) and then for each table get table metadata asynchronously (using
@@ -238,26 +259,24 @@ public class OperationTasksBuilder {
    * @param jobType
    * @param operationMode
    */
-  public void buildOperationTaskListInParallel(
+  private void buildOperationTaskListInParallelInternal(
       JobConf.JobTypeEnum jobType, OperationMode operationMode) {
     List<String> databases = tablesClient.getDatabases();
     Flux.fromIterable(databases) // iterate databases list
         .parallel(
             numParallelMetadataFetch) // Parallelize the databases list processing with N threads
         .runOn(Schedulers.boundedElastic()) // Use boundedElastic scheduler for IO-bound tasks
-        .filter(database -> tablesClient.applyDatabaseFilter(database))
+        .filter(tablesClient::applyDatabaseFilter)
         .flatMap(
             database ->
-                getAllTables(database)
+                tablesClient
+                    .getAllTablesAsync(database)
                     .flatMapMany(Flux::fromIterable)
                     .parallel(numParallelMetadataFetch) // Parallelize the get table metadate with N
                     // threads
                     .runOn(Schedulers.boundedElastic())
-                    .flatMap(
-                        tableResponseBody ->
-                            getTableMetadata(
-                                tableResponseBody)) // Get tableMetadata asynchronously for each
-            // table
+                    .flatMap(tablesClient::getTableMetadataAsync)
+            // Get tableMetadata asynchronously for each table
             )
         .doOnNext(
             tableMetadata -> {
@@ -290,55 +309,41 @@ public class OperationTasksBuilder {
         .subscribe();
   }
 
-  /**
-   * Fetch all tables for the given database asynchronously using Mono.
-   *
-   * @param database
-   * @return Mono<List<GetTableResponseBody>>
-   */
-  private Mono<List<GetTableResponseBody>> getAllTables(String database) {
-    return Mono.fromCallable(
+  private void buildDataLayoutOperationTaskListInParallel(
+      JobConf.JobTypeEnum jobType,
+      Properties properties,
+      Meter meter,
+      OperationMode operationMode) {
+    List<TableDataLayoutMetadata> tableDataLayoutMetadataList =
+        tablesClient.getTableDataLayoutMetadataListInParallel(numParallelMetadataFetch);
+    List<TableDataLayoutMetadata> selectedTableDataLayoutMetadataList =
+        rankAndSelectFromTableDataLayoutMetadataList(
+            tableDataLayoutMetadataList, properties, meter);
+    Flux.fromIterable(selectedTableDataLayoutMetadataList)
+        .doOnNext(
+            tableDataLayoutMetadata -> {
+              try {
+                log.debug(
+                    "Got table data layout metadata {} ",
+                    tableDataLayoutMetadata.getDataLayoutStrategy());
+                Optional<OperationTask<?>> optionalOperationTask =
+                    processMetadata(tableDataLayoutMetadata, jobType, operationMode);
+                if (optionalOperationTask.isPresent()) {
+                  // Put tableMetadata into operation task manager
+                  operationTaskManager.addData(optionalOperationTask.get());
+                }
+              } catch (InterruptedException e) {
+                log.warn("Interrupted while waiting for table metadata to be processed", e);
+              }
+            })
+        .doAfterTerminate(
             () -> {
-              GetAllTablesResponseBody allTablesResponseBody = tablesClient.getAllTables(database);
-              log.debug("Got all tables: {} for database {}", allTablesResponseBody, database);
-              if (allTablesResponseBody == null) {
-                return Collections.<GetTableResponseBody>emptyList();
-              }
-              return allTablesResponseBody.getResults();
+              operationTaskManager.updateDataGenerationCompletion();
+              log.info(
+                  "The metadata fetched count: {} for the job type: {}",
+                  operationTaskManager.getTotalDataCount(),
+                  jobType);
             })
-        .onErrorResume(
-            ex -> {
-              log.error("Error while fetching tables for database {}", database, ex);
-              return Mono.just(Collections.emptyList());
-            })
-        .subscribeOn(
-            Schedulers.boundedElastic()); // Offload the blocking call to boundedElastic scheduler
-  }
-
-  /**
-   * Fetch table metadata for a table asynchronously using Mono.
-   *
-   * @param getTableResponseBody
-   * @return Mono<TableMetadata>
-   */
-  private Mono<TableMetadata> getTableMetadata(GetTableResponseBody getTableResponseBody) {
-    return Mono.fromCallable(
-            () -> tablesClient.mapTableResponseToTableMetadata(getTableResponseBody))
-        .flatMap(
-            optionalTableMetadata -> {
-              if (optionalTableMetadata.isPresent()) {
-                log.debug("Got table metadata for : {}", optionalTableMetadata.get());
-                return Mono.just(optionalTableMetadata.get());
-              } else {
-                return Mono.empty();
-              }
-            })
-        .onErrorResume(
-            ex -> {
-              log.error("Error while fetching table metadata for : {}", getTableResponseBody, ex);
-              return Mono.empty();
-            })
-        .subscribeOn(
-            Schedulers.boundedElastic()); // Offload the blocking call to boundedElastic scheduler
+        .subscribe();
   }
 }

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/client/JobsClientTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/client/JobsClientTest.java
@@ -1,8 +1,6 @@
-package com.linkedin.openhouse.jobs.clients;
+package com.linkedin.openhouse.jobs.client;
 
 import com.linkedin.openhouse.common.JobState;
-import com.linkedin.openhouse.jobs.client.JobsClient;
-import com.linkedin.openhouse.jobs.client.JobsClientFactory;
 import com.linkedin.openhouse.jobs.client.api.JobApi;
 import com.linkedin.openhouse.jobs.client.model.CreateJobRequestBody;
 import com.linkedin.openhouse.jobs.client.model.JobConf;

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/scheduler/JobsSchedulerTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/scheduler/JobsSchedulerTest.java
@@ -2,25 +2,23 @@ package com.linkedin.openhouse.jobs.scheduler;
 
 import com.linkedin.openhouse.common.JobState;
 import com.linkedin.openhouse.jobs.client.JobsClient;
-import com.linkedin.openhouse.jobs.client.JobsClientFactory;
 import com.linkedin.openhouse.jobs.client.TablesClient;
-import com.linkedin.openhouse.jobs.client.TablesClientFactory;
 import com.linkedin.openhouse.jobs.client.model.JobConf;
 import com.linkedin.openhouse.jobs.client.model.JobResponseBody;
 import com.linkedin.openhouse.jobs.scheduler.tasks.JobInfoManager;
+import com.linkedin.openhouse.jobs.scheduler.tasks.OperationTask;
 import com.linkedin.openhouse.jobs.scheduler.tasks.OperationTaskFactory;
 import com.linkedin.openhouse.jobs.scheduler.tasks.OperationTaskManager;
 import com.linkedin.openhouse.jobs.scheduler.tasks.OperationTasksBuilder;
+import com.linkedin.openhouse.jobs.scheduler.tasks.TableDataLayoutStrategyGenerationTask;
 import com.linkedin.openhouse.jobs.scheduler.tasks.TableOrphanFilesDeletionTask;
 import com.linkedin.openhouse.jobs.scheduler.tasks.TableRetentionTask;
 import com.linkedin.openhouse.jobs.scheduler.tasks.TableSnapshotsExpirationTask;
 import com.linkedin.openhouse.jobs.scheduler.tasks.TableStatsCollectionTask;
-import com.linkedin.openhouse.jobs.util.Metadata;
 import com.linkedin.openhouse.jobs.util.RetentionConfig;
 import com.linkedin.openhouse.jobs.util.TableMetadata;
-import com.linkedin.openhouse.tables.client.model.GetAllTablesResponseBody;
-import com.linkedin.openhouse.tables.client.model.GetTableResponseBody;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,143 +27,43 @@ import java.util.UUID;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Disabled(
     "The jobs scheduler test class is disabled as it takes time to run. Enable it to test jobs scheduler locally")
 public class JobsSchedulerTest {
-
-  private TablesClient tablesClient;
-  private JobsClient jobsClient;
-  private Metadata tableMetadata;
-  private ThreadPoolExecutor jobExecutors;
-  private ThreadPoolExecutor statusExecutors;
-  private OperationTasksBuilder operationTasksBuilderSnapshotExpiration;
-  private OperationTasksBuilder operationTasksBuilderRetention;
-  private OperationTasksBuilder operationTasksBuilderOrphanFileDeletion;
-  private OperationTasksBuilder operationTasksBuilderStatsCollection;
-  private OperationTaskFactory<TableSnapshotsExpirationTask> tasksFactorySnapshotExpiration;
-  private OperationTaskFactory<TableRetentionTask> tasksFactoryRetention;
-  private OperationTaskFactory<TableStatsCollectionTask> tasksFactoryStatsCollection;
-  private OperationTaskFactory<TableOrphanFilesDeletionTask> tasksFactoryOrphanFileDeletion;
-  private Class<TableSnapshotsExpirationTask> operationTaskClsSnapshotExpiration =
-      TableSnapshotsExpirationTask.class;
-  private Class<TableRetentionTask> operationTaskClsRetention = TableRetentionTask.class;
-  private Class<TableStatsCollectionTask> operationTaskClsStatsCollection =
-      TableStatsCollectionTask.class;
-  private Class<TableOrphanFilesDeletionTask> operationTaskClsOrphanFileDeletion =
-      TableOrphanFilesDeletionTask.class;
-  private OperationTaskManager operationTaskManagerSnapshotExpiration;
-  private OperationTaskManager operationTaskManagerOrphanFileDeletion;
-  private JobInfoManager jobInfoManagerSnapshotExpiration;
-  private JobInfoManager jobInfoManagerOrphanFileDeletion;
-  private List<String> databases = new ArrayList<>();
-  private Map<String, GetAllTablesResponseBody> dbAllTables = new HashMap();
-  private Map<GetAllTablesResponseBody, List<GetTableResponseBody>> allTablesBodyToGetTableList =
-      new HashMap();
-  private Map<GetTableResponseBody, Optional<TableMetadata>> getTableResponseToTableMetadata =
-      new HashMap();
+  @Mock private TablesClient tablesClient;
+  @Mock private JobsClient jobsClient;
+  @Mock private JobResponseBody jobResponseBody;
   private int dbCount = 4;
   private int tableCount = 4;
   private List<TableMetadata> tableMetadataList = new ArrayList<>();
-  private JobsScheduler jobsSchedulerSnapshotExpiration;
-  private JobsScheduler jobsSchedulerOrphanFileDeletion;
-  private JobResponseBody jobResponseBody;
-  private TablesClientFactory tablesClientFactory;
-  private JobsClientFactory jobsClientFactory;
+
+  Map<JobConf.JobTypeEnum, Class<? extends OperationTask<?>>> jobTypeToClassMap =
+      new HashMap() {
+        {
+          put(JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION, TableSnapshotsExpirationTask.class);
+          put(JobConf.JobTypeEnum.RETENTION, TableRetentionTask.class);
+          put(JobConf.JobTypeEnum.ORPHAN_FILES_DELETION, TableOrphanFilesDeletionTask.class);
+          put(JobConf.JobTypeEnum.TABLE_STATS_COLLECTION, TableStatsCollectionTask.class);
+          put(
+              JobConf.JobTypeEnum.DATA_LAYOUT_STRATEGY_GENERATION,
+              TableDataLayoutStrategyGenerationTask.class);
+        }
+      };
 
   @BeforeAll
   void setup() {
-    tablesClient = Mockito.mock(TablesClient.class);
-    jobsClient = Mockito.mock(JobsClient.class);
-    tableMetadata =
-        TableMetadata.builder().dbName("db1").tableName("test_table").isPrimary(true).build();
-    tablesClientFactory = Mockito.mock(TablesClientFactory.class);
-    jobsClientFactory = Mockito.mock(JobsClientFactory.class);
-    tasksFactorySnapshotExpiration =
-        new OperationTaskFactory<>(
-            operationTaskClsSnapshotExpiration, jobsClient, tablesClient, 60000L, 60000L, 120000L);
-    tasksFactoryRetention =
-        new OperationTaskFactory<>(
-            operationTaskClsRetention, jobsClient, tablesClient, 60000L, 60000L, 120000L);
-    tasksFactoryStatsCollection =
-        new OperationTaskFactory<>(
-            operationTaskClsStatsCollection, jobsClient, tablesClient, 60000L, 60000L, 120000L);
-    tasksFactoryOrphanFileDeletion =
-        new OperationTaskFactory<>(
-            operationTaskClsOrphanFileDeletion, jobsClient, tablesClient, 60000L, 60000L, 120000L);
-    for (int i = 0; i < dbCount; i++) {
-      databases.add("db" + i);
-    }
-    populateDbAllTables(dbCount, tableCount);
+    MockitoAnnotations.openMocks(this);
     prepareTableMetadata();
-    jobExecutors =
-        new ThreadPoolExecutor(
-            2, 2, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>());
-    statusExecutors =
-        new ThreadPoolExecutor(
-            2, 2, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>());
-    operationTaskManagerSnapshotExpiration =
-        new OperationTaskManager(JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION);
-    operationTaskManagerOrphanFileDeletion =
-        new OperationTaskManager(JobConf.JobTypeEnum.ORPHAN_FILES_DELETION);
-    jobInfoManagerSnapshotExpiration = new JobInfoManager(JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION);
-    jobInfoManagerOrphanFileDeletion =
-        new JobInfoManager(JobConf.JobTypeEnum.ORPHAN_FILES_DELETION);
-    jobsSchedulerSnapshotExpiration =
-        new JobsScheduler(
-            jobExecutors,
-            statusExecutors,
-            tasksFactorySnapshotExpiration,
-            tablesClient,
-            jobsClient,
-            operationTaskManagerSnapshotExpiration,
-            jobInfoManagerSnapshotExpiration);
-    jobsSchedulerOrphanFileDeletion =
-        new JobsScheduler(
-            jobExecutors,
-            statusExecutors,
-            tasksFactoryOrphanFileDeletion,
-            tablesClient,
-            jobsClient,
-            operationTaskManagerOrphanFileDeletion,
-            jobInfoManagerOrphanFileDeletion);
-    operationTasksBuilderSnapshotExpiration =
-        new OperationTasksBuilder(
-            tasksFactorySnapshotExpiration,
-            tablesClient,
-            2,
-            jobsSchedulerSnapshotExpiration.operationTaskManager,
-            jobsSchedulerSnapshotExpiration.jobInfoManager);
-    operationTasksBuilderOrphanFileDeletion =
-        new OperationTasksBuilder(
-            tasksFactoryOrphanFileDeletion,
-            tablesClient,
-            2,
-            jobsSchedulerSnapshotExpiration.operationTaskManager,
-            jobsSchedulerSnapshotExpiration.jobInfoManager);
-    jobResponseBody = Mockito.mock(JobResponseBody.class);
-  }
-
-  private void populateDbAllTables(int dbCount, int tableCount) {
-    for (int i = 0; i < dbCount; i++) {
-      GetAllTablesResponseBody allTablesResponseBody = Mockito.mock(GetAllTablesResponseBody.class);
-      dbAllTables.put("db" + i, allTablesResponseBody);
-      List<GetTableResponseBody> tableResponseBodyList = new ArrayList<>();
-      for (int j = 0; j < tableCount; j++) {
-        GetTableResponseBody getTableResponseBody = Mockito.mock(GetTableResponseBody.class);
-        getTableResponseToTableMetadata.put(getTableResponseBody, getTableMetadata(i, j));
-        tableResponseBodyList.add(getTableResponseBody);
-      }
-      allTablesBodyToGetTableList.put(allTablesResponseBody, tableResponseBodyList);
-    }
   }
 
   private Optional<TableMetadata> getTableMetadata(int dbIndex, int tableIndex) {
@@ -187,234 +85,193 @@ public class JobsSchedulerTest {
     }
   }
 
-  private void prepareMockitoForParallelFetch() {
-    Mockito.when(tablesClient.getDatabases()).thenReturn(databases);
-    Mockito.when(tablesClient.applyDatabaseFilter(Mockito.anyString())).thenReturn(true);
-    for (int i = 0; i < dbCount; i++) {
-      GetAllTablesResponseBody getAllTablesResponseBody = dbAllTables.get("db" + i);
-      Mockito.when(tablesClient.getAllTables("db" + i)).thenReturn(getAllTablesResponseBody);
-      List<GetTableResponseBody> getTableResponseBodyList =
-          allTablesBodyToGetTableList.get(getAllTablesResponseBody);
-      Mockito.when(getAllTablesResponseBody.getResults()).thenReturn(getTableResponseBodyList);
-      for (int j = 0; j < tableCount; j++) {
-        GetTableResponseBody getTableResponseBody = getTableResponseBodyList.get(j);
-        Mockito.when(tablesClient.mapTableResponseToTableMetadata(getTableResponseBody))
-            .thenReturn(getTableResponseToTableMetadata.get(getTableResponseBody));
-      }
+  private JobsScheduler createJobsScheduler(JobConf.JobTypeEnum jobType) {
+    OperationTaskFactory<? extends OperationTask<?>> taskFactory =
+        new OperationTaskFactory<>(
+            jobTypeToClassMap.get(jobType), jobsClient, tablesClient, 1000L, 2000L, 3000L);
+    OperationTaskManager operationTaskManager = new OperationTaskManager(jobType);
+    JobInfoManager jobInfoManager = new JobInfoManager(jobType);
+    OperationTasksBuilder operationTasksBuilder =
+        Mockito.spy(
+            new OperationTasksBuilder(
+                taskFactory, tablesClient, 2, operationTaskManager, jobInfoManager));
+    ThreadPoolExecutor jobExecutors =
+        new ThreadPoolExecutor(
+            4, 4, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>());
+    ThreadPoolExecutor statusExecutors =
+        new ThreadPoolExecutor(
+            4, 4, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>());
+    return new JobsScheduler(
+        jobExecutors,
+        statusExecutors,
+        taskFactory,
+        tablesClient,
+        jobsClient,
+        operationTaskManager,
+        jobInfoManager,
+        operationTasksBuilder);
+  }
+
+  private void mockbuildOperationTaskListInParallel(JobsScheduler jobsScheduler) {
+    Mockito.doAnswer(
+            invocation -> {
+              for (TableMetadata metadata : tableMetadataList) {
+                Optional<OperationTask<?>> optionalOperationTask =
+                    jobsScheduler.tasksBuilder.processMetadata(
+                        metadata, invocation.getArgument(0), invocation.getArgument(3));
+                jobsScheduler.operationTaskManager.addData(optionalOperationTask.get());
+              }
+              jobsScheduler.operationTaskManager.updateDataGenerationCompletion();
+              return null;
+            })
+        .when(jobsScheduler.tasksBuilder)
+        .buildOperationTaskListInParallel(
+            Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+  }
+
+  private void mockbuildOperationTaskList(JobsScheduler jobsScheduler) {
+    Mockito.doAnswer(
+            invocation -> {
+              List<OperationTask<?>> operationTasks = new ArrayList<>();
+              for (TableMetadata metadata : tableMetadataList) {
+                operationTasks.add(
+                    jobsScheduler
+                        .tasksBuilder
+                        .processMetadata(
+                            metadata, invocation.getArgument(0), invocation.getArgument(3))
+                        .get());
+              }
+              return operationTasks;
+            })
+        .when(jobsScheduler.tasksBuilder)
+        .buildOperationTaskList(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+  }
+
+  private void mockLaunchJobAndPollStatus(
+      JobState jobState, JobResponseBody.StateEnum jobResponseState) {
+    String jobId = UUID.randomUUID().toString();
+    Mockito.when(
+            jobsClient.launch(
+                Mockito.anyString(),
+                Mockito.any(),
+                Mockito.anyString(),
+                Mockito.anyMap(),
+                Mockito.anyList()))
+        .thenReturn(Optional.of(jobId));
+    Mockito.when(jobsClient.getState(jobId)).thenReturn(Optional.of(jobState));
+    Mockito.when(jobsClient.getJob(jobId)).thenReturn(Optional.of(jobResponseBody));
+    Mockito.when(jobResponseBody.getState()).thenReturn(jobResponseState);
+    Mockito.when(jobResponseBody.getJobId()).thenReturn(jobId);
+    Mockito.when(jobResponseBody.getStartTimeMs()).thenReturn(0L);
+  }
+
+  private void shutDownJobScheduler(JobsScheduler jobsScheduler) {
+    jobsScheduler.jobExecutors.shutdownNow();
+    jobsScheduler.statusExecutors.shutdownNow();
+  }
+
+  @Test
+  public void testRunParallelFetchMultiMode() {
+    List<JobConf.JobTypeEnum> jobList = Arrays.asList(JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION);
+    for (JobConf.JobTypeEnum jobType : jobList) {
+      mockLaunchJobAndPollStatus(JobState.SUCCEEDED, JobResponseBody.StateEnum.SUCCEEDED);
+      JobsScheduler jobsScheduler = createJobsScheduler(jobType);
+      mockbuildOperationTaskListInParallel(jobsScheduler);
+      jobsScheduler.run(
+          jobType,
+          jobTypeToClassMap.get(jobType).toString(),
+          null,
+          false,
+          1,
+          true,
+          true,
+          16,
+          4,
+          1000,
+          30,
+          15);
+      Assertions.assertEquals(16, jobsScheduler.jobStateCountMap.get(JobState.SUCCEEDED));
+      Assertions.assertEquals(7, jobsScheduler.jobStateCountMap.size());
+      shutDownJobScheduler(jobsScheduler);
     }
-    Mockito.when(tablesClient.applyDatabaseFilter(Mockito.anyString())).thenReturn(true);
-    Mockito.when(tablesClient.applyTableMetadataFilter(Mockito.any(TableMetadata.class)))
-        .thenReturn(true);
   }
 
   @Test
-  public void testRunSnapshotExpirationParallelFetchMultiMode() {
-    String jobId = UUID.randomUUID().toString();
-    Mockito.when(tablesClientFactory.create()).thenReturn(tablesClient);
-    Mockito.when(jobsClientFactory.create()).thenReturn(jobsClient);
-    Mockito.when(
-            jobsClient.launch(
-                Mockito.anyString(),
-                Mockito.eq(JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION),
-                Mockito.anyString(),
-                Mockito.anyMap(),
-                Mockito.anyList()))
-        .thenReturn(Optional.of(jobId));
-    Mockito.when(jobsClient.getState(jobId)).thenReturn(Optional.of(JobState.SUCCEEDED));
-    Mockito.when(jobsClient.getJob(jobId)).thenReturn(Optional.of(jobResponseBody));
-    Mockito.when(jobResponseBody.getState()).thenReturn(JobResponseBody.StateEnum.SUCCEEDED);
-    Mockito.when(jobResponseBody.getJobId()).thenReturn(jobId);
-    Mockito.when(jobResponseBody.getStartTimeMs()).thenReturn(0L);
-    prepareMockitoForParallelFetch();
-    jobsSchedulerSnapshotExpiration.run(
-        JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION,
-        operationTaskClsSnapshotExpiration.toString(),
-        null,
-        operationTasksBuilderSnapshotExpiration,
-        false,
-        1,
-        true,
-        4,
-        true,
-        16,
-        2,
-        1000,
-        30,
-        15);
-    Assertions.assertEquals(
-        16, jobsSchedulerSnapshotExpiration.jobStateCountMap.get(JobState.SUCCEEDED));
-    Assertions.assertEquals(7, jobsSchedulerSnapshotExpiration.jobStateCountMap.size());
+  public void testRunParallelFetchMultiModeFailure() {
+    List<JobConf.JobTypeEnum> jobList = Arrays.asList(JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION);
+    for (JobConf.JobTypeEnum jobType : jobList) {
+      mockLaunchJobAndPollStatus(JobState.FAILED, JobResponseBody.StateEnum.FAILED);
+      JobsScheduler jobsScheduler = createJobsScheduler(jobType);
+      mockbuildOperationTaskListInParallel(jobsScheduler);
+      jobsScheduler.run(
+          jobType,
+          jobTypeToClassMap.get(jobType).toString(),
+          null,
+          false,
+          1,
+          true,
+          true,
+          16,
+          4,
+          1000,
+          30,
+          15);
+      Assertions.assertEquals(16, jobsScheduler.jobStateCountMap.get(JobState.FAILED));
+      Assertions.assertEquals(7, jobsScheduler.jobStateCountMap.size());
+      shutDownJobScheduler(jobsScheduler);
+    }
   }
 
   @Test
-  public void testRunSnapshotExpirationParallelFetchMultiModeFailure() {
-    String jobId = UUID.randomUUID().toString();
-    Mockito.when(tablesClientFactory.create()).thenReturn(tablesClient);
-    Mockito.when(jobsClientFactory.create()).thenReturn(jobsClient);
-    Mockito.when(
-            jobsClient.launch(
-                Mockito.anyString(),
-                Mockito.eq(JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION),
-                Mockito.anyString(),
-                Mockito.anyMap(),
-                Mockito.anyList()))
-        .thenReturn(Optional.of(jobId));
-    Mockito.when(jobsClient.getState(jobId)).thenReturn(Optional.of(JobState.FAILED));
-    Mockito.when(jobsClient.getJob(jobId)).thenReturn(Optional.of(jobResponseBody));
-    Mockito.when(jobResponseBody.getState()).thenReturn(JobResponseBody.StateEnum.FAILED);
-    Mockito.when(jobResponseBody.getJobId()).thenReturn(jobId);
-    Mockito.when(jobResponseBody.getStartTimeMs()).thenReturn(0L);
-    prepareMockitoForParallelFetch();
-    jobsSchedulerSnapshotExpiration.run(
-        JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION,
-        operationTaskClsSnapshotExpiration.toString(),
-        null,
-        operationTasksBuilderSnapshotExpiration,
-        false,
-        1,
-        true,
-        4,
-        true,
-        16,
-        2,
-        1000,
-        30,
-        15);
-    Assertions.assertEquals(
-        16, jobsSchedulerSnapshotExpiration.jobStateCountMap.get(JobState.FAILED));
-    Assertions.assertEquals(7, jobsSchedulerSnapshotExpiration.jobStateCountMap.size());
+  public void testRunParallelFetchSingleMode() {
+    List<JobConf.JobTypeEnum> jobList = Arrays.asList(JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION);
+    for (JobConf.JobTypeEnum jobType : jobList) {
+      mockLaunchJobAndPollStatus(JobState.SUCCEEDED, JobResponseBody.StateEnum.SUCCEEDED);
+      JobsScheduler jobsScheduler = createJobsScheduler(jobType);
+      mockbuildOperationTaskListInParallel(jobsScheduler);
+      jobsScheduler.run(
+          jobType,
+          jobTypeToClassMap.get(jobType).toString(),
+          null,
+          false,
+          1,
+          true,
+          false,
+          16,
+          4,
+          1000,
+          30,
+          15);
+      Assertions.assertEquals(16, jobsScheduler.jobStateCountMap.get(JobState.SUCCEEDED));
+      Assertions.assertEquals(7, jobsScheduler.jobStateCountMap.size());
+      shutDownJobScheduler(jobsScheduler);
+    }
   }
 
   @Test
-  public void testRunSnapshotExpirationParallelFetchSingleMode() {
-    String jobId = UUID.randomUUID().toString();
-    Mockito.when(tablesClientFactory.create()).thenReturn(tablesClient);
-    Mockito.when(jobsClientFactory.create()).thenReturn(jobsClient);
-    Mockito.when(
-            jobsClient.launch(
-                Mockito.anyString(),
-                Mockito.eq(JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION),
-                Mockito.anyString(),
-                Mockito.anyMap(),
-                Mockito.anyList()))
-        .thenReturn(Optional.of(jobId));
-    Mockito.when(jobsClient.getState(jobId)).thenReturn(Optional.of(JobState.SUCCEEDED));
-    Mockito.when(jobsClient.getJob(jobId)).thenReturn(Optional.of(jobResponseBody));
-    Mockito.when(jobResponseBody.getState()).thenReturn(JobResponseBody.StateEnum.SUCCEEDED);
-    Mockito.when(jobResponseBody.getJobId()).thenReturn(jobId);
-    Mockito.when(jobResponseBody.getStartTimeMs()).thenReturn(0L);
-    prepareMockitoForParallelFetch();
-    jobsSchedulerSnapshotExpiration.run(
-        JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION,
-        operationTaskClsSnapshotExpiration.toString(),
-        null,
-        operationTasksBuilderSnapshotExpiration,
-        false,
-        1,
-        true,
-        4,
-        false,
-        16,
-        2,
-        1000,
-        30,
-        15);
-    Assertions.assertEquals(
-        16, jobsSchedulerSnapshotExpiration.jobStateCountMap.get(JobState.SUCCEEDED));
-    Assertions.assertEquals(7, jobsSchedulerSnapshotExpiration.jobStateCountMap.size());
-  }
-
-  @Test
-  public void testRunSnapshotExpirationSequentialFetchSingleMode() {
-    String jobId = UUID.randomUUID().toString();
-    Mockito.when(tablesClientFactory.create()).thenReturn(tablesClient);
-    Mockito.when(jobsClientFactory.create()).thenReturn(jobsClient);
-    Mockito.when(tablesClient.getTableMetadataList()).thenReturn(tableMetadataList);
-    Mockito.when(
-            jobsClient.launch(
-                Mockito.anyString(),
-                Mockito.eq(JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION),
-                Mockito.anyString(),
-                Mockito.anyMap(),
-                Mockito.anyList()))
-        .thenReturn(Optional.of(jobId));
-    Mockito.when(jobsClient.getState(jobId)).thenReturn(Optional.of(JobState.SUCCEEDED));
-    Mockito.when(jobsClient.getJob(jobId)).thenReturn(Optional.of(jobResponseBody));
-    Mockito.when(jobResponseBody.getState()).thenReturn(JobResponseBody.StateEnum.SUCCEEDED);
-    Mockito.when(jobResponseBody.getJobId()).thenReturn(jobId);
-    Mockito.when(jobResponseBody.getStartTimeMs()).thenReturn(0L);
-    prepareMockitoForParallelFetch();
-    jobsSchedulerSnapshotExpiration.run(
-        JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION,
-        operationTaskClsSnapshotExpiration.toString(),
-        null,
-        operationTasksBuilderSnapshotExpiration,
-        false,
-        1,
-        false,
-        4,
-        false,
-        16,
-        2,
-        1000,
-        30,
-        15);
-    Assertions.assertEquals(
-        16, jobsSchedulerSnapshotExpiration.jobStateCountMap.get(JobState.SUCCEEDED));
-    Assertions.assertEquals(7, jobsSchedulerSnapshotExpiration.jobStateCountMap.size());
-  }
-
-  @Test
-  public void testRunOrphanFileDeletionParallelFetchMultiMode() {
-    String jobId = UUID.randomUUID().toString();
-    Mockito.when(tablesClientFactory.create()).thenReturn(tablesClient);
-    Mockito.when(jobsClientFactory.create()).thenReturn(jobsClient);
-    Mockito.when(
-            jobsClient.launch(
-                Mockito.anyString(),
-                Mockito.eq(JobConf.JobTypeEnum.ORPHAN_FILES_DELETION),
-                Mockito.anyString(),
-                Mockito.anyMap(),
-                Mockito.anyList()))
-        .thenReturn(Optional.of(jobId));
-    Mockito.when(jobsClient.getState(jobId)).thenReturn(Optional.of(JobState.SUCCEEDED));
-    Mockito.when(jobsClient.getJob(jobId)).thenReturn(Optional.of(jobResponseBody));
-    Mockito.when(jobResponseBody.getState()).thenReturn(JobResponseBody.StateEnum.SUCCEEDED);
-    Mockito.when(jobResponseBody.getJobId()).thenReturn(jobId);
-    Mockito.when(jobResponseBody.getStartTimeMs()).thenReturn(0L);
-    prepareMockitoForParallelFetch();
-    jobsSchedulerOrphanFileDeletion.run(
-        JobConf.JobTypeEnum.ORPHAN_FILES_DELETION,
-        operationTaskClsOrphanFileDeletion.toString(),
-        null,
-        operationTasksBuilderOrphanFileDeletion,
-        false,
-        1,
-        true,
-        4,
-        true,
-        16,
-        2,
-        1000,
-        30,
-        15);
-    Assertions.assertEquals(7, jobsSchedulerOrphanFileDeletion.jobStateCountMap.size());
-    Assertions.assertEquals(
-        16, jobsSchedulerOrphanFileDeletion.jobStateCountMap.get(JobState.SUCCEEDED));
-  }
-
-  @AfterEach
-  public void reset() {
-    operationTaskManagerSnapshotExpiration.resetAll();
-    operationTaskManagerOrphanFileDeletion.resetAll();
-    jobInfoManagerSnapshotExpiration.resetAll();
-    jobInfoManagerOrphanFileDeletion.resetAll();
-    jobExecutors =
-        new ThreadPoolExecutor(
-            2, 2, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>());
-    statusExecutors =
-        new ThreadPoolExecutor(
-            2, 2, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>());
+  public void testRunSequentialFetchSingleMode() {
+    List<JobConf.JobTypeEnum> jobList = Arrays.asList(JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION);
+    for (JobConf.JobTypeEnum jobType : jobList) {
+      mockLaunchJobAndPollStatus(JobState.SUCCEEDED, JobResponseBody.StateEnum.SUCCEEDED);
+      JobsScheduler jobsScheduler = createJobsScheduler(jobType);
+      mockbuildOperationTaskList(jobsScheduler);
+      jobsScheduler.run(
+          jobType,
+          jobTypeToClassMap.get(jobType).toString(),
+          null,
+          false,
+          1,
+          false,
+          false,
+          16,
+          4,
+          1000,
+          30,
+          15);
+      Assertions.assertEquals(16, jobsScheduler.jobStateCountMap.get(JobState.SUCCEEDED));
+      Assertions.assertEquals(7, jobsScheduler.jobStateCountMap.size());
+      shutDownJobScheduler(jobsScheduler);
+    }
   }
 
   @Test
@@ -423,7 +280,7 @@ public class JobsSchedulerTest {
         new String[] {
           "--type", TableRetentionTask.OPERATION_TYPE.getValue(),
           "--tablesURL", "http://test.openhouse.com",
-          "--jobsURL", "unused",
+          "--jobsURL", "http://test.openhouse.com",
           "--cluster", "unused",
         });
   }

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilderTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilderTest.java
@@ -1,9 +1,7 @@
 package com.linkedin.openhouse.jobs.scheduler.tasks;
 
 import com.linkedin.openhouse.jobs.client.JobsClient;
-import com.linkedin.openhouse.jobs.client.JobsClientFactory;
 import com.linkedin.openhouse.jobs.client.TablesClient;
-import com.linkedin.openhouse.jobs.client.TablesClientFactory;
 import com.linkedin.openhouse.jobs.client.model.JobConf;
 import com.linkedin.openhouse.jobs.util.Metadata;
 import com.linkedin.openhouse.jobs.util.RetentionConfig;
@@ -11,42 +9,29 @@ import com.linkedin.openhouse.jobs.util.TableMetadata;
 import com.linkedin.openhouse.tables.client.model.GetAllTablesResponseBody;
 import com.linkedin.openhouse.tables.client.model.GetTableResponseBody;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class OperationTasksBuilderTest {
-  private TablesClient tablesClient;
-  private JobsClient jobsClient;
+  @Mock private TablesClient tablesClient;
+  @Mock private JobsClient jobsClient;
   private Metadata tableMetadata;
-  private OperationTasksBuilder operationTasksBuilderSnapshotExpiration;
-  private OperationTasksBuilder operationTasksBuilderRetention;
-  private OperationTasksBuilder operationTasksBuilderOrphanFileDeletion;
-  private OperationTasksBuilder operationTasksBuilderStatsCollection;
-  private OperationTaskFactory<TableSnapshotsExpirationTask> tasksFactorySnapshotExpiration;
-  private OperationTaskFactory<TableRetentionTask> tasksFactoryRetention;
-  private OperationTaskFactory<TableStatsCollectionTask> tasksFactoryStatsCollection;
-  private OperationTaskFactory<TableOrphanFilesDeletionTask> tasksFactoryOrphanFileDeletion;
-  private OperationTaskManager operationTaskManagerSnapshotExpiration;
-  private OperationTaskManager operationTaskManagerOrphanFileDeletion;
-  private OperationTaskManager operationTaskManagerStatsCollection;
-  private OperationTaskManager operationTaskManagerRetention;
-  private JobInfoManager jobInfoManagerSnapshotExpiration;
-  private JobInfoManager jobInfoManagerOrphanFileDeletion;
-  private JobInfoManager jobInfoManagerStatsCollection;
-  private JobInfoManager jobInfoManagerRetention;
   private List<String> databases = new ArrayList<>();
   private Map<String, GetAllTablesResponseBody> dbAllTables = new HashMap();
   private Map<GetAllTablesResponseBody, List<GetTableResponseBody>> allTablesBodyToGetTableList =
@@ -56,79 +41,168 @@ public class OperationTasksBuilderTest {
   private int dbCount = 4;
   private int tableCount = 4;
   List<TableMetadata> tableMetadataList = new ArrayList<>();
+  Map<JobConf.JobTypeEnum, Class<? extends OperationTask<?>>> jobTypeToClassMap =
+      new HashMap() {
+        {
+          put(JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION, TableSnapshotsExpirationTask.class);
+          put(JobConf.JobTypeEnum.RETENTION, TableRetentionTask.class);
+          put(JobConf.JobTypeEnum.ORPHAN_FILES_DELETION, TableOrphanFilesDeletionTask.class);
+          put(JobConf.JobTypeEnum.TABLE_STATS_COLLECTION, TableStatsCollectionTask.class);
+          put(
+              JobConf.JobTypeEnum.DATA_LAYOUT_STRATEGY_GENERATION,
+              TableDataLayoutStrategyGenerationTask.class);
+        }
+      };
 
   @BeforeAll
   void setup() {
-    tablesClient = Mockito.mock(TablesClient.class);
-    jobsClient = Mockito.mock(JobsClient.class);
     tableMetadata =
         TableMetadata.builder().dbName("db1").tableName("test_table").isPrimary(true).build();
-    Class<TableSnapshotsExpirationTask> operationTaskClsSnapshotExpiration =
-        TableSnapshotsExpirationTask.class;
-    Class<TableRetentionTask> operationTaskClsRetention = TableRetentionTask.class;
-    Class<TableStatsCollectionTask> operationTaskClsStatsCollection =
-        TableStatsCollectionTask.class;
-    Class<TableOrphanFilesDeletionTask> operationTaskClsOrphanFileDeletion =
-        TableOrphanFilesDeletionTask.class;
-    TablesClientFactory tablesClientFactory = Mockito.mock(TablesClientFactory.class);
-    JobsClientFactory jobsClientFactory = Mockito.mock(JobsClientFactory.class);
-    tasksFactorySnapshotExpiration =
-        new OperationTaskFactory<>(
-            operationTaskClsSnapshotExpiration, jobsClient, tablesClient, 60000L, 60000L, 120000L);
-    tasksFactoryRetention =
-        new OperationTaskFactory<>(
-            operationTaskClsRetention, jobsClient, tablesClient, 60000L, 60000L, 120000L);
-    tasksFactoryStatsCollection =
-        new OperationTaskFactory<>(
-            operationTaskClsStatsCollection, jobsClient, tablesClient, 60000L, 60000L, 120000L);
-    tasksFactoryOrphanFileDeletion =
-        new OperationTaskFactory<>(
-            operationTaskClsOrphanFileDeletion, jobsClient, tablesClient, 60000L, 60000L, 120000L);
-    operationTaskManagerSnapshotExpiration =
-        new OperationTaskManager(JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION);
-    operationTaskManagerOrphanFileDeletion =
-        new OperationTaskManager(JobConf.JobTypeEnum.ORPHAN_FILES_DELETION);
-    operationTaskManagerStatsCollection =
-        new OperationTaskManager(JobConf.JobTypeEnum.TABLE_STATS_COLLECTION);
-    operationTaskManagerRetention = new OperationTaskManager(JobConf.JobTypeEnum.RETENTION);
-    jobInfoManagerSnapshotExpiration = new JobInfoManager(JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION);
-    jobInfoManagerOrphanFileDeletion =
-        new JobInfoManager(JobConf.JobTypeEnum.ORPHAN_FILES_DELETION);
-    jobInfoManagerStatsCollection = new JobInfoManager(JobConf.JobTypeEnum.TABLE_STATS_COLLECTION);
-    jobInfoManagerRetention = new JobInfoManager(JobConf.JobTypeEnum.RETENTION);
-    operationTasksBuilderSnapshotExpiration =
-        new OperationTasksBuilder(
-            tasksFactorySnapshotExpiration,
-            tablesClient,
-            2,
-            operationTaskManagerSnapshotExpiration,
-            jobInfoManagerSnapshotExpiration);
-    operationTasksBuilderRetention =
-        new OperationTasksBuilder(
-            tasksFactoryRetention,
-            tablesClient,
-            2,
-            operationTaskManagerRetention,
-            jobInfoManagerRetention);
-    operationTasksBuilderStatsCollection =
-        new OperationTasksBuilder(
-            tasksFactoryStatsCollection,
-            tablesClient,
-            2,
-            operationTaskManagerStatsCollection,
-            jobInfoManagerStatsCollection);
-    operationTasksBuilderOrphanFileDeletion =
-        new OperationTasksBuilder(
-            tasksFactoryOrphanFileDeletion,
-            tablesClient,
-            2,
-            operationTaskManagerOrphanFileDeletion,
-            jobInfoManagerOrphanFileDeletion);
     for (int i = 0; i < dbCount; i++) {
       databases.add("db" + i);
     }
     populateDbAllTables(dbCount, tableCount);
     prepareTableMetadata();
+  }
+
+  @BeforeEach
+  public void initMocks() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  public void testCreateStatusOperationTask() {
+    OperationTasksBuilder operationTasksBuilder =
+        createOperationTasksBuilder(JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION);
+    Optional<OperationTask<?>> optionalOperationTask =
+        operationTasksBuilder.createStatusOperationTask(
+            JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION,
+            tableMetadata,
+            UUID.randomUUID().toString(),
+            OperationMode.POLL);
+    Assertions.assertNotNull(optionalOperationTask);
+    Assertions.assertTrue(optionalOperationTask.isPresent());
+    Assertions.assertTrue(optionalOperationTask.get() instanceof OperationTask);
+    OperationTask<?> operationTask = optionalOperationTask.get();
+    Assertions.assertEquals(OperationMode.POLL, operationTask.operationMode);
+    Assertions.assertNotNull(operationTask.jobId);
+    Assertions.assertNotNull(operationTask.jobInfoManager);
+  }
+
+  @Test
+  public void testProcessMetadataSubmitOperation() {
+    OperationTasksBuilder operationTasksBuilder =
+        createOperationTasksBuilder(JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION);
+    Optional<OperationTask<?>> optionalOperationTask =
+        operationTasksBuilder.processMetadata(
+            tableMetadata, JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION, OperationMode.SUBMIT);
+    Assertions.assertNotNull(optionalOperationTask);
+    Assertions.assertTrue(optionalOperationTask.isPresent());
+    Assertions.assertTrue(optionalOperationTask.get() instanceof TableSnapshotsExpirationTask);
+    OperationTask<?> operationTask = optionalOperationTask.get();
+    Assertions.assertEquals(OperationMode.SUBMIT, operationTask.operationMode);
+    Assertions.assertNull(operationTask.jobId);
+    Assertions.assertNotNull(operationTask.jobInfoManager);
+  }
+
+  @Test
+  public void testBuildOperationTaskListInParallelForSnapshotExpirationVerifyAll()
+      throws InterruptedException {
+    prepareMockitoForParallelFetch();
+    OperationTasksBuilder operationTasksBuilder =
+        createOperationTasksBuilder(JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION);
+    operationTasksBuilder.buildOperationTaskListInParallel(
+        JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION, OperationMode.SUBMIT);
+    OperationTaskManager operationTaskManager = operationTasksBuilder.operationTaskManager;
+    // Make sure operation task build is completed
+    int count = 16;
+    // Make sure operation task build is completed
+    do {} while (!operationTaskManager.isDataGenerationCompleted());
+    // Poll from the queue until there is no element
+    do {
+      Assertions.assertEquals(count, operationTaskManager.getCurrentDataCount());
+      OperationTask<?> task = operationTaskManager.getData();
+      --count;
+      // The original table metadata size is 16 and after 16th item, the queue item is returned as
+      // null
+      if (count == -1) {
+        Assertions.assertNull(task);
+      } else {
+        Assertions.assertNotNull(task);
+        Assertions.assertTrue(task instanceof TableSnapshotsExpirationTask);
+        Assertions.assertEquals(OperationMode.SUBMIT, task.operationMode);
+        Assertions.assertNotNull(task.jobInfoManager);
+      }
+    } while (operationTaskManager.hasNext());
+    Assertions.assertTrue(operationTaskManager.isEmpty());
+    Assertions.assertEquals(0, operationTaskManager.getCurrentDataCount());
+    Assertions.assertEquals(16, operationTaskManager.getTotalDataCount());
+  }
+
+  @Test
+  public void testBuildOperationTaskListInParallel() throws InterruptedException {
+    List<JobConf.JobTypeEnum> jobList =
+        Arrays.asList(
+            JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION,
+            JobConf.JobTypeEnum.RETENTION,
+            JobConf.JobTypeEnum.ORPHAN_FILES_DELETION,
+            JobConf.JobTypeEnum.TABLE_STATS_COLLECTION,
+            JobConf.JobTypeEnum.DATA_LAYOUT_STRATEGY_GENERATION);
+    for (JobConf.JobTypeEnum jobType : jobList) {
+      prepareMockitoForParallelFetch();
+      OperationTasksBuilder operationTasksBuilder = createOperationTasksBuilder(jobType);
+      operationTasksBuilder.buildOperationTaskListInParallel(jobType, OperationMode.SUBMIT);
+      // Make sure operation task build is completed
+      OperationTaskManager operationTaskManager = operationTasksBuilder.operationTaskManager;
+      do {} while (!operationTaskManager.isDataGenerationCompleted());
+      Assertions.assertFalse(operationTaskManager.isEmpty());
+      Assertions.assertEquals(16, operationTaskManager.getCurrentDataCount());
+      Assertions.assertEquals(16, operationTaskManager.getTotalDataCount());
+      OperationTask<?> task = operationTaskManager.getData();
+      Assertions.assertNotNull(task);
+      Class<? extends OperationTask<?>> taskClass = jobTypeToClassMap.get(jobType);
+      Assertions.assertTrue(taskClass.isInstance(task));
+      Assertions.assertEquals(OperationMode.SUBMIT, task.operationMode);
+      Assertions.assertNotNull(task.jobInfoManager);
+    }
+  }
+
+  @Test
+  public void testBuildOperationTaskList() {
+    List<JobConf.JobTypeEnum> jobList =
+        Arrays.asList(
+            JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION,
+            JobConf.JobTypeEnum.RETENTION,
+            JobConf.JobTypeEnum.ORPHAN_FILES_DELETION,
+            JobConf.JobTypeEnum.TABLE_STATS_COLLECTION,
+            JobConf.JobTypeEnum.DATA_LAYOUT_STRATEGY_GENERATION);
+    for (JobConf.JobTypeEnum jobType : jobList) {
+      Mockito.when(tablesClient.getTableMetadataList()).thenReturn(tableMetadataList);
+      OperationTasksBuilder operationTasksBuilder = createOperationTasksBuilder(jobType);
+      List<OperationTask<?>> operationTasks =
+          operationTasksBuilder.buildOperationTaskList(jobType, null, null, OperationMode.SINGLE);
+      Assertions.assertNotNull(operationTasks);
+      // Make sure operation task build is completed
+      Assertions.assertEquals(16, operationTasks.size());
+      for (int i = 0; i < 16; i++) {
+        Assertions.assertNotNull(operationTasks.get(i));
+        Class<? extends OperationTask<?>> taskClass = jobTypeToClassMap.get(jobType);
+        Assertions.assertTrue(taskClass.isInstance(operationTasks.get(i)));
+        Assertions.assertEquals(OperationMode.SINGLE, operationTasks.get(i).operationMode);
+      }
+    }
+  }
+
+  private OperationTasksBuilder createOperationTasksBuilder(JobConf.JobTypeEnum jobType) {
+    OperationTaskFactory<? extends OperationTask<?>> tasksFactory =
+        new OperationTaskFactory<>(
+            jobTypeToClassMap.get(jobType), jobsClient, tablesClient, 60000L, 60000L, 120000L);
+    return new OperationTasksBuilder(
+        tasksFactory,
+        tablesClient,
+        2,
+        new OperationTaskManager(jobType),
+        new JobInfoManager(jobType));
   }
 
   private void populateDbAllTables(int dbCount, int tableCount) {
@@ -155,35 +229,12 @@ public class OperationTasksBuilderTest {
             .build());
   }
 
-  @Test
-  public void testCreateStatusOperationTask() {
-    Optional<OperationTask<?>> optionalOperationTask =
-        operationTasksBuilderSnapshotExpiration.createStatusOperationTask(
-            JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION,
-            tableMetadata,
-            UUID.randomUUID().toString(),
-            OperationMode.POLL);
-    Assertions.assertNotNull(optionalOperationTask);
-    Assertions.assertTrue(optionalOperationTask.isPresent());
-    Assertions.assertTrue(optionalOperationTask.get() instanceof OperationTask);
-    OperationTask<?> operationTask = optionalOperationTask.get();
-    Assertions.assertEquals(OperationMode.POLL, operationTask.operationMode);
-    Assertions.assertNotNull(operationTask.jobId);
-    Assertions.assertNotNull(operationTask.jobInfoManager);
-  }
-
-  @Test
-  public void testProcessMetadataSubmitOperation() {
-    Optional<OperationTask<?>> optionalOperationTask =
-        operationTasksBuilderSnapshotExpiration.processMetadata(
-            tableMetadata, JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION, OperationMode.SUBMIT);
-    Assertions.assertNotNull(optionalOperationTask);
-    Assertions.assertTrue(optionalOperationTask.isPresent());
-    Assertions.assertTrue(optionalOperationTask.get() instanceof TableSnapshotsExpirationTask);
-    OperationTask<?> operationTask = optionalOperationTask.get();
-    Assertions.assertEquals(OperationMode.SUBMIT, operationTask.operationMode);
-    Assertions.assertNull(operationTask.jobId);
-    Assertions.assertNotNull(operationTask.jobInfoManager);
+  private void prepareTableMetadata() {
+    for (int i = 0; i < dbCount; i++) {
+      for (int j = 0; j < tableCount; j++) {
+        tableMetadataList.add(getTableMetadata(i, j).get());
+      }
+    }
   }
 
   private void prepareMockitoForParallelFetch() {
@@ -204,160 +255,5 @@ public class OperationTasksBuilderTest {
     Mockito.when(tablesClient.applyDatabaseFilter(Mockito.anyString())).thenReturn(true);
     Mockito.when(tablesClient.applyTableMetadataFilter(Mockito.any(TableMetadata.class)))
         .thenReturn(true);
-  }
-
-  @Test
-  public void testBuildOperationTaskListInParallelForSnapshotExpiration()
-      throws InterruptedException {
-    prepareMockitoForParallelFetch();
-    operationTasksBuilderSnapshotExpiration.buildOperationTaskListInParallel(
-        JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION, OperationMode.SUBMIT);
-    // Make sure operation task build is completed
-    do {} while (!operationTaskManagerSnapshotExpiration.isDataGenerationCompleted());
-    Assertions.assertFalse(operationTaskManagerSnapshotExpiration.isEmpty());
-    Assertions.assertEquals(16, operationTaskManagerSnapshotExpiration.getTotalDataCount());
-    OperationTask<?> task = operationTaskManagerSnapshotExpiration.getData();
-    Assertions.assertNotNull(task);
-    Assertions.assertTrue(task instanceof TableSnapshotsExpirationTask);
-    Assertions.assertEquals(OperationMode.SUBMIT, task.operationMode);
-    Assertions.assertNotNull(task.jobInfoManager);
-    Assertions.assertEquals(16, operationTaskManagerSnapshotExpiration.getTotalDataCount());
-    Assertions.assertEquals(15, operationTaskManagerSnapshotExpiration.getCurrentDataCount());
-  }
-
-  @Test
-  public void testBuildOperationTaskListInParallelForSnapshotExpirationVerifyAll()
-      throws InterruptedException {
-    prepareMockitoForParallelFetch();
-    operationTasksBuilderSnapshotExpiration.buildOperationTaskListInParallel(
-        JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION, OperationMode.SUBMIT);
-    // Make sure operation task build is completed
-    int count = 16;
-    // Make sure operation task build is completed
-    do {} while (!operationTaskManagerSnapshotExpiration.isDataGenerationCompleted());
-    // Poll from the queue until there is no element
-    do {
-      Assertions.assertEquals(count, operationTaskManagerSnapshotExpiration.getCurrentDataCount());
-      OperationTask<?> task = operationTaskManagerSnapshotExpiration.getData();
-      --count;
-      // The original table metadata size is 16 and after 16th item, the queue item is returned as
-      // null
-      if (count == -1) {
-        Assertions.assertNull(task);
-      } else {
-        Assertions.assertNotNull(task);
-        Assertions.assertTrue(task instanceof TableSnapshotsExpirationTask);
-        Assertions.assertEquals(OperationMode.SUBMIT, task.operationMode);
-        Assertions.assertNotNull(task.jobInfoManager);
-      }
-    } while (operationTaskManagerSnapshotExpiration.hasNext());
-    Assertions.assertTrue(operationTaskManagerSnapshotExpiration.isEmpty());
-    Assertions.assertEquals(0, operationTaskManagerSnapshotExpiration.getCurrentDataCount());
-    Assertions.assertEquals(16, operationTaskManagerSnapshotExpiration.getTotalDataCount());
-  }
-
-  @Test
-  public void testBuildOperationTaskListInParallelForOrphanFileDeletion()
-      throws InterruptedException {
-    prepareMockitoForParallelFetch();
-    operationTasksBuilderOrphanFileDeletion.buildOperationTaskListInParallel(
-        JobConf.JobTypeEnum.ORPHAN_FILES_DELETION, OperationMode.SUBMIT);
-    // Make sure operation task build is completed
-    do {} while (!operationTaskManagerOrphanFileDeletion.isDataGenerationCompleted());
-    Assertions.assertFalse(operationTaskManagerOrphanFileDeletion.isEmpty());
-    Assertions.assertEquals(16, operationTaskManagerOrphanFileDeletion.getCurrentDataCount());
-    Assertions.assertEquals(16, operationTaskManagerOrphanFileDeletion.getTotalDataCount());
-    OperationTask<?> task = operationTaskManagerOrphanFileDeletion.getData();
-    Assertions.assertNotNull(task);
-    Assertions.assertTrue(task instanceof TableOrphanFilesDeletionTask);
-    Assertions.assertEquals(OperationMode.SUBMIT, task.operationMode);
-    Assertions.assertNotNull(task.jobInfoManager);
-  }
-
-  @Test
-  public void testBuildOperationTaskListInParallelForTableStatsCollection()
-      throws InterruptedException {
-    prepareMockitoForParallelFetch();
-    operationTasksBuilderStatsCollection.buildOperationTaskListInParallel(
-        JobConf.JobTypeEnum.TABLE_STATS_COLLECTION, OperationMode.SUBMIT);
-    // Make sure operation task build is completed
-    do {} while (!operationTaskManagerStatsCollection.isDataGenerationCompleted());
-    Assertions.assertFalse(operationTaskManagerStatsCollection.isEmpty());
-    Assertions.assertEquals(16, operationTaskManagerStatsCollection.getCurrentDataCount());
-    Assertions.assertEquals(16, operationTaskManagerStatsCollection.getTotalDataCount());
-    OperationTask<?> task = operationTaskManagerStatsCollection.getData();
-    Assertions.assertNotNull(task);
-    Assertions.assertTrue(task instanceof TableStatsCollectionTask);
-    Assertions.assertEquals(OperationMode.SUBMIT, task.operationMode);
-    Assertions.assertNotNull(task.jobInfoManager);
-  }
-
-  @Test
-  public void testBuildOperationTaskListInParallelForRetention() throws InterruptedException {
-    prepareMockitoForParallelFetch();
-    operationTasksBuilderRetention.buildOperationTaskListInParallel(
-        JobConf.JobTypeEnum.RETENTION, OperationMode.SUBMIT);
-    // Make sure operation task build is completed
-    do {} while (!operationTaskManagerRetention.isDataGenerationCompleted());
-    Assertions.assertFalse(operationTaskManagerRetention.isEmpty());
-    Assertions.assertEquals(16, operationTaskManagerRetention.getCurrentDataCount());
-    Assertions.assertEquals(16, operationTaskManagerRetention.getTotalDataCount());
-    OperationTask<?> task = operationTaskManagerRetention.getData();
-    Assertions.assertNotNull(task);
-    Assertions.assertTrue(task instanceof TableRetentionTask);
-    Assertions.assertEquals(OperationMode.SUBMIT, task.operationMode);
-    Assertions.assertNotNull(task.jobInfoManager);
-  }
-
-  private void prepareTableMetadata() {
-    for (int i = 0; i < dbCount; i++) {
-      for (int j = 0; j < tableCount; j++) {
-        tableMetadataList.add(getTableMetadata(i, j).get());
-      }
-    }
-  }
-
-  @Test
-  public void testBuildOperationTaskListForSnapshotExpiration() {
-    Mockito.when(tablesClient.getTableMetadataList()).thenReturn(tableMetadataList);
-    List<OperationTask<?>> operationTasks =
-        operationTasksBuilderSnapshotExpiration.buildOperationTaskList(
-            JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION, null, null, OperationMode.SINGLE);
-    Assertions.assertNotNull(operationTasks);
-    // Make sure operation task build is completed
-    Assertions.assertEquals(16, operationTasks.size());
-    for (int i = 0; i < 16; i++) {
-      Assertions.assertNotNull(operationTasks.get(i));
-      Assertions.assertTrue(operationTasks.get(i) instanceof TableSnapshotsExpirationTask);
-      Assertions.assertEquals(OperationMode.SINGLE, operationTasks.get(i).operationMode);
-    }
-  }
-
-  @Test
-  public void testBuildOperationTaskListForOrphanFileDeletion() {
-    Mockito.when(tablesClient.getTableMetadataList()).thenReturn(tableMetadataList);
-    List<OperationTask<?>> operationTasks =
-        operationTasksBuilderOrphanFileDeletion.buildOperationTaskList(
-            JobConf.JobTypeEnum.ORPHAN_FILES_DELETION, null, null, OperationMode.SINGLE);
-    Assertions.assertNotNull(operationTasks);
-    // Make sure operation task build is completed
-    Assertions.assertEquals(16, operationTasks.size());
-    for (int i = 0; i < 16; i++) {
-      Assertions.assertNotNull(operationTasks.get(i));
-      Assertions.assertTrue(operationTasks.get(i) instanceof TableOrphanFilesDeletionTask);
-      Assertions.assertEquals(OperationMode.SINGLE, operationTasks.get(i).operationMode);
-    }
-  }
-
-  @AfterEach
-  public void reset() {
-    operationTaskManagerSnapshotExpiration.resetAll();
-    operationTaskManagerOrphanFileDeletion.resetAll();
-    operationTaskManagerRetention.resetAll();
-    operationTaskManagerStatsCollection.resetAll();
-    jobInfoManagerSnapshotExpiration.resetAll();
-    jobInfoManagerOrphanFileDeletion.resetAll();
-    jobInfoManagerStatsCollection.resetAll();
-    jobInfoManagerRetention.resetAll();
   }
 }


### PR DESCRIPTION
## Summary

This PR enables parallel metadata fetch for DLO-exec app. It also refactors the `OperationTaskBuilderTask` and `JobsSchedulerTest`. 

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

#### Testing cluster test

Config:
```
parallelMetadataFetchMode: true
numParallelMetadataFetch: 2
multiOperationMode: true
numJobsSubmitter: 2
numJobsPoller: 2
```
DLO-gen:
```
2025-07-11 05:30:51 INFO  JobsScheduler:332 - Finishing scheduler for job type DATA_LAYOUT_STRATEGY_GENERATION, tasks stats: 4 created, 4 succeeded, 0 running, 0 queued 0 cancelled (scheduler timeout), 0 failed, 0 skipped (no state)
2025-07-11 05:30:51 INFO  JobsScheduler:346 - The total run duration of job scheduler for job type DATA_LAYOUT_STRATEGY_GENERATION is : 00:07 hours (HH:mm format)
```
DLO-exec:
```
2025-07-11 05:41:46 INFO  JobsScheduler:332 - Finishing scheduler for job type DATA_LAYOUT_STRATEGY_EXECUTION, tasks stats: 4 created, 4 succeeded, 0 running, 0 queued 0 cancelled (scheduler timeout), 0 failed, 0 skipped (no state)
2025-07-11 05:41:46 INFO  JobsScheduler:346 - The total run duration of job scheduler for job type DATA_LAYOUT_STRATEGY_EXECUTION is : 00:08 hours (HH:mm format)
```



# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
