### PR TITLE
PR1: Trinoclient in jobs

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TrinoClient.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TrinoClient.java
@@ -1,0 +1,159 @@
+package com.linkedin.openhouse.jobs.client;
+
+import com.linkedin.openhouse.jobs.util.RetryUtil;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.support.RetryTemplate;
+
+/**
+ * A generic client for querying Trino using JDBC. Supports connection management, query execution,
+ * and result processing.
+ */
+@Slf4j
+@AllArgsConstructor
+public class TrinoClient {
+  private static final int DEFAULT_QUERY_TIMEOUT_SECONDS = 300;
+  private static final int DEFAULT_FETCH_SIZE = 1000;
+
+  private final RetryTemplate retryTemplate;
+  private final String jdbcUrl;
+  private final String username;
+  private final String password;
+  private final Properties connectionProperties;
+  private final int queryTimeoutSeconds;
+  private final int fetchSize;
+
+  /** Create a new builder instance. */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Execute a query and return the results as a list of maps. Each map represents a row with column
+   * names as keys.
+   */
+  public List<Map<String, Object>> executeQuery(String sql) throws SQLException {
+    return RetryUtil.executeWithRetry(
+        retryTemplate,
+        (RetryCallback<List<Map<String, Object>>, Exception>)
+            context -> {
+              try (Connection connection = getConnection();
+                  PreparedStatement statement = connection.prepareStatement(sql)) {
+
+                statement.setQueryTimeout(queryTimeoutSeconds);
+                statement.setFetchSize(fetchSize);
+
+                try (ResultSet resultSet = statement.executeQuery()) {
+                  return processResultSet(resultSet);
+                }
+              }
+            },
+        new ArrayList<>());
+  }
+
+  /** Get a database connection. */
+  private Connection getConnection() throws SQLException {
+    if (username != null && password != null) {
+      return DriverManager.getConnection(jdbcUrl, username, password);
+    } else {
+      return DriverManager.getConnection(jdbcUrl, connectionProperties);
+    }
+  }
+
+  /** Process a ResultSet and convert it to a list of maps. */
+  private List<Map<String, Object>> processResultSet(ResultSet resultSet) throws SQLException {
+    List<Map<String, Object>> results = new ArrayList<>();
+    ResultSetMetaData metaData = resultSet.getMetaData();
+    int columnCount = metaData.getColumnCount();
+
+    while (resultSet.next()) {
+      Map<String, Object> row = new HashMap<>();
+      for (int i = 1; i <= columnCount; i++) {
+        String columnName = metaData.getColumnName(i);
+        Object value = resultSet.getObject(i);
+        row.put(columnName, value);
+      }
+      results.add(row);
+    }
+
+    return results;
+  }
+
+  /** Builder class for TrinoClient configuration. */
+  public static class Builder {
+    private String jdbcUrl;
+    private String username;
+    private String password;
+    private Properties connectionProperties;
+    private int queryTimeoutSeconds = DEFAULT_QUERY_TIMEOUT_SECONDS;
+    private int fetchSize = DEFAULT_FETCH_SIZE;
+    private RetryTemplate retryTemplate;
+
+    public Builder jdbcUrl(String jdbcUrl) {
+      this.jdbcUrl = jdbcUrl;
+      return this;
+    }
+
+    public Builder username(String username) {
+      this.username = username;
+      return this;
+    }
+
+    public Builder password(String password) {
+      this.password = password;
+      return this;
+    }
+
+    public Builder connectionProperties(Properties connectionProperties) {
+      this.connectionProperties = connectionProperties;
+      return this;
+    }
+
+    public Builder queryTimeoutSeconds(int queryTimeoutSeconds) {
+      this.queryTimeoutSeconds = queryTimeoutSeconds;
+      return this;
+    }
+
+    public Builder fetchSize(int fetchSize) {
+      this.fetchSize = fetchSize;
+      return this;
+    }
+
+    public Builder retryTemplate(RetryTemplate retryTemplate) {
+      this.retryTemplate = retryTemplate;
+      return this;
+    }
+
+    public TrinoClient build() {
+      if (jdbcUrl == null) {
+        throw new IllegalArgumentException("JDBC URL is required");
+      }
+      if (connectionProperties == null) {
+        connectionProperties = new Properties();
+      }
+      if (retryTemplate == null) {
+        retryTemplate = RetryTemplate.builder().build();
+      }
+      return new TrinoClient(
+          retryTemplate,
+          jdbcUrl,
+          username,
+          password,
+          connectionProperties,
+          queryTimeoutSeconds,
+          fetchSize);
+    }
+  }
+}

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TrinoClientFactory.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/client/TrinoClientFactory.java
@@ -1,0 +1,91 @@
+package com.linkedin.openhouse.jobs.client;
+
+import com.linkedin.openhouse.jobs.util.RetryUtil;
+import java.util.Properties;
+import lombok.AllArgsConstructor;
+import org.springframework.retry.support.RetryTemplate;
+
+/** A factory class for {@link TrinoClient}. */
+@AllArgsConstructor
+public class TrinoClientFactory {
+  private final String jdbcUrl;
+  private final String username;
+  private final String password;
+  private final Properties connectionProperties;
+  private final int queryTimeoutSeconds;
+  private final int fetchSize;
+
+  /** Create a TrinoClient with default retry template. */
+  public TrinoClient create() {
+    return create(RetryUtil.getTrinoClientRetryTemplate());
+  }
+
+  /** Create a TrinoClient with custom retry template. */
+  public TrinoClient create(RetryTemplate retryTemplate) {
+    return TrinoClient.builder()
+        .jdbcUrl(jdbcUrl)
+        .username(username)
+        .password(password)
+        .connectionProperties(connectionProperties)
+        .queryTimeoutSeconds(queryTimeoutSeconds)
+        .fetchSize(fetchSize)
+        .retryTemplate(retryTemplate)
+        .build();
+  }
+
+  /** Builder class for TrinoClientFactory configuration. */
+  public static class Builder {
+    private String jdbcUrl;
+    private String username;
+    private String password;
+    private Properties connectionProperties;
+    private int queryTimeoutSeconds = 300;
+    private int fetchSize = 1000;
+
+    public Builder jdbcUrl(String jdbcUrl) {
+      this.jdbcUrl = jdbcUrl;
+      return this;
+    }
+
+    public Builder username(String username) {
+      this.username = username;
+      return this;
+    }
+
+    public Builder password(String password) {
+      this.password = password;
+      return this;
+    }
+
+    public Builder connectionProperties(Properties connectionProperties) {
+      this.connectionProperties = connectionProperties;
+      return this;
+    }
+
+    public Builder queryTimeoutSeconds(int queryTimeoutSeconds) {
+      this.queryTimeoutSeconds = queryTimeoutSeconds;
+      return this;
+    }
+
+    public Builder fetchSize(int fetchSize) {
+      this.fetchSize = fetchSize;
+      return this;
+    }
+
+    public TrinoClientFactory build() {
+      if (jdbcUrl == null) {
+        throw new IllegalArgumentException("JDBC URL is required");
+      }
+      if (connectionProperties == null) {
+        connectionProperties = new Properties();
+      }
+      return new TrinoClientFactory(
+          jdbcUrl, username, password, connectionProperties, queryTimeoutSeconds, fetchSize);
+    }
+  }
+
+  /** Create a new builder instance. */
+  public static Builder builder() {
+    return new Builder();
+  }
+}

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/RetryUtil.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/RetryUtil.java
@@ -51,6 +51,15 @@ public final class RetryUtil {
         .build();
   }
 
+  public static RetryTemplate getTrinoClientRetryTemplate() {
+    RetryTemplateBuilder builder = new RetryTemplateBuilder();
+    return builder
+        .maxAttempts(5)
+        .customBackoff(DEFAULT_JOBS_BACKOFF_POLICY)
+        .retryOn(WebClientResponseException.InternalServerError.class)
+        .build();
+  }
+
   public static <T, E extends Throwable> T executeWithRetry(
       RetryTemplate retryTemplate, RetryCallback<T, E> callable, T defaultResult) {
     try {

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/client/TrinoClientIntegrationTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/client/TrinoClientIntegrationTest.java
@@ -1,0 +1,226 @@
+package com.linkedin.openhouse.jobs.client;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.retry.policy.NeverRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+
+/**
+ * Integration test for TrinoClient using H2 database directly. This test verifies the actual
+ * functionality of TrinoClient against a real database.
+ */
+public class TrinoClientIntegrationTest {
+
+  public static final String H2_USER = "sa";
+  public static final String H2_PASSWORD = "";
+  private static final String TEST_SCHEMA = "test_db";
+  private static final String TEST_TABLE = "test_table";
+  private static final String H2_URL =
+      "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;CASE_INSENSITIVE_IDENTIFIERS=TRUE";
+  private static TrinoClient trinoClient;
+  private static Connection h2Connection;
+
+  @BeforeAll
+  static void setUp() throws Exception {
+    // Start H2 database
+    startH2Database();
+
+    // Create TrinoClient (using H2 directly for testing)
+    createTrinoClient();
+  }
+
+  @AfterAll
+  static void tearDown() throws Exception {
+    if (h2Connection != null && !h2Connection.isClosed()) {
+      h2Connection.close();
+    }
+  }
+
+  private static void startH2Database() throws SQLException {
+    // Create H2 database connection
+    h2Connection = DriverManager.getConnection(H2_URL, H2_USER, H2_PASSWORD);
+
+    // Create test schema and table
+    try (Statement stmt = h2Connection.createStatement()) {
+      stmt.execute("CREATE SCHEMA IF NOT EXISTS " + TEST_SCHEMA);
+
+      // Create test table in the test schema
+      stmt.execute(
+          "CREATE TABLE IF NOT EXISTS "
+              + TEST_SCHEMA
+              + "."
+              + TEST_TABLE
+              + " ("
+              + "id INT PRIMARY KEY, "
+              + "name VARCHAR(100), "
+              + "age INT, "
+              + "active BOOLEAN, "
+              + "salary DECIMAL(10,2)"
+              + ")");
+
+      // Insert test data
+      stmt.execute(
+          "INSERT INTO "
+              + TEST_SCHEMA
+              + "."
+              + TEST_TABLE
+              + " VALUES "
+              + "(1, 'John Doe', 30, true, 50000.0), "
+              + "(2, 'Jane Smith', 25, false, 45000.0), "
+              + "(3, 'Bob Johnson', 35, true, 60000.0), "
+              + "(4, 'Alice Brown', 28, true, 52000.0), "
+              + "(5, 'Charlie Wilson', 32, false, 48000.0)");
+    }
+  }
+
+  private static void createTrinoClient() {
+    NeverRetryPolicy neverRetryPolicy = new NeverRetryPolicy();
+    RetryTemplate retryTemplate = RetryTemplate.builder().customPolicy(neverRetryPolicy).build();
+    trinoClient =
+        new TrinoClient(retryTemplate, H2_URL, H2_USER, H2_PASSWORD, new Properties(), 30, 1000);
+  }
+
+  @Test
+  void testBasicQueryExecution() throws SQLException {
+    // Execute a simple SELECT query
+    List<Map<String, Object>> results =
+        trinoClient.executeQuery(
+            "SELECT * FROM " + TEST_SCHEMA + "." + TEST_TABLE + " ORDER BY id");
+
+    assertNotNull(results);
+    assertEquals(5, results.size());
+
+    // Verify first row
+    Map<String, Object> firstRow = results.get(0);
+    assertEquals(1, firstRow.get("id".toUpperCase()));
+    assertEquals("John Doe", firstRow.get("name".toUpperCase()));
+    assertEquals(30, firstRow.get("age".toUpperCase()));
+    assertEquals(true, firstRow.get("active".toUpperCase()));
+    assertEquals(new BigDecimal("50000.00"), firstRow.get("salary".toUpperCase()));
+  }
+
+  @Test
+  void testQueryWithWhereClause() throws SQLException {
+    // Execute query with WHERE clause
+    List<Map<String, Object>> results =
+        trinoClient.executeQuery(
+            "SELECT * FROM "
+                + TEST_SCHEMA
+                + "."
+                + TEST_TABLE
+                + " WHERE active = true AND age > 25");
+
+    assertNotNull(results);
+    assertEquals(3, results.size());
+
+    // Verify all results are active and age > 25
+    for (Map<String, Object> row : results) {
+      assertTrue((Boolean) row.get("active".toUpperCase()));
+      assertTrue((Integer) row.get("age".toUpperCase()) > 25);
+    }
+  }
+
+  @Test
+  void testQueryWithAggregation() throws SQLException {
+    // Execute query with aggregation
+    List<Map<String, Object>> results =
+        trinoClient.executeQuery(
+            "SELECT active, COUNT(*) as count, AVG(age) as avg_age, SUM(salary) as total_salary "
+                + "FROM "
+                + TEST_SCHEMA
+                + "."
+                + TEST_TABLE
+                + " GROUP BY active");
+
+    assertNotNull(results);
+    assertEquals(2, results.size());
+
+    // Find active and inactive groups
+    Map<String, Object> activeGroup = null;
+    Map<String, Object> inactiveGroup = null;
+
+    for (Map<String, Object> row : results) {
+      if ((Boolean) row.get("active".toUpperCase())) {
+        activeGroup = row;
+      } else {
+        inactiveGroup = row;
+      }
+    }
+
+    // Verify active group
+    assertNotNull(activeGroup);
+    assertEquals(3L, activeGroup.get("count".toUpperCase()));
+    assertEquals(31.0, (Double) activeGroup.get("avg_age".toUpperCase()), 0.01);
+    assertEquals(new BigDecimal("162000.00"), activeGroup.get("total_salary".toUpperCase()));
+
+    // Verify inactive group
+    assertNotNull(inactiveGroup);
+    assertEquals(2L, inactiveGroup.get("count".toUpperCase()));
+    assertEquals(28.5, (Double) inactiveGroup.get("avg_age".toUpperCase()), 0.01);
+    assertEquals(new BigDecimal("93000.00"), inactiveGroup.get("total_salary".toUpperCase()));
+  }
+
+  @Test
+  void testQueryWithOrderByAndLimit() throws SQLException {
+    // Execute query with ORDER BY and LIMIT
+    List<Map<String, Object>> results =
+        trinoClient.executeQuery(
+            "SELECT name, salary FROM "
+                + TEST_SCHEMA
+                + "."
+                + TEST_TABLE
+                + " ORDER BY salary DESC LIMIT 3");
+
+    assertNotNull(results);
+    assertEquals(3, results.size());
+
+    // Verify results are ordered by salary descending
+    assertEquals("Bob Johnson", results.get(0).get("name".toUpperCase()));
+    assertEquals(new BigDecimal("60000.00"), results.get(0).get("salary".toUpperCase()));
+
+    assertEquals("Alice Brown", results.get(1).get("name".toUpperCase()));
+    assertEquals(new BigDecimal("52000.00"), results.get(1).get("salary".toUpperCase()));
+
+    assertEquals("John Doe", results.get(2).get("name".toUpperCase()));
+    assertEquals(new BigDecimal("50000.00"), results.get(2).get("salary".toUpperCase()));
+  }
+
+  @Test
+  void testQueryWithDifferentDataTypes() throws SQLException {
+    // Test query with different data types
+    List<Map<String, Object>> results =
+        trinoClient.executeQuery(
+            "SELECT "
+                + "CAST(id AS BIGINT) as bigint_id, "
+                + "CAST(name AS VARCHAR) as varchar_name, "
+                + "CAST(age AS INTEGER) as int_age, "
+                + "CAST(active AS BOOLEAN) as bool_active, "
+                + "CAST(salary AS DOUBLE) as double_salary "
+                + "FROM "
+                + TEST_SCHEMA
+                + "."
+                + TEST_TABLE
+                + " WHERE id = 1");
+
+    assertNotNull(results);
+    assertEquals(1, results.size());
+
+    Map<String, Object> row = results.get(0);
+    assertEquals(1L, row.get("bigint_id".toUpperCase()));
+    assertEquals("John Doe", row.get("varchar_name".toUpperCase()));
+    assertEquals(30, row.get("int_age".toUpperCase()));
+    assertEquals(true, row.get("bool_active".toUpperCase()));
+    assertEquals(50000.0, row.get("double_salary".toUpperCase()));
+  }
+}

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/client/TrinoClientTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/client/TrinoClientTest.java
@@ -1,0 +1,179 @@
+package com.linkedin.openhouse.jobs.client;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.retry.RetryPolicy;
+import org.springframework.retry.policy.NeverRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+
+public class TrinoClientTest {
+
+  private static final String TEST_JDBC_URL = "jdbc:trino://test-host:8080";
+  private static final String TEST_USERNAME = "test-user";
+  private static final String TEST_PASSWORD = "test-password";
+  private static final int TEST_QUERY_TIMEOUT = 300;
+  private static final int TEST_FETCH_SIZE = 1000;
+
+  @Mock private Connection mockConnection;
+  @Mock private PreparedStatement mockPreparedStatement;
+  @Mock private ResultSet mockResultSet;
+  @Mock private ResultSetMetaData mockResultSetMetaData;
+
+  private TrinoClient trinoClient;
+  private RetryTemplate retryTemplate;
+
+  @BeforeEach
+  void setup() throws SQLException {
+    // Initialize mocks
+    MockitoAnnotations.openMocks(this);
+
+    // Setup retry template with no retry policy for testing
+    RetryPolicy retryPolicy = new NeverRetryPolicy();
+    retryTemplate = RetryTemplate.builder().customPolicy(retryPolicy).build();
+
+    // Setup mock connection behavior
+    Mockito.when(mockConnection.prepareStatement(Mockito.anyString()))
+        .thenReturn(mockPreparedStatement);
+
+    // Setup mock statement behavior
+    Mockito.when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+
+    // Setup mock result set behavior
+    Mockito.when(mockResultSet.getMetaData()).thenReturn(mockResultSetMetaData);
+    Mockito.when(mockResultSetMetaData.getColumnCount()).thenReturn(2);
+    Mockito.when(mockResultSetMetaData.getColumnName(1)).thenReturn("column1");
+    Mockito.when(mockResultSetMetaData.getColumnName(2)).thenReturn("column2");
+
+    trinoClient =
+        new TrinoClient(
+            retryTemplate,
+            TEST_JDBC_URL,
+            TEST_USERNAME,
+            TEST_PASSWORD,
+            new Properties(),
+            TEST_QUERY_TIMEOUT,
+            TEST_FETCH_SIZE);
+  }
+
+  @Test
+  void testExecuteQuerySuccess() throws SQLException {
+    // Setup mock result set to return one row
+    Mockito.when(mockResultSet.next()).thenReturn(true, false);
+    Mockito.when(mockResultSet.getObject(1)).thenReturn("value1");
+    Mockito.when(mockResultSet.getObject(2)).thenReturn("value2");
+
+    // Mock DriverManager.getConnection to return our mock connection
+    try (MockedStatic<DriverManager> mockedDriverManager =
+        Mockito.mockStatic(DriverManager.class)) {
+      mockedDriverManager
+          .when(() -> DriverManager.getConnection(TEST_JDBC_URL, TEST_USERNAME, TEST_PASSWORD))
+          .thenReturn(mockConnection);
+
+      List<Map<String, Object>> results = trinoClient.executeQuery("SELECT * FROM test_table");
+
+      Assertions.assertNotNull(results);
+      Assertions.assertEquals(1, results.size());
+
+      Map<String, Object> row = results.get(0);
+      Assertions.assertEquals("value1", row.get("column1"));
+      Assertions.assertEquals("value2", row.get("column2"));
+
+      // Verify statement configuration
+      Mockito.verify(mockPreparedStatement).setQueryTimeout(TEST_QUERY_TIMEOUT);
+      Mockito.verify(mockPreparedStatement).setFetchSize(TEST_FETCH_SIZE);
+    }
+  }
+
+  @Test
+  void testExecuteQueryEmptyResult() throws SQLException {
+    // Setup mock result set to return no rows
+    Mockito.when(mockResultSet.next()).thenReturn(false);
+
+    try (MockedStatic<DriverManager> mockedDriverManager =
+        Mockito.mockStatic(DriverManager.class)) {
+      mockedDriverManager
+          .when(() -> DriverManager.getConnection(TEST_JDBC_URL, TEST_USERNAME, TEST_PASSWORD))
+          .thenReturn(mockConnection);
+
+      List<Map<String, Object>> results = trinoClient.executeQuery("SELECT * FROM empty_table");
+
+      Assertions.assertNotNull(results);
+      Assertions.assertEquals(0, results.size());
+    }
+  }
+
+  @Test
+  void testExecuteQueryMultipleRows() throws SQLException {
+    // Setup mock result set to return multiple rows
+    Mockito.when(mockResultSet.next()).thenReturn(true, true, true, false);
+    Mockito.when(mockResultSet.getObject(1)).thenReturn("value1", "value2", "value3");
+    Mockito.when(mockResultSet.getObject(2)).thenReturn("data1", "data2", "data3");
+
+    try (MockedStatic<DriverManager> mockedDriverManager =
+        Mockito.mockStatic(DriverManager.class)) {
+      mockedDriverManager
+          .when(() -> DriverManager.getConnection(TEST_JDBC_URL, TEST_USERNAME, TEST_PASSWORD))
+          .thenReturn(mockConnection);
+
+      List<Map<String, Object>> results = trinoClient.executeQuery("SELECT * FROM test_table");
+
+      Assertions.assertNotNull(results);
+      Assertions.assertEquals(3, results.size());
+
+      // Verify first row
+      Map<String, Object> firstRow = results.get(0);
+      Assertions.assertEquals("value1", firstRow.get("column1"));
+      Assertions.assertEquals("data1", firstRow.get("column2"));
+
+      // Verify second row
+      Map<String, Object> secondRow = results.get(1);
+      Assertions.assertEquals("value2", secondRow.get("column1"));
+      Assertions.assertEquals("data2", secondRow.get("column2"));
+
+      // Verify third row
+      Map<String, Object> thirdRow = results.get(2);
+      Assertions.assertEquals("value3", thirdRow.get("column1"));
+      Assertions.assertEquals("data3", thirdRow.get("column2"));
+    }
+  }
+
+  @Test
+  void testExecuteQueryWithDifferentColumnCounts() throws SQLException {
+    // Test with different column counts
+    Mockito.when(mockResultSetMetaData.getColumnCount()).thenReturn(1);
+    Mockito.when(mockResultSetMetaData.getColumnName(1)).thenReturn("single_column");
+    Mockito.when(mockResultSet.next()).thenReturn(true, false);
+    Mockito.when(mockResultSet.getObject(1)).thenReturn("single_value");
+
+    try (MockedStatic<DriverManager> mockedDriverManager =
+        Mockito.mockStatic(DriverManager.class)) {
+      mockedDriverManager
+          .when(() -> DriverManager.getConnection(TEST_JDBC_URL, TEST_USERNAME, TEST_PASSWORD))
+          .thenReturn(mockConnection);
+
+      List<Map<String, Object>> results =
+          trinoClient.executeQuery("SELECT single_column FROM test_table");
+
+      Assertions.assertNotNull(results);
+      Assertions.assertEquals(1, results.size());
+
+      Map<String, Object> row = results.get(0);
+      Assertions.assertEquals("single_value", row.get("single_column"));
+      Assertions.assertEquals(1, row.size()); // Only one column
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Introducing trino client for jobs to use. This will bring flexibility to query variety of data sources from java code using trino jdbc. Main use-case I am looking at is for DLO statistics and traits, we need to be able to source data from tables.

PR1: Trinoclient module in jobs.
PR2: Refactor the DLO metadata via pluggable modules, TableServiceClient (today), TrinoClient
PR3: Switch the TrinoClient to query from the data source which persists DLO metadata in jobs scheduler.
PR4: Separate out the ranking for partitioned and non-partitioned tables. Former does table-partition ranking, later does table ranking (like today).

## Changes

- [ ] Client-facing API Changes
- [X] Internal API Changes
- [ ] Bug Fixes
- [X] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [X] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [X] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
