### PR TITLE
Add snapshot ID and timestamp to TableAuditEvent for replication lag tracking

### DIFF
--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
@@ -19,7 +19,9 @@ import com.linkedin.openhouse.tables.audit.model.OperationType;
 import com.linkedin.openhouse.tables.audit.model.TableAuditEvent;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.iceberg.SnapshotRef;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -386,25 +388,47 @@ public class TableAuditAspect {
   }
 
   /**
-   * Extracts snapshot ID and timestamp from the latest snapshot in the request body. The
-   * jsonSnapshots list contains JSON-serialized Iceberg snapshots with "snapshot-id" and
-   * "timestamp-ms" fields.
+   * Extracts snapshot ID and timestamp of the main branch from the request body. The snapshotRefs
+   * map contains branch name to JSON-serialized SnapshotRef. We read the main branch's snapshot-id
+   * (this is what Iceberg treats as current-snapshot-id — see TableMetadata.Builder.setRef()) and
+   * then find the matching snapshot in jsonSnapshots to get its timestamp-ms.
+   *
+   * <p>Leaves both fields null if the main branch ref is absent (e.g. branch-only commits where
+   * main didn't advance, or non-commit operations) or if the matching snapshot can't be found.
    */
   private void extractSnapshotInfo(
       IcebergSnapshotsRequestBody requestBody,
       TableAuditEvent.TableAuditEventBuilder eventBuilder) {
     try {
+      Map<String, String> snapshotRefs = requestBody.getSnapshotRefs();
+      if (snapshotRefs == null) {
+        return;
+      }
+      String mainRefJson = snapshotRefs.get(SnapshotRef.MAIN_BRANCH);
+      if (mainRefJson == null) {
+        return;
+      }
+      com.google.gson.JsonObject mainRef =
+          com.google.gson.JsonParser.parseString(mainRefJson).getAsJsonObject();
+      if (!mainRef.has("snapshot-id")) {
+        return;
+      }
+      long mainSnapshotId = mainRef.get("snapshot-id").getAsLong();
+      eventBuilder.currentSnapshotId(mainSnapshotId);
+
+      // Find the matching snapshot in jsonSnapshots to get its timestamp-ms
       List<String> jsonSnapshots = requestBody.getJsonSnapshots();
-      if (jsonSnapshots != null && !jsonSnapshots.isEmpty()) {
-        // Use the last snapshot in the list as the current/latest snapshot
-        String latestSnapshotJson = jsonSnapshots.get(jsonSnapshots.size() - 1);
+      if (jsonSnapshots == null) {
+        return;
+      }
+      for (String snapshotJson : jsonSnapshots) {
         com.google.gson.JsonObject snapshotObj =
-            com.google.gson.JsonParser.parseString(latestSnapshotJson).getAsJsonObject();
-        if (snapshotObj.has("snapshot-id")) {
-          eventBuilder.currentSnapshotId(snapshotObj.get("snapshot-id").getAsLong());
-        }
-        if (snapshotObj.has("timestamp-ms")) {
+            com.google.gson.JsonParser.parseString(snapshotJson).getAsJsonObject();
+        if (snapshotObj.has("snapshot-id")
+            && snapshotObj.get("snapshot-id").getAsLong() == mainSnapshotId
+            && snapshotObj.has("timestamp-ms")) {
           eventBuilder.currentSnapshotTimestampMs(snapshotObj.get("timestamp-ms").getAsLong());
+          return;
         }
       }
     } catch (Exception e) {

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
@@ -21,7 +21,10 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotParser;
 import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.SnapshotRefParser;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -408,12 +411,7 @@ public class TableAuditAspect {
       if (mainRefJson == null) {
         return;
       }
-      com.google.gson.JsonObject mainRef =
-          com.google.gson.JsonParser.parseString(mainRefJson).getAsJsonObject();
-      if (!mainRef.has("snapshot-id")) {
-        return;
-      }
-      long mainSnapshotId = mainRef.get("snapshot-id").getAsLong();
+      long mainSnapshotId = SnapshotRefParser.fromJson(mainRefJson).snapshotId();
       eventBuilder.currentSnapshotId(mainSnapshotId);
 
       // Find the matching snapshot in jsonSnapshots to get its timestamp-ms. Iterate in reverse
@@ -430,12 +428,9 @@ public class TableAuditAspect {
         if (!snapshotJson.contains(mainSnapshotIdStr)) {
           continue;
         }
-        com.google.gson.JsonObject snapshotObj =
-            com.google.gson.JsonParser.parseString(snapshotJson).getAsJsonObject();
-        if (snapshotObj.has("snapshot-id")
-            && snapshotObj.get("snapshot-id").getAsLong() == mainSnapshotId
-            && snapshotObj.has("timestamp-ms")) {
-          eventBuilder.currentSnapshotTimestampMs(snapshotObj.get("timestamp-ms").getAsLong());
+        Snapshot snapshot = SnapshotParser.fromJson(snapshotJson);
+        if (snapshot.snapshotId() == mainSnapshotId) {
+          eventBuilder.currentSnapshotTimestampMs(snapshot.timestampMillis());
           return;
         }
       }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
@@ -18,6 +18,8 @@ import com.linkedin.openhouse.tables.audit.model.OperationStatus;
 import com.linkedin.openhouse.tables.audit.model.OperationType;
 import com.linkedin.openhouse.tables.audit.model.TableAuditEvent;
 import java.time.Instant;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -28,6 +30,7 @@ import org.springframework.stereotype.Component;
  * Aspect class to support table operation auditing for all controllers. It enhances the ability of
  * particular methods by adding logic of building and emitting audit events.
  */
+@Slf4j
 @Aspect
 @Component
 public class TableAuditAspect {
@@ -363,13 +366,14 @@ public class TableAuditAspect {
     } else {
       operationType = OperationType.COMMIT;
     }
-    TableAuditEvent event =
+    TableAuditEvent.TableAuditEventBuilder eventBuilder =
         TableAuditEvent.builder()
             .eventTimestamp(Instant.now())
             .databaseName(databaseId)
             .tableName(tableId)
-            .operationType(operationType)
-            .build();
+            .operationType(operationType);
+    extractSnapshotInfo(icebergSnapshotRequestBody, eventBuilder);
+    TableAuditEvent event = eventBuilder.build();
     try {
       result = (ApiResponse<GetTableResponseBody>) point.proceed();
       buildAndSendEvent(
@@ -379,6 +383,34 @@ public class TableAuditAspect {
       throw t;
     }
     return result;
+  }
+
+  /**
+   * Extracts snapshot ID and timestamp from the latest snapshot in the request body. The
+   * jsonSnapshots list contains JSON-serialized Iceberg snapshots with "snapshot-id" and
+   * "timestamp-ms" fields.
+   */
+  private void extractSnapshotInfo(
+      IcebergSnapshotsRequestBody requestBody,
+      TableAuditEvent.TableAuditEventBuilder eventBuilder) {
+    try {
+      List<String> jsonSnapshots = requestBody.getJsonSnapshots();
+      if (jsonSnapshots != null && !jsonSnapshots.isEmpty()) {
+        // Use the last snapshot in the list as the current/latest snapshot
+        String latestSnapshotJson = jsonSnapshots.get(jsonSnapshots.size() - 1);
+        com.google.gson.JsonObject snapshotObj =
+            com.google.gson.JsonParser.parseString(latestSnapshotJson).getAsJsonObject();
+        if (snapshotObj.has("snapshot-id")) {
+          eventBuilder.currentSnapshotId(snapshotObj.get("snapshot-id").getAsLong());
+        }
+        if (snapshotObj.has("timestamp-ms")) {
+          eventBuilder.currentSnapshotTimestampMs(snapshotObj.get("timestamp-ms").getAsLong());
+        }
+      }
+    } catch (Exception e) {
+      // Snapshot extraction is best-effort; don't fail the audit event
+      log.warn("Failed to extract snapshot info for audit event", e);
+    }
   }
 
   /** Install the Around advice for getAllDatabases() method in OpenHouseDatabasesApiHandler */

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
@@ -416,12 +416,20 @@ public class TableAuditAspect {
       long mainSnapshotId = mainRef.get("snapshot-id").getAsLong();
       eventBuilder.currentSnapshotId(mainSnapshotId);
 
-      // Find the matching snapshot in jsonSnapshots to get its timestamp-ms
+      // Find the matching snapshot in jsonSnapshots to get its timestamp-ms. Iterate in reverse
+      // because Iceberg appends snapshots chronologically and main's snapshot is typically the
+      // most recent. Skip snapshots whose JSON doesn't contain the target id as a cheap
+      // pre-filter before invoking the JSON parser.
       List<String> jsonSnapshots = requestBody.getJsonSnapshots();
       if (jsonSnapshots == null) {
         return;
       }
-      for (String snapshotJson : jsonSnapshots) {
+      String mainSnapshotIdStr = Long.toString(mainSnapshotId);
+      for (int i = jsonSnapshots.size() - 1; i >= 0; i--) {
+        String snapshotJson = jsonSnapshots.get(i);
+        if (!snapshotJson.contains(mainSnapshotIdStr)) {
+          continue;
+        }
         com.google.gson.JsonObject snapshotObj =
             com.google.gson.JsonParser.parseString(snapshotJson).getAsJsonObject();
         if (snapshotObj.has("snapshot-id")

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/model/TableAuditEvent.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/model/TableAuditEvent.java
@@ -36,4 +36,8 @@ public class TableAuditEvent extends BaseAuditEvent {
   private String grantee;
 
   private String role;
+
+  private Long currentSnapshotId;
+
+  private Long currentSnapshotTimestampMs;
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/RequestConstants.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/RequestConstants.java
@@ -91,10 +91,14 @@ public final class RequestConstants {
           + "\"schema-id\" : 0\n"
           + "}\n";
 
+  public static final String TEST_MAIN_SNAPSHOT_REF_JSON =
+      "{\"snapshot-id\":2151407017102313398,\"type\":\"branch\"}";
+
   public static final IcebergSnapshotsRequestBody TEST_ICEBERG_SNAPSHOTS_REQUEST_BODY =
       IcebergSnapshotsRequestBody.builder()
           .baseTableVersion("v1")
           .jsonSnapshots(Collections.singletonList(TEST_ICEBERG_SNAPSHOT_JSON))
+          .snapshotRefs(Collections.singletonMap("main", TEST_MAIN_SNAPSHOT_REF_JSON))
           .createUpdateTableRequestBody(TEST_CREATE_TABLE_REQUEST_BODY)
           .build();
 
@@ -102,6 +106,7 @@ public final class RequestConstants {
       IcebergSnapshotsRequestBody.builder()
           .baseTableVersion("v1")
           .jsonSnapshots(Collections.singletonList(TEST_ICEBERG_SNAPSHOT_JSON))
+          .snapshotRefs(Collections.singletonMap("main", TEST_MAIN_SNAPSHOT_REF_JSON))
           .createUpdateTableRequestBody(
               TEST_CREATE_TABLE_REQUEST_BODY
                   .toBuilder()
@@ -117,6 +122,7 @@ public final class RequestConstants {
           IcebergSnapshotsRequestBody.builder()
               .baseTableVersion("INITIAL_VERSION")
               .jsonSnapshots(Collections.singletonList(TEST_ICEBERG_SNAPSHOT_JSON))
+              .snapshotRefs(Collections.singletonMap("main", TEST_MAIN_SNAPSHOT_REF_JSON))
               .createUpdateTableRequestBody(TEST_CREATE_TABLE_REQUEST_BODY)
               .build();
 

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
@@ -6,8 +6,13 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.linkedin.openhouse.common.audit.AuditHandler;
+import com.linkedin.openhouse.tables.api.spec.v0.request.IcebergSnapshotsRequestBody;
 import com.linkedin.openhouse.tables.audit.model.TableAuditEvent;
 import com.linkedin.openhouse.tables.mock.RequestConstants;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -100,6 +105,83 @@ public class IcebergSnapshotsApiHandlerAuditTest {
     // failure
     assertEquals(2151407017102313398L, actualEvent.getCurrentSnapshotId().longValue());
     assertEquals(1669126937912L, actualEvent.getCurrentSnapshotTimestampMs().longValue());
+  }
+
+  @Test
+  public void testPutIcebergSnapshotsBranchOnlyCommitLeavesSnapshotInfoNull() throws Exception {
+    // Simulate a branch-only commit where main is absent from snapshotRefs.
+    // In this case the main branch ref doesn't exist, so currentSnapshotId /
+    // currentSnapshotTimestampMs should be null.
+    IcebergSnapshotsRequestBody branchOnlyRequestBody =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion("v1")
+            .jsonSnapshots(Collections.singletonList(RequestConstants.TEST_ICEBERG_SNAPSHOT_JSON))
+            .snapshotRefs(
+                Collections.singletonMap(
+                    "my_branch", "{\"snapshot-id\":2151407017102313398,\"type\":\"branch\"}"))
+            .createUpdateTableRequestBody(RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY)
+            .build();
+
+    mvc.perform(
+        MockMvcRequestBuilders.put(
+                String.format(
+                    CURRENT_MAJOR_VERSION_PREFIX
+                        + "/databases/d200/tables/tb1/iceberg/v2/snapshots"))
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(branchOnlyRequestBody.toJson()));
+    Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
+    TableAuditEvent actualEvent = argCaptor.getValue();
+    assertNull(actualEvent.getCurrentSnapshotId());
+    assertNull(actualEvent.getCurrentSnapshotTimestampMs());
+  }
+
+  @Test
+  public void testPutIcebergSnapshotsMainPointsToOlderSnapshot() throws Exception {
+    // Simulate a branch-write where jsonSnapshots has 2 snapshots but main still points to the
+    // older one.
+    // Verifies we pick the main snapshot, not the last snapshot in the list.
+    String olderSnapshotJson =
+        "{\n"
+            + "  \"snapshot-id\" : 100,\n"
+            + "  \"timestamp-ms\" : 1000,\n"
+            + "  \"summary\" : {\"operation\": \"append\"},\n"
+            + "  \"manifest-list\" : \"/tmp/old.avro\",\n"
+            + "  \"schema-id\" : 0\n"
+            + "}";
+    String newerSnapshotJson =
+        "{\n"
+            + "  \"snapshot-id\" : 200,\n"
+            + "  \"parent-snapshot-id\" : 100,\n"
+            + "  \"timestamp-ms\" : 2000,\n"
+            + "  \"summary\" : {\"operation\": \"append\"},\n"
+            + "  \"manifest-list\" : \"/tmp/new.avro\",\n"
+            + "  \"schema-id\" : 0\n"
+            + "}";
+    Map<String, String> refs = new HashMap<>();
+    refs.put("main", "{\"snapshot-id\":100,\"type\":\"branch\"}"); // main stayed at older snapshot
+    refs.put("feature", "{\"snapshot-id\":200,\"type\":\"branch\"}"); // branch has newer snapshot
+
+    IcebergSnapshotsRequestBody branchWriteRequestBody =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion("v1")
+            .jsonSnapshots(Arrays.asList(olderSnapshotJson, newerSnapshotJson))
+            .snapshotRefs(refs)
+            .createUpdateTableRequestBody(RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY)
+            .build();
+
+    mvc.perform(
+        MockMvcRequestBuilders.put(
+                String.format(
+                    CURRENT_MAJOR_VERSION_PREFIX
+                        + "/databases/d200/tables/tb1/iceberg/v2/snapshots"))
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(branchWriteRequestBody.toJson()));
+    Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
+    TableAuditEvent actualEvent = argCaptor.getValue();
+    assertEquals(100L, actualEvent.getCurrentSnapshotId().longValue());
+    assertEquals(1000L, actualEvent.getCurrentSnapshotTimestampMs().longValue());
   }
 
   @Test

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
@@ -69,6 +69,40 @@ public class IcebergSnapshotsApiHandlerAuditTest {
   }
 
   @Test
+  public void testPutIcebergSnapshotsContainsSnapshotInfo() throws Exception {
+    mvc.perform(
+        MockMvcRequestBuilders.put(
+                String.format(
+                    CURRENT_MAJOR_VERSION_PREFIX
+                        + "/databases/d200/tables/tb1/iceberg/v2/snapshots"))
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(RequestConstants.TEST_ICEBERG_SNAPSHOTS_REQUEST_BODY.toJson()));
+    Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
+    TableAuditEvent actualEvent = argCaptor.getValue();
+    assertEquals(2151407017102313398L, actualEvent.getCurrentSnapshotId().longValue());
+    assertEquals(1669126937912L, actualEvent.getCurrentSnapshotTimestampMs().longValue());
+  }
+
+  @Test
+  public void testPutIcebergSnapshotsFailedPathStillHasSnapshotInfo() throws Exception {
+    mvc.perform(
+        MockMvcRequestBuilders.put(
+                String.format(
+                    CURRENT_MAJOR_VERSION_PREFIX
+                        + "/databases/d400/tables/tb1/iceberg/v2/snapshots"))
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(RequestConstants.TEST_ICEBERG_SNAPSHOTS_REQUEST_BODY.toJson()));
+    Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
+    TableAuditEvent actualEvent = argCaptor.getValue();
+    // Snapshot info is extracted from request body before execution, so it's present even on
+    // failure
+    assertEquals(2151407017102313398L, actualEvent.getCurrentSnapshotId().longValue());
+    assertEquals(1669126937912L, actualEvent.getCurrentSnapshotTimestampMs().longValue());
+  }
+
+  @Test
   public void testCTASCommitPhase() throws Exception {
     mvc.perform(
         MockMvcRequestBuilders.put(

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/model/TableAuditModelConstants.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/model/TableAuditModelConstants.java
@@ -223,6 +223,8 @@ public final class TableAuditModelConstants {
           .user(USER)
           .operationStatus(OperationStatus.SUCCESS)
           .operationType(OperationType.COMMIT)
+          .currentSnapshotId(2151407017102313398L)
+          .currentSnapshotTimestampMs(1669126937912L)
           .build();
 
   public static final TableAuditEvent TABLE_AUDIT_EVENT_PUT_ICEBERG_SNAPSHOTS_FAILED =
@@ -233,6 +235,8 @@ public final class TableAuditModelConstants {
           .user(USER)
           .operationStatus(OperationStatus.FAILED)
           .operationType(OperationType.COMMIT)
+          .currentSnapshotId(2151407017102313398L)
+          .currentSnapshotTimestampMs(1669126937912L)
           .build();
 
   public static final TableAuditEvent TABLE_AUDIT_EVENT_PUT_ICEBERG_SNAPSHOTS_CTAS =
@@ -243,6 +247,8 @@ public final class TableAuditModelConstants {
           .user(USER)
           .operationStatus(OperationStatus.SUCCESS)
           .operationType(OperationType.STAGED_COMMIT)
+          .currentSnapshotId(2151407017102313398L)
+          .currentSnapshotTimestampMs(1669126937912L)
           .build();
 
   public static final TableAuditEvent TABLE_AUDIT_EVENT_GET_ALL_DATABASES_SUCCESS =


### PR DESCRIPTION
## Summary
Enrich the table audit event emitted on putIcebergSnapshots with the Iceberg snapshot ID and timestamp from the request body. This enables near real-time replication staleness measurement by comparing snapshot timestamps between primary and replica tables.

- Add currentSnapshotId and currentSnapshotTimestampMs fields to TableAuditEvent
- Extract snapshot info from jsonSnapshots in TableAuditAspect (best-effort, no latency impact)
- Add tests verifying snapshot fields are present on both success and failure paths.

#### Why this change is needed:                                                                                                                                                                                                                                   
OpenHouse replicates Iceberg tables across clusters (Holdem and War) for disaster recovery / read replica mechanism. Measuring replication staleness — how far behind a replica is from its primary — requires comparing Iceberg snapshot timestamps between the two.                 
                                                                                                                                                   
Today, the only event with snapshot timestamps is OpenHouseTableStatsEvent, which runs as a daily batch job that takes ~20 hours to complete on production. This means staleness can only be detected with a 24-44 hour delay — too slow for tables with replication intervals as short as 1 hour.
                                                                                                                                                   
OpenhouseTableAuditEvent is emitted in real-time on every putIcebergSnapshots call — both when users write to primary tables and when replication pipeline commits to replica tables. By including the Iceberg snapshot timestamp in this event, we can compute replication staleness in real-time and alert when it exceeds the configured interval (e.g. interval is 1H but lag is 6H).                                                      

## Changes
- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [X] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [X] Manually Tested on local docker setup.


Validated end-to-end with Spark 3.5 + Iceberg 1.5 in local Docker. After applying the fix, audit events for a branch-write scenario correctly report main's snapshot (unchanged), not the branch snapshot:                                                                                       
                                                  
| Event | Operation | currentSnapshotId | currentSnapshotTimestampMs |                                                                             
|-------|-----------|-------------------|----------------------------|                                                 
| 1 | INSERT 1 to main | `3185925322137581677` | `1776678245887` |                                                                                 
| 2 | CREATE BRANCH staging | `3185925322137581677` (unchanged) | `1776678245887` (unchanged) |
| 3 | INSERT to branch_staging | `3185925322137581677` (unchanged) | `1776678245887` (unchanged) |                                                 
| 4 | INSERT 3 to main | `7107739783015246721` (new) | `1776678252907` (new) |                                                                     
                                                                                                                                                     

- [X] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
