### PR TITLE
Block users from setting policies table property

### DIFF
--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -177,7 +177,14 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
         TimePartitionSpecBuilder.builderFor(metadata.schema(), metadata.spec()).build());
     createUpdateTableRequestBody.setClustering(
         ClusteringSpecBuilder.builderFor(metadata.schema(), metadata.spec()).build());
-    createUpdateTableRequestBody.setPolicies(buildUpdatedPolicies(metadata));
+    // On table creation (base == null), only set policies if coming from SET POLICY command
+    // (indicated by UPDATED_OPENHOUSE_POLICY_KEY). This prevents users from setting policies
+    // via CREATE TABLE ... TBLPROPERTIES('policies'='...'). Policies should only be managed
+    // through dedicated policy commands (SET POLICY / UNSET POLICY).
+    createUpdateTableRequestBody.setPolicies(
+        base == null && !metadata.properties().containsKey(UPDATED_OPENHOUSE_POLICY_KEY)
+            ? null
+            : buildUpdatedPolicies(metadata));
     createUpdateTableRequestBody.setTableProperties(
         metadata.properties().entrySet().stream()
             .filter(entry -> !UPDATED_OPENHOUSE_POLICY_KEY.equals(entry.getKey()))

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -177,14 +177,7 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
         TimePartitionSpecBuilder.builderFor(metadata.schema(), metadata.spec()).build());
     createUpdateTableRequestBody.setClustering(
         ClusteringSpecBuilder.builderFor(metadata.schema(), metadata.spec()).build());
-    // On table creation (base == null), only set policies if coming from SET POLICY command
-    // (indicated by UPDATED_OPENHOUSE_POLICY_KEY). This prevents users from setting policies
-    // via CREATE TABLE ... TBLPROPERTIES('policies'='...'). Policies should only be managed
-    // through dedicated policy commands (SET POLICY / UNSET POLICY).
-    createUpdateTableRequestBody.setPolicies(
-        base == null && !metadata.properties().containsKey(UPDATED_OPENHOUSE_POLICY_KEY)
-            ? null
-            : buildUpdatedPolicies(metadata));
+    createUpdateTableRequestBody.setPolicies(buildUpdatedPolicies(metadata));
     createUpdateTableRequestBody.setTableProperties(
         metadata.properties().entrySet().stream()
             .filter(entry -> !UPDATED_OPENHOUSE_POLICY_KEY.equals(entry.getKey()))

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/ddl/AlterTableTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/ddl/AlterTableTest.java
@@ -51,6 +51,34 @@ public class AlterTableTest {
   }
 
   @Test
+  public void testSetPoliciesTablePropsBlocked() {
+    GetTableResponseBody existingTable =
+        mockGetTableResponseBody(
+            "dbAlter",
+            "tb2",
+            "c1",
+            "dbAlter.tb2.c1",
+            "UUID",
+            mockTableLocationDefaultSchema(TableIdentifier.of("dbAlter", "tb2")),
+            "v1",
+            baseSchema,
+            null,
+            null);
+    mockTableService.enqueue(mockResponse(200, existingTable)); // doRefresh()
+    mockTableService.enqueue(mockResponse(200, existingTable)); // doRefresh()
+    mockTableService.enqueue(mockResponse(200, existingTable)); // doRefresh()
+
+    // Server rejects the commit because 'policies' is a preserved key
+    mockTableService.enqueue(mockResponse(400, existingTable)); // doCommit()
+
+    Assertions.assertThrows(
+        Exception.class,
+        () ->
+            spark.sql(
+                "ALTER TABLE openhouse.dbAlter.tb2 SET TBLPROPERTIES('policies'='{\"retention\":{\"count\":1,\"granularity\":\"DAY\"}}')"));
+  }
+
+  @Test
   public void testUnsetTableProps() {
     final String key = "key";
     final String value = "value";

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/BasePreservedKeyChecker.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/BasePreservedKeyChecker.java
@@ -19,7 +19,7 @@ public class BasePreservedKeyChecker implements PreservedKeyChecker {
    * in different environment.
    */
   public boolean isKeyPreserved(String key) {
-    return IS_OH_PREFIXED.test(key);
+    return IS_OH_PREFIXED.test(key) || InternalRepositoryUtils.POLICIES_KEY.equals(key);
   }
 
   /**
@@ -47,6 +47,6 @@ public class BasePreservedKeyChecker implements PreservedKeyChecker {
 
   @Override
   public String describePreservedSpace() {
-    return "table properties starting with `openhouse.` cannot be modified";
+    return "table properties starting with `openhouse.` and the `policies` key cannot be modified";
   }
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
@@ -95,6 +95,67 @@ public class RepositoryTest {
   }
 
   @Test
+  void testPoliciesKeyIsPreserved() {
+    // Verify that 'policies' is recognized as a preserved key
+    Assertions.assertTrue(preservedKeyChecker.isKeyPreserved("policies"));
+    Assertions.assertFalse(preservedKeyChecker.isKeyPreserved("userKey"));
+
+    // Verify that extractPreservedProps includes 'policies'
+    Map<String, String> inputMap = new HashMap<>();
+    inputMap.put("openhouse.key1", "value1");
+    inputMap.put("policies", "{\"retention\":{\"count\":3,\"granularity\":\"HOUR\"}}");
+    inputMap.put("userKey", "userValue");
+    TableDto mockTableDto = Mockito.mock(TableDto.class);
+
+    Map<String, String> result =
+        InternalRepositoryUtils.extractPreservedProps(inputMap, mockTableDto, preservedKeyChecker);
+
+    Assertions.assertEquals(2, result.size());
+    Assertions.assertTrue(result.containsKey("openhouse.key1"));
+    Assertions.assertTrue(result.containsKey("policies"));
+    Assertions.assertFalse(result.containsKey("userKey"));
+  }
+
+  @Test
+  public void testUpdateTableWithModifiedPoliciesInTablePropsBlocked() {
+    // Create a table with policies
+    TableDto createDto =
+        TABLE_DTO
+            .toBuilder()
+            .tableId("tblPoliciesPreserved")
+            .tableVersion(INITIAL_TABLE_VERSION)
+            .policies(TABLE_POLICIES)
+            .build();
+    TableDto createdDto = openHouseInternalRepository.save(createDto);
+
+    // Attempt to update the table with modified 'policies' in tableProperties
+    Map<String, String> updatedTableProps = new HashMap<>(createdDto.getTableProperties());
+    updatedTableProps.put("policies", "{}");
+    TableDto updateDto =
+        createdDto
+            .toBuilder()
+            .tableId("tblPoliciesPreserved")
+            .tableVersion(createdDto.getTableLocation())
+            .tableProperties(updatedTableProps)
+            .build();
+
+    UnsupportedClientOperationException e =
+        Assertions.assertThrows(
+            UnsupportedClientOperationException.class,
+            () -> openHouseInternalRepository.save(updateDto));
+    Assertions.assertTrue(e.getMessage().contains("policies"));
+
+    // Cleanup
+    TableDtoPrimaryKey primaryKey =
+        TableDtoPrimaryKey.builder()
+            .tableId("tblPoliciesPreserved")
+            .databaseId(TABLE_DTO.getDatabaseId())
+            .build();
+    openHouseInternalRepository.deleteById(primaryKey);
+    Assertions.assertFalse(openHouseInternalRepository.existsById(primaryKey));
+  }
+
+  @Test
   public void testOpenHouseRepository() {
     TableDto creationDTO = TABLE_DTO.toBuilder().tableVersion(INITIAL_TABLE_VERSION).build();
 
@@ -357,7 +418,7 @@ public class RepositoryTest {
         e.getMessage()
             .startsWith(
                 "Bad tblproperties provided: Can't add, alter or drop table properties due to the restriction: "
-                    + "[table properties starting with `openhouse.` cannot be modified], diff in existing "
+                    + "[table properties starting with `openhouse.` and the `policies` key cannot be modified], diff in existing "
                     + "& provided table properties: {"));
 
     openHouseInternalRepository.deleteById(primaryKey);


### PR DESCRIPTION
Core idea: `policies` is a system-managed key, not a user property — It's the serialized form of multiple policy configs managed by the server. Users shouldn't be directly reading/writing this JSON blob. That's what SET POLICY / UNSET POLICY exists for.

This adds 'policies' to the PreservedKeyChecker so the server rejects any attempt to directly modify the policies key in table properties. The existing checkIfPreservedTblPropsModified mechanism handles all cases:
- SET/UNSET TBLPROPERTIES('policies') is blocked (value mismatch)
- Normal updates pass (policies value unchanged in tableProperties)
- SET POLICY commands pass (uses updated.openhouse.policy, not policies)
- Replication passes (skipEligibilityCheck bypasses preserved check)
- Table creation passes (allowKeyInCreation filters it, dedicated field re-adds)


### Note
`CREATE TABLE ... TBLPROPERTIES('policies'='...')` still sets policies on table creation. Blocking this on CREATE adds client-side complexity due to replication flows (as replication copies properties including policies).

## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [X] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.

```
  Test 1: SET POLICY (RETENTION=21d) — should PASS

  scala> spark.sql("ALTER TABLE openhouse.db_docker_test.pol_v2 SET POLICY (RETENTION=21d)")
  Result: Success. Policies set via dedicated command. ✅

  Test 2: Verify policies set

  scala> spark.sql("SHOW TBLPROPERTIES openhouse.db_docker_test.pol_v2").show(false)
  Result: policies property contains retention config {"retention":{"count":21,"granularity":"DAY"}}. ✅

  Test 3: SET TBLPROPERTIES('policies'='{}') — should FAIL

  scala> spark.sql("ALTER TABLE openhouse.db_docker_test.pol_v2 SET TBLPROPERTIES('policies'='{}')")
  Result: Blocked with error:
  400 , {"status":"BAD_REQUEST","error":"Bad Request","message":"Bad tblproperties provided: Can't add, alter or drop table properties due to the restriction: [table properties starting with
  `openhouse.` and the `policies` key cannot be modified]"}
  ✅

  Test 4: UNSET TBLPROPERTIES('policies') — should FAIL

  scala> spark.sql("ALTER TABLE openhouse.db_docker_test.pol_v2 UNSET TBLPROPERTIES('policies')")
  Result: Blocked with same error:
  400 , {"status":"BAD_REQUEST","error":"Bad Request","message":"Bad tblproperties provided: Can't add, alter or drop table properties due to the restriction: [table properties starting with
  `openhouse.` and the `policies` key cannot be modified]"}
  ✅

  Test 5: Normal SET TBLPROPERTIES — should PASS

  scala> spark.sql("ALTER TABLE openhouse.db_docker_test.pol_v2 SET TBLPROPERTIES('mykey'='myval')")
  Result: Success. Normal table properties unaffected. ✅

  Test 6: SET POLICY (RETENTION=30d) — should PASS

  scala> spark.sql("ALTER TABLE openhouse.db_docker_test.pol_v2 SET POLICY (RETENTION=30d)")
  Result: Success. Policy management via dedicated commands still works after all operations. ✅

```

- [X] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
