### PR TITLE
[DataLoader] Add performance observability with tags/metrics separation

### DIFF
--- a/integrations/python/dataloader/src/openhouse/dataloader/__init__.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/__init__.py
@@ -1,5 +1,6 @@
 from importlib.metadata import version
 
+from openhouse.dataloader._observability import EnrichingObserver, PerfConfig
 from openhouse.dataloader.catalog import OpenHouseCatalog, OpenHouseCatalogError
 from openhouse.dataloader.data_loader import DataLoaderContext, JvmConfig, OpenHouseDataLoader
 from openhouse.dataloader.filters import always_true, col
@@ -9,6 +10,8 @@ __all__ = [
     "OpenHouseDataLoader",
     "DataLoaderContext",
     "JvmConfig",
+    "PerfConfig",
+    "EnrichingObserver",
     "OpenHouseCatalog",
     "OpenHouseCatalogError",
     "always_true",

--- a/integrations/python/dataloader/src/openhouse/dataloader/_observability.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/_observability.py
@@ -1,0 +1,135 @@
+"""Performance observability for the OpenHouse data loader.
+
+Provides lightweight instrumentation to track time spent in each stage
+and data volumes processed. Events are emitted through a pluggable
+observer pattern with zero overhead when no observer is configured.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+_perf_logger = logging.getLogger("openhouse.dataloader.perf")
+
+
+@dataclass
+class PerfEvent:
+    """A performance measurement event.
+
+    ``tags`` are low-cardinality dimensions for grouping/filtering (e.g. database,
+    table, file_format).  ``metrics`` are measured values (e.g. row_count,
+    batch_count, response_bytes).
+    """
+
+    operation: str
+    duration_ms: float
+    tags: dict[str, str] = field(default_factory=dict)
+    metrics: dict[str, int | float] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"operation": self.operation, "duration_ms": self.duration_ms, **self.tags, **self.metrics}
+
+
+@runtime_checkable
+class PerfObserver(Protocol):
+    """Protocol for receiving performance events."""
+
+    def emit(self, event: PerfEvent) -> None: ...
+
+
+class NullPerfObserver:
+    """Default no-op observer with zero overhead."""
+
+    def emit(self, event: PerfEvent) -> None:
+        pass
+
+
+class LoggingPerfObserver:
+    """Observer that logs events to ``openhouse.dataloader.perf`` at DEBUG level."""
+
+    def emit(self, event: PerfEvent) -> None:
+        _perf_logger.debug("%s", event.to_dict())
+
+
+class CompositeObserver:
+    """Fans out events to multiple observers."""
+
+    def __init__(self, *observers: PerfObserver) -> None:
+        self._observers = observers
+
+    def emit(self, event: PerfEvent) -> None:
+        for observer in self._observers:
+            observer.emit(event)
+
+
+_observer: PerfObserver = NullPerfObserver()
+
+
+def set_observer(obs: PerfObserver) -> None:
+    """Set the performance observer for the data loader.
+
+    Also forwards to ``pyiceberg.observability.set_observer()`` if available,
+    so a single call enables both layers.
+    """
+    global _observer
+    _observer = obs
+
+    try:
+        from pyiceberg.observability import set_observer as pyiceberg_set_observer
+
+        pyiceberg_set_observer(obs)
+    except (ImportError, ModuleNotFoundError):
+        pass
+
+
+def get_observer() -> PerfObserver:
+    """Return the current performance observer."""
+    return _observer
+
+
+class _PerfTimerContext:
+    """Mutable context returned by ``perf_timer``.
+
+    Use ``.tag()`` for dimensions (low-cardinality strings) and
+    ``.metric()`` for measured values (counts, sizes, etc.).
+    """
+
+    def __init__(self) -> None:
+        self.tags: dict[str, str] = {}
+        self.metrics: dict[str, int | float] = {}
+
+    def tag(self, key: str, value: str) -> None:
+        """Set a dimension tag on the performance event."""
+        self.tags[key] = value
+
+    def metric(self, key: str, value: int | float) -> None:
+        """Set a metric value on the performance event."""
+        self.metrics[key] = value
+
+
+@contextmanager
+def perf_timer(operation: str, **tags: str) -> Iterator[_PerfTimerContext]:
+    """Context manager that measures elapsed time and emits a ``PerfEvent``.
+
+    Keyword arguments are recorded as dimension tags.  Use ``ctx.metric()``
+    inside the block for measured values.
+
+    Usage::
+
+        with perf_timer("dataloader.iter") as ctx:
+            ctx.metric("split_count", n)
+            ...
+    """
+    ctx = _PerfTimerContext()
+    ctx.tags.update(tags)
+    start = time.monotonic()
+    try:
+        yield ctx
+    finally:
+        duration_ms = (time.monotonic() - start) * 1000
+        _observer.emit(PerfEvent(operation=operation, duration_ms=duration_ms, tags=ctx.tags, metrics=ctx.metrics))

--- a/integrations/python/dataloader/src/openhouse/dataloader/_observability.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/_observability.py
@@ -7,9 +7,10 @@ observer pattern with zero overhead when no observer is configured.
 
 from __future__ import annotations
 
+import importlib
 import logging
 import time
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any, Protocol, runtime_checkable
@@ -90,6 +91,70 @@ def set_observer(obs: PerfObserver) -> None:
 def get_observer() -> PerfObserver:
     """Return the current performance observer."""
     return _observer
+
+
+@dataclass(frozen=True)
+class PerfConfig:
+    """Serializable perf configuration that travels with splits to workers.
+
+    Attributes:
+        tags: Session-level tags injected into every performance event
+            (e.g. cluster, tenant).  Per-event tags override these.
+        observer_type: Observer to bootstrap on workers.  ``"logging"``
+            (default) creates a :class:`LoggingPerfObserver`, ``"null"``
+            creates a :class:`NullPerfObserver`, and a dotted import path
+            (e.g. ``"mypackage.KafkaObserver"``) dynamically imports and
+            instantiates the class.
+        observer_kwargs: Constructor keyword arguments forwarded to the
+            observer created by *observer_type*.
+    """
+
+    tags: Mapping[str, str] = field(default_factory=dict)
+    observer_type: str = "logging"
+    observer_kwargs: Mapping[str, Any] = field(default_factory=dict)
+
+
+class EnrichingObserver:
+    """Wraps an observer and prepends session-level tags to every event.
+
+    Per-event tags take precedence over session tags.
+    """
+
+    def __init__(self, inner: PerfObserver, session_tags: Mapping[str, str]) -> None:
+        self._inner = inner
+        self._session_tags = session_tags
+
+    def emit(self, event: PerfEvent) -> None:
+        event.tags = {**self._session_tags, **event.tags}
+        self._inner.emit(event)
+
+
+def _create_observer(observer_type: str, observer_kwargs: Mapping[str, Any] | None = None) -> PerfObserver:
+    """Create an observer instance from a type descriptor and kwargs."""
+    kwargs = dict(observer_kwargs) if observer_kwargs else {}
+    if observer_type == "logging":
+        return LoggingPerfObserver(**kwargs)
+    if observer_type == "null":
+        return NullPerfObserver()
+    module_path, class_name = observer_type.rsplit(".", 1)
+    module = importlib.import_module(module_path)
+    cls = getattr(module, class_name)
+    observer: PerfObserver = cls(**kwargs)
+    return observer
+
+
+def bootstrap_observer(config: PerfConfig) -> None:
+    """Idempotent worker-side observer setup from serialized config.
+
+    If an observer other than :class:`NullPerfObserver` is already set
+    (e.g. the planner process already configured one), this is a no-op.
+    """
+    if not isinstance(get_observer(), NullPerfObserver):
+        return
+    observer = _create_observer(config.observer_type, config.observer_kwargs)
+    if config.tags:
+        observer = EnrichingObserver(observer, config.tags)
+    set_observer(observer)
 
 
 class _PerfTimerContext:

--- a/integrations/python/dataloader/src/openhouse/dataloader/_table_scan_context.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/_table_scan_context.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from pyiceberg.expressions import AlwaysTrue, BooleanExpression
 from pyiceberg.io import FileIO, load_file_io
 from pyiceberg.schema import Schema
 from pyiceberg.table.metadata import TableMetadata
 
+from openhouse.dataloader._observability import PerfConfig
 from openhouse.dataloader.table_identifier import TableIdentifier
+
+_DEFAULT_PERF_CONFIG = PerfConfig()
 
 
 def _unpickle_scan_context(
@@ -17,6 +20,7 @@ def _unpickle_scan_context(
     row_filter: BooleanExpression,
     table_id: TableIdentifier,
     worker_jvm_args: str | None = None,
+    perf_config: PerfConfig = _DEFAULT_PERF_CONFIG,
 ) -> TableScanContext:
     return TableScanContext(
         table_metadata=table_metadata,
@@ -25,6 +29,7 @@ def _unpickle_scan_context(
         row_filter=row_filter,
         table_id=table_id,
         worker_jvm_args=worker_jvm_args,
+        perf_config=perf_config,
     )
 
 
@@ -42,6 +47,7 @@ class TableScanContext:
         table_id: Identifier for the table being scanned
         row_filter: Row-level filter expression pushed down to the scan
         worker_jvm_args: JVM arguments applied when the JNI JVM is created in worker processes
+        perf_config: Serializable performance configuration that travels with splits
     """
 
     table_metadata: TableMetadata
@@ -50,6 +56,7 @@ class TableScanContext:
     table_id: TableIdentifier
     row_filter: BooleanExpression = AlwaysTrue()
     worker_jvm_args: str | None = None
+    perf_config: PerfConfig = field(default_factory=PerfConfig)
 
     def __reduce__(self) -> tuple:
         return (
@@ -61,5 +68,6 @@ class TableScanContext:
                 self.row_filter,
                 self.table_id,
                 self.worker_jvm_args,
+                self.perf_config,
             ),
         )

--- a/integrations/python/dataloader/src/openhouse/dataloader/catalog.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/catalog.py
@@ -9,6 +9,8 @@ from pyiceberg.serializers import FromInputFile
 from pyiceberg.table import Table
 from pyiceberg.typedef import Identifier
 
+from openhouse.dataloader._observability import perf_timer
+
 logger = logging.getLogger(__name__)
 
 _TABLE_LOCATION = "tableLocation"
@@ -68,32 +70,35 @@ class OpenHouseCatalog(Catalog):
         database, table = self.identifier_to_database_and_table(identifier)
         url = f"{self._uri}/v1/databases/{database}/tables/{table}"
 
-        response = self._session.get(url, timeout=self._timeout)
-        if not response.ok:
-            if response.status_code == 404:
-                raise NoSuchTableError(f"Table {database}.{table} does not exist")
-            raise OSError(
-                f"Failed to load table {database}.{table}: HTTP {response.status_code}. Response: {response.text}"
+        with perf_timer("catalog.load_table", database=database, table=table) as t:
+            response = self._session.get(url, timeout=self._timeout)
+            t.metric("status_code", response.status_code)
+            t.metric("response_bytes", len(response.content))
+            if not response.ok:
+                if response.status_code == 404:
+                    raise NoSuchTableError(f"Table {database}.{table} does not exist")
+                raise OSError(
+                    f"Failed to load table {database}.{table}: HTTP {response.status_code}. Response: {response.text}"
+                )
+
+            table_response = response.json()
+            metadata_location = table_response.get(_TABLE_LOCATION)
+            if not metadata_location:
+                raise OpenHouseCatalogError(
+                    f"Response for table {database}.{table} is missing '{_TABLE_LOCATION}'. Response: {table_response}"
+                )
+
+            file_io = load_file_io(properties=self.properties, location=metadata_location)
+            metadata_file = file_io.new_input(metadata_location)
+            metadata = FromInputFile.table_metadata(metadata_file)
+
+            return Table(
+                identifier=(database, table),
+                metadata=metadata,
+                metadata_location=metadata_location,
+                io=file_io,
+                catalog=self,
             )
-
-        table_response = response.json()
-        metadata_location = table_response.get(_TABLE_LOCATION)
-        if not metadata_location:
-            raise OpenHouseCatalogError(
-                f"Response for table {database}.{table} is missing '{_TABLE_LOCATION}'. Response: {table_response}"
-            )
-
-        file_io = load_file_io(properties=self.properties, location=metadata_location)
-        metadata_file = file_io.new_input(metadata_location)
-        metadata = FromInputFile.table_metadata(metadata_file)
-
-        return Table(
-            identifier=(database, table),
-            metadata=metadata,
-            metadata_location=metadata_location,
-            io=file_io,
-            catalog=self,
-        )
 
     # -- Unsupported operations --
     # Required by the Catalog ABC but not needed for read-only table loading.

--- a/integrations/python/dataloader/src/openhouse/dataloader/data_loader.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/data_loader.py
@@ -12,11 +12,9 @@ from tenacity import Retrying, retry_if_exception, stop_after_attempt, wait_expo
 
 from openhouse.dataloader._jvm import apply_libhdfs_opts
 from openhouse.dataloader._observability import (
-    LoggingPerfObserver,
-    NullPerfObserver,
-    get_observer,
+    PerfConfig,
+    bootstrap_observer,
     perf_timer,
-    set_observer,
 )
 from openhouse.dataloader._table_scan_context import TableScanContext
 from openhouse.dataloader._timer import log_duration
@@ -122,6 +120,7 @@ class OpenHouseDataLoader:
         context: DataLoaderContext | None = None,
         max_attempts: int = 3,
         batch_size: int | None = None,
+        perf_config: PerfConfig | None = None,
     ):
         """
         Args:
@@ -138,6 +137,9 @@ class OpenHouseDataLoader:
                 Passed to PyArrow's Scanner which produces batches of at most this many
                 rows. Smaller values reduce peak memory but increase per-batch overhead.
                 None uses the PyArrow default (~131K rows).
+            perf_config: Serializable performance configuration.  Controls which
+                observer is bootstrapped on planner and worker processes and which
+                session-level tags are injected into every performance event.
         """
         if branch is not None and branch.strip() == "":
             raise ValueError("branch must not be empty or whitespace")
@@ -151,8 +153,8 @@ class OpenHouseDataLoader:
         self._context = context or DataLoaderContext()
         self._max_attempts = max_attempts
         self._batch_size = batch_size
-        if isinstance(get_observer(), NullPerfObserver):
-            set_observer(LoggingPerfObserver())
+        self._perf_config = perf_config or PerfConfig()
+        bootstrap_observer(self._perf_config)
 
         if self._context.jvm_config is not None and self._context.jvm_config.planner_args is not None:
             apply_libhdfs_opts(self._context.jvm_config.planner_args)
@@ -264,6 +266,7 @@ class OpenHouseDataLoader:
                 row_filter=row_filter,
                 table_id=self._table_id,
                 worker_jvm_args=self._context.jvm_config.worker_args if self._context.jvm_config else None,
+                perf_config=self._perf_config,
             )
 
             # plan_files() materializes all tasks at once (PyIceberg doesn't support streaming)

--- a/integrations/python/dataloader/src/openhouse/dataloader/data_loader.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/data_loader.py
@@ -11,6 +11,13 @@ from requests import HTTPError
 from tenacity import Retrying, retry_if_exception, stop_after_attempt, wait_exponential
 
 from openhouse.dataloader._jvm import apply_libhdfs_opts
+from openhouse.dataloader._observability import (
+    LoggingPerfObserver,
+    NullPerfObserver,
+    get_observer,
+    perf_timer,
+    set_observer,
+)
 from openhouse.dataloader._table_scan_context import TableScanContext
 from openhouse.dataloader._timer import log_duration
 from openhouse.dataloader.data_loader_split import DataLoaderSplit
@@ -144,6 +151,8 @@ class OpenHouseDataLoader:
         self._context = context or DataLoaderContext()
         self._max_attempts = max_attempts
         self._batch_size = batch_size
+        if isinstance(get_observer(), NullPerfObserver):
+            set_observer(LoggingPerfObserver())
 
         if self._context.jvm_config is not None and self._context.jvm_config.planner_args is not None:
             apply_libhdfs_opts(self._context.jvm_config.planner_args)
@@ -164,17 +173,18 @@ class OpenHouseDataLoader:
     @cached_property
     def snapshot_id(self) -> int | None:
         """Snapshot ID of the loaded table, or None if the table has no snapshots"""
-        if self._snapshot_id is not None:
-            return self._snapshot_id
-        if self._table_id.branch:
-            snapshot = self._iceberg_table.snapshot_by_name(self._table_id.branch)
-            if snapshot is None:
-                raise ValueError(
-                    f"Branch '{self._table_id.branch}' not found for table "
-                    f"{self._table_id.database}.{self._table_id.table}"
-                )
-            return snapshot.snapshot_id
-        return self._iceberg_table.metadata.current_snapshot_id
+        with perf_timer("dataloader.resolve_snapshot"):
+            if self._snapshot_id is not None:
+                return self._snapshot_id
+            if self._table_id.branch:
+                snapshot = self._iceberg_table.snapshot_by_name(self._table_id.branch)
+                if snapshot is None:
+                    raise ValueError(
+                        f"Branch '{self._table_id.branch}' not found for table "
+                        f"{self._table_id.database}.{self._table_id.table}"
+                    )
+                return snapshot.snapshot_id
+            return self._iceberg_table.metadata.current_snapshot_id
 
     def _verify_snapshot(self, snapshot: Snapshot | None) -> None:
         """Log the resolved snapshot or raise if a user-provided snapshot_id was not found."""
@@ -193,19 +203,20 @@ class OpenHouseDataLoader:
         and filter predicates. Returns ``None`` if there is no transformer or the
         transformer returns ``None``.
         """
-        transformer = self._context.table_transformer
-        if transformer is None:
-            return None
-        execution_context = self._context.execution_context or {}
-        sql = transformer.transform(self._table_id, execution_context)
-        if sql is None:
-            return None
-        sql = to_datafusion_sql(sql, transformer.dialect, table=self._table_id)
-        outer_cols = ", ".join(_quote_identifier(c) for c in self._columns) if self._columns else "*"
-        combined = f"SELECT {outer_cols} FROM ({sql}) AS _t"
-        if self._filters and not isinstance(self._filters, AlwaysTrue):
-            combined += f" WHERE {_to_datafusion_sql(self._filters)}"
-        return combined
+        with perf_timer("dataloader.build_query"):
+            transformer = self._context.table_transformer
+            if transformer is None:
+                return None
+            execution_context = self._context.execution_context or {}
+            sql = transformer.transform(self._table_id, execution_context)
+            if sql is None:
+                return None
+            sql = to_datafusion_sql(sql, transformer.dialect, table=self._table_id)
+            outer_cols = ", ".join(_quote_identifier(c) for c in self._columns) if self._columns else "*"
+            combined = f"SELECT {outer_cols} FROM ({sql}) AS _t"
+            if self._filters and not isinstance(self._filters, AlwaysTrue):
+                combined += f" WHERE {_to_datafusion_sql(self._filters)}"
+            return combined
 
     def __iter__(self) -> Iterator[DataLoaderSplit]:
         """Iterate over data splits for distributed data loading of the table.
@@ -213,58 +224,62 @@ class OpenHouseDataLoader:
         Yields:
             DataLoaderSplit for each file scan task in the table
         """
-        table = self._iceberg_table
+        with perf_timer("dataloader.iter") as ctx:
+            table = self._iceberg_table
 
-        scan_kwargs: dict = {}
-        if self.snapshot_id is not None:
-            scan_kwargs["snapshot_id"] = self.snapshot_id
+            scan_kwargs: dict = {}
+            if self.snapshot_id is not None:
+                scan_kwargs["snapshot_id"] = self.snapshot_id
 
-        query = self._build_query()
-        if query is not None:
-            plan = optimize_scan(query, dialect=DataFusion.DIALECT)
-            optimized_sql = plan.sql
-            row_filter = _to_pyiceberg(plan.row_filter)
-            if plan.source_columns is not None:
-                scan_kwargs["selected_fields"] = tuple(plan.source_columns)
-            logger.info(
-                "Split SQL optimized from '%s' to '%s' with pushdown predicates %s and projections %s",
-                query,
-                optimized_sql,
-                row_filter,
-                plan.source_columns,
+            query = self._build_query()
+            if query is not None:
+                plan = optimize_scan(query, dialect=DataFusion.DIALECT)
+                optimized_sql = plan.sql
+                row_filter = _to_pyiceberg(plan.row_filter)
+                if plan.source_columns is not None:
+                    scan_kwargs["selected_fields"] = tuple(plan.source_columns)
+                logger.info(
+                    "Split SQL optimized from '%s' to '%s' with pushdown predicates %s and projections %s",
+                    query,
+                    optimized_sql,
+                    row_filter,
+                    plan.source_columns,
+                )
+            else:
+                optimized_sql = None
+                row_filter = _to_pyiceberg(self._filters)
+                if self._columns:
+                    scan_kwargs["selected_fields"] = tuple(self._columns)
+
+            scan_kwargs["row_filter"] = row_filter
+
+            scan = table.scan(**scan_kwargs)
+
+            self._verify_snapshot(scan.snapshot())
+
+            scan_context = TableScanContext(
+                table_metadata=table.metadata,
+                io=table.io,
+                projected_schema=scan.projection(),
+                row_filter=row_filter,
+                table_id=self._table_id,
+                worker_jvm_args=self._context.jvm_config.worker_args if self._context.jvm_config else None,
             )
-        else:
-            optimized_sql = None
-            row_filter = _to_pyiceberg(self._filters)
-            if self._columns:
-                scan_kwargs["selected_fields"] = tuple(self._columns)
 
-        scan_kwargs["row_filter"] = row_filter
-
-        scan = table.scan(**scan_kwargs)
-
-        self._verify_snapshot(scan.snapshot())
-
-        scan_context = TableScanContext(
-            table_metadata=table.metadata,
-            io=table.io,
-            projected_schema=scan.projection(),
-            row_filter=row_filter,
-            table_id=self._table_id,
-            worker_jvm_args=self._context.jvm_config.worker_args if self._context.jvm_config else None,
-        )
-
-        # plan_files() materializes all tasks at once (PyIceberg doesn't support streaming)
-        # Manifests are read in parallel with one thread per manifest
-        scan_tasks = _retry(
-            lambda: scan.plan_files(), label=f"plan_files {self._table_id}", max_attempts=self._max_attempts
-        )
-
-        for scan_task in scan_tasks:
-            yield DataLoaderSplit(
-                file_scan_task=scan_task,
-                scan_context=scan_context,
-                transform_sql=optimized_sql,
-                udf_registry=self._context.udf_registry,
-                batch_size=self._batch_size,
+            # plan_files() materializes all tasks at once (PyIceberg doesn't support streaming)
+            # Manifests are read in parallel with one thread per manifest
+            scan_tasks = _retry(
+                lambda: scan.plan_files(), label=f"plan_files {self._table_id}", max_attempts=self._max_attempts
             )
+
+            split_count = 0
+            for scan_task in scan_tasks:
+                split_count += 1
+                yield DataLoaderSplit(
+                    file_scan_task=scan_task,
+                    scan_context=scan_context,
+                    transform_sql=optimized_sql,
+                    udf_registry=self._context.udf_registry,
+                    batch_size=self._batch_size,
+                )
+            ctx.metric("split_count", split_count)

--- a/integrations/python/dataloader/src/openhouse/dataloader/data_loader_split.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/data_loader_split.py
@@ -10,6 +10,7 @@ from pyiceberg.io.pyarrow import ArrowScan
 from pyiceberg.table import ArrivalOrder, FileScanTask
 
 from openhouse.dataloader._jvm import apply_libhdfs_opts
+from openhouse.dataloader._observability import perf_timer
 from openhouse.dataloader._table_scan_context import TableScanContext
 from openhouse.dataloader.filters import _quote_identifier
 from openhouse.dataloader.table_identifier import TableIdentifier
@@ -30,11 +31,12 @@ def _create_transform_session(
     Returns a ready-to-query SessionContext where UDFs are registered and the
     target schema exists.
     """
-    session = SessionContext()
-    udf_registry.register_udfs(session)
+    with perf_timer("dataloader.create_transform_session"):
+        session = SessionContext()
+        udf_registry.register_udfs(session)
 
-    session.sql(f"CREATE SCHEMA IF NOT EXISTS {_quote_identifier(table_id.database)}").collect()
-    return session
+        session.sql(f"CREATE SCHEMA IF NOT EXISTS {_quote_identifier(table_id.database)}").collect()
+        return session
 
 
 def _bind_batch_table(session: SessionContext, table_id: TableIdentifier, batch: RecordBatch) -> None:
@@ -81,38 +83,56 @@ class DataLoaderSplit:
         delete files, and partition spec lookups. The number of batches loaded
         into memory at once is bounded to prevent using too much memory at once.
         """
-        ctx = self._scan_context
-        if ctx.worker_jvm_args is not None:
-            apply_libhdfs_opts(ctx.worker_jvm_args)
-        arrow_scan = ArrowScan(
-            table_metadata=ctx.table_metadata,
-            io=ctx.io,
-            projected_schema=ctx.projected_schema,
-            row_filter=ctx.row_filter,
-        )
+        with perf_timer("dataloader.split_iter") as timer_ctx:
+            ctx = self._scan_context
+            if ctx.worker_jvm_args is not None:
+                apply_libhdfs_opts(ctx.worker_jvm_args)
+            arrow_scan = ArrowScan(
+                table_metadata=ctx.table_metadata,
+                io=ctx.io,
+                projected_schema=ctx.projected_schema,
+                row_filter=ctx.row_filter,
+            )
 
-        batches = arrow_scan.to_record_batches(
-            [self._file_scan_task],
-            order=ArrivalOrder(concurrent_streams=1, batch_size=self._batch_size),
-        )
+            batches = arrow_scan.to_record_batches(
+                [self._file_scan_task],
+                order=ArrivalOrder(concurrent_streams=1, batch_size=self._batch_size),
+            )
 
-        if self._transform_sql is None:
-            yield from batches
-        else:
-            # Materialize the first batch before creating the transform session
-            # so that the HDFS JVM starts (and picks up worker_jvm_args) before
-            # any UDF registration code can trigger JNI.
-            batch_iter = iter(batches)
-            first = next(batch_iter, None)
-            if first is None:
-                return
-            session = _create_transform_session(self._scan_context.table_id, self._udf_registry)
-            yield from self._apply_transform(session, first)
-            for batch in batch_iter:
-                yield from self._apply_transform(session, batch)
+            batch_count = 0
+            row_count = 0
+            if self._transform_sql is None:
+                for batch in batches:
+                    batch_count += 1
+                    row_count += batch.num_rows
+                    yield batch
+            else:
+                # Materialize the first batch before creating the transform session
+                # so that the HDFS JVM starts (and picks up worker_jvm_args) before
+                # any UDF registration code can trigger JNI.
+                batch_iter = iter(batches)
+                first = next(batch_iter, None)
+                if first is not None:
+                    session = _create_transform_session(self._scan_context.table_id, self._udf_registry)
+                    for transformed in self._apply_transform(session, first):
+                        batch_count += 1
+                        row_count += transformed.num_rows
+                        yield transformed
+                    for batch in batch_iter:
+                        for transformed in self._apply_transform(session, batch):
+                            batch_count += 1
+                            row_count += transformed.num_rows
+                            yield transformed
+            timer_ctx.metric("batch_count", batch_count)
+            timer_ctx.metric("row_count", row_count)
 
     def _apply_transform(self, session: SessionContext, batch: RecordBatch) -> Iterator[RecordBatch]:
         """Execute the transform SQL against a single RecordBatch."""
-        _bind_batch_table(session, self._scan_context.table_id, batch)
-        df = session.sql(self._transform_sql)  # type: ignore[arg-type]  # caller guarantees not None
-        yield from df.collect()
+        with perf_timer("dataloader.apply_transform") as ctx:
+            ctx.metric("input_rows", batch.num_rows)
+            _bind_batch_table(session, self._scan_context.table_id, batch)
+            df = session.sql(self._transform_sql)  # type: ignore[arg-type]  # caller guarantees not None
+            result = df.collect()
+            output_rows = sum(rb.num_rows for rb in result)
+            ctx.metric("output_rows", output_rows)
+            yield from result

--- a/integrations/python/dataloader/src/openhouse/dataloader/data_loader_split.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/data_loader_split.py
@@ -10,7 +10,7 @@ from pyiceberg.io.pyarrow import ArrowScan
 from pyiceberg.table import ArrivalOrder, FileScanTask
 
 from openhouse.dataloader._jvm import apply_libhdfs_opts
-from openhouse.dataloader._observability import perf_timer
+from openhouse.dataloader._observability import bootstrap_observer, perf_timer
 from openhouse.dataloader._table_scan_context import TableScanContext
 from openhouse.dataloader.filters import _quote_identifier
 from openhouse.dataloader.table_identifier import TableIdentifier
@@ -25,13 +25,14 @@ def to_sql_identifier(table_id: TableIdentifier) -> str:
 def _create_transform_session(
     table_id: TableIdentifier,
     udf_registry: UDFRegistry,
+    **tags: str,
 ) -> SessionContext:
     """Create a DataFusion SessionContext for running split-level transforms.
 
     Returns a ready-to-query SessionContext where UDFs are registered and the
     target schema exists.
     """
-    with perf_timer("dataloader.create_transform_session"):
+    with perf_timer("dataloader.create_transform_session", **tags):
         session = SessionContext()
         udf_registry.register_udfs(session)
 
@@ -83,7 +84,8 @@ class DataLoaderSplit:
         delete files, and partition spec lookups. The number of batches loaded
         into memory at once is bounded to prevent using too much memory at once.
         """
-        with perf_timer("dataloader.split_iter") as timer_ctx:
+        bootstrap_observer(self._scan_context.perf_config)
+        with perf_timer("dataloader.split_iter", **self._scan_context.perf_config.tags) as timer_ctx:
             ctx = self._scan_context
             if ctx.worker_jvm_args is not None:
                 apply_libhdfs_opts(ctx.worker_jvm_args)
@@ -113,7 +115,9 @@ class DataLoaderSplit:
                 batch_iter = iter(batches)
                 first = next(batch_iter, None)
                 if first is not None:
-                    session = _create_transform_session(self._scan_context.table_id, self._udf_registry)
+                    session = _create_transform_session(
+                        self._scan_context.table_id, self._udf_registry, **self._scan_context.perf_config.tags
+                    )
                     for transformed in self._apply_transform(session, first):
                         batch_count += 1
                         row_count += transformed.num_rows
@@ -128,7 +132,7 @@ class DataLoaderSplit:
 
     def _apply_transform(self, session: SessionContext, batch: RecordBatch) -> Iterator[RecordBatch]:
         """Execute the transform SQL against a single RecordBatch."""
-        with perf_timer("dataloader.apply_transform") as ctx:
+        with perf_timer("dataloader.apply_transform", **self._scan_context.perf_config.tags) as ctx:
             ctx.metric("input_rows", batch.num_rows)
             _bind_batch_table(session, self._scan_context.table_id, batch)
             df = session.sql(self._transform_sql)  # type: ignore[arg-type]  # caller guarantees not None

--- a/integrations/python/dataloader/tests/test_observability.py
+++ b/integrations/python/dataloader/tests/test_observability.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import pickle
 from unittest.mock import MagicMock
 
 import pyarrow as pa
@@ -19,10 +20,13 @@ from pyiceberg.types import LongType, NestedField, StringType
 
 from openhouse.dataloader._observability import (
     CompositeObserver,
+    EnrichingObserver,
     LoggingPerfObserver,
     NullPerfObserver,
+    PerfConfig,
     PerfEvent,
     PerfObserver,
+    bootstrap_observer,
     get_observer,
     perf_timer,
     set_observer,
@@ -334,5 +338,257 @@ def test_data_loader_transform_emits_perf_events(tmp_path):
         assert transform_event.metrics["input_rows"] == 3
         assert transform_event.metrics["output_rows"] == 3
         assert transform_event.duration_ms > 0
+    finally:
+        set_observer(original)
+
+
+# --- PerfConfig tests ---
+
+
+def test_perf_config_defaults():
+    config = PerfConfig()
+    assert dict(config.tags) == {}
+    assert config.observer_type == "logging"
+    assert dict(config.observer_kwargs) == {}
+
+
+def test_perf_config_is_frozen():
+    config = PerfConfig(tags={"k": "v"})
+    with pytest.raises(AttributeError):
+        config.observer_type = "null"  # type: ignore[misc]
+
+
+def test_perf_config_pickle_round_trip():
+    config = PerfConfig(tags={"cluster": "prod", "tenant": "t1"}, observer_type="null", observer_kwargs={"x": 1})
+    restored = pickle.loads(pickle.dumps(config))
+    assert restored.tags["cluster"] == "prod"
+    assert restored.tags["tenant"] == "t1"
+    assert restored.observer_type == "null"
+    assert restored.observer_kwargs["x"] == 1
+
+
+def test_perf_config_pickle_default():
+    """Default PerfConfig survives pickle round-trip."""
+    config = PerfConfig()
+    restored = pickle.loads(pickle.dumps(config))
+    assert dict(restored.tags) == {}
+    assert restored.observer_type == "logging"
+
+
+# --- EnrichingObserver tests ---
+
+
+def test_enriching_observer_prepends_session_tags():
+    events: list[PerfEvent] = []
+
+    class Collector:
+        def emit(self, event: PerfEvent) -> None:
+            events.append(event)
+
+    inner = Collector()
+    enriching = EnrichingObserver(inner, {"cluster": "prod", "tenant": "t1"})
+    event = PerfEvent(operation="test.enrich", duration_ms=1.0, tags={"extra": "yes"})
+    enriching.emit(event)
+
+    assert len(events) == 1
+    assert events[0].tags["cluster"] == "prod"
+    assert events[0].tags["tenant"] == "t1"
+    assert events[0].tags["extra"] == "yes"
+
+
+def test_enriching_observer_per_event_tags_override_session():
+    events: list[PerfEvent] = []
+
+    class Collector:
+        def emit(self, event: PerfEvent) -> None:
+            events.append(event)
+
+    inner = Collector()
+    enriching = EnrichingObserver(inner, {"env": "staging"})
+    event = PerfEvent(operation="test.override", duration_ms=1.0, tags={"env": "prod"})
+    enriching.emit(event)
+
+    assert events[0].tags["env"] == "prod"
+
+
+def test_enriching_observer_empty_session_tags():
+    events: list[PerfEvent] = []
+
+    class Collector:
+        def emit(self, event: PerfEvent) -> None:
+            events.append(event)
+
+    inner = Collector()
+    enriching = EnrichingObserver(inner, {})
+    event = PerfEvent(operation="test.empty", duration_ms=1.0, tags={"k": "v"})
+    enriching.emit(event)
+
+    assert events[0].tags == {"k": "v"}
+
+
+# --- bootstrap_observer tests ---
+
+
+def test_bootstrap_observer_sets_logging_by_default():
+    original = get_observer()
+    try:
+        set_observer(NullPerfObserver())
+        bootstrap_observer(PerfConfig())
+        obs = get_observer()
+        assert isinstance(obs, LoggingPerfObserver)
+    finally:
+        set_observer(original)
+
+
+def test_bootstrap_observer_sets_enriching_with_tags():
+    original = get_observer()
+    try:
+        set_observer(NullPerfObserver())
+        bootstrap_observer(PerfConfig(tags={"cluster": "prod"}))
+        obs = get_observer()
+        assert isinstance(obs, EnrichingObserver)
+    finally:
+        set_observer(original)
+
+
+def test_bootstrap_observer_null_type():
+    original = get_observer()
+    try:
+        set_observer(NullPerfObserver())
+        bootstrap_observer(PerfConfig(observer_type="null"))
+        obs = get_observer()
+        assert isinstance(obs, NullPerfObserver)
+    finally:
+        set_observer(original)
+
+
+def test_bootstrap_observer_idempotent():
+    """bootstrap_observer does not replace an already-configured observer."""
+    original = get_observer()
+    try:
+        custom = _MockObserver()
+        set_observer(custom)
+        bootstrap_observer(PerfConfig(observer_type="null"))
+        assert get_observer() is custom
+    finally:
+        set_observer(original)
+
+
+def test_bootstrap_observer_dotted_import_path():
+    """bootstrap_observer can instantiate a custom observer from a dotted import path."""
+    original = get_observer()
+    try:
+        set_observer(NullPerfObserver())
+        # Use LoggingPerfObserver via its dotted path as a stand-in for a custom observer
+        bootstrap_observer(PerfConfig(observer_type="openhouse.dataloader._observability.LoggingPerfObserver"))
+        obs = get_observer()
+        assert isinstance(obs, LoggingPerfObserver)
+    finally:
+        set_observer(original)
+
+
+def test_bootstrap_observer_dotted_import_with_tags():
+    """Dotted import observer gets wrapped with EnrichingObserver when tags are provided."""
+    original = get_observer()
+    try:
+        set_observer(NullPerfObserver())
+        bootstrap_observer(
+            PerfConfig(
+                tags={"env": "test"},
+                observer_type="openhouse.dataloader._observability.LoggingPerfObserver",
+            )
+        )
+        obs = get_observer()
+        assert isinstance(obs, EnrichingObserver)
+    finally:
+        set_observer(original)
+
+
+# --- Integration: PerfConfig with data loader ---
+
+
+def test_data_loader_with_perf_config_tags(tmp_path):
+    """Session tags from PerfConfig appear on split-level perf events."""
+    catalog = _make_real_catalog(tmp_path)
+    observer = _MockObserver()
+
+    original = get_observer()
+    try:
+        set_observer(observer)
+        config = PerfConfig(tags={"cluster": "prod", "tenant": "t1"})
+
+        loader = OpenHouseDataLoader(catalog=catalog, database="db", table="tbl", perf_config=config)
+        batches = [batch for split in loader for batch in split]
+        assert len(batches) >= 1
+
+        # split_iter events should carry the session tags
+        split_event = next(e for e in observer.events if e.operation == "dataloader.split_iter")
+        assert split_event.tags["cluster"] == "prod"
+        assert split_event.tags["tenant"] == "t1"
+    finally:
+        set_observer(original)
+
+
+def test_data_loader_perf_config_transform_tags(tmp_path):
+    """Session tags appear on transform perf events when PerfConfig is used."""
+    catalog = _make_real_catalog(tmp_path)
+    observer = _MockObserver()
+
+    original = get_observer()
+    try:
+        set_observer(observer)
+        config = PerfConfig(tags={"env": "staging"})
+
+        loader = OpenHouseDataLoader(
+            catalog=catalog,
+            database="db",
+            table="tbl",
+            context=DataLoaderContext(table_transformer=_MaskingTransformer()),
+            perf_config=config,
+        )
+        batches = [batch for split in loader for batch in split]
+        assert len(batches) >= 1
+
+        # Transform events should also carry the session tags
+        transform_event = next(e for e in observer.events if e.operation == "dataloader.apply_transform")
+        assert transform_event.tags["env"] == "staging"
+
+        session_event = next(e for e in observer.events if e.operation == "dataloader.create_transform_session")
+        assert session_event.tags["env"] == "staging"
+    finally:
+        set_observer(original)
+
+
+def test_pickle_split_with_perf_config(tmp_path):
+    """A pickled DataLoaderSplit carries its PerfConfig and bootstraps on the worker side."""
+    catalog = _make_real_catalog(tmp_path)
+
+    original = get_observer()
+    try:
+        set_observer(NullPerfObserver())
+        config = PerfConfig(tags={"cluster": "test"})
+
+        loader = OpenHouseDataLoader(catalog=catalog, database="db", table="tbl", perf_config=config)
+        splits = list(loader)
+        assert len(splits) == 1
+
+        # Pickle round-trip the split (simulating send to worker)
+        pickled = pickle.dumps(splits[0])
+        restored_split = pickle.loads(pickled)
+
+        # Simulate fresh worker: reset to NullPerfObserver
+        set_observer(NullPerfObserver())
+        assert isinstance(get_observer(), NullPerfObserver)
+
+        # Iterating the restored split should bootstrap the observer
+        set_observer(NullPerfObserver())
+
+        # The split's __iter__ calls bootstrap_observer which replaces the NullPerfObserver
+        batches = list(restored_split)
+        assert len(batches) >= 1
+
+        # After iteration, observer should no longer be NullPerfObserver
+        obs = get_observer()
+        assert not isinstance(obs, NullPerfObserver)
     finally:
         set_observer(original)

--- a/integrations/python/dataloader/tests/test_observability.py
+++ b/integrations/python/dataloader/tests/test_observability.py
@@ -1,0 +1,338 @@
+"""Tests for the performance observability module."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from pyiceberg.io import load_file_io
+from pyiceberg.manifest import DataFile, FileFormat
+from pyiceberg.partitioning import UNPARTITIONED_PARTITION_SPEC
+from pyiceberg.schema import Schema
+from pyiceberg.table import FileScanTask
+from pyiceberg.table.metadata import new_table_metadata
+from pyiceberg.table.sorting import UNSORTED_SORT_ORDER
+from pyiceberg.types import LongType, NestedField, StringType
+
+from openhouse.dataloader._observability import (
+    CompositeObserver,
+    LoggingPerfObserver,
+    NullPerfObserver,
+    PerfEvent,
+    PerfObserver,
+    get_observer,
+    perf_timer,
+    set_observer,
+)
+from openhouse.dataloader.data_loader import DataLoaderContext, OpenHouseDataLoader
+from openhouse.dataloader.data_loader_split import to_sql_identifier
+from openhouse.dataloader.table_transformer import TableTransformer
+
+# --- PerfEvent tests ---
+
+
+def test_perf_event_to_dict():
+    event = PerfEvent(operation="test.op", duration_ms=42.5, tags={"key": "val"}, metrics={"rows": 10})
+    d = event.to_dict()
+    assert d == {"operation": "test.op", "duration_ms": 42.5, "key": "val", "rows": 10}
+
+
+def test_perf_event_to_dict_empty():
+    event = PerfEvent(operation="test.op", duration_ms=1.0)
+    d = event.to_dict()
+    assert d == {"operation": "test.op", "duration_ms": 1.0}
+
+
+def test_perf_event_tags_and_metrics_are_separate():
+    event = PerfEvent(operation="test.op", duration_ms=1.0, tags={"db": "prod"}, metrics={"rows": 42})
+    assert "db" not in event.metrics
+    assert "rows" not in event.tags
+
+
+# --- Observer tests ---
+
+
+def test_null_observer_does_not_raise():
+    obs = NullPerfObserver()
+    obs.emit(PerfEvent(operation="noop", duration_ms=0.0))
+
+
+def test_logging_observer_logs_at_debug(caplog):
+    import logging
+
+    with caplog.at_level(logging.DEBUG, logger="openhouse.dataloader.perf"):
+        obs = LoggingPerfObserver()
+        obs.emit(PerfEvent(operation="test.log", duration_ms=5.0, metrics={"x": 1}))
+
+    assert len(caplog.records) == 1
+    assert "test.log" in caplog.records[0].message
+
+
+def test_composite_observer_fans_out():
+    events_a: list[PerfEvent] = []
+    events_b: list[PerfEvent] = []
+
+    class CollectorA:
+        def emit(self, event: PerfEvent) -> None:
+            events_a.append(event)
+
+    class CollectorB:
+        def emit(self, event: PerfEvent) -> None:
+            events_b.append(event)
+
+    composite = CompositeObserver(CollectorA(), CollectorB())
+    event = PerfEvent(operation="fan.out", duration_ms=1.0)
+    composite.emit(event)
+
+    assert len(events_a) == 1
+    assert len(events_b) == 1
+    assert events_a[0] is event
+    assert events_b[0] is event
+
+
+def test_null_observer_satisfies_protocol():
+    assert isinstance(NullPerfObserver(), PerfObserver)
+
+
+def test_logging_observer_satisfies_protocol():
+    assert isinstance(LoggingPerfObserver(), PerfObserver)
+
+
+# --- set_observer / get_observer tests ---
+
+
+def test_set_and_get_observer():
+    original = get_observer()
+    try:
+        custom = NullPerfObserver()
+        set_observer(custom)
+        assert get_observer() is custom
+    finally:
+        set_observer(original)
+
+
+def test_init_does_not_override_custom_observer(tmp_path):
+    """Creating an OpenHouseDataLoader does not replace a user-configured observer."""
+    catalog = _make_real_catalog(tmp_path)
+    observer = _MockObserver()
+
+    original = get_observer()
+    try:
+        set_observer(observer)
+        OpenHouseDataLoader(catalog=catalog, database="db", table="tbl")
+        assert get_observer() is observer
+    finally:
+        set_observer(original)
+
+
+# --- perf_timer tests ---
+
+
+def test_perf_timer_emits_event():
+    events: list[PerfEvent] = []
+
+    class Collector:
+        def emit(self, event: PerfEvent) -> None:
+            events.append(event)
+
+    original = get_observer()
+    try:
+        set_observer(Collector())
+        with perf_timer("test.timer", extra="val"):
+            pass
+
+        assert len(events) == 1
+        assert events[0].operation == "test.timer"
+        assert events[0].duration_ms >= 0
+        assert events[0].tags["extra"] == "val"
+    finally:
+        set_observer(original)
+
+
+def test_perf_timer_tag_and_metric():
+    events: list[PerfEvent] = []
+
+    class Collector:
+        def emit(self, event: PerfEvent) -> None:
+            events.append(event)
+
+    original = get_observer()
+    try:
+        set_observer(Collector())
+        with perf_timer("test.set") as ctx:
+            ctx.tag("db", "prod")
+            ctx.metric("count", 42)
+
+        assert events[0].tags["db"] == "prod"
+        assert events[0].metrics["count"] == 42
+    finally:
+        set_observer(original)
+
+
+def test_perf_timer_emits_on_exception():
+    events: list[PerfEvent] = []
+
+    class Collector:
+        def emit(self, event: PerfEvent) -> None:
+            events.append(event)
+
+    original = get_observer()
+    try:
+        set_observer(Collector())
+        with pytest.raises(ValueError, match="boom"), perf_timer("test.error"):
+            raise ValueError("boom")
+
+        assert len(events) == 1
+        assert events[0].operation == "test.error"
+        assert events[0].duration_ms >= 0
+    finally:
+        set_observer(original)
+
+
+# --- Integration: data loader emits perf events ---
+
+
+COL_ID = "id"
+COL_NAME = "name"
+
+TEST_SCHEMA = Schema(
+    NestedField(field_id=1, name=COL_ID, field_type=LongType(), required=False),
+    NestedField(field_id=2, name=COL_NAME, field_type=StringType(), required=False),
+)
+
+TEST_DATA = {
+    COL_ID: [1, 2, 3],
+    COL_NAME: ["alice", "bob", "charlie"],
+}
+
+
+def _write_parquet(tmp_path, data: dict, filename: str = "test.parquet") -> str:
+    file_path = str(tmp_path / filename)
+    table = pa.table(data)
+    fields = [field.with_metadata({b"PARQUET:field_id": str(i + 1).encode()}) for i, field in enumerate(table.schema)]
+    pq.write_table(table.cast(pa.schema(fields)), file_path)
+    return file_path
+
+
+def _make_real_catalog(tmp_path, data: dict = TEST_DATA, iceberg_schema: Schema = TEST_SCHEMA):
+    file_path = _write_parquet(tmp_path, data)
+
+    metadata = new_table_metadata(
+        schema=iceberg_schema,
+        partition_spec=UNPARTITIONED_PARTITION_SPEC,
+        sort_order=UNSORTED_SORT_ORDER,
+        location=str(tmp_path),
+        properties={},
+    )
+    io = load_file_io(properties={}, location=file_path)
+
+    data_file = DataFile.from_args(
+        file_path=file_path,
+        file_format=FileFormat.PARQUET,
+        record_count=len(next(iter(data.values()))),
+        file_size_in_bytes=os.path.getsize(file_path),
+    )
+    data_file._spec_id = 0
+    task = FileScanTask(data_file=data_file)
+
+    def fake_scan(**kwargs):
+        scan = MagicMock()
+        scan.projection.return_value = iceberg_schema
+        scan.plan_files.return_value = [task]
+        return scan
+
+    mock_table = MagicMock()
+    mock_table.metadata = metadata
+    mock_table.io = io
+    mock_table.scan.side_effect = fake_scan
+
+    catalog = MagicMock()
+    catalog.load_table.return_value = mock_table
+    return catalog
+
+
+class _MockObserver:
+    """Test observer that collects all emitted events."""
+
+    def __init__(self) -> None:
+        self.events: list[PerfEvent] = []
+
+    def emit(self, event: PerfEvent) -> None:
+        self.events.append(event)
+
+
+def test_data_loader_iter_emits_perf_events(tmp_path):
+    """Full iteration through data loader emits expected perf events."""
+    catalog = _make_real_catalog(tmp_path)
+    observer = _MockObserver()
+
+    original = get_observer()
+    try:
+        set_observer(observer)
+
+        loader = OpenHouseDataLoader(catalog=catalog, database="db", table="tbl")
+
+        batches = [batch for split in loader for batch in split]
+        assert len(batches) >= 1
+
+        operations = [e.operation for e in observer.events]
+        assert "dataloader.resolve_snapshot" in operations
+        assert "dataloader.iter" in operations
+        assert "dataloader.split_iter" in operations
+
+        # Check iter event has split_count
+        iter_event = next(e for e in observer.events if e.operation == "dataloader.iter")
+        assert iter_event.metrics["split_count"] == 1
+        assert iter_event.duration_ms > 0
+
+        # Check split_iter has batch/row counts
+        split_event = next(e for e in observer.events if e.operation == "dataloader.split_iter")
+        assert split_event.metrics["batch_count"] >= 1
+        assert split_event.metrics["row_count"] == 3
+        assert split_event.duration_ms > 0
+    finally:
+        set_observer(original)
+
+
+class _MaskingTransformer(TableTransformer):
+    def __init__(self):
+        super().__init__(dialect="datafusion")
+
+    def transform(self, table, context):
+        return f"SELECT id, 'MASKED' as name FROM {to_sql_identifier(table)}"
+
+
+def test_data_loader_transform_emits_perf_events(tmp_path):
+    """Transform path emits build_query, create_transform_session, and apply_transform events."""
+    catalog = _make_real_catalog(tmp_path)
+    observer = _MockObserver()
+
+    original = get_observer()
+    try:
+        set_observer(observer)
+
+        loader = OpenHouseDataLoader(
+            catalog=catalog,
+            database="db",
+            table="tbl",
+            context=DataLoaderContext(table_transformer=_MaskingTransformer()),
+        )
+
+        batches = [batch for split in loader for batch in split]
+        assert len(batches) >= 1
+
+        operations = [e.operation for e in observer.events]
+        assert "dataloader.build_query" in operations
+        assert "dataloader.create_transform_session" in operations
+        assert "dataloader.apply_transform" in operations
+
+        # Check apply_transform has row counts
+        transform_event = next(e for e in observer.events if e.operation == "dataloader.apply_transform")
+        assert transform_event.metrics["input_rows"] == 3
+        assert transform_event.metrics["output_rows"] == 3
+        assert transform_event.duration_ms > 0
+    finally:
+        set_observer(original)


### PR DESCRIPTION
## Summary
- Adds a pluggable `PerfObserver` pattern for performance instrumentation of the data loader
- New `_observability.py` module with `PerfEvent`, `PerfObserver` protocol, `NullPerfObserver`, `LoggingPerfObserver`, `CompositeObserver`, and `perf_timer` context manager
- `PerfEvent` separates `tags` (low-cardinality dimensions) from `metrics` (measured values) for Prometheus/OTEL/Kafka compatibility
- Instruments 7 stages: `dataloader.iter`, `dataloader.split_iter`, `dataloader.resolve_snapshot`, `dataloader.build_query`, `dataloader.apply_transform`, `dataloader.create_transform_session`, `catalog.load_table`
- Default observer is `LoggingPerfObserver` (DEBUG level to `openhouse.dataloader.perf`), auto-set on first `OpenHouseDataLoader` creation unless a custom observer is already configured
- `set_observer()` bridges to `pyiceberg.observability.set_observer()` when available

## Why a separate `_observability.py` instead of importing from pyiceberg?

The dataloader's `_observability.py` is intentionally independent from `pyiceberg.observability` ([li-iceberg-python#52](https://github.com/linkedin/iceberg-python/pull/52)). The two modules share the same design (PerfEvent/PerfObserver/perf_timer) but are not coupled because:

1. **Different release cycles.** The dataloader ships on its own cadence; depending on an unreleased pyiceberg observability module would block this PR until the upstream fork is published.
2. **Different logger namespaces.** The dataloader logs to `openhouse.dataloader.perf` while pyiceberg logs to `pyiceberg.perf`, keeping the two layers distinguishable in log output.
3. **Bridge, not dependency.** `set_observer()` in the dataloader forwards to `pyiceberg.observability.set_observer()` when available, so a single call enables both layers without a hard import dependency.
4. **Convergence path.** Once pyiceberg publishes `observability.py` in a released version, the dataloader module can be reduced to a thin re-export + bridge. The `PerfEvent`/`PerfObserver` contracts are identical by design to make this migration straightforward.

## Test plan
- [x] 217 unit tests pass (`make verify`)
- [x] 15 dedicated observability tests covering PerfEvent, all observer types, perf_timer, tag/metric separation, and full integration with data loader iteration and transform paths
- [ ] Integration tests against Docker OpenHouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)