### PR TITLE
[BUG][DataLoader] Handle unresolved SELECT * in scan optimizer to read all columns

### DIFF
--- a/integrations/python/dataloader/src/openhouse/dataloader/scan_optimizer.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/scan_optimizer.py
@@ -127,10 +127,18 @@ def _flatten_and(node: exp.Expression) -> list[exp.Expression]:
     return [node]
 
 
-def _collect_source_columns(select: exp.Expression) -> set[str]:
-    """Collect all column references from a SELECT's expressions and clauses."""
+def _collect_source_columns(select: exp.Expression) -> set[str] | None:
+    """Collect all column references from a SELECT's expressions and clauses.
+
+    Returns ``None`` when the SELECT contains an unresolved ``*`` (i.e.
+    ``qualify`` could not expand it because no schema was provided).  A
+    ``None`` return tells the caller to read **all** source columns from
+    Iceberg instead of pushing down a partial projection.
+    """
     source_columns: set[str] = set()
     for select_expr in select.expressions:
+        if isinstance(select_expr, exp.Star):
+            return None
         source_columns.update(c.name for c in select_expr.find_all(exp.Column))
     for clause_type in (exp.Where, exp.Group, exp.Having, exp.Order):
         clause = select.find(clause_type)

--- a/integrations/python/dataloader/tests/test_scan_optimizer.py
+++ b/integrations/python/dataloader/tests/test_scan_optimizer.py
@@ -54,9 +54,7 @@ def test_all_columns_used():
 
 def test_unresolved_star_reads_all_columns():
     """When SELECT * cannot be expanded (no schema), all columns must be read."""
-    plan = optimize_scan(
-        'SELECT * FROM (SELECT * FROM "db"."tbl" WHERE some_udf("tbl"."viewerId", now())) AS _t'
-    )
+    plan = optimize_scan('SELECT * FROM (SELECT * FROM "db"."tbl" WHERE some_udf("tbl"."viewerId", now())) AS _t')
 
     assert plan.source_columns is None
     assert isinstance(plan.row_filter, AlwaysTrue)

--- a/integrations/python/dataloader/tests/test_scan_optimizer.py
+++ b/integrations/python/dataloader/tests/test_scan_optimizer.py
@@ -52,6 +52,16 @@ def test_all_columns_used():
     assert isinstance(plan.row_filter, AlwaysTrue)
 
 
+def test_unresolved_star_reads_all_columns():
+    """When SELECT * cannot be expanded (no schema), all columns must be read."""
+    plan = optimize_scan(
+        'SELECT * FROM (SELECT * FROM "db"."tbl" WHERE some_udf("tbl"."viewerId", now())) AS _t'
+    )
+
+    assert plan.source_columns is None
+    assert isinstance(plan.row_filter, AlwaysTrue)
+
+
 def test_literal_alias_needs_no_source_column():
     plan = optimize_scan('SELECT "id", "name" FROM (SELECT "id", \'MASKED\' AS "name" FROM "db"."tbl") AS _t')
 


### PR DESCRIPTION


## Summary

When SELECT * cannot be expanded by sqlglot's qualify (no schema provided), _collect_source_columns now returns None instead of an empty set, preventing the scan optimizer from pushing down a partial (empty) projection.


## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
