### PR TITLE
Avoid contention in otel emission

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/AppsOtelEmitter.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/AppsOtelEmitter.java
@@ -22,7 +22,7 @@ public class AppsOtelEmitter extends OpenHouseOtelEmitter {
   }
 
   @Override
-  public <T> T executeWithStats(
+  public synchronized <T> T executeWithStats(
       Callable<T> callable, String scope, String metricPrefix, Attributes attributes)
       throws Exception {
     long startTime = System.currentTimeMillis();

--- a/services/common/src/main/java/com/linkedin/openhouse/common/metrics/OpenHouseOtelEmitter.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/metrics/OpenHouseOtelEmitter.java
@@ -31,7 +31,7 @@ public class OpenHouseOtelEmitter implements OtelEmitter {
   }
 
   @Override
-  public void count(String scope, String metric, long count, Attributes attributes) {
+  public synchronized void count(String scope, String metric, long count, Attributes attributes) {
     for (OpenTelemetry otel : otels) {
       Meter meter = otel.getMeter(scope);
       LongCounter counter = meter.counterBuilder(metric).build();
@@ -44,7 +44,7 @@ public class OpenHouseOtelEmitter implements OtelEmitter {
   }
 
   @Override
-  public void time(String scope, String metric, long amount, Attributes attributes) {
+  public synchronized void time(String scope, String metric, long amount, Attributes attributes) {
     for (OpenTelemetry otel : otels) {
       Meter meter = otel.getMeter(scope);
       LongHistogram histogram =
@@ -58,7 +58,7 @@ public class OpenHouseOtelEmitter implements OtelEmitter {
   }
 
   @Override
-  public void gauge(String scope, String metric, long value, Attributes attributes) {
+  public synchronized void gauge(String scope, String metric, long value, Attributes attributes) {
     for (OpenTelemetry otel : otels) {
       Meter meter = otel.getMeter(scope);
       LongGaugeBuilder gaugeBuilder =


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->
Jobs-scheduler and all operation tasks are holding the same instance of otel emitter, causing contention in the emission and reduction of data points collected. Adding synchronized block to avoid that.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [x] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

No need for tests.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
