### PR TITLE
Extend histogram bucket cap for HTTP and catalog metadata update timers

### DIFF
--- a/services/tables/src/main/resources/application.properties
+++ b/services/tables/src/main/resources/application.properties
@@ -20,5 +20,7 @@ management.endpoint.prometheus.enabled=true
 management.endpoint.beans.enabled=true
 management.metrics.distribution.percentiles-histogram.all=true
 management.metrics.distribution.maximum-expected-value.catalog_metadata_retrieval_latency=600s
+management.metrics.distribution.maximum-expected-value.catalog_metadata_update_latency=600s
+management.metrics.distribution.maximum-expected-value.http.server.requests=600s
 server.shutdown=graceful
 spring.lifecycle.timeout-per-shutdown-phase=60s

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/MetricsHistogramConfigurationTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/MetricsHistogramConfigurationTest.java
@@ -53,6 +53,13 @@ public class MetricsHistogramConfigurationTest {
       "${management.metrics.distribution.maximum-expected-value.catalog_metadata_retrieval_latency:}")
   private String maxExpectedValueConfig;
 
+  @Value(
+      "${management.metrics.distribution.maximum-expected-value.catalog_metadata_update_latency:}")
+  private String maxExpectedValueUpdateConfig;
+
+  @Value("${management.metrics.distribution.maximum-expected-value.http.server.requests:}")
+  private String maxExpectedValueHttpConfig;
+
   @Value("${management.metrics.distribution.percentiles-histogram.all:false}")
   private boolean percentilesHistogramEnabled;
 
@@ -78,6 +85,23 @@ public class MetricsHistogramConfigurationTest {
         "600s",
         maxExpectedValueConfig,
         "maximum-expected-value.catalog_metadata_retrieval_latency should be set to 600s");
+  }
+
+  @Test
+  void testMaxExpectedValueConfigurationIsSetForUpdateLatency() {
+    assertEquals(
+        "600s",
+        maxExpectedValueUpdateConfig,
+        "maximum-expected-value.catalog_metadata_update_latency should be set to 600s");
+  }
+
+  @Test
+  void testMaxExpectedValueConfigurationIsSetForHttpServerRequests() {
+    assertEquals(
+        "600s",
+        maxExpectedValueHttpConfig,
+        "maximum-expected-value.http.server.requests should be set to 600s so that "
+            + "http_server_requests_seconds histogram buckets do not saturate at the default 30s cap");
   }
 
   /** Tests that percentiles histogram is enabled for all metrics. */
@@ -158,6 +182,60 @@ public class MetricsHistogramConfigurationTest {
                 + "This validates the maximum-expected-value.catalog_metadata_retrieval_latency=600s configuration. "
                 + "Found max bucket: %.1fs, all buckets: [%s]",
             maxBucketSeconds, bucketList));
+  }
+
+  @Test
+  void testHistogramBucketsExtendTo600SecondsForUpdateLatency() {
+    assertTimerHistogramExtendsTo600s(
+        "catalog_metadata_update_latency",
+        "maximum-expected-value.catalog_metadata_update_latency=600s");
+  }
+
+  @Test
+  void testHistogramBucketsExtendTo600SecondsForHttpServerRequests() {
+    // Spring Boot's auto-instrumented timer for HTTP requests is registered as
+    // "http.server.requests" — it's exported to Prometheus as http_server_requests_seconds.
+    assertTimerHistogramExtendsTo600s(
+        "http.server.requests", "maximum-expected-value.http.server.requests=600s");
+  }
+
+  private void assertTimerHistogramExtendsTo600s(String timerName, String configDescription) {
+    Timer timer = meterRegistry.timer(timerName);
+
+    timer.record(100, TimeUnit.MILLISECONDS);
+    timer.record(1, TimeUnit.SECONDS);
+    timer.record(60, TimeUnit.SECONDS);
+    timer.record(600, TimeUnit.SECONDS);
+    timer.record(700, TimeUnit.SECONDS);
+
+    HistogramSnapshot snapshot = timer.takeSnapshot();
+    CountAtBucket[] buckets = snapshot.histogramCounts();
+
+    assertTrue(
+        buckets.length > 0,
+        String.format("Histogram for %s should have bucket entries", timerName));
+
+    double maxBucketSeconds =
+        Arrays.stream(buckets)
+            .mapToDouble(b -> b.bucket(TimeUnit.SECONDS))
+            .filter(b -> b != Double.POSITIVE_INFINITY)
+            .max()
+            .orElse(0);
+
+    String bucketList =
+        Arrays.stream(buckets)
+            .map(b -> String.valueOf(b.bucket(TimeUnit.SECONDS)))
+            .reduce((a, b) -> a + ", " + b)
+            .orElse("none");
+
+    assertTrue(
+        maxBucketSeconds >= 600.0,
+        String.format(
+            "Histogram for %s should have buckets extending to at least 600s. "
+                + "This validates the %s configuration. "
+                + "Without this override the default 30s cap would saturate p99/max around 31s. "
+                + "Found max bucket: %.1fs, all buckets: [%s]",
+            timerName, configDescription, maxBucketSeconds, bucketList));
   }
 
   /**


### PR DESCRIPTION
## Summary
The p99 latency alert for `PUT /v1/databases/{databaseId}/tables/{tableId}` on tables-service was saturating at exactly **~31s**, regardless of how slow snapshot commits actually got. Investigation showed this is not a real timeout — it's a  
  Micrometer histogram artifact:
                                                                                                                                                                                                                                                    
  - `application.properties` enables `management.metrics.distribution.percentiles-histogram.all=true`, so all timers publish histograms.                                                                                                            
  - Micrometer's default `Timer.maximumExpectedValue` is **30s**. The pre-computed `PercentileHistogramBuckets` table is truncated at this cap, with the highest finite bucket near ~30.5s (rounded to ~31s in dashboards).
  - Anything slower lands in the `+Inf` bucket and is invisible to `histogram_quantile`, so p99/max visually pin at 31s.                                                                                                                            
  - The existing override for `catalog_metadata_retrieval_latency=600s` proved this; the same pattern was missing for the HTTP server timer and the catalog update timer, both of which can legitimately exceed 30s during metastore contention.  

Max latency is always capped at 31s although put snapshot takes higher:
<img width="2830" height="856" alt="image" src="https://github.com/user-attachments/assets/b77762af-8455-4c24-9581-ad34ae6c1d4e" />

 
### Changes
 - Override Micrometer's default 30s `maximumExpectedValue` for `http.server.requests` and `catalog_metadata_update_latency` in tables-service, raising them to 600s.                                                                              
  - Add tests covering both the property wiring and the resulting histogram bucket boundaries.

 **`services/tables/src/main/resources/application.properties`**
  - Add `maximum-expected-value.catalog_metadata_update_latency=600s`
  - Add `maximum-expected-value.http.server.requests=600s` (Spring's auto-instrumented HTTP timer; exported to Prometheus as `http_server_requests_seconds`)                                                                                        
                                                                                                                                                                                                                                                    
  **`services/tables/src/test/java/.../MetricsHistogramConfigurationTest.java`**                                                                                                                                                                    
  - Add two property-level assertions (`testMaxExpectedValueConfigurationIsSetForUpdateLatency`, `testMaxExpectedValueConfigurationIsSetForHttpServerRequests`).                                                                                    
  - Add two live-registry assertions verifying histogram buckets actually extend to ≥600s for the new timers.                                                                                                                                       
  - Factor shared bucket-assertion logic into `assertTimerHistogramExtendsTo600s(...)`.  
<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
`./gradlew :services:tables:test --tests "MetricsHistogramConfigurationTest"` — all 9 tests pass (3 new + 6 existing).
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
