### PR TITLE
Handle edge case on creating a renamed replica table

### DIFF
--- a/cluster/storage/src/test/java/com/linkedin/openhouse/cluster/storage/BaseStorageTableLocationIdTest.java
+++ b/cluster/storage/src/test/java/com/linkedin/openhouse/cluster/storage/BaseStorageTableLocationIdTest.java
@@ -1,0 +1,44 @@
+package com.linkedin.openhouse.cluster.storage;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class BaseStorageTableLocationIdTest {
+
+  // Minimal subclass to test protected method
+  static class TestStorage extends BaseStorage {
+    @Override
+    public StorageType.Type getType() {
+      return StorageType.LOCAL;
+    }
+
+    @Override
+    public StorageClient<?> getClient() {
+      return null;
+    }
+  }
+
+  @Test
+  void testDefaultLocationId() {
+    TestStorage storage = new TestStorage();
+    Map<String, String> props = new HashMap<>();
+    String tableId = "tableA";
+    String tableUUID = "uuid123";
+    String result = storage.calculateTableLocationId(tableId, tableUUID, props);
+    assertEquals("tableA-uuid123", result);
+  }
+
+  @Test
+  void testOverrideLocationId() {
+    TestStorage storage = new TestStorage();
+    Map<String, String> props = new HashMap<>();
+    props.put("openhouse.replicaTableLocationId", "tableARenamed-123");
+    String tableId = "tableA";
+    String tableUUID = "uuid123";
+    String result = storage.calculateTableLocationId(tableId, tableUUID, props);
+    assertEquals("tableARenamed-123", result);
+  }
+}


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn) Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

The following issue can occur when creating a replica table on a table that was renamed:
1. Source table is renamed from tableIdA -> tableIdB
2. Source table HDFS location still remains as `.../dbName/tableIdA`
3. Replica table is created for the renamed table under `../dbName/tableIdB`

This causes the replica table to not work as expected as replication jobs expect a 1-1 mapping of folder paths.

Since tableId is no longer immutable, we need to pass in a table location hint when creating replica tables to handle this edge case

## Changes

- [ ] Client-facing API Changes
- [x] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Added unit tests

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
