### PR TITLE
Reverting sort order commit due to api change from createTable to buildTable

### DIFF
--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/CatalogConstants.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/CatalogConstants.java
@@ -4,7 +4,6 @@ package com.linkedin.openhouse.internal.catalog;
 public final class CatalogConstants {
   public static final String SNAPSHOTS_JSON_KEY = "snapshotsJsonToBePut";
   public static final String SNAPSHOTS_REFS_KEY = "snapshotsRefs";
-  public static final String SORT_ORDER_KEY = "sortOrder";
   public static final String IS_STAGE_CREATE_KEY = "isStageCreate";
   public static final String OPENHOUSE_UUID_KEY = "openhouse.tableUUID";
   public static final String OPENHOUSE_TABLEID_KEY = "openhouse.tableId";

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -40,7 +40,6 @@ import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.SortDirection;
 import org.apache.iceberg.SortField;
 import org.apache.iceberg.SortOrder;
-import org.apache.iceberg.SortOrderParser;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.TableProperties;
@@ -245,15 +244,9 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
       String serializedSnapshotRefs = properties.remove(CatalogConstants.SNAPSHOTS_REFS_KEY);
       boolean isStageCreate =
           Boolean.parseBoolean(properties.remove(CatalogConstants.IS_STAGE_CREATE_KEY));
-      String sortOrderJson = properties.remove(CatalogConstants.SORT_ORDER_KEY);
       logPropertiesMap(properties);
 
       TableMetadata updatedMetadata = metadata.replaceProperties(properties);
-
-      if (sortOrderJson != null) {
-        SortOrder sortOrder = SortOrderParser.fromJson(updatedMetadata.schema(), sortOrderJson);
-        updatedMetadata = updatedMetadata.replaceSortOrder(sortOrder);
-      }
 
       if (serializedSnapshotsToPut != null) {
         List<Snapshot> snapshotsToPut =

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
@@ -37,8 +37,6 @@ import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
-import org.apache.iceberg.SortOrder;
-import org.apache.iceberg.SortOrderParser;
 import org.apache.iceberg.StaticTableOperations;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
@@ -546,7 +544,6 @@ public class OpenHouseCatalog extends BaseMetastoreCatalog
 
     private final ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builder();
     private PartitionSpec spec = PartitionSpec.unpartitioned();
-    private SortOrder sortOrder = SortOrder.unsorted();
 
     OpenHouseTableBuilder(TableIdentifier identifier, Schema schema) {
       super(identifier, schema);
@@ -574,13 +571,6 @@ public class OpenHouseCatalog extends BaseMetastoreCatalog
     public TableBuilder withProperty(String key, String value) {
       this.propertiesBuilder.put(key, value);
       super.withProperty(key, value);
-      return this;
-    }
-
-    @Override
-    public TableBuilder withSortOrder(SortOrder sortOrder) {
-      this.sortOrder = sortOrder != null ? sortOrder : SortOrder.unsorted();
-      super.withSortOrder(sortOrder);
       return this;
     }
 
@@ -627,7 +617,6 @@ public class OpenHouseCatalog extends BaseMetastoreCatalog
       createUpdateTableRequestBody.setClustering(
           ClusteringSpecBuilder.builderFor(schema, spec).build());
       createUpdateTableRequestBody.setTableProperties(propertiesBuilder.build());
-      createUpdateTableRequestBody.setSortOrder(SortOrderParser.toJson(sortOrder));
       String tableLocation =
           tableApi
               .createTableV1(identifier.namespace().toString(), createUpdateTableRequestBody)

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -26,7 +26,6 @@ import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.SnapshotParser;
 import org.apache.iceberg.SnapshotRefParser;
-import org.apache.iceberg.SortOrderParser;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.BadRequestException;
@@ -134,8 +133,7 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
     } else {
       return !base.schema().sameSchema(metadata.schema())
           || !base.properties().equals(metadata.properties())
-          || !base.spec().equals(metadata.spec())
-          || !base.sortOrder().equals(metadata.sortOrder());
+          || !base.spec().equals(metadata.spec());
     }
   }
 
@@ -180,7 +178,6 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
         metadata.properties().entrySet().stream()
             .filter(entry -> !UPDATED_OPENHOUSE_POLICY_KEY.equals(entry.getKey()))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-    createUpdateTableRequestBody.setSortOrder(SortOrderParser.toJson(metadata.sortOrder()));
     // set tableType from incoming metadata to createUpdateTableRequestBody
     if (metadata.properties() != null
         && metadata.properties().containsKey(OPENHOUSE_TABLE_TYPE_KEY)) {

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/CatalogOperationTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/CatalogOperationTest.java
@@ -17,9 +17,7 @@ import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
-import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.Transaction;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchTableException;
@@ -352,63 +350,6 @@ public class CatalogOperationTest extends OpenHouseSparkITest {
       // Ensure that the original db name is preserved
       Assertions.assertEquals(
           renamedTable.name(), "openhouse.dB.rename_test_renamed_case_SENSITIVE");
-    }
-  }
-
-  @Test
-  public void testAlterTableSetSortOrder() throws Exception {
-    try (SparkSession spark = getSparkSession()) {
-      Catalog catalog = getOpenHouseCatalog(spark);
-      spark.sql("CREATE TABLE openhouse.db.test_sort_order (id int, data string)");
-      spark.sql("ALTER TABLE openhouse.db.test_sort_order WRITE ORDERED BY (id)");
-      Table table = catalog.loadTable(TableIdentifier.of("db", "test_sort_order"));
-      Assertions.assertEquals(
-          SortOrder.builderFor(table.schema()).asc("id").build(), table.sortOrder());
-      String distribution =
-          spark
-              .sql("show tblproperties openhouse.db.test_sort_order")
-              .filter("key='write.distribution-mode'")
-              .select("value")
-              .first()
-              .getString(0);
-      Assertions.assertEquals("range", distribution);
-    }
-  }
-
-  @Test
-  public void testAlterTableUnsetSortOrder() throws Exception {
-    try (SparkSession spark = getSparkSession()) {
-      Catalog catalog = getOpenHouseCatalog(spark);
-      spark.sql("CREATE TABLE openhouse.db.test_sort_order_unset (id int, data string)");
-      spark.sql("ALTER TABLE openhouse.db.test_sort_order_unset WRITE ORDERED BY (id)");
-      spark.sql("ALTER TABLE openhouse.db.test_sort_order_unset WRITE UNORDERED");
-      Table table = catalog.loadTable(TableIdentifier.of("db", "test_sort_order_unset"));
-      Assertions.assertEquals(SortOrder.unsorted(), table.sortOrder());
-    }
-  }
-
-  @Test
-  public void testAlterTableSortOrderCTAS() throws Exception {
-    try (SparkSession spark = getSparkSession()) {
-      Catalog catalog = getOpenHouseCatalog(spark);
-      spark.sql("CREATE TABLE openhouse.db.t1 (id int, data string)");
-      spark.sql("ALTER TABLE openhouse.db.t1 WRITE ORDERED BY (id)");
-      Table oldTable = catalog.loadTable(TableIdentifier.of("db", "t1"));
-      // CTAS with sort order is only supported through catalog API
-      Transaction transaction =
-          catalog
-              .buildTable(TableIdentifier.of("db", "test_sort_order_ctas"), oldTable.schema())
-              .withSortOrder(oldTable.sortOrder())
-              .createTransaction();
-      transaction.commitTransaction();
-      Table newTable = catalog.loadTable(TableIdentifier.of("db", "test_sort_order_ctas"));
-      Assertions.assertEquals(
-          SortOrder.builderFor(oldTable.schema()).asc("id").build(), newTable.sortOrder());
-      // CTAS with sort order is not supported through SQL API
-      spark.sql(
-          "CREATE TABLE openhouse.db.test_sort_order_ctas_sql AS SELECT * FROM openhouse.db.t1");
-      Table newSqlTable = catalog.loadTable(TableIdentifier.of("db", "test_sort_order_ctas_sql"));
-      Assertions.assertEquals(SortOrder.unsorted(), newSqlTable.sortOrder());
     }
   }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/CreateUpdateTableRequestBody.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/CreateUpdateTableRequestBody.java
@@ -107,14 +107,6 @@ public class CreateUpdateTableRequestBody {
   @Builder.Default
   private TableType tableType = TableType.PRIMARY_TABLE;
 
-  @Schema(
-      nullable = true,
-      description = "The sort order of a table",
-      example =
-          "\"sortOrder\":{\"order-id\":1,\"fields\":[{\"transform\":\"identity\",\"source-id\":1,\"direction\":\"asc\",\"null-order\":\"nulls-first\"}]}")
-  @Valid
-  private String sortOrder;
-
   public String toJson() {
     return new GsonBuilder().serializeNulls().create().toJson(this);
   }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/response/GetTableResponseBody.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/response/GetTableResponseBody.java
@@ -98,14 +98,6 @@ public class GetTableResponseBody {
   @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   private TableType tableType;
 
-  @Schema(
-      nullable = true,
-      description = "The sort order of a table",
-      example =
-          "\"sortOrder\":{\"order-id\":1,\"fields\":[{\"transform\":\"identity\",\"source-id\":1,\"direction\":\"asc\",\"null-order\":\"nulls-first\"}]}")
-  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
-  private String sortOrder;
-
   public String toJson() {
     return new Gson().toJson(this);
   }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/OpenHouseTablesApiValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/OpenHouseTablesApiValidator.java
@@ -20,9 +20,6 @@ import java.util.UUID;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import org.apache.commons.lang.StringUtils;
-import org.apache.iceberg.Schema;
-import org.apache.iceberg.SortOrder;
-import org.apache.iceberg.SortOrderParser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -99,10 +96,6 @@ public class OpenHouseTablesApiValidator implements TablesApiValidator {
               "schema : provided %s, should contain at least one column",
               createUpdateTableRequestBody.getSchema()));
     }
-    validateSortOrder(
-        createUpdateTableRequestBody.getSortOrder(),
-        createUpdateTableRequestBody.getSchema(),
-        validationFailures);
     validationFailures.addAll(validateUUIDForReplicaTable(createUpdateTableRequestBody));
     if (!validationFailures.isEmpty()) {
       throw new RequestValidationFailureException(validationFailures);
@@ -222,10 +215,6 @@ public class OpenHouseTablesApiValidator implements TablesApiValidator {
               createUpdateTableRequestBody.getClustering().size(),
               MAX_ALLOWED_CLUSTERING_COLUMNS));
     }
-    validateSortOrder(
-        createUpdateTableRequestBody.getSortOrder(),
-        createUpdateTableRequestBody.getSchema(),
-        validationFailures);
     if (!validationFailures.isEmpty()) {
       throw new RequestValidationFailureException(validationFailures);
     }
@@ -359,18 +348,6 @@ public class OpenHouseTablesApiValidator implements TablesApiValidator {
     } else if (!tableId.matches(ALPHA_NUM_UNDERSCORE_REGEX)) {
       validationFailures.add(
           String.format("tableId : provided %s, %s", tableId, ALPHA_NUM_UNDERSCORE_ERROR_MSG));
-    }
-  }
-
-  private void validateSortOrder(String sortOrder, String schema, List<String> validationFailures) {
-    if (sortOrder != null) {
-      try {
-        Schema icebergSchema = getSchemaFromSchemaJson(schema);
-        SortOrder icebergSortOrder = SortOrderParser.fromJson(icebergSchema, sortOrder);
-      } catch (IllegalArgumentException e) {
-        validationFailures.add(
-            String.format("sortOrder : provided %s is not a valid sort order", sortOrder));
-      }
     }
   }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/TablesMapper.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/TablesMapper.java
@@ -14,7 +14,6 @@ import com.linkedin.openhouse.tables.dto.mapper.iceberg.PoliciesSpecMapper;
 import com.linkedin.openhouse.tables.model.TableDto;
 import com.linkedin.openhouse.tables.model.TableDtoPrimaryKey;
 import java.util.HashMap;
-import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.mapstruct.Mapper;
@@ -32,8 +31,7 @@ import org.springframework.data.domain.Page;
       PoliciesSpecMapper.class,
       HashMap.class,
       TableType.class,
-      DefaultColumnPattern.class,
-      SortOrder.class
+      DefaultColumnPattern.class
     },
     uses = {PartitionSpecMapper.class, PoliciesSpecMapper.class})
 public interface TablesMapper {
@@ -65,9 +63,8 @@ public interface TablesMapper {
     @Mapping(
         source = "requestBody.baseTableVersion",
         target = "tableVersion"), /* store base version to check later */
-    @Mapping(source = "requestBody.sortOrder", target = "sortOrder"),
     @Mapping(target = "lastModifiedTime", ignore = true),
-    @Mapping(target = "creationTime", ignore = true),
+    @Mapping(target = "creationTime", ignore = true)
   })
   TableDto toTableDto(TableDto tableDto, CreateUpdateTableRequestBody requestBody);
 
@@ -107,7 +104,6 @@ public interface TablesMapper {
         source = "requestBody.createUpdateTableRequestBody.tableType",
         target = "tableType",
         defaultExpression = "java(TableType.PRIMARY_TABLE)"),
-    @Mapping(source = "requestBody.createUpdateTableRequestBody.sortOrder", target = "sortOrder"),
     @Mapping(target = "lastModifiedTime", ignore = true),
     @Mapping(target = "creationTime", ignore = true)
   })

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/model/TableDto.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/model/TableDto.java
@@ -57,8 +57,6 @@ public class TableDto {
 
   private TableType tableType;
 
-  private String sortOrder;
-
   @Convert(converter = TimePartitionSpecConverter.class)
   private TimePartitionSpec timePartitioning;
 

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/InternalRepositoryUtils.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/InternalRepositoryUtils.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.iceberg.SortOrderParser;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.UpdateProperties;
 
@@ -151,7 +150,6 @@ public final class InternalRepositoryUtils {
             .tableType(tableTypeMapper.toTableType(table))
             .jsonSnapshots(null)
             .tableProperties(megaProps)
-            .sortOrder(SortOrderParser.toJson(table.sortOrder()))
             .build();
 
     return tableDto;

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesControllerTest.java
@@ -1492,61 +1492,6 @@ public class TablesControllerTest {
   }
 
   @Test
-  public void testSetSortOrder() throws Exception {
-    MvcResult createResult =
-        RequestAndValidateHelper.createTableAndValidateResponse(
-            GET_TABLE_RESPONSE_BODY, mvc, storageManager);
-    GetTableResponseBody container = GetTableResponseBody.builder().sortOrder(SORT_ORDER).build();
-    GetTableResponseBody updateResponseBody = buildGetTableResponseBody(createResult, container);
-    MvcResult mvcResult =
-        mvc.perform(
-                MockMvcRequestBuilders.put(
-                        String.format(
-                            ValidationUtilities.CURRENT_MAJOR_VERSION_PREFIX
-                                + "/databases/%s/tables/%s",
-                            GET_TABLE_RESPONSE_BODY.getDatabaseId(),
-                            GET_TABLE_RESPONSE_BODY.getTableId()))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(buildCreateUpdateTableRequestBody(updateResponseBody).toJson())
-                    .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andReturn();
-    String sortOrder = JsonPath.read(mvcResult.getResponse().getContentAsString(), "$.sortOrder");
-    Assertions.assertEquals(SORT_ORDER, sortOrder);
-    RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, updateResponseBody);
-  }
-
-  @Test
-  public void testUnSetSortOrder() throws Exception {
-    GetTableResponseBody getTableResponseBody =
-        GET_TABLE_RESPONSE_BODY.toBuilder().sortOrder(SORT_ORDER).build();
-    MvcResult createResult =
-        RequestAndValidateHelper.createTableAndValidateResponse(
-            getTableResponseBody, mvc, storageManager);
-    GetTableResponseBody updateResponseBody =
-        buildGetTableResponseBody(createResult, GetTableResponseBody.builder().build())
-            .toBuilder()
-            .sortOrder(null)
-            .build();
-    MvcResult mvcResult =
-        mvc.perform(
-                MockMvcRequestBuilders.put(
-                        String.format(
-                            ValidationUtilities.CURRENT_MAJOR_VERSION_PREFIX
-                                + "/databases/%s/tables/%s",
-                            GET_TABLE_RESPONSE_BODY.getDatabaseId(),
-                            GET_TABLE_RESPONSE_BODY.getTableId()))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(buildCreateUpdateTableRequestBody(updateResponseBody).toJson())
-                    .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andReturn();
-    String sortOrder = JsonPath.read(mvcResult.getResponse().getContentAsString(), "$.sortOrder");
-    Assertions.assertEquals(UNSORTED_SORT_ORDER, sortOrder);
-    RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, updateResponseBody);
-  }
-
-  @Test
   @SneakyThrows
   public void testSearchSoftDeletedTables() {
     RequestAndValidateHelper.createTableAndValidateResponse(

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/model/TableModelConstants.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/model/TableModelConstants.java
@@ -60,8 +60,6 @@ public final class TableModelConstants {
 
   public static final String TEST_USER_PRINCIPAL;
   public static final String CLUSTER_NAME;
-  public static final String SORT_ORDER;
-  public static final String UNSORTED_SORT_ORDER;
 
   static {
     COL_PAT = RetentionColumnPattern.builder().columnName("name").pattern("'yyyy'").build();
@@ -118,9 +116,6 @@ public final class TableModelConstants {
     TEST_USER = "testUser";
     TEST_USER_PRINCIPAL = "testUserPrincipal";
     CLUSTER_NAME = "local-cluster";
-    SORT_ORDER =
-        "{\"order-id\":1,\"fields\":[{\"transform\":\"identity\",\"source-id\":1,\"direction\":\"asc\",\"null-order\":\"nulls-first\"}]}";
-    UNSORTED_SORT_ORDER = "{\"order-id\":0,\"fields\":[]}";
     try {
       HEALTH_SCHEMA_LITERAL =
           ResourceIoHelper.getSchemaJsonFromResource("dummy_healthy_schema.json");
@@ -165,7 +160,6 @@ public final class TableModelConstants {
         .schema(evolvedSchema)
         .timePartitioning(base.getTimePartitioning())
         .clustering(base.getClustering())
-        .sortOrder(base.getSortOrder())
         .build();
   }
 
@@ -186,7 +180,6 @@ public final class TableModelConstants {
         .clustering(null)
         .tableProperties(base.getTableProperties())
         .policies(base.getPolicies())
-        .sortOrder(base.getSortOrder())
         .build();
   }
 
@@ -232,7 +225,6 @@ public final class TableModelConstants {
                               .transformParams(Collections.singletonList("10"))
                               .build())
                       .build()))
-          .sortOrder(UNSORTED_SORT_ORDER)
           .build();
 
   public static final GetTableResponseBody GET_TABLE_RESPONSE_BODY_RESERVED_PROP =
@@ -257,7 +249,6 @@ public final class TableModelConstants {
               Arrays.asList(
                   ClusteringColumn.builder().columnName("name").build(),
                   ClusteringColumn.builder().columnName("id").build()))
-          .sortOrder(UNSORTED_SORT_ORDER)
           .build();
 
   public static final GetTableResponseBody GET_TABLE_RESPONSE_BODY_NULL_PROP =
@@ -275,7 +266,6 @@ public final class TableModelConstants {
           .timePartitioning(null)
           .clustering(null)
           .policies(TABLE_POLICIES)
-          .sortOrder(UNSORTED_SORT_ORDER)
           .build();
 
   public static final GetTableResponseBody GET_TABLE_RESPONSE_BODY_WITH_TABLE_TYPE =
@@ -301,7 +291,6 @@ public final class TableModelConstants {
               Arrays.asList(
                   ClusteringColumn.builder().columnName("id").build(),
                   ClusteringColumn.builder().columnName("name").build()))
-          .sortOrder(UNSORTED_SORT_ORDER)
           .build();
 
   public static final TableDto TABLE_DTO =
@@ -325,7 +314,6 @@ public final class TableModelConstants {
           .policies(TABLE_DTO.getPolicies())
           .stageCreate(true)
           .tableType(TableType.PRIMARY_TABLE)
-          .sortOrder(UNSORTED_SORT_ORDER)
           .build();
 
   public static final GetTableResponseBody GET_TABLE_RESPONSE_BODY_SAME_DB =
@@ -350,7 +338,6 @@ public final class TableModelConstants {
                   ClusteringColumn.builder().columnName("id").build()))
           .tableProperties(buildTableProperties(TABLE_PROPS))
           .policies(TABLE_POLICIES)
-          .sortOrder(UNSORTED_SORT_ORDER)
           .build();
   public static final TableDto TABLE_DTO_SAME_DB =
       TableModelConstants.buildTableDto(GET_TABLE_RESPONSE_BODY_SAME_DB);
@@ -378,7 +365,6 @@ public final class TableModelConstants {
               Arrays.asList(
                   ClusteringColumn.builder().columnName("name").build(),
                   ClusteringColumn.builder().columnName("id").build()))
-          .sortOrder(UNSORTED_SORT_ORDER)
           .build();
   public static final TableDto TABLE_DTO_DIFF_DB =
       TableModelConstants.buildTableDto(GET_TABLE_RESPONSE_BODY_DIFF_DB);
@@ -407,7 +393,6 @@ public final class TableModelConstants {
                   Arrays.asList(
                       ClusteringColumn.builder().columnName("name").build(),
                       ClusteringColumn.builder().columnName("id").build()))
-              .sortOrder(UNSORTED_SORT_ORDER)
               .build();
 
   public static final CreateUpdateTableRequestBody CREATE_TABLE_REQUEST_BODY =
@@ -419,7 +404,6 @@ public final class TableModelConstants {
           .tableProperties(buildTableProperties(TABLE_PROPS))
           .policies(TABLE_POLICIES)
           .baseTableVersion(INITIAL_TABLE_VERSION)
-          .sortOrder(UNSORTED_SORT_ORDER)
           .build();
 
   public static final IcebergSnapshotsRequestBody ICEBERG_SNAPSHOTS_REQUEST_BODY =
@@ -445,7 +429,6 @@ public final class TableModelConstants {
         .clustering(getTableResponseBody.getClustering())
         .policies(getTableResponseBody.getPolicies())
         .tableType(getTableResponseBody.getTableType())
-        .sortOrder(getTableResponseBody.getSortOrder())
         .build();
   }
 
@@ -479,7 +462,6 @@ public final class TableModelConstants {
                             .transformParams(Collections.singletonList("10"))
                             .build())
                     .build()))
-        .sortOrder(UNSORTED_SORT_ORDER)
         .build();
   }
 
@@ -502,7 +484,6 @@ public final class TableModelConstants {
         .baseTableVersion(getTableResponseBody.getTableLocation())
         .stageCreate(stageCreate)
         .tableType(getTableResponseBody.getTableType())
-        .sortOrder(getTableResponseBody.getSortOrder())
         .build();
   }
 
@@ -527,7 +508,6 @@ public final class TableModelConstants {
                 .convertToEntityAttribute(JsonPath.read(content, "$.clustering").toString()))
         .stageCreate(stageCreate)
         .baseTableVersion(JsonPath.read(content, "$.tableLocation"))
-        .sortOrder(JsonPath.read(content, "$.sortOrder"))
         .build();
   }
 
@@ -562,7 +542,6 @@ public final class TableModelConstants {
         .policies(
             new PoliciesSpecConverter()
                 .convertToEntityAttribute(JsonPath.read(content, "$.policies").toString()))
-        .sortOrder(JsonPath.read(content, "$.sortOrder"))
         .build();
   }
 
@@ -644,10 +623,6 @@ public final class TableModelConstants {
                 ? new Gson()
                     .fromJson(JsonPath.read(content, "$.policies").toString(), Policies.class)
                 : getTableResponseBody.getPolicies())
-        .sortOrder(
-            getTableResponseBody.getSortOrder() == null
-                ? JsonPath.read(content, "$.sortOrder")
-                : getTableResponseBody.getSortOrder())
         .build();
   }
 
@@ -664,8 +639,7 @@ public final class TableModelConstants {
                 .clustering(tableDto.getClustering())
                 .baseTableVersion(tableDto.getTableLocation())
                 .tableType(tableDto.getTableType())
-                .policies(tableDto.getPolicies())
-                .sortOrder(tableDto.getSortOrder());
+                .policies(tableDto.getPolicies());
     if (tableDto.isStageCreate()) {
       createUpdateTableRequestBodyBuilder.stageCreate(true);
     }
@@ -688,7 +662,6 @@ public final class TableModelConstants {
         .clustering(getTableResponseBody.getClustering())
         .policies(policies)
         .tableProperties(getTableResponseBody.getTableProperties())
-        .sortOrder(getTableResponseBody.getSortOrder())
         .build();
   }
 


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

Sort order support PR https://github.com/linkedin/openhouse/pull/351 changes a critical API call in `OpenhouseInternalCatalog` to use `buildTable` instead of `createTable`. This changes some of the dependencies where extension classes have overridden `createTable` with special logic to populate properties with location information.

We want to revert this PR for now to unblock downstream as well as create a new PR to make `OpenHouseRepositoryImpl` more extensible to handle the above property logic instead.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
