### PR TITLE
Handle replication process compatible table creation for tables created for replication

### DIFF
--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/hdfs/HdfsStorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/hdfs/HdfsStorageClient.java
@@ -5,6 +5,7 @@ import com.linkedin.openhouse.cluster.storage.StorageType;
 import com.linkedin.openhouse.cluster.storage.configs.StorageProperties;
 import java.io.IOException;
 import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -66,6 +67,19 @@ public class HdfsStorageClient extends BaseStorageClient<FileSystem> {
     } catch (IOException e) {
       throw new ServiceUnavailableException(
           "Exception checking path existence " + e.getMessage(), e);
+    }
+  }
+
+  /** Clean up resources when the bean is destroyed. */
+  @PreDestroy
+  public void cleanup() {
+    if (fs != null) {
+      try {
+        log.info("Closing FileSystem for HdfsStorageClient");
+        fs.close();
+      } catch (IOException e) {
+        log.error("Error closing FileSystem during HdfsStorageClient cleanup", e);
+      }
     }
   }
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/local/LocalStorageClient.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FilterFileSystem;
@@ -148,6 +149,19 @@ public class LocalStorageClient extends BaseStorageClient<FileSystem> {
     } catch (IOException e) {
       throw new ServiceUnavailableException(
           "Exception checking path existence " + e.getMessage(), e);
+    }
+  }
+
+  /** Clean up resources when the bean is destroyed. */
+  @PreDestroy
+  public void cleanup() {
+    if (fs != null) {
+      try {
+        log.info("Closing FileSystem for LocalStorageClient");
+        fs.close();
+      } catch (IOException e) {
+        log.error("Error closing FileSystem during LocalStorageClient cleanup", e);
+      }
     }
   }
 }

--- a/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/s3/S3StorageClient.java
+++ b/cluster/storage/src/main/java/com/linkedin/openhouse/cluster/storage/s3/S3StorageClient.java
@@ -9,6 +9,7 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.iceberg.aws.AwsClientFactories;
@@ -97,6 +98,19 @@ public class S3StorageClient extends BaseStorageClient<S3Client> {
     } catch (URISyntaxException | S3Exception e) {
       throw new ServiceUnavailableException(
           "Error checking S3 object existence: " + e.getMessage(), e);
+    }
+  }
+
+  /** Clean up resources when the bean is destroyed. */
+  @PreDestroy
+  public void cleanup() {
+    if (s3 != null) {
+      try {
+        log.info("Closing S3Client for S3StorageClient");
+        s3.close();
+      } catch (Exception e) {
+        log.error("Error closing S3Client during S3StorageClient cleanup", e);
+      }
     }
   }
 }

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/CatalogConstants.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/CatalogConstants.java
@@ -6,6 +6,7 @@ public final class CatalogConstants {
   public static final String SNAPSHOTS_REFS_KEY = "snapshotsRefs";
   public static final String SORT_ORDER_KEY = "sortOrder";
   public static final String IS_STAGE_CREATE_KEY = "isStageCreate";
+  public static final String OPENHOUSE_TABLE_VERSION = "openhouse.tableVersion";
   public static final String OPENHOUSE_UUID_KEY = "openhouse.tableUUID";
   public static final String OPENHOUSE_TABLEID_KEY = "openhouse.tableId";
   public static final String OPENHOUSE_DATABASEID_KEY = "openhouse.databaseId";
@@ -13,6 +14,7 @@ public final class CatalogConstants {
   public static final String OPENHOUSE_TABLEURI_KEY = "openhouse.tableUri";
   public static final String OPENHOUSE_CLUSTERID_KEY = "openhouse.clusterId";
   public static final String INITIAL_VERSION = "INITIAL_VERSION";
+  public static final String LAST_UPDATED_MS = "last-updated-ms";
   public static final String APPENDED_SNAPSHOTS = "appended_snapshots";
   public static final String STAGED_SNAPSHOTS = "staged_snapshots";
   public static final String CHERRY_PICKED_SNAPSHOTS = "cherry_picked_snapshots";

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -69,7 +69,8 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
         snapshotInspector,
         houseTableMapper,
         tableIdentifier,
-        new MetricsReporter(this.meterRegistry, METRICS_PREFIX, Lists.newArrayList()));
+        new MetricsReporter(this.meterRegistry, METRICS_PREFIX, Lists.newArrayList()),
+        fileIOManager);
   }
 
   @Override

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -6,7 +6,12 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.gson.Gson;
 import com.linkedin.openhouse.cluster.metrics.micrometer.MetricsReporter;
+import com.linkedin.openhouse.cluster.storage.Storage;
+import com.linkedin.openhouse.cluster.storage.StorageClient;
+import com.linkedin.openhouse.cluster.storage.hdfs.HdfsStorageClient;
+import com.linkedin.openhouse.cluster.storage.local.LocalStorageClient;
 import com.linkedin.openhouse.internal.catalog.exception.InvalidIcebergSnapshotException;
+import com.linkedin.openhouse.internal.catalog.fileio.FileIOManager;
 import com.linkedin.openhouse.internal.catalog.mapper.HouseTableMapper;
 import com.linkedin.openhouse.internal.catalog.model.HouseTable;
 import com.linkedin.openhouse.internal.catalog.model.HouseTablePrimaryKey;
@@ -14,6 +19,7 @@ import com.linkedin.openhouse.internal.catalog.repository.HouseTableRepository;
 import com.linkedin.openhouse.internal.catalog.repository.exception.HouseTableCallerException;
 import com.linkedin.openhouse.internal.catalog.repository.exception.HouseTableConcurrentUpdateException;
 import com.linkedin.openhouse.internal.catalog.repository.exception.HouseTableNotFoundException;
+import com.linkedin.openhouse.internal.catalog.utils.MetadataUpdateUtils;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -29,6 +35,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
@@ -69,6 +76,8 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
   TableIdentifier tableIdentifier;
 
   MetricsReporter metricsReporter;
+
+  FileIOManager fileIOManager;
 
   private static final Gson GSON = new Gson();
 
@@ -227,16 +236,21 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
       Map<String, String> properties = new HashMap<>(metadata.properties());
       failIfRetryUpdate(properties);
 
-      String currentTsString = String.valueOf(Instant.now(Clock.systemUTC()).toEpochMilli());
-      properties.put(getCanonicalFieldName("lastModifiedTime"), currentTsString);
-      if (base == null) {
-        properties.put(getCanonicalFieldName("creationTime"), currentTsString);
-      }
       properties.put(
           getCanonicalFieldName("tableVersion"),
           properties.getOrDefault(
               getCanonicalFieldName("tableLocation"), CatalogConstants.INITIAL_VERSION));
       properties.put(getCanonicalFieldName("tableLocation"), newMetadataLocation);
+
+      String currentTsString = String.valueOf(Instant.now(Clock.systemUTC()).toEpochMilli());
+      if (isReplicatedTableCreate(properties)) {
+        currentTsString =
+            metadata.properties().getOrDefault(CatalogConstants.LAST_UPDATED_MS, currentTsString);
+      }
+      properties.put(getCanonicalFieldName("lastModifiedTime"), currentTsString);
+      if (base == null) {
+        properties.put(getCanonicalFieldName("creationTime"), currentTsString);
+      }
 
       if (properties.containsKey(CatalogConstants.EVOLVED_SCHEMA_KEY)) {
         properties.remove(CatalogConstants.EVOLVED_SCHEMA_KEY);
@@ -304,6 +318,9 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
          * TableMetadata)}
          */
         refreshFromMetadataLocation(newMetadataLocation);
+      }
+      if (isReplicatedTableCreate(properties)) {
+        updateMetadataFieldForStageCreate(metadata, newMetadataLocation);
       }
       commitStatus = CommitStatus.SUCCESS;
     } catch (InvalidIcebergSnapshotException e) {
@@ -604,5 +621,42 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
     for (Map.Entry<String, String> entry : map.entrySet()) {
       log.debug(entry.getKey() + ":" + entry.getValue());
     }
+  }
+
+  /**
+   * Updates metadata field for staged tables by extracting updateTimeStamp from metadata.properties
+   * and updating the metadata file.
+   *
+   * @param metadata The table metadata containing properties
+   */
+  private void updateMetadataFieldForStageCreate(TableMetadata metadata, String tableLocation) {
+    try {
+      String updateTimeStamp = metadata.properties().get(CatalogConstants.LAST_UPDATED_MS);
+      if (updateTimeStamp != null) {
+        Storage storage = fileIOManager.getStorage(fileIO);
+        // Metadata update support only for HDFS and local storage for replication support
+        if (storage != null
+            && (storage.getClient() instanceof HdfsStorageClient
+                || storage.getClient() instanceof LocalStorageClient)) {
+          StorageClient<?> client = storage.getClient();
+          FileSystem fs = (FileSystem) client.getNativeClient();
+          if (tableLocation != null) {
+            MetadataUpdateUtils.updateMetadataField(
+                fs, tableLocation, CatalogConstants.LAST_UPDATED_MS, Long.valueOf(updateTimeStamp));
+          }
+        }
+      }
+    } catch (Exception e) {
+      log.error("Failed to update metadata field for staged table: {}", tableIdentifier, e);
+    }
+  }
+
+  private boolean isReplicatedTableCreate(Map<String, String> properties) {
+    return Boolean.parseBoolean(
+            properties.getOrDefault(CatalogConstants.OPENHOUSE_IS_TABLE_REPLICATED_KEY, "false"))
+        && properties
+            .getOrDefault(
+                CatalogConstants.OPENHOUSE_TABLE_VERSION, CatalogConstants.INITIAL_VERSION)
+            .equals(CatalogConstants.INITIAL_VERSION);
   }
 }

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/utils/MetadataUpdateUtils.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/utils/MetadataUpdateUtils.java
@@ -1,0 +1,108 @@
+package com.linkedin.openhouse.internal.catalog.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.IOUtils;
+
+/**
+ * Utility class for updating metadata files in HDFS. Provides methods to read, modify, and write
+ * JSON metadata files.
+ */
+@Slf4j
+public class MetadataUpdateUtils {
+
+  /**
+   * Updates a specific field in a metadata file located at the given HDFS path.
+   *
+   * @param fs The Hadoop FileSystem instance
+   * @param hdfsPath The path to the metadata file in HDFS
+   * @param fieldName The name of the field to update
+   * @param updatedValue The new value for the field
+   * @throws IOException if there's an error reading or writing the file
+   */
+  public static void updateMetadataField(
+      FileSystem fs, String hdfsPath, String fieldName, Long updatedValue) throws IOException {
+    try {
+      InputStream inputStream = fs.open(new Path(hdfsPath));
+      String jsonString = readInputStream(inputStream);
+      IOUtils.closeStream(inputStream);
+
+      String updatedJsonString = updateJsonField(jsonString, fieldName, updatedValue);
+
+      OutputStream outputStream = fs.create(new Path(hdfsPath), true);
+      writeOutputStream(outputStream, updatedJsonString);
+      IOUtils.closeStream(outputStream);
+
+      log.info("Updated json metadata string: {}", updatedJsonString);
+    } catch (IOException e) {
+      String errMsg =
+          String.format(
+              "Failed to update metadata file at path: %s. Error: %s", hdfsPath, e.getMessage());
+      log.error(errMsg);
+      throw new IOException(errMsg);
+    }
+  }
+
+  /**
+   * Reads the content of an InputStream and returns it as a String.
+   *
+   * @param inputStream The InputStream to read from
+   * @return The content as a String
+   * @throws IOException if there's an error reading the stream
+   */
+  private static String readInputStream(InputStream inputStream) throws IOException {
+    try (BufferedReader reader =
+        new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+      StringBuilder content = new StringBuilder();
+      String line;
+      while ((line = reader.readLine()) != null) {
+        content.append(line);
+      }
+      return content.toString();
+    }
+  }
+
+  /**
+   * Writes content to an OutputStream.
+   *
+   * @param outputStream The OutputStream to write to
+   * @param content The content to write
+   * @throws IOException if there's an error writing to the stream
+   */
+  private static void writeOutputStream(OutputStream outputStream, String content)
+      throws IOException {
+    try (BufferedWriter writer =
+        new BufferedWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8))) {
+      writer.write(content);
+    }
+  }
+
+  /**
+   * Updates a specific field in a JSON string with a new value.
+   *
+   * @param jsonString The JSON string to modify
+   * @param fieldName The name of the field to update
+   * @param updatedValue The new value for the field
+   * @return The updated JSON string with pretty printing
+   * @throws IOException if there's an error parsing or writing the JSON
+   */
+  private static String updateJsonField(String jsonString, String fieldName, long updatedValue)
+      throws IOException {
+    ObjectMapper objectMapper = new ObjectMapper();
+    JsonNode jsonNode = objectMapper.readTree(jsonString);
+    ((ObjectNode) jsonNode).put(fieldName, updatedValue);
+    return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonNode);
+  }
+}

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
@@ -4,8 +4,10 @@ import static com.linkedin.openhouse.internal.catalog.mapper.HouseTableSerdeUtil
 import static org.mockito.Mockito.*;
 
 import com.linkedin.openhouse.cluster.metrics.micrometer.MetricsReporter;
+import com.linkedin.openhouse.cluster.storage.StorageClient;
 import com.linkedin.openhouse.cluster.storage.StorageType;
 import com.linkedin.openhouse.cluster.storage.local.LocalStorage;
+import com.linkedin.openhouse.cluster.storage.local.LocalStorageClient;
 import com.linkedin.openhouse.internal.catalog.fileio.FileIOManager;
 import com.linkedin.openhouse.internal.catalog.mapper.HouseTableMapper;
 import com.linkedin.openhouse.internal.catalog.model.HouseTable;
@@ -15,6 +17,7 @@ import com.linkedin.openhouse.internal.catalog.repository.exception.HouseTableCa
 import com.linkedin.openhouse.internal.catalog.repository.exception.HouseTableConcurrentUpdateException;
 import com.linkedin.openhouse.internal.catalog.repository.exception.HouseTableNotFoundException;
 import com.linkedin.openhouse.internal.catalog.repository.exception.HouseTableRepositoryStateUnknownException;
+import com.linkedin.openhouse.internal.catalog.utils.MetadataUpdateUtils;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -28,6 +31,10 @@ import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import org.apache.commons.compress.utils.Lists;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -42,6 +49,7 @@ import org.apache.iceberg.common.DynFields;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Assertions;
@@ -72,6 +80,10 @@ public class OpenHouseInternalTableOperationsTest {
   @Captor private ArgumentCaptor<TableMetadata> tblMetadataCaptor;
   @Mock private FileIOManager fileIOManager;
   @Mock private MetricsReporter mockMetricsReporter;
+  @Mock private FileSystem mockFileSystem;
+  @Mock private LocalStorageClient mockLocalStorageClient;
+  @Mock private FSDataInputStream mockFSDataInputStream;
+  @Mock private FSDataOutputStream mockFSDataOutputStream;
 
   private OpenHouseInternalTableOperations openHouseInternalTableOperations;
   private OpenHouseInternalTableOperations openHouseInternalTableOperationsWithMockMetrics;
@@ -94,7 +106,8 @@ public class OpenHouseInternalTableOperationsTest {
             Mockito.mock(SnapshotInspector.class),
             mockHouseTableMapper,
             TEST_TABLE_IDENTIFIER,
-            new MetricsReporter(new SimpleMeterRegistry(), "TEST_CATALOG", Lists.newArrayList()));
+            new MetricsReporter(new SimpleMeterRegistry(), "TEST_CATALOG", Lists.newArrayList()),
+            fileIOManager);
 
     // Create a separate instance with mock metrics reporter for testing metrics
     openHouseInternalTableOperationsWithMockMetrics =
@@ -104,7 +117,8 @@ public class OpenHouseInternalTableOperationsTest {
             Mockito.mock(SnapshotInspector.class),
             mockHouseTableMapper,
             TEST_TABLE_IDENTIFIER,
-            mockMetricsReporter);
+            mockMetricsReporter,
+            fileIOManager);
 
     LocalStorage localStorage = mock(LocalStorage.class);
     when(fileIOManager.getStorage(fileIO)).thenReturn(localStorage);
@@ -246,6 +260,125 @@ public class OpenHouseInternalTableOperationsTest {
       Assertions.assertTrue(updatedProperties.containsKey(getCanonicalFieldName("tableLocation")));
       Mockito.verify(mockHouseTableRepository, Mockito.times(1)).save(Mockito.eq(mockHouseTable));
     }
+  }
+
+  @Test
+  void testDoCommitUpdateMetadataForInitalVersionCommit() throws IOException {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(CatalogConstants.LAST_UPDATED_MS, "1233232423");
+    properties.put(CatalogConstants.OPENHOUSE_IS_TABLE_REPLICATED_KEY, "true");
+    properties.put(CatalogConstants.OPENHOUSE_TABLE_VERSION, CatalogConstants.INITIAL_VERSION);
+    TableMetadata base = BASE_TABLE_METADATA;
+
+    TableMetadata metadata = base.replaceProperties(properties);
+
+    // Setup mocks for filesystem operations
+    LocalStorage mockLocalStorage = mock(LocalStorage.class);
+    when(fileIOManager.getStorage(any(FileIO.class))).thenReturn(mockLocalStorage);
+    when(mockLocalStorage.getClient()).thenReturn((StorageClient) mockLocalStorageClient);
+    when(mockLocalStorageClient.getNativeClient()).thenReturn(mockFileSystem);
+
+    // Mock filesystem operations for MetadataUpdateUtils.updateMetadataField
+    when(mockFileSystem.open(any(Path.class))).thenReturn(mockFSDataInputStream);
+    when(mockFileSystem.create(any(Path.class), eq(true))).thenReturn(mockFSDataOutputStream);
+
+    // Mock input stream to return JSON content that can be parsed
+    String mockJsonContent = "{\"last-updated-ms\": 1233232422}";
+    when(mockFSDataInputStream.read(any(byte[].class)))
+        .thenAnswer(
+            invocation -> {
+              byte[] buffer = invocation.getArgument(0);
+              byte[] content = mockJsonContent.getBytes();
+              System.arraycopy(content, 0, buffer, 0, Math.min(content.length, buffer.length));
+              return content.length;
+            });
+    when(mockFSDataInputStream.read()).thenReturn(-1); // EOF
+
+    try (MockedStatic<MetadataUpdateUtils> mockedMetadataUpdateUtils =
+        mockStatic(MetadataUpdateUtils.class)) {
+      openHouseInternalTableOperations.doCommit(base, metadata);
+
+      // Verify updateMetadataField was called
+      mockedMetadataUpdateUtils.verify(
+          () ->
+              MetadataUpdateUtils.updateMetadataField(
+                  eq(mockFileSystem), anyString(), eq("last-updated-ms"), eq(1233232423L)));
+    }
+
+    Mockito.verify(mockHouseTableMapper).toHouseTable(tblMetadataCaptor.capture(), Mockito.any());
+
+    Map<String, String> updatedProperties = tblMetadataCaptor.getValue().properties();
+    Assertions.assertEquals(
+        CatalogConstants.INITIAL_VERSION,
+        updatedProperties.get(getCanonicalFieldName("tableVersion")));
+
+    Assertions.assertTrue(updatedProperties.containsKey(getCanonicalFieldName("tableLocation")));
+    Mockito.verify(mockHouseTableRepository, Mockito.times(1)).save(Mockito.eq(mockHouseTable));
+
+    // Verify filesystem operations were performed
+    verify(fileIOManager).getStorage(any(FileIO.class));
+    // Called 3 times: 2x for instanceof checks, 1x for assignment
+    verify(mockLocalStorage, times(3)).getClient();
+    verify(mockLocalStorageClient).getNativeClient();
+  }
+
+  @Test
+  void testDoCommitUpdateMetadataNotCalledForNonReplicatedTable() throws IOException {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("last-updated-ms", "1233232423");
+    properties.put(CatalogConstants.OPENHOUSE_TABLE_VERSION, CatalogConstants.INITIAL_VERSION);
+    TableMetadata base = BASE_TABLE_METADATA;
+
+    TableMetadata metadata = base.replaceProperties(properties);
+
+    // Setup mocks for filesystem operations
+    LocalStorage mockLocalStorage = mock(LocalStorage.class);
+    when(fileIOManager.getStorage(any(FileIO.class))).thenReturn(mockLocalStorage);
+    when(mockLocalStorage.getClient()).thenReturn((StorageClient) mockLocalStorageClient);
+    when(mockLocalStorageClient.getNativeClient()).thenReturn(mockFileSystem);
+
+    try (MockedStatic<MetadataUpdateUtils> mockedMetadataUpdateUtils =
+        mockStatic(MetadataUpdateUtils.class)) {
+      openHouseInternalTableOperations.doCommit(base, metadata);
+
+      // Verify updateMetadataField was NOT called since table is not replicated
+      mockedMetadataUpdateUtils.verifyNoInteractions();
+    }
+
+    Mockito.verify(mockHouseTableRepository, Mockito.times(1)).save(Mockito.any(HouseTable.class));
+  }
+
+  @Test
+  void testDoCommitUpdateMetadataNotCalledForNonInitialVersionCommit() throws IOException {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("last-updated-ms", "1233232423");
+    properties.put(CatalogConstants.OPENHOUSE_IS_TABLE_REPLICATED_KEY, "true");
+    properties.put(CatalogConstants.OPENHOUSE_TABLE_VERSION, "v1.0.0");
+
+    // Set tableLocation to a non-INITIAL_VERSION value so that tableVersion gets set to this value
+    // This will cause isReplicatedTableCreate to return false since tableVersion != INITIAL_VERSION
+    properties.put(getCanonicalFieldName("tableLocation"), "some-existing-table-location");
+
+    // Use existing table metadata (base != null) to simulate a snapshot commit rather than table
+    // creation
+    TableMetadata base = BASE_TABLE_METADATA;
+    TableMetadata metadata = base.replaceProperties(properties);
+
+    // Setup mocks for filesystem operations
+    LocalStorage mockLocalStorage = mock(LocalStorage.class);
+    when(fileIOManager.getStorage(any(FileIO.class))).thenReturn(mockLocalStorage);
+    when(mockLocalStorage.getClient()).thenReturn((StorageClient) mockLocalStorageClient);
+    when(mockLocalStorageClient.getNativeClient()).thenReturn(mockFileSystem);
+
+    try (MockedStatic<MetadataUpdateUtils> mockedMetadataUpdateUtils =
+        mockStatic(MetadataUpdateUtils.class)) {
+      openHouseInternalTableOperations.doCommit(base, metadata);
+
+      // Verify updateMetadataField was NOT called since this is not an initial version commit
+      mockedMetadataUpdateUtils.verifyNoInteractions();
+    }
+
+    Mockito.verify(mockHouseTableRepository, Mockito.times(1)).save(Mockito.any(HouseTable.class));
   }
 
   @Test
@@ -852,7 +985,8 @@ public class OpenHouseInternalTableOperationsTest {
             Mockito.mock(SnapshotInspector.class),
             mockHouseTableMapper,
             TEST_TABLE_IDENTIFIER,
-            realMetricsReporter);
+            realMetricsReporter,
+            fileIOManager);
 
     // Setup mock behavior
     HouseTablePrimaryKey primaryKey =

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTestWithSettableComponents.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTestWithSettableComponents.java
@@ -104,7 +104,8 @@ public class RepositoryTestWithSettableComponents {
             snapshotInspector,
             houseTableMapper,
             tableIdentifier,
-            new MetricsReporter(this.meterRegistry, "test", Lists.newArrayList()));
+            new MetricsReporter(this.meterRegistry, "test", Lists.newArrayList()),
+            fileIOManager);
     ((SettableCatalogForTest) catalog).setOperation(actualOps);
     TableDto creationDTO = TABLE_DTO.toBuilder().tableVersion(INITIAL_TABLE_VERSION).build();
     creationDTO = openHouseInternalRepository.save(creationDTO);
@@ -120,7 +121,8 @@ public class RepositoryTestWithSettableComponents {
             snapshotInspector,
             houseTableMapper,
             tableIdentifier,
-            new MetricsReporter(this.meterRegistry, "test", Lists.newArrayList()));
+            new MetricsReporter(this.meterRegistry, "test", Lists.newArrayList()),
+            fileIOManager);
     OpenHouseInternalTableOperations spyOperations = Mockito.spy(mockOps);
     doReturn(actualOps.current()).when(spyOperations).refresh();
     BaseTable spyOptsMockedTable = Mockito.spy(new BaseTable(spyOperations, realTable.name()));
@@ -200,7 +202,8 @@ public class RepositoryTestWithSettableComponents {
               snapshotInspector,
               houseTableMapper,
               tableIdentifier,
-              new MetricsReporter(this.meterRegistry, "test", Lists.newArrayList()));
+              new MetricsReporter(this.meterRegistry, "test", Lists.newArrayList()),
+              fileIOManager);
       OpenHouseInternalTableOperations spyOperations = Mockito.spy(mockOps);
       BaseTable spyOptsMockedTable =
           Mockito.spy(


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

Issue: Create table process does not handle table properties tables which require replication compatiblity.
Such tables require the `lastUpdatedMillis` timestamp to follow lineage lineage of Primary tables. Since primary tables are always created before Replicated table,  `primaryTable.lastUpdatedMillis` >  `replicaTable.lastUpdatedMillis`. 
Table commits on replica containing snapshots from Primary table fails as commit process requires  snapshot.timestamp > table.lastUpdatedMillis.

Fix: Allow table creation process to set the `lastUpdatedMillis` field in table metadata by passing a new field in table property via `properties.last-updates-ms`. This is only application for tables requiring replication (should have property.isReplicatedTable`)


- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
Docker testing:
1. Create Replica table with isReplicatedProperty = true - passed and last-updated-ms (lastUpdatedMillis) is reflected in table metadata
2. Create Primary table with isReplicatedProperty = true - passed and last-updated-ms (lastUpdatedMillis) is reflected in table metadata
3. Create Primary table with isReplicatedProperty = false - passed and last-updated-ms (lastUpdatedMillis) is set to currentTimestamp


CRUD operation in tables succeed

```
scala> spark.sql("insert into db.active_replica6 values('a', 'b')").show()
++
||
++
++


scala> spark.sql("select * from db.active_replica6").show()
+---+----+
| id|name|
+---+----+
|  a|   b|
+---+----+


scala> spark.sql("show tblProperties db.active_replica6").show()
+--------------------+--------------------+
|                 key|               value|
+--------------------+--------------------+
|openhouse.lastMod...|       1755215715485|
| openhouse.tableUUID|2a02f33a-ad9b-467...|
|  openhouse.tableUri|LocalHadoopCluste...|
|openhouse.creatio...|       1755134384295|
|   openhouse.tableId|     active_replica6|
|write.metadata.de...|                true|
|                 key|               value|
|openhouse.tableLo...|/data/openhouse/d...|
|write.metadata.pr...|                  28|
|openhouse.tableCr...|           openhouse|
| openhouse.tableType|       PRIMARY_TABLE|
|            policies|                    |
|openhouse.databaseId|                  db|
|openhouse.isTable...|                true|
| openhouse.clusterId|  LocalHadoopCluster|
|              format|         iceberg/orc|
|openhouse.tableVe...|/data/openhouse/d...|
| current-snapshot-id| 1205631819648875310|
|     last-updated-ms|       1755134384295|
|write.format.default|                 orc|
+--------------------+--------------------+
only showing top 20 rows


scala> spark.sql("show tblProperties db.active_replica6").show(100, false)
+------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------+
|key                                       |value                                                                                                                           |
+------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------+
|openhouse.lastModifiedTime                |1755215715485                                                                                                                   |
|openhouse.tableUUID                       |2a02f33a-ad9b-4677-8c57-8e3b8326567d                                                                                            |
|openhouse.tableUri                        |LocalHadoopCluster.db.active_replica6                                                                                           |
|openhouse.creationTime                    |1755134384295                                                                                                                   |
|openhouse.tableId                         |active_replica6                                                                                                                 |
|write.metadata.delete-after-commit.enabled|true                                                                                                                            |
|key                                       |value                                                                                                                           |
|openhouse.tableLocation                   |/data/openhouse/db/active_replica6-2a02f33a-ad9b-4677-8c57-8e3b8326567d/00001-d282fa1a-684f-4370-aaf1-6fc4c0911a6d.metadata.json|
|write.metadata.previous-versions-max      |28                                                                                                                              |
|openhouse.tableCreator                    |openhouse                                                                                                                       |
|openhouse.tableType                       |PRIMARY_TABLE                                                                                                                   |
|policies                                  |                                                                                                                                |
|openhouse.databaseId                      |db                                                                                                                              |
|openhouse.isTableReplicated               |true                                                                                                                            |
|openhouse.clusterId                       |LocalHadoopCluster                                                                                                              |
|format                                    |iceberg/orc                                                                                                                     |
|openhouse.tableVersion                    |/data/openhouse/db/active_replica6-2a02f33a-ad9b-4677-8c57-8e3b8326567d/00000-bb85c6c7-b879-4d85-9cf1-71cee6e81223.metadata.json|
|current-snapshot-id                       |1205631819648875310                                                                                                             |
|last-updated-ms                           |1755134384295                                                                                                                   |
|write.format.default                      |orc                                                                                                                             |
|write.parquet.compression-codec           |zstd                                                                                                                            |
|openhouse.appended_snapshots              |1205631819648875310                                                                                                             |
+------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------+


scala> spark.sql("drop table db.active_replica6").show()
++
||
++
++


scala> spark.sql("drop table db.active_replica7").show()
++
||
++
++


``` 

<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
