### PR TITLE
Fail retention app when the columnPattern mismatch partition spec for…

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -50,6 +50,7 @@ import org.apache.iceberg.actions.RewriteDataFiles;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.spark.actions.SparkActions;
@@ -333,6 +334,15 @@ public final class Operations implements AutoCloseable {
     TableScan scan = table.newScan().filter(filter);
     try (CloseableIterable<FileScanTask> filesIterable = scan.planFiles()) {
       List<FileScanTask> filesList = Lists.newArrayList(filesIterable);
+      for (FileScanTask task : filesList) {
+        if (task.residual() != Expressions.alwaysTrue()) {
+          throw new IllegalStateException(
+              String.format(
+                  "Retention with backup enabled requires a metadata-only delete for table %s, "
+                      + "but file %s has residual filter %s, which would require a row-level rewrite.",
+                  fqtn, task.file().path(), task.residual()));
+        }
+      }
       return filesList.stream()
           .collect(
               Collectors.groupingBy(

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -334,15 +334,17 @@ public final class Operations implements AutoCloseable {
     TableScan scan = table.newScan().filter(filter);
     try (CloseableIterable<FileScanTask> filesIterable = scan.planFiles()) {
       List<FileScanTask> filesList = Lists.newArrayList(filesIterable);
-      for (FileScanTask task : filesList) {
-        if (task.residual() != Expressions.alwaysTrue()) {
-          throw new IllegalStateException(
-              String.format(
-                  "Retention with backup enabled requires a metadata-only delete for table %s, "
-                      + "but file %s has residual filter %s, which would require a row-level rewrite.",
-                  fqtn, task.file().path(), task.residual()));
-        }
-      }
+      filesList.stream()
+          .filter(task -> task.residual() != Expressions.alwaysTrue())
+          .findFirst()
+          .ifPresent(
+              task -> {
+                throw new IllegalStateException(
+                    String.format(
+                        "Retention with backup enabled requires a metadata-only delete for table %s, "
+                            + "but file %s has residual filter %s, which would require a row-level rewrite.",
+                        fqtn, task.file().path(), task.residual()));
+              });
       return filesList.stream()
           .collect(
               Collectors.groupingBy(

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -335,7 +335,7 @@ public final class Operations implements AutoCloseable {
     try (CloseableIterable<FileScanTask> filesIterable = scan.planFiles()) {
       List<FileScanTask> filesList = Lists.newArrayList(filesIterable);
       filesList.stream()
-          .filter(task -> task.residual() != Expressions.alwaysTrue())
+          .filter(task -> !Expressions.alwaysTrue().isEquivalentTo(task.residual()))
           .findFirst()
           .ifPresent(
               task -> {

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -310,6 +310,54 @@ public class OperationsTest extends OpenHouseSparkITest {
   }
 
   @Test
+  public void testRetentionWithBackupFailsWhenColumnPatternMismatchesPartition() throws Exception {
+    final String tableName = "db.test_retention_backup_pattern_mismatch";
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      // The table is partitioned on `datepartition`, but retention will filter
+      // on `time_col` using a pattern unrelated to the partitioning. For each
+      // file's per-file min/max to actually straddle the cutoff (and produce
+      // a non-trivial residual), both `time_col` values within a partition
+      // must live in the same data file — so we force a single writer task
+      // via the COALESCE(1) hint.
+      ops.spark().sql(String.format("DROP TABLE IF EXISTS %s", tableName)).show();
+      ops.spark()
+          .sql(
+              String.format(
+                  "CREATE TABLE %s (data string, datepartition string, time_col string) "
+                      + "PARTITIONED BY (datepartition)",
+                  tableName))
+          .show();
+      ops.spark()
+          .sql(
+              "SELECT data, datepartition, time_col FROM VALUES "
+                  + "('a', '2024-01', '2020-01-01-00'), "
+                  + "('b', '2024-01', '2030-01-01-00'), "
+                  + "('c', '2024-02', '2020-01-01-00'), "
+                  + "('d', '2024-02', '2030-01-01-00') "
+                  + "AS t(data, datepartition, time_col)")
+          .coalesce(1)
+          .writeTo(tableName)
+          .append();
+
+      // Fix `now` so the cutoff (now - 1 day, formatted yyyy-MM-dd-HH) falls
+      // strictly between each file's min ("2020-01-01-00") and max
+      // ("2030-01-01-00") — forcing a non-trivial residual on every file.
+      ZonedDateTime now = ZonedDateTime.of(2025, 6, 15, 10, 0, 0, 0, ZoneOffset.UTC);
+      IllegalStateException ex =
+          Assertions.assertThrows(
+              IllegalStateException.class,
+              () ->
+                  ops.runRetention(
+                      tableName, "time_col", "yyyy-MM-dd-HH", "day", 1, true, ".backup", now));
+      Assertions.assertTrue(
+          ex.getMessage().contains("metadata-only delete"),
+          "Expected metadata-only delete error, got: " + ex.getMessage());
+      // DELETE should not have executed: all 4 rows remain.
+      verifyRowCount(ops, tableName, 4);
+    }
+  }
+
+  @Test
   public void testOrphanFilesDeletionJavaAPI() throws Exception {
     final String tableName = "db.test_ofd_java";
     final String testOrphanFileName = "data/test_orphan_file.orc";


### PR DESCRIPTION
## Summary

Fail retention app when the columnPattern mismatch partition spec for HCR tables. Sometimes users use a non-partitioned column for retention policy, and this will cause rewrite data files in the retention job. If we enable rename, this will cause data loss. So we decided to fail the operation when the delete is not a metdata-only operation. We detect it by checking if all the planned files have no residual from the the patition data.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
