### PR TITLE
[DataLoader] Add context manager support to OpenHouseDataLoader

### DIFF
--- a/integrations/python/dataloader/CLAUDE.md
+++ b/integrations/python/dataloader/CLAUDE.md
@@ -115,7 +115,7 @@ Build row filters using `col()` with comparison operators (`==`, `!=`, `>`, `>=`
 
 ## Architecture Notes
 
-- **OpenHouseDataLoader** iterates over `DataLoaderSplit` objects (one per Iceberg file scan task). Each split is independently callable and pickle-safe for distributed frameworks.
+- **OpenHouseDataLoader** iterates over `DataLoaderSplit` objects (one per Iceberg file scan task). Each split is independently callable and pickle-safe for distributed frameworks. It supports context manager usage (`with OpenHouseDataLoader(...) as loader:`) to ensure the underlying catalog is closed on exit.
 - **Transforms** are applied per-split at read time: the `TableTransformer` produces SQL in its native dialect, which is transpiled to DataFusion SQL once, then executed against each RecordBatch via a DataFusion `SessionContext`.
 - **Retry logic** in `data_loader.py` retries `OSError` (network/storage I/O) and HTTP 5xx errors with exponential backoff. Non-transient `HTTPError` (4xx) is not retried.
 - **OpenHouseCatalog** is read-only; all write operations raise `NotImplementedError`. It supports context manager usage (`with OpenHouseCatalog(...) as cat:`).

--- a/integrations/python/dataloader/README.md
+++ b/integrations/python/dataloader/README.md
@@ -5,21 +5,21 @@ A Python library for distributed data loading of OpenHouse tables
 ## Quickstart
 
 ```python
-from openhouse.dataloader import OpenHouseDataLoader
+from openhouse.dataloader import OpenHouseCatalog, OpenHouseDataLoader
 
-loader = OpenHouseDataLoader("my_database", "my_table")
+with OpenHouseCatalog("my_catalog", uri="https://...") as catalog:
+    with OpenHouseDataLoader(catalog, "my_database", "my_table") as loader:
+        # Access table metadata
+        loader.table_properties  # table properties as a dict
+        loader.snapshot_id        # snapshot ID of the loaded table
 
-# Access table metadata
-loader.table_properties  # table properties as a dict
-loader.snapshot_id        # snapshot ID of the loaded table
+        for split in loader:
+            # Get table properties (also available per-split)
+            split.table_properties
 
-for split in loader:
-    # Get table properties (also available per-split)
-    split.table_properties
-
-    # Load data
-    for batch in split:
-        process(batch)
+            # Load data
+            for batch in split:
+                process(batch)
 ```
 
 ## Filters

--- a/integrations/python/dataloader/README.md
+++ b/integrations/python/dataloader/README.md
@@ -5,21 +5,20 @@ A Python library for distributed data loading of OpenHouse tables
 ## Quickstart
 
 ```python
-from openhouse.dataloader import OpenHouseCatalog, OpenHouseDataLoader
+from openhouse.dataloader import OpenHouseDataLoader
 
-with OpenHouseCatalog("my_catalog", uri="https://...") as catalog:
-    with OpenHouseDataLoader(catalog, "my_database", "my_table") as loader:
-        # Access table metadata
-        loader.table_properties  # table properties as a dict
-        loader.snapshot_id        # snapshot ID of the loaded table
+with OpenHouseDataLoader("my_database", "my_table") as loader:
+    # Access table metadata
+    loader.table_properties  # table properties as a dict
+    loader.snapshot_id        # snapshot ID of the loaded table
 
-        for split in loader:
-            # Get table properties (also available per-split)
-            split.table_properties
+    for split in loader:
+        # Get table properties (also available per-split)
+        split.table_properties
 
-            # Load data
-            for batch in split:
-                process(batch)
+        # Load data
+        for batch in split:
+            process(batch)
 ```
 
 ## Filters

--- a/integrations/python/dataloader/src/openhouse/dataloader/data_loader.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/data_loader.py
@@ -2,7 +2,8 @@ import logging
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from functools import cached_property
-from types import MappingProxyType
+from types import MappingProxyType, TracebackType
+from typing import Self
 
 from pyiceberg.catalog import Catalog
 from pyiceberg.table import Table
@@ -111,6 +112,17 @@ class OpenHouseDataLoader:
         self._filters = filters if filters is not None else always_true()
         self._context = context or DataLoaderContext()
         self._max_attempts = max_attempts
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        self._catalog.close()
 
     @cached_property
     def _iceberg_table(self) -> Table:

--- a/integrations/python/dataloader/tests/test_data_loader.py
+++ b/integrations/python/dataloader/tests/test_data_loader.py
@@ -115,6 +115,26 @@ def _materialize(loader: OpenHouseDataLoader) -> pa.Table:
     return pa.Table.from_batches(batches) if batches else pa.table({})
 
 
+def test_context_manager_enter_returns_self():
+    catalog = MagicMock()
+    loader = OpenHouseDataLoader(catalog=catalog, database="db", table="tbl")
+    assert loader.__enter__() is loader
+
+
+def test_context_manager_exit_closes_catalog():
+    catalog = MagicMock()
+    loader = OpenHouseDataLoader(catalog=catalog, database="db", table="tbl")
+    loader.__exit__(None, None, None)
+    catalog.close.assert_called_once()
+
+
+def test_context_manager_with_statement():
+    catalog = MagicMock()
+    with OpenHouseDataLoader(catalog=catalog, database="db", table="tbl") as loader:
+        assert isinstance(loader, OpenHouseDataLoader)
+    catalog.close.assert_called_once()
+
+
 def test_table_properties_returns_metadata_properties(tmp_path):
     catalog = _make_real_catalog(tmp_path, properties={"custom.key": "myvalue"})
 


### PR DESCRIPTION
## Summary
Enable `with` statement usage so the underlying catalog is automatically closed on exit, matching the existing pattern in OpenHouseCatalog.

## Changes

- [x] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [x] Documentation
- [x] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
