### PR TITLE
Fix hadoop docker build

### DIFF
--- a/infra/recipes/docker-compose/common/spark/spark-base-hadoop2.8.dockerfile
+++ b/infra/recipes/docker-compose/common/spark/spark-base-hadoop2.8.dockerfile
@@ -1,9 +1,11 @@
-FROM openjdk:11.0.11-jdk-slim-buster as builder
+FROM eclipse-temurin:11-jdk-jammy as builder
 
-RUN apt-get update && apt-get install -y \
-    git curl vim zip software-properties-common ssh net-tools ca-certificates \
+# Update package lists and install packages with proper security
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl vim zip unzip software-properties-common ssh net-tools ca-certificates \
     # Add Dependencies for PySpark \
-    python3 python3-pip python3-numpy python3-matplotlib python3-scipy python3-pandas python3-simpy
+    python3 python3-pip python3-numpy python3-matplotlib python3-scipy python3-pandas python3-simpy && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --install "/usr/bin/python" "python" "$(which python3)" 1
 
@@ -25,7 +27,7 @@ RUN curl --no-verbose -o apache-spark.tgz \
   && rm apache-spark.tgz
 
 # install maven to build apache livy
-RUN curl --no-verbose -o maven.tgz https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+RUN curl --no-verbose -o maven.tgz https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
   && mkdir -p /opt/maven \
   && tar -xf maven.tgz -C /opt/maven --strip-components=1 \
   && rm maven.tgz


### PR DESCRIPTION
## Summary
  Critical Changes:
  1. Base image update: FROM openjdk:11.0.11-jdk-slim-buster → FROM eclipse-temurin:11-jdk-jammy
    - Why needed: The old OpenJDK image is deprecated/unavailable, causing Docker build failures
  2. Maven download URL fix: https://dlcdn.apache.org/maven/maven-3/ → https://archive.apache.org/dist/maven/maven-3/
    - Why needed: The dlcdn.apache.org mirror is unreliable/unavailable, causing download failures during build

  Additional Changes (for best practices but not strictly required):
  3. Package installation optimization: Added --no-install-recommends, unzip, cleanup commands
    - Why helpful: Reduces image size and follows Docker best practices, but not required for functionality
  4. Chained RUN commands: Combined apt commands with && and cleanup
    - Why helpful: Reduces Docker layers and image size, but not required for functionality

  The two critical changes are updating the base image and fixing the Maven download URL. Without these, the Docker build would fail completely. The other changes improve the build but aren't strictly necessary for basic functionality.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [X] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests


## Testing Done

- [X] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
