### PR TITLE
Fix active->active replication

### DIFF
--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -70,7 +70,7 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
   private static final String UPDATED_OPENHOUSE_POLICY_KEY = "updated.openhouse.policy";
   private static final String OPENHOUSE_TABLE_TYPE_KEY = "openhouse.tableType";
   private static final String OPENHOUSE_CLUSTER_ID_KEY = "openhouse.clusterId";
-  private static final String TBL_IS_REPLICATED_KEY = "openhouse.isTableReplicated";
+  private static final String OPENHOUSE_IS_TABLE_REPLICATED_KEY = "openhouse.isTableReplicated";
   private static final String POLICIES_KEY = "policies";
   static final String INITIAL_TABLE_VERSION = "INITIAL_VERSION";
 
@@ -184,9 +184,11 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
       createUpdateTableRequestBody.setTableType(getTableType(base, metadata));
     }
     // If base table is a replicated table, retain the property from base table
-    if (base != null && base.properties().containsKey(TBL_IS_REPLICATED_KEY)) {
+    if (base != null && base.properties().containsKey(OPENHOUSE_IS_TABLE_REPLICATED_KEY)) {
       Map<String, String> newTblProperties = createUpdateTableRequestBody.getTableProperties();
-      newTblProperties.put(TBL_IS_REPLICATED_KEY, base.properties().get(TBL_IS_REPLICATED_KEY));
+      newTblProperties.put(
+          OPENHOUSE_IS_TABLE_REPLICATED_KEY,
+          base.properties().get(OPENHOUSE_IS_TABLE_REPLICATED_KEY));
       createUpdateTableRequestBody.setTableProperties(newTblProperties);
     }
     return createUpdateTableRequestBody;

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -326,6 +326,11 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
     if (tableDto.getTableType() != null) {
       propertiesMap.put(getCanonicalFieldName(TABLE_TYPE_KEY), tableDto.getTableType().toString());
     }
+    // add a default property to indicate replicationState for table.
+    // Required in addition to tableType to indicate if primary table is replicated or not
+    propertiesMap.put(
+        OPENHOUSE_IS_TABLE_REPLICATED_KEY,
+        tableDto.getTableProperties().getOrDefault(OPENHOUSE_IS_TABLE_REPLICATED_KEY, "false"));
 
     if (tableDto.isStageCreate()) {
       meterRegistry.counter(MetricsConstant.REPO_TABLE_CREATED_CTR_STAGED).increment();

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesControllerTest.java
@@ -310,9 +310,9 @@ public class TablesControllerTest {
     // drop a prop under openhouse namespace
     container = GetTableResponseBody.builder().tableProperties(null).build();
     GetTableResponseBody dropOpenhouseProp = buildGetTableResponseBody(mvcResult, container);
-    dropOpenhouseProp.getTableProperties().remove("openhouse.clusterId");
+    dropOpenhouseProp.getTableProperties().remove("openhouse.tableUri");
     RequestAndValidateHelper.updateTableWithReservedPropsAndValidateResponse(
-        mvc, dropOpenhouseProp, "openhouse.clusterId");
+        mvc, dropOpenhouseProp, "openhouse.tableUri");
 
     RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, GET_TABLE_RESPONSE_BODY);
   }
@@ -1058,6 +1058,7 @@ public class TablesControllerTest {
         propertiesFromResult.get("openhouse.tableType"), TableType.PRIMARY_TABLE.toString());
     Assertions.assertEquals(
         propertiesFromResult.get("openhouse.tableUUID"), responseBody.getTableUUID());
+    Assertions.assertEquals(propertiesFromResult.get("openhouse.isTableReplicated"), "true");
     RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, GET_TABLE_RESPONSE_BODY);
   }
 


### PR DESCRIPTION
## Summary
For Active-> Active table replication, a new property `openhouse.isTableReplicated` is required to identify Primary tables which are replicated. It is used to a tablesService layer to skip certain validations which will fail for requests coming from replication due to differences in table properties.  

This property was not getting added to table metadata and hence replication process was failing in active-> active cases. 

Fix: Add it while curating the table properties in table creation step. Default value should be false. 
Only tables which are created for replication use case should have openhouse.isTableReplicated = true

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
Tests added
Verified in Docker container that newly created tables have this property.

<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
