### PR TITLE
Remove quantiles for histogram http server request metric as the metric gets malformed at the scrapper end

### DIFF
--- a/services/housetables/src/main/resources/application.properties
+++ b/services/housetables/src/main/resources/application.properties
@@ -19,3 +19,4 @@ management.metrics.distribution.percentiles-histogram.hikaricp.connections.acqui
 management.metrics.distribution.percentiles-histogram.hikaricp.connections.usage=true
 management.metrics.distribution.percentiles-histogram.hikaricp.connections.creation=true
 spring.datasource.hikari.maximum-pool-size=20
+management.metrics.distribution.percentiles.http.server.requests=

--- a/services/jobs/src/main/resources/application.properties
+++ b/services/jobs/src/main/resources/application.properties
@@ -16,3 +16,4 @@ management.endpoint.prometheus.enabled=true
 management.endpoint.beans.enabled=true
 management.metrics.web.server.request.autotime.percentiles=0.5,0.75,0.9,0.95,0.99
 management.metrics.distribution.percentiles-histogram.http.server.requests=true
+management.metrics.distribution.percentiles.http.server.requests=

--- a/services/tables/src/main/resources/application.properties
+++ b/services/tables/src/main/resources/application.properties
@@ -23,3 +23,4 @@ management.metrics.distribution.percentiles-histogram.jvm.gc.pause=true
 management.metrics.distribution.percentiles-histogram.hikaricp.connections.acquire=true
 management.metrics.distribution.percentiles-histogram.hikaricp.connections.usage=true
 management.metrics.distribution.percentiles-histogram.hikaricp.connections.creation=true
+management.metrics.distribution.percentiles.http.server.requests=


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

The springboot version 2.7 emits a malformed `http_server_requests_seconds` histogram metrics that contains both quantiles and buckets. This confuses the scraper and regard it as a summary metric instead (since summary metric has quantiles, histogram metric has buckets). Current linkedin internal metrics store does not support summary, so as a result `http_server_requests_seconds` will get dropped. In the old scrapper it used to work as there was a hack done. But with new fluentbit based scrapper it does not work and similar hack is not done like in the old tool. One way to fix this issue is to upgrade springboot version to higher version lik 3.3 or above (see https://github.com/spring-projects/spring-boot/issues/41880 ) but that come is more changes and effort. Spring removed the malformed histogram in newer version (Refer to https://github.com/micrometer-metrics/micrometer/wiki/1.13-Migration-Guide#histogram-vs-summary ). So the other option is to explicitly setting the config `management.metrics.distribution.percentiles.http.server.requests` to empty for all the spring boot application and this option works.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

**Before the fix:**

```
# TYPE http_server_requests_seconds histogram
http_server_requests_seconds{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",quantile="0.5",} 0.014548992
http_server_requests_seconds{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",quantile="0.75",} 0.016121856
http_server_requests_seconds{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",quantile="0.9",} 0.04390912
http_server_requests_seconds{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",quantile="0.95",} 0.04390912
http_server_requests_seconds{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",quantile="0.99",} 0.04390912
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.001",} 0.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.001048576",} 0.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.001398101",} 0.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.001747626",} 0.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.002097151",} 0.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.002446676",} 0.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.002796201",} 0.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.003145726",} 0.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.003495251",} 0.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.003844776",} 1.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.004194304",} 1.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.005592405",} 1.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.006990506",} 2.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.008388607",} 2.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.009786708",} 2.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.011184809",} 2.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.01258291",} 3.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.013981011",} 3.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.015379112",} 6.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.016777216",} 7.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.022369621",} 8.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.027962026",} 8.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.033554431",} 8.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.039146836",} 8.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.044739241",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.050331646",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.055924051",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.061516456",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.067108864",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.089478485",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.111848106",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.134217727",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.156587348",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.178956969",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.20132659",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.223696211",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.246065832",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.268435456",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.357913941",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.447392426",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.536870911",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.626349396",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.715827881",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.805306366",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.894784851",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.984263336",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="1.073741824",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="1.431655765",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="1.789569706",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="2.147483647",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="2.505397588",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="2.863311529",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="3.22122547",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="3.579139411",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="3.937053352",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="4.294967296",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="5.726623061",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="7.158278826",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="8.589934591",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="10.021590356",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="11.453246121",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="12.884901886",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="14.316557651",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="15.748213416",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="17.179869184",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="22.906492245",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="28.633115306",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="30.0",} 9.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="+Inf",} 9.0
http_server_requests_seconds_count{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",} 9.0
http_server_requests_seconds_sum{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",} 0.144239541
# HELP http_server_requests_seconds_max Duration of HTTP server request handling
# TYPE http_server_requests_seconds_max gauge
http_server_requests_seconds_max{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",} 0.043722792
# HELP executor_pool_max_threads The maximum allowed number of threads in the pool
# TYPE executor_pool_max_threads gauge
```

**After the fix:**
```
# HELP http_server_requests_seconds Duration of HTTP server request handling
# TYPE http_server_requests_seconds histogram
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.001",} 0.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.001048576",} 0.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.001398101",} 0.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.001747626",} 0.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.002097151",} 0.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.002446676",} 1.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.002796201",} 2.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.003145726",} 3.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.003495251",} 4.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.003844776",} 4.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.004194304",} 5.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.005592405",} 17.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.006990506",} 38.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.008388607",} 109.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.009786708",} 191.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.011184809",} 210.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.01258291",} 220.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.013981011",} 223.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.015379112",} 224.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.016777216",} 224.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.022369621",} 229.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.027962026",} 229.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.033554431",} 230.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.039146836",} 230.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.044739241",} 230.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.050331646",} 230.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.055924051",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.061516456",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.067108864",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.089478485",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.111848106",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.134217727",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.156587348",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.178956969",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.20132659",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.223696211",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.246065832",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.268435456",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.357913941",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.447392426",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.536870911",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.626349396",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.715827881",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.805306366",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.894784851",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="0.984263336",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="1.073741824",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="1.431655765",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="1.789569706",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="2.147483647",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="2.505397588",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="2.863311529",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="3.22122547",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="3.579139411",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="3.937053352",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="4.294967296",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="5.726623061",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="7.158278826",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="8.589934591",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="10.021590356",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="11.453246121",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="12.884901886",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="14.316557651",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="15.748213416",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="17.179869184",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="22.906492245",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="28.633115306",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="30.0",} 231.0
http_server_requests_seconds_bucket{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",le="+Inf",} 231.0
http_server_requests_seconds_count{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",} 231.0
http_server_requests_seconds_sum{application="tables",client_name="unspecified",clusterName="LocalHadoopCluster",exception="None",method="GET",outcome="SUCCESS",status="200",uri="/actuator/prometheus",} 2.068104204
```

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
