### PR TITLE
[RTAS]: Fix bug - remove fs scheme from tableLocation in commit

### DIFF
--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -249,14 +249,11 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
       failIfRetryUpdate(properties);
       restoreOverriddenProperties(properties);
 
-      // Remove the fs scheme from the tableVersion to match the HTS entry
       properties.put(
           getCanonicalFieldName("tableVersion"),
           properties.getOrDefault(
               getCanonicalFieldName("tableLocation"), CatalogConstants.INITIAL_VERSION));
       properties.put(getCanonicalFieldName("tableLocation"), newMetadataLocation);
-
-      log.info("tableVersion here: {}", properties.get(getCanonicalFieldName("tableVersion")));
 
       String currentTsString = String.valueOf(Instant.now(Clock.systemUTC()).toEpochMilli());
       if (isReplicatedTableCreate(properties)) {

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -29,7 +29,6 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import java.io.IOException;
-import java.net.URI;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -251,14 +250,13 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
       restoreOverriddenProperties(properties);
 
       // Remove the fs scheme from the tableVersion to match the HTS entry
-      String previousTableLocation =
+      properties.put(
+          getCanonicalFieldName("tableVersion"),
           properties.getOrDefault(
-              getCanonicalFieldName("tableLocation"), CatalogConstants.INITIAL_VERSION);
-      if (!previousTableLocation.equals(CatalogConstants.INITIAL_VERSION)) {
-        previousTableLocation = URI.create(previousTableLocation).getPath();
-      }
-      properties.put(getCanonicalFieldName("tableVersion"), previousTableLocation);
+              getCanonicalFieldName("tableLocation"), CatalogConstants.INITIAL_VERSION));
       properties.put(getCanonicalFieldName("tableLocation"), newMetadataLocation);
+
+      log.info("tableVersion here: {}", properties.get(getCanonicalFieldName("tableVersion")));
 
       String currentTsString = String.valueOf(Instant.now(Clock.systemUTC()).toEpochMilli());
       if (isReplicatedTableCreate(properties)) {

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -29,6 +29,7 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import java.io.IOException;
+import java.net.URI;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -249,10 +250,14 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
       failIfRetryUpdate(properties);
       restoreOverriddenProperties(properties);
 
-      properties.put(
-          getCanonicalFieldName("tableVersion"),
+      // Remove the fs scheme from the tableVersion to match the HTS entry
+      String previousTableLocation =
           properties.getOrDefault(
-              getCanonicalFieldName("tableLocation"), CatalogConstants.INITIAL_VERSION));
+              getCanonicalFieldName("tableLocation"), CatalogConstants.INITIAL_VERSION);
+      if (!previousTableLocation.equals(CatalogConstants.INITIAL_VERSION)) {
+        previousTableLocation = URI.create(previousTableLocation).getPath();
+      }
+      properties.put(getCanonicalFieldName("tableVersion"), previousTableLocation);
       properties.put(getCanonicalFieldName("tableLocation"), newMetadataLocation);
 
       String currentTsString = String.valueOf(Instant.now(Clock.systemUTC()).toEpochMilli());

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -429,7 +429,12 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
     Map<String, String> dtoMap = tableDto.convertToMap();
     for (String htsFieldName : HTS_FIELD_NAMES) {
       if (dtoMap.get(htsFieldName) != null) {
-        propertiesMap.put(getCanonicalFieldName(htsFieldName), dtoMap.get(htsFieldName));
+        if (htsFieldName.equals("tableLocation")) {
+          propertiesMap.put(
+              getCanonicalFieldName(htsFieldName), getSchemeLessPath(dtoMap.get(htsFieldName)));
+        } else {
+          propertiesMap.put(getCanonicalFieldName(htsFieldName), dtoMap.get(htsFieldName));
+        }
       }
     }
 

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RequestAndValidateHelper.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RequestAndValidateHelper.java
@@ -87,13 +87,14 @@ public final class RequestAndValidateHelper {
             .andExpect(jsonPath("$.databaseId", is(equalTo(getTableResponseBody.getDatabaseId()))))
             .andExpect(jsonPath("$.clusterId", is(equalTo(getTableResponseBody.getClusterId()))))
             .andExpect(jsonPath("$.tableUri", is(equalTo(getTableResponseBody.getTableUri()))))
+            .andExpect(
+                jsonPath("$.tableVersion", is(equalTo(stripPathScheme(previousTableLocation)))))
             .andReturn();
     ValidationUtilities.validateUUID(mvcResult, getTableResponseBody.getTableUUID());
     ValidationUtilities.validateSchema(mvcResult, getTableResponseBody.getSchema());
     validateWritableTableProperties(mvcResult, getTableResponseBody.getTableProperties());
     ValidationUtilities.validateLocation(
         mvcResult, storageManager.getDefaultStorage().getClient().getRootPrefix());
-    ValidationUtilities.validateTableVersion(mvcResult, previousTableLocation);
 
     ValidationUtilities.validateTimestamp(
         mvcResult,
@@ -326,6 +327,12 @@ public final class RequestAndValidateHelper {
             .andExpect(jsonPath("$.databaseId", is(equalTo(databaseId))))
             .andExpect(jsonPath("$.clusterId", is(equalTo(clusterId))))
             .andExpect(jsonPath("$.tableType", is(equalTo(tableType.toString()))))
+            .andExpect(
+                jsonPath(
+                    "$.tableVersion",
+                    is(
+                        equalTo(
+                            stripPathScheme(icebergSnapshotsRequestBody.getBaseTableVersion())))))
             .andReturn();
 
     validateSnapshots(catalog, result, icebergSnapshotsRequestBody);

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/ValidationUtilities.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/ValidationUtilities.java
@@ -162,13 +162,6 @@ public final class ValidationUtilities {
     return true;
   }
 
-  static void validateTableVersion(MvcResult result, String expectedTableVersion)
-      throws UnsupportedEncodingException {
-    String actualTableVersion =
-        stripPathScheme(JsonPath.read(result.getResponse().getContentAsString(), "$.tableVersion"));
-    Assertions.assertEquals(stripPathScheme(expectedTableVersion), actualTableVersion);
-  }
-
   static void validateMetadataInPutSnapshotsRequest(
       MvcResult result, IcebergSnapshotsRequestBody icebergSnapshotsRequestBody)
       throws UnsupportedEncodingException {
@@ -178,7 +171,6 @@ public final class ValidationUtilities {
     validateWritableTableProperties(result, expectedRequestBody.getTableProperties());
     validatePolicies(result, expectedRequestBody.getPolicies());
     ValidationUtilities.validateTimePartition(result, expectedRequestBody.getTimePartitioning());
-    validateTableVersion(result, expectedRequestBody.getBaseTableVersion());
   }
 
   static void validateSnapshots(

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImplTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImplTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.linkedin.openhouse.cluster.configs.ClusterProperties;
+import com.linkedin.openhouse.internal.catalog.mapper.HouseTableSerdeUtils;
 import com.linkedin.openhouse.tables.common.TableType;
 import com.linkedin.openhouse.tables.dto.mapper.iceberg.PoliciesSpecMapper;
 import com.linkedin.openhouse.tables.model.TableDto;
@@ -87,6 +88,19 @@ public class OpenHouseInternalRepositoryImplTest {
     Assertions.assertEquals(
         userProvidedMaxMetadataVersions,
         actualProps.get(TableProperties.METADATA_PREVIOUS_VERSIONS_MAX));
+  }
+
+  @Test
+  void testComputePropsForTableCreation_tableLocation() {
+    TableDto tableDto = createTableDto(new HashMap<>());
+    tableDto = tableDto.toBuilder().tableLocation("file:///data/openhouse/db/table").build();
+
+    Map<String, String> actualProps =
+        openHouseInternalRepository.computePropsForTableCreation(tableDto);
+
+    Assertions.assertEquals(
+        "/data/openhouse/db/table",
+        actualProps.get(HouseTableSerdeUtils.getCanonicalFieldName("tableLocation")));
   }
 
   private TableDto createTableDto(Map<String, String> properties) {


### PR DESCRIPTION
## Summary
Spark shell tests in the gateway failed for:
```
liopenhouse.relocated.org.apache.iceberg.exceptions.CommitFailedException: 409 , {"status":"CONFLICT","error":"Conflict","message":"Entity with key[ltx1-holdem-openhouse.u_openhouse.testRtas2] is modified by another process already, nested exception message: com.linkedin.openhouse.internal.catalog.repository.exception.HouseTableConcurrentUpdateException: ","stacktrace":null,"cause":"com.linkedin.openhouse.internal.catalog.repository.exception.HouseTableConcurrentUpdateException: "}
```
This is because mysql stores the `metadata_location` without the scheme ([code](https://github.com/linkedin/openhouse/blob/main/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java#L243)), but the tableVersion in the put snapshot request starts with `hdfs://ltx1-holdem` ([code](https://github.com/linkedin/openhouse/blob/main/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/InternalRepositoryUtils.java#L118)). The `UserTableVersionMapper.toVersion()` throws an error if they don't match. So to fix the bug, I remove the scheme from `tableLocation` when the tables service tries to commit.

The spark E2E tests didn't capture it because we use `HouseTablesH2Repository` in the local testing mode which totally bypass the HTS service.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

I choose to keep the scheme in the response to client because the Iceberg spec mandates fs scheme. On the other hand, to avoid the hts issue in the write path, I remove the scheme from the property `openhouse.tableLocation` when we try to create or replace a table (The update / put snapshot path succeeded because we load the underlying table without a scheme). 

To ensure no regression will happen, I added one test and rollbacked the test changes in this [PR](https://github.com/linkedin/openhouse/pull/523/changes#diff-1a0f4606c5659b78fde6597e3a0f2b1561cbd6732170dfaff5920458b7f4e6c0). The original tests ensured that all write paths end up having a `tableVersion` without a scheme, which guardrail that the hts issue won't happen. It was a sloppy move to remove them. 

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Local docker tests:
```
scala> spark.sql("CREATE OR REPLACE TABLE openhouse.u_openhouse.testRtas3 AS SELECT * FROM openhouse.u_openhouse.testRtas2")
res6: org.apache.spark.sql.DataFrame = []                                       

scala> spark.sql("CREATE OR REPLACE TABLE openhouse.u_lejiang.testRtas3 PARTITIONED BY (part) AS SELECT id, data, CASE WHEN (id % 2) = 0 THEN 'even' ELSE 'odd' END AS part FROM openhouse.u_openhouse.testRtas2 ORDER BY 3, 1")
res7: org.apache.spark.sql.DataFrame = []                                       

scala> spark.sql("show tblproperties openhouse.u_openhouse.testRtas3").show(100, false)
+------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
|key                                       |value                                                                                                                              |
+------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------+
|current-snapshot-id                       |2523561310658406053                                                                                                                |
|format                                    |iceberg/orc                                                                                                                        |
|format-version                            |2                                                                                                                                  |
|openhouse.clusterId                       |LocalHadoopCluster                                                                                                                 |
|openhouse.creationTime                    |1776208292604                                                                                                                      |
|openhouse.databaseId                      |u_openhouse                                                                                                                        |
|openhouse.isTableReplicated               |false                                                                                                                              |
|openhouse.lastModifiedTime                |1776208292604                                                                                                                      |
|openhouse.tableCreator                    |DUMMY_ANONYMOUS_USER                                                                                                               |
|openhouse.tableId                         |testRtas3                                                                                                                          |
|openhouse.tableLocation                   |/data/openhouse/u_openhouse/testRtas3-83a337d5-6b73-4fe5-9fe7-32f63ec3f0f7/00000-b99aa89d-34f3-4752-b63e-6b83a2fc2577.metadata.json|
|openhouse.tableType                       |PRIMARY_TABLE                                                                                                                      |
|openhouse.tableUUID                       |83a337d5-6b73-4fe5-9fe7-32f63ec3f0f7                                                                                               |
|openhouse.tableUri                        |LocalHadoopCluster.u_openhouse.testRtas3                                                                                           |
|openhouse.tableVersion                    |INITIAL_VERSION                                                                                                                    |
|policies                                  |                                                                                                                                   |
|write.format.default                      |orc                                                                                                                                |
|write.metadata.delete-after-commit.enabled|true                                                                                                                               |
|write.metadata.previous-versions-max      |28                                                                                                                                 |
|write.parquet.compression-codec           |zstd                                                                                                                               |
+------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------+


scala> spark.sql("SELECT * FROM openhouse.u_openhouse.testRtas3").show(false)
+---+----+
|id |data|
+---+----+
|1  |a   |
|2  |b   |
|1  |a   |
|2  |b   |
|3  |c   |
|3  |c   |
+---+----+
```
# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
