### PR TITLE
fix tables-service connecting directly to DB

### DIFF
--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/TablesSpringApplication.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/TablesSpringApplication.java
@@ -5,8 +5,8 @@ import org.springframework.boot.actuate.autoconfigure.security.servlet.Managemen
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SuppressWarnings({"PMD", "checkstyle:hideutilityclassconstructor"})
 @SpringBootApplication(
@@ -28,11 +28,10 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
       "com.linkedin.openhouse.tables.toggle.model"
     })
 @EnableAutoConfiguration(
-    exclude = {SecurityAutoConfiguration.class, ManagementWebSecurityAutoConfiguration.class})
-@EnableJpaRepositories(
-    basePackages = {
-      "com.linkedin.openhouse.internal.catalog.repository",
-      "com.linkedin.openhouse.tables.toggle.repository"
+    exclude = {
+      SecurityAutoConfiguration.class,
+      ManagementWebSecurityAutoConfiguration.class,
+      DataSourceAutoConfiguration.class
     })
 public class TablesSpringApplication {
 


### PR DESCRIPTION
## Summary
problem: OpenHouse's GET /table is the most used table endpoint and has 1k+ QPS. However, there is extremely high customer observed latency on this endpoint. 

<img width="1600" height="489" alt="image" src="https://github.com/user-attachments/assets/6f273eac-0ad6-4326-b68d-789dc74dda3d" />
customer observed latency

note the times and the magnitude of latency, e.g. 21:06:00 and 15-25 seconds

<img width="1600" height="496" alt="image" src="https://github.com/user-attachments/assets/cad5f415-0e9f-469b-8292-0e0b776ab003" />
within tables-service, latency to acquire a hikaricp connection from the pool

note that we see at 21:06:00, a 17-30 seconds latency

we even see logs which prove that GET /table is calling tables-service and tables-service is directly connecting to the DB and timing out while waiting on a connection: 
```bash
org.springframework.transaction.CannotCreateTransactionException: Could not open JPA EntityManager for transaction; nested exception is org.hibernate.exception.JDBCConnectionException: Unable to acquire JDBC Connection
	at org.springframework.orm.jpa.JpaTransactionManager.doBegin(JpaTransactionManager.java:467)
	at org.springframework.transaction.support.AbstractPlatformTransactionManager.startTransaction(AbstractPlatformTransactionManager.java:400)
	at org.springframework.transaction.support.AbstractPlatformTransactionManager.getTransaction(AbstractPlatformTransactionManager.java:373)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.createTransactionIfNecessary(TransactionAspectSupport.java:595)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:382)
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.dao.support.PersistenceExceptionTranslationInterceptor.invoke(PersistenceExceptionTranslationInterceptor.java:137)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.data.jpa.repository.support.CrudMethodMetadataPostProcessor$CrudMethodMetadataPopulatingMethodInterceptor.invoke(CrudMethodMetadataPostProcessor.java:174)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:215)
	at jdk.proxy2/jdk.proxy2.$Proxy196.findById(Unknown Source)
	at com.linkedin.openhouse.internal.catalog.OpenHouseInternalCatalog.resolveFileIO(OpenHouseInternalCatalog.java:172)
	at com.linkedin.openhouse.internal.catalog.OpenHouseInternalCatalog.newTableOps(OpenHouseInternalCatalog.java:66)
	at org.apache.iceberg.BaseMetastoreCatalog.loadTable(BaseMetastoreCatalog.java:48)
```

further on through the stack trace we can see this specific exception is a timeout at 30 seconds
```bash
Caused by: java.sql.SQLTransientConnectionException: HikariPool-1 - Connection is not available, request timed out after 30000ms.
	at com.zaxxer.hikari.pool.HikariPool.createTimeoutException(HikariPool.java:696)
	at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:197)
	at com.zaxxer.hikari.pool.HikariPool.getConnection(HikariPool.java:162)
	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:128)
	at org.hibernate.engine.jdbc.connections.internal.DatasourceConnectionProviderImpl.getConnection(DatasourceConnectionProviderImpl.java:122)
	at org.hibernate.internal.NonContextualJdbcConnectionAccess.obtainConnection(NonContextualJdbcConnectionAccess.java:38)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.acquireConnectionIfNeeded(LogicalConnectionManagedImpl.java:108)
```

The tables-service is not supposed to connect to the database directly at all. Listing the processes connected to the database via `SELECT host, user FROM information_schema.PROCESSLIST;` confirms that the tables-service k8s pods have active connections to the database.

Looking back through closed-source blame and git history and found this comment:
```java
// FIXME: Remove this line once BDP-10738 is done to have deployed /tables hitting real /hts
@EnableJpaRepositories(basePackages = {"com.linkedin.openhouse.internal.catalog.repository"})
```

which appears to have been accidentally removed without ever being fixed, https://github.com/linkedin-multiproduct/openhouse/pull/76/files#diff-4997022cdace9b7df048b23510d75a8b2b4ba72c4e97305591c17a4199b8e5d9L11

If we look at the intended path, which is house-tables to database, both latency to acquire hikaricp connection and usage time of hikaricp connection are both very low

<img width="1257" height="288" alt="image" src="https://github.com/user-attachments/assets/75379606-86d7-4fa3-a1c1-e1108c56dc22" />

<img width="1257" height="288" alt="image" src="https://github.com/user-attachments/assets/b7de6b83-0880-47d1-9504-e416db683ac5" />

Solution:
We remove @EnableJpaRepositories, set up tests to prevent it from regressing, and remove the configuration of JDBC from being shared with tables-service. this works because there are currently two beans on the classpath, where the autoconfigured bean is taking precedence. once we remove it, the real bean will take affect.

```bash
curl -s "http://localhost:8000/actuator/beans" | jq '.contexts.application.beans.openHouseInternalCatalog')

1. "houseTableRepository":
{
"scope": "singleton",
"type": "com.linkedin.openhouse.internal.catalog.repository.HouseTableRepository",
"resource": "com.linkedin.openhouse.internal.catalog.repository.HouseTableRepository defined in @EnableJpaRepositories declared on
TablesSpringApplication",
"dependencies": ["houseTableRepositoryImpl", "(inner bean)#2ead6ba4", "(inner bean)#6274670b", "(inner bean)#759de304", "jpaMappingContext"]
}
2. "houseTableRepositoryImpl":
{
"scope": "singleton",
"type": "com.linkedin.openhouse.internal.catalog.repository.HouseTableRepositoryImpl$$EnhancerBySpringCGLIB$$e75bf294",
"resource": "URL [jar:file:/home/openhouse/tables.jar!/BOOT-INF/lib/internalcatalog.jar!/com/linkedin/openhouse/internal/catalog/repository/HouseTab
leRepositoryImpl.class]",
"dependencies": ["provideApiInstance", "houseTableMapperImpl"]
}
```

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [X] Bug Fixes
- [ ] New Features
- [X] Performance Improvements
- [ ] Code Style
- [X] Refactoring
- [ ] Documentation
- [X] Tests


## Testing Done
<!--- Check any relevant boxes with "x" -->

- [X] Manually Tested on local docker setup. Please include commands ran, and their output.
- [X] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [X] Some other form of testing like staging or soak time in production. Please explain.

after deploying to docker in hadoop+spark mode, we can see that the hikaricp metrics are no longer being emitted ✅  which helps us know that hikaricp isn't being auto-configured 
<img width="1270" height="698" alt="image" src="https://github.com/user-attachments/assets/66b41eb6-2863-4a2e-8689-a642369ffd6a" />


POST'ing to tables-service still works
```bash
openhouse on  fix-tables-service [$!?] via ☕ v17.0.5
➜ curl "${curlArgs[@]}" -XGET http://localhost:8000/v1/databases/d3/tables/t2
{"tableId":"t2","databaseId":"d3","clusterId":"LocalHadoopCluster","tableUri":"LocalHadoopCluster.d3.t2","tableUUID":"4fc25bd2-e8ec-455f-9573-5f2b0c409bf9","tableLocation":"hdfs://namenode:9000/data/openhouse/d3/t2-4fc25bd2-e8ec-455f-9573-5f2b0c409bf9/00000-b331718d-18b9-493a-8334-992e3de05cc0.metadata.json","tableVersion":"INITIAL_VERSION","tableCreator":"DUMMY_ANONYMOUS_USER","schema":"{\"type\":\"struct\",\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"string\"},{\"id\":2,\"name\":\"name\",\"required\":true,\"type\":\"string\"},{\"id\":3,\"name\":\"ts\",\"required\":true,\"type\":\"timestamp\"}]}","lastModifiedTime":1753231655334,"creationTime":1753231655334,"tableProperties":{"write.parquet.compression-codec":"zstd","policies":"","write.metadata.delete-after-commit.enabled":"true","openhouse.isTableReplicated":"false","openhouse.tableId":"t2","openhouse.clusterId":"LocalHadoopCluster","openhouse.lastModifiedTime":"1753231655334","openhouse.tableVersion":"INITIAL_VERSION","write.format.default":"orc","openhouse.creationTime":"1753231655334","openhouse.tableUri":"LocalHadoopCluster.d3.t2","write.metadata.previous-versions-max":"28","openhouse.databaseId":"d3","openhouse.tableType":"PRIMARY_TABLE","openhouse.tableLocation":"/data/openhouse/d3/t2-4fc25bd2-e8ec-455f-9573-5f2b0c409bf9/00000-b331718d-18b9-493a-8334-992e3de05cc0.metadata.json","openhouse.tableUUID":"4fc25bd2-e8ec-455f-9573-5f2b0c409bf9","key":"value","openhouse.tableCreator":"DUMMY_ANONYMOUS_USER"},"timePartitioning":{"columnName":"ts","granularity":"HOUR"},"clustering":[{"columnName":"name","transform":null}],"policies":null,"tableType":"PRIMARY_TABLE"}%

openhouse on  fix-tables-service [$!?] via ☕ v17.0.5
➜ curl "${curlArgs[@]}" -XPOST http://localhost:8000/v1/databases/d3/tables/ --data-raw '{
  "tableId": "t2",
  "databaseId": "d3",
  "baseTableVersion": "INITIAL_VERSION",
  "clusterId": "LocalHadoopCluster",
  "schema": "{\"type\": \"struct\", \"fields\": [{\"id\": 1,\"required\": true,\"name\": \"id\",\"type\": \"string\"},{\"id\": 2,\"required\": true,\"name\": \"name\",\"type\": \"string\"},{\"id\": 3,\"required\": true,\"name\": \"ts\",\"type\": \"timestamp\"}]}",
  "timePartitioning": {
    "columnName": "ts",
    "granularity": "HOUR"
  },
  "clustering": [
    {
      "columnName": "name"
    }
  ],
  "tableProperties": {
    "key": "value"
  }
}'
{"tableId":"t2","databaseId":"d3","clusterId":"LocalHadoopCluster","tableUri":"LocalHadoopCluster.d3.t2","tableUUID":"4fc25bd2-e8ec-455f-9573-5f2b0c409bf9","tableLocation":"hdfs://namenode:9000/data/openhouse/d3/t2-4fc25bd2-e8ec-455f-9573-5f2b0c409bf9/00000-b331718d-18b9-493a-8334-992e3de05cc0.metadata.json","tableVersion":"INITIAL_VERSION","tableCreator":"DUMMY_ANONYMOUS_USER","schema":"{\"type\":\"struct\",\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"string\"},{\"id\":2,\"name\":\"name\",\"required\":true,\"type\":\"string\"},{\"id\":3,\"name\":\"ts\",\"required\":true,\"type\":\"timestamp\"}]}","lastModifiedTime":1753231655334,"creationTime":1753231655334,"tableProperties":{"write.parquet.compression-codec":"zstd","policies":"","write.metadata.delete-after-commit.enabled":"true","openhouse.isTableReplicated":"false","openhouse.tableId":"t2","openhouse.clusterId":"LocalHadoopCluster","openhouse.lastModifiedTime":"1753231655334","openhouse.tableVersion":"INITIAL_VERSION","write.format.default":"orc","openhouse.creationTime":"1753231655334","openhouse.tableUri":"LocalHadoopCluster.d3.t2","write.metadata.previous-versions-max":"28","openhouse.databaseId":"d3","openhouse.tableType":"PRIMARY_TABLE","openhouse.tableLocation":"/data/openhouse/d3/t2-4fc25bd2-e8ec-455f-9573-5f2b0c409bf9/00000-b331718d-18b9-493a-8334-992e3de05cc0.metadata.json","openhouse.tableUUID":"4fc25bd2-e8ec-455f-9573-5f2b0c409bf9","key":"value","openhouse.tableCreator":"DUMMY_ANONYMOUS_USER"},"timePartitioning":{"columnName":"ts","granularity":"HOUR"},"clustering":[{"columnName":"name","transform":null}],"policies":null,"tableType":"PRIMARY_TABLE"}%
```

spark e2e test is still working
<img width="1270" height="698" alt="image" src="https://github.com/user-attachments/assets/74802914-7f6f-4778-b96f-7afb3c2771f7" />


# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.


TODO: 
1. add test to prevent regressons of having jpa autoconfiguration
2. refactor database config so that tables-service cannot use the jdbc connection