### PR TITLE
Add stream-results option for orphan files deletion

### DIFF
--- a/apps/spark-3.5/src/test/java/com/linkedin/openhouse/jobs/spark/StreamResultsOrphanFilesDeletionTest.java
+++ b/apps/spark-3.5/src/test/java/com/linkedin/openhouse/jobs/spark/StreamResultsOrphanFilesDeletionTest.java
@@ -1,0 +1,102 @@
+package com.linkedin.openhouse.jobs.spark;
+
+import com.linkedin.openhouse.common.metrics.DefaultOtelConfig;
+import com.linkedin.openhouse.common.metrics.OtelEmitter;
+import com.linkedin.openhouse.jobs.util.AppsOtelEmitter;
+import com.linkedin.openhouse.tablestest.OpenHouseSparkITest;
+import java.util.Arrays;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test for stream-results option in orphan files deletion. This test runs only on Spark
+ * 3.5 with Iceberg 1.5 where the streaming implementation is available. It verifies that
+ * stream-results mode caps the returned paths at maxOrphanFileSampleSize while still deleting all
+ * orphan files, and that non-streaming mode returns all paths regardless of sample size.
+ */
+@Slf4j
+public class StreamResultsOrphanFilesDeletionTest extends OpenHouseSparkITest {
+  private static final String BACKUP_DIR = ".backup";
+  private final OtelEmitter otelEmitter =
+      new AppsOtelEmitter(Arrays.asList(DefaultOtelConfig.getOpenTelemetry()));
+
+  private void prepareTable(Operations ops, String tableName) {
+    ops.spark().sql(String.format("DROP TABLE IF EXISTS %s", tableName)).show();
+    ops.spark()
+        .sql(String.format("CREATE TABLE openhouse.%s (data string, ts timestamp)", tableName))
+        .show();
+  }
+
+  private void populateTable(Operations ops, String tableName, int numRows) {
+    for (int row = 0; row < numRows; ++row) {
+      ops.spark()
+          .sql(String.format("INSERT INTO %s VALUES ('v%d', current_timestamp())", tableName, row))
+          .show();
+    }
+  }
+
+  @Test
+  public void testStreamResultsCapsReturnedPaths() throws Exception {
+    final String tableName = "db.test_stream_results_ofd";
+    final int numOrphanFiles = 10;
+    final int maxSampleSize = 3;
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      prepareTable(ops, tableName);
+      populateTable(ops, tableName, 3);
+      Table table = ops.getTable(tableName);
+      FileSystem fs = ops.fs();
+      for (int i = 0; i < numOrphanFiles; i++) {
+        fs.createNewFile(new Path(table.location(), "data/orphan_stream_" + i + ".orc"));
+      }
+      DeleteOrphanFiles.Result result =
+          ops.deleteOrphanFiles(
+              table, System.currentTimeMillis(), false, BACKUP_DIR, 1, true, maxSampleSize);
+      List<String> paths = Lists.newArrayList(result.orphanFileLocations().iterator());
+      // Streaming mode caps returned paths at maxSampleSize
+      Assertions.assertEquals(
+          maxSampleSize, paths.size(), "Streaming should return at most maxSampleSize paths");
+      // All orphan files should still be deleted
+      for (int i = 0; i < numOrphanFiles; i++) {
+        Assertions.assertFalse(
+            fs.exists(new Path(table.location(), "data/orphan_stream_" + i + ".orc")),
+            "Orphan file should be deleted");
+      }
+    }
+  }
+
+  @Test
+  public void testNonStreamReturnsAllPaths() throws Exception {
+    final String tableName = "db.test_non_stream_ofd";
+    final int numOrphanFiles = 10;
+    final int maxSampleSize = 3;
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      prepareTable(ops, tableName);
+      populateTable(ops, tableName, 3);
+      Table table = ops.getTable(tableName);
+      FileSystem fs = ops.fs();
+      for (int i = 0; i < numOrphanFiles; i++) {
+        fs.createNewFile(new Path(table.location(), "data/orphan_nostream_" + i + ".orc"));
+      }
+      DeleteOrphanFiles.Result result =
+          ops.deleteOrphanFiles(
+              table, System.currentTimeMillis(), false, BACKUP_DIR, 1, false, maxSampleSize);
+      List<String> paths = Lists.newArrayList(result.orphanFileLocations().iterator());
+      // Non-streaming ignores maxSampleSize - returns all paths
+      Assertions.assertEquals(
+          numOrphanFiles, paths.size(), "Non-streaming should return all orphan file paths");
+      // All orphan files should be deleted
+      for (int i = 0; i < numOrphanFiles; i++) {
+        Assertions.assertFalse(
+            fs.exists(new Path(table.location(), "data/orphan_nostream_" + i + ".orc")),
+            "Orphan file should be deleted");
+      }
+    }
+  }
+}

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -108,9 +108,15 @@ public final class Operations implements AutoCloseable {
       long olderThanTimestampMillis,
       boolean backupEnabled,
       String backupDir,
-      int concurrentDeletes) {
+      int concurrentDeletes,
+      boolean streamResults,
+      int maxOrphanFileSampleSize) {
 
-    DeleteOrphanFiles operation = SparkActions.get(spark).deleteOrphanFiles(table);
+    DeleteOrphanFiles operation =
+        SparkActions.get(spark)
+            .deleteOrphanFiles(table)
+            .option("stream-results", String.valueOf(streamResults))
+            .option("max-orphan-file-sample-size", String.valueOf(maxOrphanFileSampleSize));
     // if time filter is not provided it defaults to 3 days
     if (olderThanTimestampMillis > 0) {
       operation = operation.olderThan(olderThanTimestampMillis);

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/OrphanFilesDeletionSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/OrphanFilesDeletionSparkApp.java
@@ -30,6 +30,9 @@ public class OrphanFilesDeletionSparkApp extends BaseTableSparkApp {
   private final long ttlSeconds;
   private final String backupDir;
   private final int concurrentDeletes;
+  private final boolean streamResults;
+  private final int maxOrphanFileSampleSize;
+  private static final int DEFAULT_MAX_ORPHAN_FILE_SAMPLE_SIZE = 20000;
 
   public OrphanFilesDeletionSparkApp(
       String jobId,
@@ -38,11 +41,15 @@ public class OrphanFilesDeletionSparkApp extends BaseTableSparkApp {
       long ttlSeconds,
       OtelEmitter otelEmitter,
       String backupDir,
-      int concurrentDeletes) {
+      int concurrentDeletes,
+      boolean streamResults,
+      int maxOrphanFileSampleSize) {
     super(jobId, stateManager, fqtn, otelEmitter);
     this.ttlSeconds = ttlSeconds;
     this.backupDir = backupDir;
     this.concurrentDeletes = concurrentDeletes;
+    this.streamResults = streamResults;
+    this.maxOrphanFileSampleSize = maxOrphanFileSampleSize;
   }
 
   @Override
@@ -65,7 +72,9 @@ public class OrphanFilesDeletionSparkApp extends BaseTableSparkApp {
             olderThanTimestampMillis,
             backupEnabled,
             backupDir,
-            concurrentDeletes);
+            concurrentDeletes,
+            streamResults,
+            maxOrphanFileSampleSize);
     List<String> orphanFileLocations = Lists.newArrayList(result.orphanFileLocations().iterator());
     log.info(
         "Detected {} orphan files older than {}ms",
@@ -100,6 +109,18 @@ public class OrphanFilesDeletionSparkApp extends BaseTableSparkApp {
             "s", "skipStaging", false, "Whether to skip staging orphan files before deletion"));
     extraOptions.add(new Option("b", "backupDir", true, "Backup directory for deleted data"));
     extraOptions.add(new Option("c", "concurrentDeletes", true, "Number of concurrent deletes"));
+    extraOptions.add(
+        new Option(
+            null,
+            "streamResults",
+            false,
+            "Stream orphan file deletions instead of collecting all paths into driver memory"));
+    extraOptions.add(
+        new Option(
+            null,
+            "maxOrphanFileSampleSize",
+            true,
+            "Maximum number of orphan file paths to return in the result when streaming"));
     CommandLine cmdLine = createCommandLine(args, extraOptions);
     return new OrphanFilesDeletionSparkApp(
         getJobId(cmdLine),
@@ -110,6 +131,10 @@ public class OrphanFilesDeletionSparkApp extends BaseTableSparkApp {
             TimeUnit.DAYS.toSeconds(1)),
         otelEmitter,
         cmdLine.getOptionValue("backupDir", ".backup"),
-        Integer.parseInt(cmdLine.getOptionValue("concurrentDeletes", "10")));
+        Integer.parseInt(cmdLine.getOptionValue("concurrentDeletes", "10")),
+        cmdLine.hasOption("streamResults"),
+        Integer.parseInt(
+            cmdLine.getOptionValue(
+                "maxOrphanFileSampleSize", String.valueOf(DEFAULT_MAX_ORPHAN_FILE_SAMPLE_SIZE))));
   }
 }

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -325,7 +325,8 @@ public class OperationsTest extends OpenHouseSparkITest {
       fs.createNewFile(orphanFilePath);
       fs.createNewFile(dataManifestPath);
       DeleteOrphanFiles.Result result =
-          ops.deleteOrphanFiles(table, System.currentTimeMillis(), true, BACKUP_DIR, 5);
+          ops.deleteOrphanFiles(
+              table, System.currentTimeMillis(), true, BACKUP_DIR, 5, false, 20000);
       List<String> orphanFiles = Lists.newArrayList(result.orphanFileLocations().iterator());
       Assertions.assertTrue(
           fs.exists(new Path(table.location(), new Path(BACKUP_DIR, testOrphanFileName))));
@@ -351,12 +352,13 @@ public class OperationsTest extends OpenHouseSparkITest {
       FileSystem fs = ops.fs();
       fs.createNewFile(orphanFilePath);
       fs.createNewFile(dataManifestPath);
-      ops.deleteOrphanFiles(table, System.currentTimeMillis(), true, BACKUP_DIR, 5);
+      ops.deleteOrphanFiles(table, System.currentTimeMillis(), true, BACKUP_DIR, 5, false, 20000);
       Path backupFilePath = new Path(table.location(), new Path(BACKUP_DIR, testOrphanFileName));
       Assertions.assertTrue(fs.exists(backupFilePath));
       // run delete operation again and verify that files in .backup are not listed as Orphan
       DeleteOrphanFiles.Result result =
-          ops.deleteOrphanFiles(table, System.currentTimeMillis(), true, BACKUP_DIR, 5);
+          ops.deleteOrphanFiles(
+              table, System.currentTimeMillis(), true, BACKUP_DIR, 5, false, 20000);
       List<String> orphanFiles = Lists.newArrayList(result.orphanFileLocations().iterator());
       Assertions.assertEquals(0, orphanFiles.size());
       Assertions.assertTrue(fs.exists(backupFilePath));
@@ -379,7 +381,8 @@ public class OperationsTest extends OpenHouseSparkITest {
       fs.createNewFile(orphanFilePath);
       fs.createNewFile(dataManifestPath);
       DeleteOrphanFiles.Result result =
-          ops.deleteOrphanFiles(table, System.currentTimeMillis(), true, BACKUP_DIR, 5);
+          ops.deleteOrphanFiles(
+              table, System.currentTimeMillis(), true, BACKUP_DIR, 5, false, 20000);
       List<String> orphanFiles = Lists.newArrayList(result.orphanFileLocations().iterator());
       Assertions.assertFalse(
           fs.exists(new Path(table.location(), new Path(BACKUP_DIR, testOrphanFileName))));
@@ -406,7 +409,8 @@ public class OperationsTest extends OpenHouseSparkITest {
       fs.createNewFile(orphanFilePath);
       fs.createNewFile(dataManifestPath);
       DeleteOrphanFiles.Result result =
-          ops.deleteOrphanFiles(table, System.currentTimeMillis(), false, BACKUP_DIR, 5);
+          ops.deleteOrphanFiles(
+              table, System.currentTimeMillis(), false, BACKUP_DIR, 5, false, 20000);
       List<String> orphanFiles = Lists.newArrayList(result.orphanFileLocations().iterator());
       Assertions.assertFalse(
           fs.exists(new Path(table.location(), new Path(BACKUP_DIR, testOrphanFileName))));
@@ -431,7 +435,8 @@ public class OperationsTest extends OpenHouseSparkITest {
       FileSystem fs = ops.fs();
       fs.createNewFile(orphanFilePath);
       DeleteOrphanFiles.Result result =
-          ops.deleteOrphanFiles(table, System.currentTimeMillis(), true, BACKUP_DIR, 5);
+          ops.deleteOrphanFiles(
+              table, System.currentTimeMillis(), true, BACKUP_DIR, 5, false, 20000);
       List<String> orphanFiles = Lists.newArrayList(result.orphanFileLocations().iterator());
       Assertions.assertFalse(
           fs.exists(new Path(table.location(), new Path(BACKUP_DIR, testOrphanFileName))));
@@ -743,7 +748,7 @@ public class OperationsTest extends OpenHouseSparkITest {
       fs.createNewFile(dataManifestPath);
       log.info("Created orphan file {}", testOrphanFile1);
       log.info("Created orphan file {}", testOrphanFile2);
-      ops.deleteOrphanFiles(table, System.currentTimeMillis(), true, TRASH_DIR, 5);
+      ops.deleteOrphanFiles(table, System.currentTimeMillis(), true, TRASH_DIR, 5, false, 20000);
       Assertions.assertTrue(
           fs.exists(new Path(table.location(), (new Path(TRASH_DIR, testOrphanFile1)))));
       Assertions.assertTrue(


### PR DESCRIPTION
## Summary

Adds --streamResults and --maxOrphanFileSampleSize CLI flags to OrphanFilesDeletionSparkApp. When stream-results is enabled, orphan file paths are streamed via toLocalIterator() instead of being collected into driver memory, preventing OOM on tables with large numbers of orphan files. The sample size controls how many paths are returned in the result (default 20000).

On Iceberg 1.2 (Spark 3.1) the options are safely ignored. On Iceberg 1.5 (Spark 3.5) streaming mode is activated.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [X] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [X] Added new tests for the changes made. - Includes integration tests for Spark 3.5 that verify:
- Streaming mode caps returned paths at maxOrphanFileSampleSize while still deleting all orphan files
- Non-streaming mode returns all paths regardless of sample size
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
