### PR TITLE
Keep min OFD TTL for replica table as 3 days if provided TTL is less than 3 days

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/OrphanFilesDeletionSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/OrphanFilesDeletionSparkApp.java
@@ -34,7 +34,7 @@ public class OrphanFilesDeletionSparkApp extends BaseTableSparkApp {
   private final boolean streamResults;
   private final int maxOrphanFileSampleSize;
   private static final int DEFAULT_MAX_ORPHAN_FILE_SAMPLE_SIZE = 20000;
-  private static final int DEFAULT_MIN_OFD_TTL_IN_DAYS = 2;
+  private static final int DEFAULT_MIN_OFD_TTL_IN_DAYS = 3;
 
   public OrphanFilesDeletionSparkApp(
       String jobId,

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/OrphanFilesDeletionSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/OrphanFilesDeletionSparkApp.java
@@ -8,6 +8,7 @@ import com.linkedin.openhouse.jobs.util.AppConstants;
 import com.linkedin.openhouse.jobs.util.AppsOtelEmitter;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -27,12 +28,13 @@ import org.apache.iceberg.actions.DeleteOrphanFiles;
  */
 @Slf4j
 public class OrphanFilesDeletionSparkApp extends BaseTableSparkApp {
-  private final long ttlSeconds;
+  private long ttlSeconds;
   private final String backupDir;
   private final int concurrentDeletes;
   private final boolean streamResults;
   private final int maxOrphanFileSampleSize;
   private static final int DEFAULT_MAX_ORPHAN_FILE_SAMPLE_SIZE = 20000;
+  private static final int DEFAULT_MIN_OFD_TTL_IN_DAYS = 2;
 
   public OrphanFilesDeletionSparkApp(
       String jobId,
@@ -54,6 +56,7 @@ public class OrphanFilesDeletionSparkApp extends BaseTableSparkApp {
 
   @Override
   protected void runInner(Operations ops) {
+    updateTtlSeconds(ops);
     long olderThanTimestampMillis =
         System.currentTimeMillis() - TimeUnit.SECONDS.toMillis(ttlSeconds);
     Table table = ops.getTable(fqtn);
@@ -85,6 +88,26 @@ public class OrphanFilesDeletionSparkApp extends BaseTableSparkApp {
         AppConstants.ORPHAN_FILE_COUNT,
         orphanFileLocations.size(),
         Attributes.of(AttributeKey.stringKey(AppConstants.TABLE_NAME), fqtn));
+  }
+
+  /**
+   * Validate and keep min OFD TTL for replica table as 3 days if provided TTL is less than 3 days
+   *
+   * @param ops
+   */
+  private void updateTtlSeconds(Operations ops) {
+    Table table = ops.getTable(fqtn);
+    String tableType =
+        table
+            .properties()
+            .getOrDefault(AppConstants.OPENHOUSE_TABLE_TYPE_KEY, AppConstants.TABLE_TYPE_PRIMARY);
+    if (AppConstants.TABLE_TYPE_REPLICA.equals(tableType)) {
+      long days = Duration.ofSeconds(ttlSeconds).toDays();
+      // Keep the min default OFD TTL for replica tables
+      if (days < DEFAULT_MIN_OFD_TTL_IN_DAYS) {
+        ttlSeconds = TimeUnit.DAYS.toSeconds(DEFAULT_MIN_OFD_TTL_IN_DAYS);
+      }
+    }
   }
 
   public static void main(String[] args) {

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/OrphanFilesDeletionSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/OrphanFilesDeletionSparkApp.java
@@ -101,6 +101,7 @@ public class OrphanFilesDeletionSparkApp extends BaseTableSparkApp {
         table
             .properties()
             .getOrDefault(AppConstants.OPENHOUSE_TABLE_TYPE_KEY, AppConstants.TABLE_TYPE_PRIMARY);
+    // Check if replica table and update TTL
     if (AppConstants.TABLE_TYPE_REPLICA.equals(tableType)) {
       long days = Duration.ofSeconds(ttlSeconds).toDays();
       // Keep the min default OFD TTL for replica tables
@@ -108,6 +109,15 @@ public class OrphanFilesDeletionSparkApp extends BaseTableSparkApp {
         ttlSeconds = TimeUnit.DAYS.toSeconds(DEFAULT_MIN_OFD_TTL_IN_DAYS);
       }
     }
+  }
+
+  /**
+   * Get ttl in seconds
+   *
+   * @return long
+   */
+  protected long getTtlSeconds() {
+    return ttlSeconds;
   }
 
   public static void main(String[] args) {

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/AppConstants.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/AppConstants.java
@@ -56,6 +56,9 @@ public final class AppConstants {
   // Maintenance jobs table properties keys
   public static final String BACKUP_ENABLED_KEY = "retention.backup.enabled";
   public static final String BACKUP_DIR_KEY = "retention.backup.dir";
+  public static final String OPENHOUSE_TABLE_TYPE_KEY = "openhouse.tableType";
+  public static final String TABLE_TYPE_PRIMARY = "PRIMARY_TABLE";
+  public static final String TABLE_TYPE_REPLICA = "REPLICA_TABLE";
 
   private AppConstants() {}
 }

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OrphanFilesDeletionSparkAppTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OrphanFilesDeletionSparkAppTest.java
@@ -1,0 +1,98 @@
+package com.linkedin.openhouse.jobs.spark;
+
+import com.linkedin.openhouse.common.metrics.DefaultOtelConfig;
+import com.linkedin.openhouse.common.metrics.OtelEmitter;
+import com.linkedin.openhouse.jobs.util.AppsOtelEmitter;
+import com.linkedin.openhouse.tablestest.OpenHouseSparkITest;
+import java.util.Arrays;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class OrphanFilesDeletionSparkAppTest extends OpenHouseSparkITest {
+  private final OtelEmitter otelEmitter =
+      new AppsOtelEmitter(Arrays.asList(DefaultOtelConfig.getOpenTelemetry()));
+
+  @Test
+  public void testTtlSecondsPrimaryTableOneDayTtl() throws Exception {
+    final String tableName = "db.test_ofd1";
+
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      // create table
+      prepareTable(ops, tableName);
+      // create and test ofd spark job
+      OrphanFilesDeletionSparkApp app =
+          new OrphanFilesDeletionSparkApp(
+              "test-ofd-job1", null, tableName, 86400, otelEmitter, ".backup");
+      Assertions.assertEquals(86400, app.getTtlSeconds());
+    }
+  }
+
+  @Test
+  public void testTtlSecondsPrimaryTableThreeDayTtl() throws Exception {
+    final String tableName = "db.test_ofd2";
+
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      // create table
+      prepareTable(ops, tableName);
+      // create and test ofd spark job
+      OrphanFilesDeletionSparkApp app =
+          new OrphanFilesDeletionSparkApp(
+              "test-ofd-job2", null, tableName, 259200, otelEmitter, ".backup");
+      Assertions.assertEquals(259200, app.getTtlSeconds());
+    }
+  }
+
+  @Test
+  public void testTtlSecondsReplicaTableOneDayTtl() throws Exception {
+    final String tableName = "db.test_ofd3";
+
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      // create table
+      prepareReplicaTable(ops, tableName);
+      // create and test ofd spark job
+      OrphanFilesDeletionSparkApp app =
+          new OrphanFilesDeletionSparkApp(
+              "test-ofd-job3", null, tableName, 86400, otelEmitter, ".backup");
+      app.runInner(ops);
+      Assertions.assertEquals(259200, app.getTtlSeconds());
+    }
+  }
+
+  @Test
+  public void testTtlSecondsReplicaTableThreeDayTtl() throws Exception {
+    final String tableName = "db.test_ofd4";
+
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      // create table
+      prepareReplicaTable(ops, tableName);
+      // create and test ofd spark job
+      OrphanFilesDeletionSparkApp app =
+          new OrphanFilesDeletionSparkApp(
+              "test-ofd-job4", null, tableName, 259200, otelEmitter, ".backup");
+      app.runInner(ops);
+      Assertions.assertEquals(259200, app.getTtlSeconds());
+    }
+  }
+
+  private static void prepareTable(Operations ops, String tableName) {
+    ops.spark().sql(String.format("DROP TABLE IF EXISTS %s", tableName)).show();
+    ops.spark()
+        .sql(
+            String.format(
+                "CREATE TABLE %s (data string, ts timestamp) partitioned by (days(ts))", tableName))
+        .show();
+    ops.spark().sql(String.format("SHOW TBLPROPERTIES %s", tableName)).show(false);
+  }
+
+  private static void prepareReplicaTable(Operations ops, String tableName) {
+    ops.spark().sql(String.format("DROP TABLE IF EXISTS %s", tableName)).show();
+    ops.spark()
+        .sql(
+            String.format(
+                "CREATE TABLE %s (data string, ts timestamp) partitioned by (days(ts)) "
+                    + "TBLPROPERTIES ('openhouse.tableType' = 'REPLICA_TABLE')",
+                tableName))
+        .show();
+    ops.spark().sql(String.format("SHOW TBLPROPERTIES %s", tableName)).show(false);
+  }
+}

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OrphanFilesDeletionSparkAppTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OrphanFilesDeletionSparkAppTest.java
@@ -22,7 +22,7 @@ public class OrphanFilesDeletionSparkAppTest extends OpenHouseSparkITest {
       // create and test ofd spark job
       OrphanFilesDeletionSparkApp app =
           new OrphanFilesDeletionSparkApp(
-              "test-ofd-job1", null, tableName, 86400, otelEmitter, ".backup");
+              "test-ofd-job1", null, tableName, 86400, otelEmitter, ".backup", 1, false, 100);
       Assertions.assertEquals(86400, app.getTtlSeconds());
     }
   }
@@ -37,7 +37,7 @@ public class OrphanFilesDeletionSparkAppTest extends OpenHouseSparkITest {
       // create and test ofd spark job
       OrphanFilesDeletionSparkApp app =
           new OrphanFilesDeletionSparkApp(
-              "test-ofd-job2", null, tableName, 259200, otelEmitter, ".backup");
+              "test-ofd-job2", null, tableName, 259200, otelEmitter, ".backup", 1, false, 100);
       Assertions.assertEquals(259200, app.getTtlSeconds());
     }
   }
@@ -52,7 +52,7 @@ public class OrphanFilesDeletionSparkAppTest extends OpenHouseSparkITest {
       // create and test ofd spark job
       OrphanFilesDeletionSparkApp app =
           new OrphanFilesDeletionSparkApp(
-              "test-ofd-job3", null, tableName, 86400, otelEmitter, ".backup");
+              "test-ofd-job3", null, tableName, 86400, otelEmitter, ".backup", 1, false, 100);
       app.runInner(ops);
       Assertions.assertEquals(259200, app.getTtlSeconds());
     }
@@ -68,7 +68,7 @@ public class OrphanFilesDeletionSparkAppTest extends OpenHouseSparkITest {
       // create and test ofd spark job
       OrphanFilesDeletionSparkApp app =
           new OrphanFilesDeletionSparkApp(
-              "test-ofd-job4", null, tableName, 259200, otelEmitter, ".backup");
+              "test-ofd-job4", null, tableName, 259200, otelEmitter, ".backup", 1, false, 100);
       app.runInner(ops);
       Assertions.assertEquals(259200, app.getTtlSeconds());
     }


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

We have decided to reduce OFD TTL internally within LI to min value to speed up the clean up of orphan files. However, would like to keep replica table TTL to 3 days so that replication process does not leave the replica table in corrupted state if replication is failing on a table for consecutive days. The 3 days TTL aligns with the current TTL set internally.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done

This would be verified internally.
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
