### PR TITLE
new endpoint for namespaceExists using database acl

### DIFF
--- a/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/SmokeTest.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/SmokeTest.java
@@ -176,18 +176,19 @@ public class SmokeTest {
 
   @Test
   public void testNamespaceExistsWhenNamespaceExists() {
-    // Mock response for successful ACL policies fetch (indicating namespace exists)
+    // Mock response for successful ACL policies fetch with actual policies (indicating namespace
+    // exists)
     mockTableService.enqueue(
         new MockResponse()
             .setResponseCode(200)
-            .setBody("{\"results\":[]}")
+            .setBody("{\"results\":[{\"principal\":\"user1\",\"privilege\":\"READ\"}]}")
             .addHeader("Content-Type", "application/json"));
 
     OpenHouseCatalog openHouseCatalog = new OpenHouseCatalog();
     openHouseCatalog.initialize("openhouse", ImmutableMap.of(CatalogProperties.URI, url));
 
     boolean exists = openHouseCatalog.namespaceExists(Namespace.of("test_db"));
-    Assertions.assertTrue(exists, "Namespace should exist when API returns 200");
+    Assertions.assertTrue(exists, "Namespace should exist when API returns 200 with ACL policies");
   }
 
   @Test
@@ -205,7 +206,7 @@ public class SmokeTest {
 
   @Test
   public void testNamespaceExistsWithEmptyAclPoliciesResponse() {
-    // Mock response for successful ACL policies fetch with empty results
+    // Mock response for successful ACL policies fetch with empty results (should return false)
     mockTableService.enqueue(
         new MockResponse()
             .setResponseCode(200)
@@ -216,7 +217,7 @@ public class SmokeTest {
     openHouseCatalog.initialize("openhouse", ImmutableMap.of(CatalogProperties.URI, url));
 
     boolean exists = openHouseCatalog.namespaceExists(Namespace.of("db_with_no_policies"));
-    Assertions.assertTrue(exists, "Namespace should exist even when it has no ACL policies");
+    Assertions.assertFalse(exists, "Namespace should not exist when it has no ACL policies");
   }
 
   @Test

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
@@ -405,7 +405,11 @@ public class OpenHouseCatalog extends BaseMetastoreCatalog
                 e -> Mono.error(new WebClientRequestWithMessageException(e)))
             .blockOptional();
 
-    boolean exists = result.isPresent();
+    // Namespace exists only if we got a response AND there are ACL policies
+    boolean exists =
+        result.isPresent()
+            && result.get().getResults() != null
+            && !result.get().getResults().isEmpty();
     log.debug("Calling namespaceExists succeeded - namespace exists: {}", exists);
     return exists;
   }


### PR DESCRIPTION
## Summary
problem: namespaceExists is unimplemented which requires users like trino to implement client side hacks, e.g. always return true. 

solution: since OpenHouse has a table centric model, with namespace being a derived entity, we rely on our acl service to return presence of database. when openhouse implements a namespace object , this implementation will be changed to depend on that object's existence. the client API will remain the same. 

## Changes

- [X] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

## Testing Done
new tests added

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

