### PR TITLE
Bump hikaricp default max size

### DIFF
--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/config/db/jdbc/JdbcProviderConfiguration.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/config/db/jdbc/JdbcProviderConfiguration.java
@@ -58,13 +58,12 @@ public class JdbcProviderConfiguration {
     DataSourceProperties properties = dataSourceProperties();
 
     // Set database-specific properties
-    if (dbType == DatabaseConfiguration.SupportedDbTypes.ICEBERG) {
-      properties.setUrl(H2_DEFAULT_URL);
-    } else {
-      properties.setUrl(clusterProperties.getClusterHouseTablesDatabaseUrl());
-      properties.setUsername(clusterProperties.getClusterHouseTablesDatabaseUsername());
-      properties.setPassword(clusterProperties.getClusterHouseTablesDatabasePassword());
-    }
+    properties.setUrl(
+        dbType == DatabaseConfiguration.SupportedDbTypes.ICEBERG
+            ? H2_DEFAULT_URL
+            : clusterProperties.getClusterHouseTablesDatabaseUrl());
+    properties.setUsername(clusterProperties.getClusterHouseTablesDatabaseUsername());
+    properties.setPassword(clusterProperties.getClusterHouseTablesDatabasePassword());
 
     return properties.initializeDataSourceBuilder().type(HikariDataSource.class).build();
   }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/config/db/jdbc/JdbcProviderConfiguration.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/config/db/jdbc/JdbcProviderConfiguration.java
@@ -2,15 +2,14 @@ package com.linkedin.openhouse.housetables.config.db.jdbc;
 
 import com.linkedin.openhouse.cluster.configs.ClusterProperties;
 import com.linkedin.openhouse.housetables.config.db.DatabaseConfiguration;
-import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import javax.sql.DataSource;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 
 /**
  * Configure JDBC sources such as h2, mysql, postgres
@@ -26,18 +25,17 @@ import org.springframework.context.annotation.Configuration;
 @Slf4j
 public class JdbcProviderConfiguration {
 
-  @Autowired private ClusterProperties clusterProperties;
+  private final ClusterProperties clusterProperties;
 
-  @Bean
-  @ConfigurationProperties("spring.datasource")
-  public DataSourceProperties dataSourceProperties() {
-    return new DataSourceProperties();
+  public JdbcProviderConfiguration(ClusterProperties clusterProperties) {
+    this.clusterProperties = clusterProperties;
   }
 
   @Bean
-  @ConfigurationProperties("spring.datasource.hikari")
-  public HikariConfig hikariConfig() {
-    return new HikariConfig();
+  @Primary
+  @ConfigurationProperties("spring.datasource")
+  public DataSourceProperties dataSourceProperties() {
+    return new DataSourceProperties();
   }
 
   /**
@@ -48,22 +46,26 @@ public class JdbcProviderConfiguration {
   private static final String H2_DEFAULT_URL = "jdbc:h2:mem:htsdb;MODE=MySQL;DB_CLOSE_DELAY=-1";
 
   @Bean
-  public DataSource provideJdbcDataSource() {
+  @Primary
+  @ConfigurationProperties("spring.datasource.hikari")
+  public DataSource dataSource() {
     DatabaseConfiguration.SupportedDbTypes dbType =
         DatabaseConfiguration.SupportedDbTypes.valueOf(
             clusterProperties.getClusterHouseTablesDatabaseType());
 
-    log.info(String.format("Using %s database for HouseTables service", dbType));
+    log.info("Using {} database for HouseTables service", dbType);
 
-    HikariConfig config = hikariConfig();
-    //  if storage type is Iceberg, use H2 as the default jdbc database
-    config.setJdbcUrl(
-        dbType == DatabaseConfiguration.SupportedDbTypes.ICEBERG
-            ? H2_DEFAULT_URL
-            : clusterProperties.getClusterHouseTablesDatabaseUrl());
-    config.setUsername(clusterProperties.getClusterHouseTablesDatabaseUsername());
-    config.setPassword(clusterProperties.getClusterHouseTablesDatabasePassword());
+    DataSourceProperties properties = dataSourceProperties();
 
-    return new HikariDataSource(config);
+    // Set database-specific properties
+    if (dbType == DatabaseConfiguration.SupportedDbTypes.ICEBERG) {
+      properties.setUrl(H2_DEFAULT_URL);
+    } else {
+      properties.setUrl(clusterProperties.getClusterHouseTablesDatabaseUrl());
+      properties.setUsername(clusterProperties.getClusterHouseTablesDatabaseUsername());
+      properties.setPassword(clusterProperties.getClusterHouseTablesDatabasePassword());
+    }
+
+    return properties.initializeDataSourceBuilder().type(HikariDataSource.class).build();
   }
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/config/db/jdbc/JdbcProviderConfiguration.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/config/db/jdbc/JdbcProviderConfiguration.java
@@ -4,7 +4,6 @@ import com.linkedin.openhouse.cluster.configs.ClusterProperties;
 import com.linkedin.openhouse.housetables.config.db.DatabaseConfiguration;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -38,7 +37,6 @@ public class JdbcProviderConfiguration {
 
   @Bean
   @Primary
-  @ConfigurationProperties("spring.datasource")
   public DataSourceProperties dataSourceProperties() {
     DatabaseConfiguration.SupportedDbTypes dbType =
         DatabaseConfiguration.SupportedDbTypes.valueOf(

--- a/services/housetables/src/main/resources/application.properties
+++ b/services/housetables/src/main/resources/application.properties
@@ -18,3 +18,4 @@ management.metrics.distribution.percentiles-histogram.jvm.gc.pause=true
 management.metrics.distribution.percentiles-histogram.hikaricp.connections.acquire=true
 management.metrics.distribution.percentiles-histogram.hikaricp.connections.usage=true
 management.metrics.distribution.percentiles-histogram.hikaricp.connections.creation=true
+spring.datasource.hikari.maximum-pool-size=20

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/config/HikariCpConfigTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/config/HikariCpConfigTest.java
@@ -1,0 +1,26 @@
+package com.linkedin.openhouse.housetables.config;
+
+import com.linkedin.openhouse.common.test.cluster.PropertyOverrideContextInitializer;
+import com.zaxxer.hikari.HikariDataSource;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@ContextConfiguration(initializers = PropertyOverrideContextInitializer.class)
+@TestPropertySource(properties = {"spring.datasource.hikari.maximum-pool-size=20"})
+public class HikariCpConfigTest {
+
+  @Autowired private DataSource dataSource;
+
+  @Test
+  public void testHikariCpMaximumPoolSize() {
+    Assertions.assertTrue(dataSource instanceof HikariDataSource);
+    HikariDataSource hikariDataSource = (HikariDataSource) dataSource;
+    Assertions.assertEquals(20, hikariDataSource.getMaximumPoolSize());
+  }
+}


### PR DESCRIPTION
## Summary
problem: OpenHouse QPS is constrained. the server's pattern of queries (frequent table refresh via hts load_table), requires a lot of point query select's to the backing datasource. 

see what happens at scale

1k GET table qps:
<img width="835" height="306" alt="image" src="https://github.com/user-attachments/assets/005c021f-f365-42a9-9327-f162209fdfb3" />

latency at the same time range:
<img width="835" height="306" alt="image" src="https://github.com/user-attachments/assets/d9df4591-d33c-4685-9752-eeb15d04abbd" />

hikaricp connection acquisition accounting for significant portion of this:
<img width="835" height="306" alt="image" src="https://github.com/user-attachments/assets/2764a5d8-600f-41c8-8ae8-ab9217846bf6" />

and a database is not throttling hikari:
(cpu is low) 
<img width="1691" height="531" alt="image" src="https://github.com/user-attachments/assets/25741966-d963-47b7-8f18-5788fce340d8" />

total QPS to a sample database instance is at most 7600 which is well below what this db instance can tolerate which is 40-50k 

solution: we reduce the throttle with hikaricp cap raised x2 per. this pooling is configured per HTS instance so e.g. 16 hts instances and 160 hikaricp connections available will become 280. in addition, the code as is was not properly accepting the application.properties as springboot documents. so I refactored a bit so that it is more standard and auto configures using springboot's documented hikaricp connection properties from the application.properties without imepratively finding the key and setting it to the DB config object

TODO: find the rest of the source of latency, since hikaricp only accounts for a significatn portion but not all 

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [X] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

higher QPS supported now 

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [X] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

all looks good

➜ docker compose -f infra/recipes/docker-compose/oh-only/docker-compose.yml up

openhouse on  main [$?] via ☕ v21.0.6 
➜ curl "${curlArgs[@]}" -XPOST http://localhost:8000/v1/databases/d3/tables/ --data-raw '{                                                                                                                                                                                                                                    
  "tableId": "t1",     
  "databaseId": "d3",     
  "baseTableVersion": "INITIAL_VERSION",
  "clusterId": "LocalFSCluster",
  "schema": "{\"type\": \"struct\", \"fields\": [{\"id\": 1,\"required\": true,\"name\": \"id\",\"type\": \"string\"},{\"id\": 2,\"required\": true,\"name\": \"name\",\"type\": \"string\"},{\"id\": 3,\"required\": true,\"name\": \"ts\",\"type\": \"timestamp\"}]}",
  "timePartitioning": {
    "columnName": "ts",   
    "granularity": "HOUR"
  },                                                                                                                                                                                                                                                                                                                    <....
{"tableId":"t1","databaseId":"d3","clusterId":"LocalFSCluster","tableUri":"LocalFSCluster.d3.t1","tableUUID":"f58a7f16-c1e4-40c0-b7be-5fec4956d8ac","tableLocation":"file:/tmp/d3/t1-f58a7f16-c1e4-40c0-b7be-5fec4956d8ac/00000-df2b0854-2c8b-4bf9-a065-89551b9c34ed.metadata.json","tableVersion":"INITIAL_VERSION","tableCre
ator":"DUMMY_ANONYMOUS_USER","schema":"{\"type\":\"struct\",\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"string\"},{\"id\":2,\"name\":\"name\",\"required\":true,\"type\":\"string\"},{\"id\":3,\"name\":\"ts\",\"required\":true,\"type\":\"timestamp\"}]}","lastModifiedTime":17527087
13870,"creationTime":1752708713870,"tableProperties":{"write.parquet.compression-codec":"zstd","policies":"","write.metadata.delete-after-commit.enabled":"true","openhouse.isTableReplicated":"false","openhouse.tableId":"t1","openhouse.clusterId":"LocalFSCluster","openhouse.lastModifiedTime":"1752708713870","openhouse
.tableVersion":"INITIAL_VERSION","write.format.default":"orc","openhouse.creationTime":"1752708713870","openhouse.tableUri":"LocalFSCluster.d3.t1","write.metadata.previous-versions-max":"28","openhouse.databaseId":"d3","openhouse.tableType":"PRIMARY_TABLE","openhouse.tableLocation":"/tmp/d3/t1-f58a7f16-c1e4-40c0-b7be
-5fec4956d8ac/00000-df2b0854-2c8b-4bf9-a065-89551b9c34ed.metadata.json","openhouse.tableUUID":"f58a7f16-c1e4-40c0-b7be-5fec4956d8ac","key":"value","openhouse.tableCreator":"DUMMY_ANONYMOUS_USER"},"timePartitioning":{"columnName":"ts","granularity":"HOUR"},"clustering":[{"columnName":"name","transform":null}],"policie
s":null,"tableType":"PRIMARY_TABLE"}%                                                                                                                                                                                                                                                                                         

openhouse on  main [$?] via ☕ v21.0.6 
➜ curl "${curlArgs[@]}" -XGET http://localhost:8000/v1/databases/d3/tables/t1 

{"tableId":"t1","databaseId":"d3","clusterId":"LocalFSCluster","tableUri":"LocalFSCluster.d3.t1","tableUUID":"f58a7f16-c1e4-40c0-b7be-5fec4956d8ac","tableLocation":"file:/tmp/d3/t1-f58a7f16-c1e4-40c0-b7be-5fec4956d8ac/00000-df2b0854-2c8b-4bf9-a065-89551b9c34ed.metadata.json","tableVersion":"INITIAL_VERSION","tableCre
ator":"DUMMY_ANONYMOUS_USER","schema":"{\"type\":\"struct\",\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"string\"},{\"id\":2,\"name\":\"name\",\"required\":true,\"type\":\"string\"},{\"id\":3,\"name\":\"ts\",\"required\":true,\"type\":\"timestamp\"}]}","lastModifiedTime":17527087
13870,"creationTime":1752708713870,"tableProperties":{"write.parquet.compression-codec":"zstd","policies":"","write.metadata.delete-after-commit.enabled":"true","openhouse.isTableReplicated":"false","openhouse.tableId":"t1","openhouse.clusterId":"LocalFSCluster","openhouse.lastModifiedTime":"1752708713870","openhouse
.tableVersion":"INITIAL_VERSION","write.format.default":"orc","openhouse.creationTime":"1752708713870","openhouse.tableUri":"LocalFSCluster.d3.t1","write.metadata.previous-versions-max":"28","openhouse.databaseId":"d3","openhouse.tableType":"PRIMARY_TABLE","openhouse.tableLocation":"/tmp/d3/t1-f58a7f16-c1e4-40c0-b7be
-5fec4956d8ac/00000-df2b0854-2c8b-4bf9-a065-89551b9c34ed.metadata.json","openhouse.tableUUID":"f58a7f16-c1e4-40c0-b7be-5fec4956d8ac","key":"value","openhouse.tableCreator":"DUMMY_ANONYMOUS_USER"},"timePartitioning":{"columnName":"ts","granularity":"HOUR"},"clustering":[{"columnName":"name","transform":null}],"policie
s":null,"tableType":"PRIMARY_TABLE"}%                                                                                                                                                                                                                                                                                         

openhouse on  main [$?] via ☕ v21.0.6 
➜ 


# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

