### PR TITLE
Adding historyConfig to table metadata for maintenance jobs

### DIFF
--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/client/TablesClientTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/client/TablesClientTest.java
@@ -501,7 +501,8 @@ public class TablesClientTest {
 
   private TableDataLayoutMetadata createTableDataLayoutMetadataMock() {
     TableDataLayoutMetadata metadata = Mockito.mock(TableDataLayoutMetadata.class);
-    Mockito.when(metadata.getDataLayoutStrategy()).thenReturn(Mockito.mock(DataLayoutStrategy.class));
+    Mockito.when(metadata.getDataLayoutStrategy())
+        .thenReturn(Mockito.mock(DataLayoutStrategy.class));
     Mockito.when(metadata.getDbName()).thenReturn("db");
     Mockito.when(metadata.getTableName()).thenReturn("table");
     Mockito.when(metadata.getCreationTimeMs()).thenReturn(1L);


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->
HistoryConfig is supposed to be passed as params to SnapshotsExpirationJob in order to control the number of snapshots.
However, the the config properties are not propagated as params, resulting in SE job running with default snapshot retention.

Fix: Add historyConfig to metadata which is passed to SE job.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
Added unit tests.
Local testing [In progress]
Stage env testing [after deployment]

<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
