### PR TITLE
Fix bug in otel refactoring - pass otelEmitter to status poll tasks

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
@@ -830,7 +830,11 @@ public class JobsScheduler {
                   if (jobInfo != null) {
                     Optional<OperationTask<?>> optionalOperationTask =
                         tasksBuilder.createStatusOperationTask(
-                            jobType, jobInfo.getMetadata(), jobInfo.getJobId(), OperationMode.POLL);
+                            jobType,
+                            jobInfo.getMetadata(),
+                            jobInfo.getJobId(),
+                            OperationMode.POLL,
+                            otelEmitter);
                     if (optionalOperationTask.isPresent()) {
                       log.info("Submitting status task {}", optionalOperationTask.get());
                       statusTaskList.add(optionalOperationTask.get());

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
@@ -192,9 +192,14 @@ public class OperationTasksBuilder {
   }
 
   public Optional<OperationTask<?>> createStatusOperationTask(
-      JobConf.JobTypeEnum jobType, Metadata metadata, String jobId, OperationMode operationMode) {
+      JobConf.JobTypeEnum jobType,
+      Metadata metadata,
+      String jobId,
+      OperationMode operationMode,
+      OtelEmitter otelEmitter) {
     try {
       OperationTask<?> task = taskFactory.create(metadata);
+      task.setOtelEmitter(otelEmitter);
       if (!task.shouldRun()) {
         log.info("Skipping task {}", task);
         return Optional.empty();

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilderTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilderTest.java
@@ -90,7 +90,8 @@ public class OperationTasksBuilderTest {
             JobConf.JobTypeEnum.SNAPSHOTS_EXPIRATION,
             tableMetadata,
             UUID.randomUUID().toString(),
-            OperationMode.POLL);
+            OperationMode.POLL,
+            otelEmitter);
     Assertions.assertNotNull(optionalOperationTask);
     Assertions.assertTrue(optionalOperationTask.isPresent());
     Assertions.assertTrue(optionalOperationTask.get() instanceof OperationTask);


### PR DESCRIPTION
## Summary
In previous [PR](https://github.com/linkedin/openhouse/pull/360), only the submit task (one type of operation tasks) is passed by with `OtelEmitter`. This causes null pointer exceptions for the status poll tasks. This PR fixes this issue.

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
