### PR TITLE
Disable Jackson FAIL_ON_UNKNOWN_PROPERTIES to prevent deserialization…

### DIFF
--- a/client/secureclient/src/main/java/com/linkedin/openhouse/client/ssl/HousetablesApiClientFactory.java
+++ b/client/secureclient/src/main/java/com/linkedin/openhouse/client/ssl/HousetablesApiClientFactory.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.client.ssl;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.openhouse.housetables.client.invoker.ApiClient;
 import java.net.MalformedURLException;
@@ -32,7 +33,9 @@ public final class HousetablesApiClientFactory extends WebClientFactory {
   @Override
   protected WebClient.Builder createWebClientBuilder() {
     DateFormat defaultDateFormat = ApiClient.createDefaultDateFormat();
-    ObjectMapper defaultObjectMapper = ApiClient.createDefaultObjectMapper(defaultDateFormat);
+    ObjectMapper defaultObjectMapper =
+        ApiClient.createDefaultObjectMapper(defaultDateFormat)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     return ApiClient.buildWebClientBuilder(defaultObjectMapper);
   }
 

--- a/client/secureclient/src/main/java/com/linkedin/openhouse/client/ssl/JobsApiClientFactory.java
+++ b/client/secureclient/src/main/java/com/linkedin/openhouse/client/ssl/JobsApiClientFactory.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.client.ssl;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.openhouse.jobs.client.invoker.ApiClient;
 import java.net.MalformedURLException;
@@ -32,7 +33,9 @@ public final class JobsApiClientFactory extends WebClientFactory {
   @Override
   protected WebClient.Builder createWebClientBuilder() {
     DateFormat defaultDateFormat = ApiClient.createDefaultDateFormat();
-    ObjectMapper defaultObjectMapper = ApiClient.createDefaultObjectMapper(defaultDateFormat);
+    ObjectMapper defaultObjectMapper =
+        ApiClient.createDefaultObjectMapper(defaultDateFormat)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     return ApiClient.buildWebClientBuilder(defaultObjectMapper);
   }
 

--- a/client/secureclient/src/main/java/com/linkedin/openhouse/client/ssl/TablesApiClientFactory.java
+++ b/client/secureclient/src/main/java/com/linkedin/openhouse/client/ssl/TablesApiClientFactory.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.client.ssl;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.openhouse.tables.client.invoker.ApiClient;
 import java.net.MalformedURLException;
@@ -33,7 +34,9 @@ public final class TablesApiClientFactory extends WebClientFactory {
   @Override
   protected WebClient.Builder createWebClientBuilder() {
     DateFormat defaultDateFormat = ApiClient.createDefaultDateFormat();
-    ObjectMapper defaultObjectMapper = ApiClient.createDefaultObjectMapper(defaultDateFormat);
+    ObjectMapper defaultObjectMapper =
+        ApiClient.createDefaultObjectMapper(defaultDateFormat)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     return ApiClient.buildWebClientBuilder(defaultObjectMapper);
   }
 

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/utils/MetadataUpdateUtils.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/utils/MetadataUpdateUtils.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.internal.catalog.utils;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -100,7 +101,8 @@ public class MetadataUpdateUtils {
    */
   private static String updateJsonField(String jsonString, String fieldName, long updatedValue)
       throws IOException {
-    ObjectMapper objectMapper = new ObjectMapper();
+    ObjectMapper objectMapper =
+        new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     JsonNode jsonNode = objectMapper.readTree(jsonString);
     ((ObjectNode) jsonNode).put(fieldName, updatedValue);
     return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonNode);

--- a/services/housetables/src/main/resources/application.properties
+++ b/services/housetables/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+spring.jackson.deserialization.fail-on-unknown-properties=false
 spring.codec.max-in-memory-size=20MB
 springdoc.packages-to-scan=com.linkedin.openhouse, com.linkedin.openhouse.housetables
 springdoc.swagger-ui.disable-swagger-default-url=true

--- a/services/jobs/src/main/resources/application.properties
+++ b/services/jobs/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+spring.jackson.deserialization.fail-on-unknown-properties=false
 spring.codec.max-in-memory-size=20MB
 springdoc.packages-to-scan=com.linkedin.openhouse.jobs
 springdoc.swagger-ui.disable-swagger-default-url=true

--- a/services/tables/src/main/resources/application.properties
+++ b/services/tables/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 spring.mvc.throw-exception-if-no-handler-found=true
 spring.mvc.static-path-pattern=favicon.ico
 spring.web.resources.static-locations=classpath:/static
+spring.jackson.deserialization.fail-on-unknown-properties=false
 spring.codec.max-in-memory-size=20MB
 springdoc.packages-to-scan=com.linkedin.openhouse.tables
 springdoc.swagger-ui.disable-swagger-default-url=true


### PR DESCRIPTION
… failures during rolling deployments

## Summary
Jackson's default ObjectMapper throws exceptions on unknown JSON fields, which causes failures when newer service versions introduce new fields while older instances are still running during rolling deployments. 

Changes:
- Configure ObjectMapper in MetadataUpdateUtils to disable FAIL_ON_UNKNOWN_PROPERTIES
- Add spring.jackson.deserialization.fail-on-unknown-properties=false to all Spring Boot service application.properties (tables, jobs, housetables)

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
