### PR TITLE
Consolidate single-level namespace validation in OpenHouseInternalCatalog

### DIFF
--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -79,7 +79,7 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
 
   @Override
   protected boolean isValidIdentifier(TableIdentifier tableIdentifier) {
-    return tableIdentifier != null && tableIdentifier.namespace().levels().length == 1;
+    return tableIdentifier != null && NamespaceUtil.isSingleLevel(tableIdentifier.namespace());
   }
 
   @Override
@@ -94,7 +94,7 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
 
   @Override
   public List<TableIdentifier> listTables(Namespace namespace) {
-    NamespaceUtil.checkSingleLevelNamespace(namespace);
+    NamespaceUtil.checkAtMostSingleLevelNamespace(namespace);
     // TODO: Implement SupportsNamespace interface and listNamespaces() method to remove this
     //  branch. This is anti-pattern and only a temporary solution.
     if (namespace.isEmpty()) {
@@ -108,7 +108,7 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
   }
 
   public Page<TableIdentifier> listTables(Namespace namespace, Pageable pageable) {
-    NamespaceUtil.checkSingleLevelNamespace(namespace);
+    NamespaceUtil.checkAtMostSingleLevelNamespace(namespace);
     if (namespace.isEmpty()) {
       return houseTableRepository
           .findAll(pageable)
@@ -189,7 +189,7 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
 
   public Page<SoftDeletedTableDto> searchSoftDeletedTables(
       Namespace namespace, String tableId, Pageable pageable) {
-    NamespaceUtil.checkSingleLevelNamespace(namespace);
+    NamespaceUtil.checkAtMostSingleLevelNamespace(namespace);
 
     try {
       return houseTableRepository

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -9,6 +9,7 @@ import com.linkedin.openhouse.cluster.storage.selector.StorageSelector;
 import com.linkedin.openhouse.common.api.spec.TableUri;
 import com.linkedin.openhouse.common.exception.AlreadyExistsException;
 import com.linkedin.openhouse.common.exception.NoSuchSoftDeletedUserTableException;
+import com.linkedin.openhouse.common.utils.NamespaceUtil;
 import com.linkedin.openhouse.internal.catalog.fileio.FileIOManager;
 import com.linkedin.openhouse.internal.catalog.mapper.HouseTableMapper;
 import com.linkedin.openhouse.internal.catalog.model.HouseTable;
@@ -31,7 +32,6 @@ import org.apache.iceberg.Transaction;
 import org.apache.iceberg.UpdateProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.SupportsPrefixOperations;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -94,10 +94,7 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
 
   @Override
   public List<TableIdentifier> listTables(Namespace namespace) {
-    if (namespace.levels().length > 1) {
-      throw new ValidationException(
-          "Input namespace has more than one levels " + String.join(".", namespace.levels()));
-    }
+    NamespaceUtil.checkSingleLevelNamespace(namespace);
     // TODO: Implement SupportsNamespace interface and listNamespaces() method to remove this
     //  branch. This is anti-pattern and only a temporary solution.
     if (namespace.isEmpty()) {
@@ -111,10 +108,7 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
   }
 
   public Page<TableIdentifier> listTables(Namespace namespace, Pageable pageable) {
-    if (namespace.levels().length > 1) {
-      throw new ValidationException(
-          "Input namespace has more than one levels " + String.join(".", namespace.levels()));
-    }
+    NamespaceUtil.checkSingleLevelNamespace(namespace);
     if (namespace.isEmpty()) {
       return houseTableRepository
           .findAll(pageable)
@@ -195,10 +189,7 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
 
   public Page<SoftDeletedTableDto> searchSoftDeletedTables(
       Namespace namespace, String tableId, Pageable pageable) {
-    if (namespace.levels().length > 1) {
-      throw new ValidationException(
-          "Input namespace has more than one levels " + String.join(".", namespace.levels()));
-    }
+    NamespaceUtil.checkSingleLevelNamespace(namespace);
 
     try {
       return houseTableRepository

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -79,7 +79,7 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
 
   @Override
   protected boolean isValidIdentifier(TableIdentifier tableIdentifier) {
-    return tableIdentifier != null && NamespaceUtil.isSingleLevel(tableIdentifier.namespace());
+    return tableIdentifier != null && NamespaceUtil.isTableNamespace(tableIdentifier.namespace());
   }
 
   @Override
@@ -94,7 +94,7 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
 
   @Override
   public List<TableIdentifier> listTables(Namespace namespace) {
-    NamespaceUtil.checkAtMostSingleLevelNamespace(namespace);
+    NamespaceUtil.validateOperationNamespace(namespace);
     // TODO: Implement SupportsNamespace interface and listNamespaces() method to remove this
     //  branch. This is anti-pattern and only a temporary solution.
     if (namespace.isEmpty()) {
@@ -108,7 +108,7 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
   }
 
   public Page<TableIdentifier> listTables(Namespace namespace, Pageable pageable) {
-    NamespaceUtil.checkAtMostSingleLevelNamespace(namespace);
+    NamespaceUtil.validateOperationNamespace(namespace);
     if (namespace.isEmpty()) {
       return houseTableRepository
           .findAll(pageable)
@@ -189,7 +189,7 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
 
   public Page<SoftDeletedTableDto> searchSoftDeletedTables(
       Namespace namespace, String tableId, Pageable pageable) {
-    NamespaceUtil.checkAtMostSingleLevelNamespace(namespace);
+    NamespaceUtil.validateOperationNamespace(namespace);
 
     try {
       return houseTableRepository

--- a/services/common/src/main/java/com/linkedin/openhouse/common/utils/NamespaceUtil.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/utils/NamespaceUtil.java
@@ -20,6 +20,13 @@ public final class NamespaceUtil {
   private NamespaceUtil() {}
 
   /**
+   * Maximum number of namespace levels OpenHouse accepts. A "table namespace" is exactly this deep;
+   * an "operation namespace" is at most this deep. Adjust here if OpenHouse ever extends its
+   * namespace contract (e.g. to support {@code catalog.database.table}).
+   */
+  private static final int MAX_NAMESPACE_DEPTH = 1;
+
+  /**
    * Returns whether {@code namespace} can host an OpenHouse base table.
    *
    * <p>Used by {@code isValidIdentifier(...)} to gate which {@link
@@ -28,7 +35,7 @@ public final class NamespaceUtil {
    * because there is no database under which to place the table.
    */
   public static boolean isTableNamespace(Namespace namespace) {
-    return namespace != null && namespace.levels().length == 1;
+    return namespace != null && namespace.levels().length == MAX_NAMESPACE_DEPTH;
   }
 
   /**
@@ -41,7 +48,7 @@ public final class NamespaceUtil {
    * @throws ValidationException if {@code namespace} cannot be used as an operation argument
    */
   public static void validateOperationNamespace(Namespace namespace) {
-    if (namespace.levels().length > 1) {
+    if (namespace.levels().length > MAX_NAMESPACE_DEPTH) {
       throw new ValidationException(
           "Input namespace has more than one levels " + String.join(".", namespace.levels()));
     }

--- a/services/common/src/main/java/com/linkedin/openhouse/common/utils/NamespaceUtil.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/utils/NamespaceUtil.java
@@ -8,6 +8,15 @@ public final class NamespaceUtil {
   private NamespaceUtil() {}
 
   /**
+   * Returns whether {@code namespace} matches OpenHouse's {@code database.table} identifier shape,
+   * i.e. has exactly one level. Used by {@code isValidIdentifier(...)} to gate which identifiers
+   * are treated as base tables (vs. metadata-table fallbacks, longer-namespace lookups, etc.).
+   */
+  public static boolean isSingleLevel(Namespace namespace) {
+    return namespace != null && namespace.levels().length == 1;
+  }
+
+  /**
    * Enforce OpenHouse's database-only namespace shape on callers that accept a {@link Namespace}
    * argument.
    *
@@ -18,7 +27,7 @@ public final class NamespaceUtil {
    * @param namespace the namespace to validate
    * @throws ValidationException if the namespace has more than one level
    */
-  public static void checkSingleLevelNamespace(Namespace namespace) {
+  public static void checkAtMostSingleLevelNamespace(Namespace namespace) {
     if (namespace.levels().length > 1) {
       throw new ValidationException(
           "Input namespace has more than one levels " + String.join(".", namespace.levels()));

--- a/services/common/src/main/java/com/linkedin/openhouse/common/utils/NamespaceUtil.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/utils/NamespaceUtil.java
@@ -3,31 +3,44 @@ package com.linkedin.openhouse.common.utils;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.exceptions.ValidationException;
 
-/** Utility class for validating Iceberg {@link Namespace} objects in OpenHouse. */
+/**
+ * Helpers that encode OpenHouse's namespace contract for {@link Namespace} arguments.
+ *
+ * <p>OpenHouse currently identifies base tables with {@code database.table}, so a "table namespace"
+ * is exactly one level (the database) and an "operation namespace" — the {@code Namespace} argument
+ * to a database-scoped catalog method — is at most one level (with the empty namespace acting as a
+ * sentinel for "across all databases").
+ *
+ * <p>The two predicates are intentionally separate concepts, not stricter/looser flavors of the
+ * same rule. If OpenHouse ever changes its namespace shape (e.g. to support {@code
+ * catalog.database.table}), the rule bodies update here and the call-site names continue to read
+ * correctly.
+ */
 public final class NamespaceUtil {
   private NamespaceUtil() {}
 
   /**
-   * Returns whether {@code namespace} matches OpenHouse's {@code database.table} identifier shape,
-   * i.e. has exactly one level. Used by {@code isValidIdentifier(...)} to gate which identifiers
-   * are treated as base tables (vs. metadata-table fallbacks, longer-namespace lookups, etc.).
+   * Returns whether {@code namespace} can host an OpenHouse base table.
+   *
+   * <p>Used by {@code isValidIdentifier(...)} to gate which {@link
+   * org.apache.iceberg.catalog.TableIdentifier}s are treated as base tables (vs. metadata-table
+   * fallbacks, longer-namespace lookups, etc.). The empty namespace is not a table namespace
+   * because there is no database under which to place the table.
    */
-  public static boolean isSingleLevel(Namespace namespace) {
+  public static boolean isTableNamespace(Namespace namespace) {
     return namespace != null && namespace.levels().length == 1;
   }
 
   /**
-   * Enforce OpenHouse's database-only namespace shape on callers that accept a {@link Namespace}
-   * argument.
+   * Validate that {@code namespace} is a legal argument to a database-scoped catalog operation
+   * (e.g. {@code listTables}, {@code searchSoftDeletedTables}).
    *
-   * <p>OpenHouse identifies base tables with {@code database.table}, so the namespace portion is at
-   * most a single level. The empty namespace is permitted because several callers use it to mean
-   * "across all databases" (e.g. {@code listTables(Namespace.empty())}).
+   * <p>The empty namespace is permitted because callers use it as a sentinel for "across all
+   * databases" (e.g. {@code listTables(Namespace.empty())}).
    *
-   * @param namespace the namespace to validate
-   * @throws ValidationException if the namespace has more than one level
+   * @throws ValidationException if {@code namespace} cannot be used as an operation argument
    */
-  public static void checkAtMostSingleLevelNamespace(Namespace namespace) {
+  public static void validateOperationNamespace(Namespace namespace) {
     if (namespace.levels().length > 1) {
       throw new ValidationException(
           "Input namespace has more than one levels " + String.join(".", namespace.levels()));

--- a/services/common/src/main/java/com/linkedin/openhouse/common/utils/NamespaceUtil.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/utils/NamespaceUtil.java
@@ -1,0 +1,27 @@
+package com.linkedin.openhouse.common.utils;
+
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.exceptions.ValidationException;
+
+/** Utility class for validating Iceberg {@link Namespace} objects in OpenHouse. */
+public final class NamespaceUtil {
+  private NamespaceUtil() {}
+
+  /**
+   * Enforce OpenHouse's database-only namespace shape on callers that accept a {@link Namespace}
+   * argument.
+   *
+   * <p>OpenHouse identifies base tables with {@code database.table}, so the namespace portion is at
+   * most a single level. The empty namespace is permitted because several callers use it to mean
+   * "across all databases" (e.g. {@code listTables(Namespace.empty())}).
+   *
+   * @param namespace the namespace to validate
+   * @throws ValidationException if the namespace has more than one level
+   */
+  public static void checkSingleLevelNamespace(Namespace namespace) {
+    if (namespace.levels().length > 1) {
+      throw new ValidationException(
+          "Input namespace has more than one levels " + String.join(".", namespace.levels()));
+    }
+  }
+}

--- a/services/common/src/test/java/com/linkedin/openhouse/common/utils/NamespaceUtilTest.java
+++ b/services/common/src/test/java/com/linkedin/openhouse/common/utils/NamespaceUtilTest.java
@@ -8,38 +8,38 @@ import org.junit.jupiter.api.Test;
 public class NamespaceUtilTest {
 
   @Test
-  public void testIsSingleLevel() {
-    Assertions.assertFalse(NamespaceUtil.isSingleLevel(null));
-    Assertions.assertFalse(NamespaceUtil.isSingleLevel(Namespace.empty()));
-    Assertions.assertTrue(NamespaceUtil.isSingleLevel(Namespace.of("db")));
-    Assertions.assertFalse(NamespaceUtil.isSingleLevel(Namespace.of("a", "b")));
-    Assertions.assertFalse(NamespaceUtil.isSingleLevel(Namespace.of("a", "b", "c")));
+  public void testIsTableNamespace() {
+    Assertions.assertFalse(NamespaceUtil.isTableNamespace(null));
+    Assertions.assertFalse(NamespaceUtil.isTableNamespace(Namespace.empty()));
+    Assertions.assertTrue(NamespaceUtil.isTableNamespace(Namespace.of("db")));
+    Assertions.assertFalse(NamespaceUtil.isTableNamespace(Namespace.of("a", "b")));
+    Assertions.assertFalse(NamespaceUtil.isTableNamespace(Namespace.of("a", "b", "c")));
   }
 
   @Test
-  public void testCheckAtMostSingleLevelNamespaceAllowsEmpty() {
+  public void testValidateOperationNamespaceAllowsEmpty() {
     Assertions.assertDoesNotThrow(
-        () -> NamespaceUtil.checkAtMostSingleLevelNamespace(Namespace.empty()));
+        () -> NamespaceUtil.validateOperationNamespace(Namespace.empty()));
   }
 
   @Test
-  public void testCheckAtMostSingleLevelNamespaceAllowsSingleLevel() {
+  public void testValidateOperationNamespaceAllowsSingleLevel() {
     Assertions.assertDoesNotThrow(
-        () -> NamespaceUtil.checkAtMostSingleLevelNamespace(Namespace.of("db")));
+        () -> NamespaceUtil.validateOperationNamespace(Namespace.of("db")));
   }
 
   @Test
-  public void testCheckAtMostSingleLevelNamespaceRejectsMultiLevel() {
+  public void testValidateOperationNamespaceRejectsMultiLevel() {
     ValidationException twoLevel =
         Assertions.assertThrows(
             ValidationException.class,
-            () -> NamespaceUtil.checkAtMostSingleLevelNamespace(Namespace.of("a", "b")));
+            () -> NamespaceUtil.validateOperationNamespace(Namespace.of("a", "b")));
     Assertions.assertEquals("Input namespace has more than one levels a.b", twoLevel.getMessage());
 
     ValidationException threeLevel =
         Assertions.assertThrows(
             ValidationException.class,
-            () -> NamespaceUtil.checkAtMostSingleLevelNamespace(Namespace.of("a", "b", "c")));
+            () -> NamespaceUtil.validateOperationNamespace(Namespace.of("a", "b", "c")));
     Assertions.assertEquals(
         "Input namespace has more than one levels a.b.c", threeLevel.getMessage());
   }

--- a/services/common/src/test/java/com/linkedin/openhouse/common/utils/NamespaceUtilTest.java
+++ b/services/common/src/test/java/com/linkedin/openhouse/common/utils/NamespaceUtilTest.java
@@ -1,0 +1,36 @@
+package com.linkedin.openhouse.common.utils;
+
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class NamespaceUtilTest {
+
+  @Test
+  public void testCheckSingleLevelNamespaceAllowsEmpty() {
+    Assertions.assertDoesNotThrow(() -> NamespaceUtil.checkSingleLevelNamespace(Namespace.empty()));
+  }
+
+  @Test
+  public void testCheckSingleLevelNamespaceAllowsSingleLevel() {
+    Assertions.assertDoesNotThrow(
+        () -> NamespaceUtil.checkSingleLevelNamespace(Namespace.of("db")));
+  }
+
+  @Test
+  public void testCheckSingleLevelNamespaceRejectsMultiLevel() {
+    ValidationException twoLevel =
+        Assertions.assertThrows(
+            ValidationException.class,
+            () -> NamespaceUtil.checkSingleLevelNamespace(Namespace.of("a", "b")));
+    Assertions.assertEquals("Input namespace has more than one levels a.b", twoLevel.getMessage());
+
+    ValidationException threeLevel =
+        Assertions.assertThrows(
+            ValidationException.class,
+            () -> NamespaceUtil.checkSingleLevelNamespace(Namespace.of("a", "b", "c")));
+    Assertions.assertEquals(
+        "Input namespace has more than one levels a.b.c", threeLevel.getMessage());
+  }
+}

--- a/services/common/src/test/java/com/linkedin/openhouse/common/utils/NamespaceUtilTest.java
+++ b/services/common/src/test/java/com/linkedin/openhouse/common/utils/NamespaceUtilTest.java
@@ -8,28 +8,38 @@ import org.junit.jupiter.api.Test;
 public class NamespaceUtilTest {
 
   @Test
-  public void testCheckSingleLevelNamespaceAllowsEmpty() {
-    Assertions.assertDoesNotThrow(() -> NamespaceUtil.checkSingleLevelNamespace(Namespace.empty()));
+  public void testIsSingleLevel() {
+    Assertions.assertFalse(NamespaceUtil.isSingleLevel(null));
+    Assertions.assertFalse(NamespaceUtil.isSingleLevel(Namespace.empty()));
+    Assertions.assertTrue(NamespaceUtil.isSingleLevel(Namespace.of("db")));
+    Assertions.assertFalse(NamespaceUtil.isSingleLevel(Namespace.of("a", "b")));
+    Assertions.assertFalse(NamespaceUtil.isSingleLevel(Namespace.of("a", "b", "c")));
   }
 
   @Test
-  public void testCheckSingleLevelNamespaceAllowsSingleLevel() {
+  public void testCheckAtMostSingleLevelNamespaceAllowsEmpty() {
     Assertions.assertDoesNotThrow(
-        () -> NamespaceUtil.checkSingleLevelNamespace(Namespace.of("db")));
+        () -> NamespaceUtil.checkAtMostSingleLevelNamespace(Namespace.empty()));
   }
 
   @Test
-  public void testCheckSingleLevelNamespaceRejectsMultiLevel() {
+  public void testCheckAtMostSingleLevelNamespaceAllowsSingleLevel() {
+    Assertions.assertDoesNotThrow(
+        () -> NamespaceUtil.checkAtMostSingleLevelNamespace(Namespace.of("db")));
+  }
+
+  @Test
+  public void testCheckAtMostSingleLevelNamespaceRejectsMultiLevel() {
     ValidationException twoLevel =
         Assertions.assertThrows(
             ValidationException.class,
-            () -> NamespaceUtil.checkSingleLevelNamespace(Namespace.of("a", "b")));
+            () -> NamespaceUtil.checkAtMostSingleLevelNamespace(Namespace.of("a", "b")));
     Assertions.assertEquals("Input namespace has more than one levels a.b", twoLevel.getMessage());
 
     ValidationException threeLevel =
         Assertions.assertThrows(
             ValidationException.class,
-            () -> NamespaceUtil.checkSingleLevelNamespace(Namespace.of("a", "b", "c")));
+            () -> NamespaceUtil.checkAtMostSingleLevelNamespace(Namespace.of("a", "b", "c")));
     Assertions.assertEquals(
         "Input namespace has more than one levels a.b.c", threeLevel.getMessage());
   }


### PR DESCRIPTION
## Summary

Follow-up to #538 ([review thread](https://github.com/linkedin/openhouse/pull/538)). Consolidates OpenHouse's namespace-shape rule — currently asserted in four places inside `OpenHouseInternalCatalog` — into a single helper `NamespaceUtil` in `:services:common`. Behavior and error messages are unchanged.

The previous PR added an `isValidIdentifier(...)` override that, like the existing `listTables` / paginated `listTables` / `searchSoftDeletedTables` checks, encoded OpenHouse's namespace-shape constraint inline. Reviewer asked to route those checks through one place. This PR does that for the server-side catalog. Client-side `OpenHouseCatalog` has the same pattern in 7 sites; that can be a separate follow-up if desired (kept out of scope here to avoid coupling the server module's `:services:common` helper across the wire to the thin Java client runtime).

### Helper API

Two predicates on `Namespace`. They are intentionally separate concepts, not stricter/looser flavors of the same rule — the names reflect the namespace's *role*, not its *shape*, so a future change to the contract (e.g. supporting `catalog.database.table`) requires editing only the helper bodies, not the call-site names.

- `NamespaceUtil.isTableNamespace(Namespace)` — predicate, true when the namespace can host an OpenHouse base table. Used by `isValidIdentifier(...)`. Empty namespace is **not** a table namespace because there is no database under which to place a table.
- `NamespaceUtil.validateOperationNamespace(Namespace)` — throws `ValidationException` when the namespace cannot be used as the argument to a database-scoped catalog operation. Used by `listTables` / paginated `listTables` / `searchSoftDeletedTables`. Empty namespace **is** accepted because callers use it as a sentinel for "across all databases" (e.g. `listTables(Namespace.empty())`).

### Sites refactored in `OpenHouseInternalCatalog`

- `isValidIdentifier(TableIdentifier)` → `NamespaceUtil.isTableNamespace(...)`
- `listTables(Namespace)` → `NamespaceUtil.validateOperationNamespace(...)`
- `listTables(Namespace, Pageable)` → `NamespaceUtil.validateOperationNamespace(...)`
- `searchSoftDeletedTables(Namespace, String, Pageable)` → `NamespaceUtil.validateOperationNamespace(...)`

The previously inlined exception type (`ValidationException`) and message string (`"Input namespace has more than one levels " + String.join(".", namespace.levels())`) are preserved exactly inside the helper.

### Why `:services:common`

`OpenHouseInternalCatalog` already depends on `:services:common`, and `:services:common` already pulls in the Iceberg conventions, so `Namespace` and `ValidationException` are available there. The helper is `final` with a private constructor, mirroring the existing `PageableUtil` style.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [x] Tests

Refactoring:

- New `com.linkedin.openhouse.common.utils.NamespaceUtil` in `:services:common` exposing `isTableNamespace(Namespace)` and `validateOperationNamespace(Namespace)`. Identical exception type and identical error message string as the previous inline checks.
- Four call sites in `OpenHouseInternalCatalog` now delegate to the helper. Unused `org.apache.iceberg.exceptions.ValidationException` import removed.

Tests:

- New `NamespaceUtilTest` covering: `isTableNamespace` for null / empty / single-level / multi-level inputs, and `validateOperationNamespace` for empty (allowed), single-level (allowed), and multi-level (rejected with the exact pre-existing error message text — so any accidental wording change in a future edit fails loudly).
- Existing `OpenHouseInternalCatalogTest` continues to pass — it exercises `isValidIdentifier` end-to-end and is the regression guard for the table-namespace predicate.

## Testing Done

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Added new tests for the changes made:

- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew :services:common:build :iceberg:openhouse:internalcatalog:build` — BUILD SUCCESSFUL. All existing tests pass, including `OpenHouseInternalCatalogTest` from #538 (which exercises `isValidIdentifier`) and `HouseTableRepositoryImplTest` (which exercises the list/search paths whose validation block was extracted).
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew :services:common:spotlessCheck :iceberg:openhouse:internalcatalog:spotlessCheck` — clean.
- New `NamespaceUtilTest` runs as part of `:services:common:build`.

Testing gaps / risks:

- I did not run the full repo build (only the two modules touched). Downstream modules consume `OpenHouseInternalCatalog` indirectly via Spring wiring; behavior is byte-for-byte identical (same exception type, same message), so the blast radius should be limited to compile-only impact, but a CI run is the authoritative signal.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.