### PR TITLE
Add db/table dimensions to our metadata retrieval latency metric

### DIFF
--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/InternalCatalogMetricsConstant.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/InternalCatalogMetricsConstant.java
@@ -18,4 +18,8 @@ public final class InternalCatalogMetricsConstant {
 
   static final String METADATA_UPDATE_LATENCY = "metadata_update_latency";
   static final String METADATA_RETRIEVAL_LATENCY = "metadata_retrieval_latency";
+
+  // Tag constants for metric dimensions
+  static final String DATABASE_TAG = "database";
+  static final String TABLE_TAG = "table";
 }

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -118,7 +118,12 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
     Runnable r = () -> super.refreshFromMetadataLocation(metadataLoc);
     if (needToReload) {
       metricsReporter.executeWithStats(
-          r, InternalCatalogMetricsConstant.METADATA_RETRIEVAL_LATENCY);
+          r,
+          InternalCatalogMetricsConstant.METADATA_RETRIEVAL_LATENCY,
+          InternalCatalogMetricsConstant.DATABASE_TAG,
+          tableIdentifier.namespace().toString(),
+          InternalCatalogMetricsConstant.TABLE_TAG,
+          tableIdentifier.name());
     } else {
       r.run();
     }


### PR DESCRIPTION
## Summary
problem: super high GET table qps customers are observing higher latency. metadata refresh on server may be contributing to it. but the problem is that we can't see metadata refresh latency metric , besides at a cluster scope and averaged per minute. without slicing by table/customer, we don't know whether metadata refresh is affecting a customer. this is what the current metric looks like:
![image](https://github.com/user-attachments/assets/1a0561e2-c589-4e43-b150-2aff1574efcf)


solution: add database and table to catalog_metadata_retrieval_latency_seconds_max metric 

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [X] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests


## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [X] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.
