### PR TITLE
Add sparkVersion field to JobLaunchConf

### DIFF
--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/config/JobLaunchConf.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/config/JobLaunchConf.java
@@ -30,4 +30,5 @@ public class JobLaunchConf implements Serializable {
   @Builder.Default private List<String> dependencies = new ArrayList<>();
   @Builder.Default private Map<String, String> sparkProperties = new HashMap<>();
   private String engineType;
+  private String sparkVersion;
 }

--- a/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/LivyJobsCoordinatorTest.java
+++ b/services/jobs/src/test/java/com/linkedin/openhouse/jobs/mock/LivyJobsCoordinatorTest.java
@@ -34,7 +34,8 @@ public class LivyJobsCoordinatorTest {
             "test.jar",
             Collections.emptyList(),
             Maps.newHashMap(),
-            "livy");
+            "livy",
+            null);
     responseBody.addProperty("id", testExecutionId);
     ExchangeFunction exchangeFunction =
         request -> {
@@ -60,7 +61,8 @@ public class LivyJobsCoordinatorTest {
             "test.jar",
             Collections.emptyList(),
             Maps.newHashMap(),
-            "livy");
+            "livy",
+            null);
     ExchangeFunction exchangeFunction =
         request -> {
           Assertions.assertEquals(HttpMethod.POST, request.method());


### PR DESCRIPTION
## Summary
- Adds `sparkVersion` field to `JobLaunchConf` to allow per-job Spark version configuration via `jobs.yaml`
- Enables gradual migration of maintenance jobs from Spark 3.1 to 3.5 without code changes. Starting with OFD - picks up stream-results option for remove orphan files (https://github.com/linkedin/iceberg/pull/234) to prevent driver OOM when removing large numbers of orphan files.

## Changes
- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [X] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [X] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
