### PR TITLE
Fix OpenHouse metadata fallback validation

### DIFF
--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -78,6 +78,11 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
   }
 
   @Override
+  protected boolean isValidIdentifier(TableIdentifier tableIdentifier) {
+    return tableIdentifier != null && tableIdentifier.namespace().levels().length == 1;
+  }
+
+  @Override
   public String name() {
     return getClass().getSimpleName();
   }

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalogTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalogTest.java
@@ -1,0 +1,26 @@
+package com.linkedin.openhouse.internal.catalog;
+
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class OpenHouseInternalCatalogTest {
+
+  @Test
+  void testIsValidIdentifierRequiresDatabaseTableShape() {
+    TestOpenHouseInternalCatalog catalog = new TestOpenHouseInternalCatalog();
+
+    Assertions.assertFalse(catalog.isValidBaseIdentifier(TableIdentifier.of("db")));
+    Assertions.assertTrue(catalog.isValidBaseIdentifier(TableIdentifier.of("db", "table")));
+    Assertions.assertTrue(catalog.isValidBaseIdentifier(TableIdentifier.of("db", "partitions")));
+    Assertions.assertFalse(
+        catalog.isValidBaseIdentifier(TableIdentifier.of("db", "table", "partitions")));
+  }
+
+  private static class TestOpenHouseInternalCatalog extends OpenHouseInternalCatalog {
+
+    boolean isValidBaseIdentifier(TableIdentifier identifier) {
+      return isValidIdentifier(identifier);
+    }
+  }
+}

--- a/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/SmokeTest.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/SmokeTest.java
@@ -12,8 +12,10 @@ import com.linkedin.openhouse.relocated.reactor.core.publisher.Mono;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -153,6 +155,28 @@ public class SmokeTest {
     Assertions.assertThrows(
         NoSuchTableException.class,
         () -> openHouseCatalog.loadTable(TableIdentifier.of("db", "table")));
+  }
+
+  @Test
+  public void testCatalogMissingMetadataTableDoesNotRetryWithCollapsedBaseIdentifier()
+      throws InterruptedException {
+    mockTableService.enqueue(
+        new MockResponse().setResponseCode(404).addHeader("Content-Type", "application/json"));
+    mockTableService.enqueue(
+        new MockResponse().setResponseCode(404).addHeader("Content-Type", "application/json"));
+
+    OpenHouseCatalog openHouseCatalog = new OpenHouseCatalog();
+    openHouseCatalog.initialize("openhouse", ImmutableMap.of(CatalogProperties.URI, url));
+
+    Assertions.assertThrows(
+        NoSuchTableException.class,
+        () -> openHouseCatalog.loadTable(TableIdentifier.of("db", "partitions")));
+
+    Assertions.assertEquals(1, mockTableService.getRequestCount());
+    RecordedRequest request = mockTableService.takeRequest(1, TimeUnit.SECONDS);
+    Assertions.assertNotNull(request);
+    Assertions.assertEquals("/v1/databases/db/tables/partitions", request.getPath());
+    Assertions.assertNull(mockTableService.takeRequest(100, TimeUnit.MILLISECONDS));
   }
 
   @Test

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
@@ -285,6 +285,11 @@ public class OpenHouseCatalog extends BaseMetastoreCatalog
         .build();
   }
 
+  @Override
+  protected boolean isValidIdentifier(TableIdentifier tableIdentifier) {
+    return tableIdentifier != null && tableIdentifier.namespace().levels().length == 1;
+  }
+
   /**
    * it's necessary to return null. This function only gets called from {@link
    * BaseMetastoreCatalog}, just before doCommit(). {@link

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/ddl/CreateTablePartitionedTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/ddl/CreateTablePartitionedTest.java
@@ -18,7 +18,6 @@ public class CreateTablePartitionedTest {
     String tbName = "tbpartitionedclustered";
     mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // doRefresh()
     mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // doRefresh()
-    mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // doRefresh()
 
     Object getTableResponseBody =
         mockGetTableResponseBody(
@@ -50,7 +49,6 @@ public class CreateTablePartitionedTest {
   @Test
   public void testCreateTimePartitionAndTransformClusteredTable() {
     String tbName = "tbpartitionedtransformclustered";
-    mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // doRefresh()
     mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // doRefresh()
     mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // doRefresh()
 
@@ -85,7 +83,6 @@ public class CreateTablePartitionedTest {
   public void testCreateTimePartitionedTableSuccessful() {
     for (String transform : ImmutableList.of("days", "months", "hours", "years")) {
       String tbName = "tbpartitioned" + transform;
-      mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // doRefresh()
       mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // doRefresh()
       mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // doRefresh()
 
@@ -125,7 +122,6 @@ public class CreateTablePartitionedTest {
             "identity(name)", "name", "identity(count)", "count", "truncate(10, timeLong)")) {
       String tbName =
           "tbclustered_" + transform.replace('(', '_').replace(')', '_').replace(", ", "_");
-      mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // doRefresh()
       mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // doRefresh()
       mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // doRefresh()
 

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/ddl/CreateTableTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/ddl/CreateTableTest.java
@@ -20,7 +20,6 @@ public class CreateTableTest {
   public void testCreateTable() {
     mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // doRefresh()
     mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // doRefresh()
-    mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // doRefresh()
 
     Object getTableResponseBody =
         mockGetTableResponseBody(

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/ddl/CreateTableWithPropsTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/ddl/CreateTableWithPropsTest.java
@@ -20,7 +20,6 @@ public class CreateTableWithPropsTest {
   public void testCreateTableWithPropsSuccessful() {
     mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // doRefresh()
     mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // doRefresh()
-    mockTableService.enqueue(mockResponse(404, mockGetAllTableResponseBody())); // doRefresh()
 
     GetTableResponseBody mockResponse =
         mockGetTableResponseBody(

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/dml/CTASTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/dml/CTASTest.java
@@ -40,10 +40,6 @@ public class CTASTest {
             mockGetAllTableResponseBody())); // Verify table to create doesn't exist, in doRefresh()
     mockTableService.enqueue(
         mockResponse(
-            404, mockGetAllTableResponseBody())); // Verify database to create doesn't exist, in
-    // doRefresh()
-    mockTableService.enqueue(
-        mockResponse(
             404,
             mockGetAllTableResponseBody())); // Verify table to create doesn't exist, in doRefresh()
     mockTableService.enqueue(


### PR DESCRIPTION
## Summary

No linked issue.

### Background

Iceberg supports virtual *metadata tables* that expose information about a real base table by appending a suffix to its identifier — e.g. `db.events.partitions`, `db.events.snapshots`, `db.events.files`. They aren't stored separately; they're constructed on the fly by loading the base table (`db.events`) and exposing one of its metadata facets.

`OpenHouseCatalog` (the Java client, used by e.g. a Spark driver) and `OpenHouseInternalCatalog` (running inside the OpenHouse tables service) both *extend* Iceberg's `BaseMetastoreCatalog`. They inherit `loadTable(...)`, including its metadata-table resolution algorithm:

1. Try `identifier` as a base table.
2. If that misses, check whether `identifier` *could* be a metadata identifier — its last component is a known metadata-table name **and** the collapsed base (everything except that last component) is a valid base-table identifier per the catalog.
3. If both, retry the lookup against the collapsed base. If it succeeds, return the corresponding metadata view.

For `OpenHouseCatalog`, each "lookup" in steps 1 and 3 is an HTTP request from the client to the OpenHouse server. (For `OpenHouseInternalCatalog` it's a DB read inside the server.)

The "is this a valid base-table identifier?" check in step 2 is delegated to the subclass via a hook:

```java
protected boolean isValidIdentifier(TableIdentifier tableIdentifier) {
  // by default allow all identifiers
  return true;
}
```

The default is permissive because different subclasses of `BaseMetastoreCatalog` use different identifier shapes. OpenHouse always uses `database.table`, but **it never overrode this hook** — so the inherited metadata fallback treated any collapsed base as potentially valid.

### Problem

Consider `loadTable(TableIdentifier.of("db", "partitions"))` against `OpenHouseCatalog`:

1. Try `db.partitions` as a base table → client sends `GET /v1/databases/db/tables/partitions` → server returns 404.
2. The fallback check: `partitions` is a known metadata-table name, and the collapsed base — an identifier with empty namespace and name `"db"` — passes the permissive default. Fallback proceeds.
3. Try the collapsed base → client sends a second `GET` for an identifier with no database (URL is something like `/v1/databases//tables/db`) → server returns 404.
4. `NoSuchTableException` is thrown — but it references the collapsed base `db`, not the identifier `db.partitions` the caller actually asked about.

This isn't just a wasted extra request. Because the failure surfaces against the collapsed base instead of the real identifier, the same misbehaviour corrupts create/PUT flows too: if a user genuinely wants to create `db.partitions`, the existence check first tries to resolve `db`, fails to find it, and surfaces a misleading "table `db` not found" error instead of cleanly recognising that `db.partitions` doesn't yet exist and proceeding with the create.

### Solutions Considered

#### Option 1 (selected): Override `isValidIdentifier(...)` in OpenHouse catalogs

Override `isValidIdentifier(TableIdentifier)` in both `OpenHouseCatalog` (client) and `OpenHouseInternalCatalog` (server) so OpenHouse only treats identifiers with a single namespace level (`database.table`) as valid base tables.

This is the catalog-specific extension point that `BaseMetastoreCatalog` already exposes for exactly this purpose. It makes OpenHouse's existing implicit `database.table` contract explicit at the validation hook Iceberg already consults. Real metadata-table behavior is preserved (e.g. `db.events.partitions` still resolves correctly because the collapsed base `db.events` is a valid OpenHouse identifier), but invalid collapsed-base retries (e.g. `db.partitions` → `db`) are stopped before they hit the network.

Pros:

- Localized to OpenHouse, no upstream coordination required.
- Uses Iceberg's intended extension point for catalog-specific identifier shape.
- Aligns client and server catalog behavior with one consistent rule.
- Removes an unnecessary request and a misleading error path.

Cons:

- The OpenHouse `database.table` rule is still asserted in multiple OpenHouse code paths (`listTables`, `dropTable`, ACL methods, `OpenHouseTableOperations`, `HouseTablePrimaryKey`, etc.). This change centralizes it for Iceberg fallback purposes but does not yet collapse all those checks into one helper.

#### Option 2 (rejected): Change Iceberg's default validation

Push a stricter default `isValidIdentifier(...)` (or a stricter metadata-fallback contract) into `BaseMetastoreCatalog` upstream so that other catalogs would also avoid the collapsed-base retry.

Pros:

- Would benefit any catalog that has a fixed identifier shape.

Cons:

- Iceberg intentionally supports identifiers with zero, one, or many namespace levels because different catalogs legitimately use different shapes (e.g. nested namespaces, single-level tables). Tightening the default risks regressions in other catalogs that rely on the permissive behavior.
- The catalog-specific rule is OpenHouse's, not Iceberg's. `BaseMetastoreCatalog` already exposes `isValidIdentifier(...)` as the per-catalog extension point for exactly this kind of constraint, so the right fix is to use that hook rather than redefine the default for everyone.
- Requires upstream review and a release cadence we don't control, while the actual bug only manifests against OpenHouse.

For these reasons, Option 1 is the safer and more correct fix and is the one implemented here. The narrow override gives OpenHouse the behavior it wants without changing semantics for any other Iceberg catalog.

### Engine compatibility

Summary of what changes for users of each query engine. None of these are SQL syntax, schema, or query result changes — the user-facing differences are limited to behavior on tables whose names happen to match an Iceberg metadata-table type (`partitions`, `snapshots`, `history`, `files`, `manifests`, `refs`, …).

| Engine path | Change? |
|---|---|
| **Spark `CREATE TABLE openhouse.db.partitions` (or any name matching a metadata-type)** | **Now works.** Previously the existence check during create resolved the collapsed base `db` instead of the requested `db.partitions`, surfacing a misleading "table `db` not found" error and blocking the create. After the fix, the existence check correctly targets `db.partitions` and the create proceeds. |
| Spark `CREATE TABLE` for any other identifier | Same outcome, 1 fewer HTTP request |
| Spark `SELECT` against an existing table named `partitions`/`snapshots`/etc | None — already worked, still works |
| Spark `SELECT` against a missing table named `partitions`/`snapshots`/etc | Cleaner error message (now references `db.partitions` instead of `db`) + 1 fewer HTTP request |
| Spark base table queries (`SELECT * FROM openhouse.db.events`) | None |
| Spark metadata table queries (`SELECT * FROM openhouse.db.events.partitions`) | None |
| Trino `CREATE TABLE` for tables named `partitions`/`snapshots`/etc | Now works (same root cause and fix as Spark) |
| Trino base table and metadata queries | None — Trino's `$partitions` syntax doesn't use Iceberg's metadata fallback at all |
| Trino missing-table errors for `partitions`-named tables | Cleaner error message + 1 fewer HTTP request |
| Flink (mirror of Spark behavior) | Same as Spark |
| Direct Java client with multi-namespace identifiers | Now fails fast at the client instead of failing later at the server |

One thing worth flagging: error message text for `loadTable` failures against tables whose names match a metadata-table type (e.g. `db.partitions`) changes from `"Table does not exist: db"` to `"Table does not exist: db.partitions"`. Anything pattern-matching against the old text would need to update — but `NoSuchTableException` is normally caught by type, and the new message correctly references the identifier the caller actually asked about.

### Deployment coordination

**No coordination required between server and client deploys.** The client (`OpenHouseCatalog`) and server (`OpenHouseInternalCatalog`) overrides are independent: each makes its `isValidIdentifier(...)` decision locally in its own JVM, with no RPC involved. The REST contract is unchanged — the server still receives `(database, table)` as separate URL path components, so there's no new wire format or protocol negotiation.

| Server | Client | Behavior |
|---|---|---|
| Old | Old | Bug present (existing behavior) |
| **New** | Old | Server's internal flows fixed; old clients still trigger the bug locally (no breakage, just unchanged for them) |
| Old | **New** | Client fully fixed; server unchanged — old server doesn't need to know anything new |
| **New** | **New** | Fully fixed everywhere |

Server can deploy first (the typical OpenHouse rollout pattern) without any client impact. Spark/Trino/Flink users pick up the client-side benefit as they bump their `openhouse-java-runtime` dependency on their own schedule.

## Changes

- [ ] Client-facing API Changes
- [x] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.

Internal API Changes:

- Override `isValidIdentifier(...)` in both `OpenHouseCatalog` and `OpenHouseInternalCatalog` so OpenHouse only treats identifiers with a single namespace level as valid base tables for metadata fallback.

Bug Fixes:

- Stop missing metadata-table lookups like `db.partitions` from retrying against an invalid collapsed base identifier.
- Keep valid metadata-table resolution unchanged for real OpenHouse base table identifiers (e.g. `db.events.partitions`).
- Align Spark 3.1 mocked create and CTAS tests with the reduced request sequence after the invalid fallback is removed.

Tests:

- Add a Java client smoke regression that asserts `db.partitions` only triggers the original lookup and returns `NoSuchTableException`.
- Add `OpenHouseInternalCatalogTest` to lock in the internal catalog identifier-validation shape.
- Update the Spark 3.1 create and CTAS mock suites for the new request flow.

## Testing Done

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made for this pull request.

Added new tests for the changes made:

- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew :integrations:java:iceberg-1.2:openhouse-java-itest:test --tests com.linkedin.openhouse.javaclient.SmokeTest`
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew :iceberg:openhouse:internalcatalog:test --tests com.linkedin.openhouse.internal.catalog.OpenHouseInternalCatalogTest`

Updated existing tests to reflect the changes made:

- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew :integrations:spark:spark-3.1:openhouse-spark-itest:catalogTest --tests com.linkedin.openhouse.spark.catalogtest.PartitionTest`
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew :integrations:spark:spark-3.1:openhouse-spark-itest:test --tests com.linkedin.openhouse.spark.e2e.ddl.CreateTableTest --tests com.linkedin.openhouse.spark.e2e.ddl.CreateTablePartitionedTest --tests com.linkedin.openhouse.spark.e2e.ddl.CreateTableWithPropsTest --tests com.linkedin.openhouse.spark.e2e.dml.CTASTest`

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.

Made with [Cursor](https://cursor.com)
