### PR TITLE
Bump mapstruct 1.5.0.Beta1 → 1.5.5.Final

### DIFF
--- a/buildSrc/src/main/groovy/openhouse.java-minimal-conventions.gradle
+++ b/buildSrc/src/main/groovy/openhouse.java-minimal-conventions.gradle
@@ -9,7 +9,7 @@ targetCompatibility = JavaVersion.VERSION_1_8
 
 ext {
   lombokVersion = '1.18.20'
-  mapStructVersion = '1.5.0.Beta1'
+  mapStructVersion = '1.5.5.Final'
 }
 
 checkstyle {

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/TablesMapper.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/TablesMapper.java
@@ -135,8 +135,8 @@ public interface TablesMapper {
 
   @Mappings({
     @Mapping(
-        conditionExpression = "java(tableIdentifier.namespace() != null)",
-        expression = "java(tableIdentifier.namespace().toString())",
+        expression =
+            "java(tableIdentifier.namespace() != null ? tableIdentifier.namespace().toString() : null)",
         target = "databaseId"),
     @Mapping(expression = "java(tableIdentifier.name())", target = "tableId")
   })
@@ -150,8 +150,8 @@ public interface TablesMapper {
 
   @Mappings({
     @Mapping(
-        conditionExpression = "java(tableIdentifier.namespace() != null)",
-        expression = "java(tableIdentifier.namespace().toString())",
+        expression =
+            "java(tableIdentifier.namespace() != null ? tableIdentifier.namespace().toString() : null)",
         target = "databaseId"),
     @Mapping(expression = "java(tableIdentifier.name())", target = "tableId")
   })


### PR DESCRIPTION
## Summary

Replace the pre-release mapstruct pin (`1.5.0.Beta1`) that has been in place since OpenHouse's initial commit with `1.5.5.Final`, the last release in the 1.5 line.

## Why

`1.5.0.Beta1` is a pre-release from February 2022 and has been superseded by nine stable patches in the 1.5 line. Staying on a Beta is a needless risk — stable releases in 1.5 are API-compatible and strictly bug-fix only.

## Compatibility fix

`1.5.5.Final` tightened `@Mapping` validation and now rejects an annotation that sets both `conditionExpression` and `expression` — `1.5.0.Beta1` silently allowed the combination. Two mappings in `TablesMapper` relied on that combination:

```java
// before
@Mapping(
    conditionExpression = "java(tableIdentifier.namespace() != null)",
    expression = "java(tableIdentifier.namespace().toString())",
    target = "databaseId")
```

Intent: "if `namespace()` is non-null, set `databaseId` to `namespace().toString()`, otherwise leave the target unset."

Rewritten as a single `expression` with a ternary:

```java
// after
@Mapping(
    expression =
        "java(tableIdentifier.namespace() != null ? tableIdentifier.namespace().toString() : null)",
    target = "databaseId")
```

Behaviorally equivalent at both call sites (`toTableDtoPrimaryKey(TableIdentifier)` and `toTableDto(TableIdentifier)`) — the target is a freshly constructed DTO whose default value for the unset field is also `null`, so "unset" and "set to null" collapse to the same end state.

## Testing

- `./gradlew compileJava` — all modules compile
- `./gradlew :services:tables:test --tests com.linkedin.openhouse.tables.mock.mapper.*` — all mapper tests pass

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests