### PR TITLE
Revert "Pin mysql-connector-j and use current coordinates (#561)"

### DIFF
--- a/services/housetables/build.gradle
+++ b/services/housetables/build.gradle
@@ -47,7 +47,7 @@ dependencies {
   // See https://stackoverflow.com/questions/43574426 for details.
   implementation "jakarta.xml.bind:jakarta.xml.bind-api:2.3.2"
   implementation "org.glassfish.jaxb:jaxb-runtime:2.3.2"
-  implementation "com.mysql:mysql-connector-j:8.4.0"
+  implementation "mysql:mysql-connector-java:8.+"
   implementation "org.jetbrains:annotations:16.0.3"
   testImplementation(testFixtures(project(':services:common')))
 }


### PR DESCRIPTION
Reverts #561.

The new `com.mysql:mysql-connector-j:8.4.0` coordinate causes license issues in ELR (LinkedIn's external library review). Reverting to restore the previous `mysql:mysql-connector-java:8.+` declaration while we work through ELR.