### PR TITLE
[DataLoader] Fix for batch sizes greater than 8192 not being honored when a table transformer is used

### DIFF
--- a/integrations/python/dataloader/src/openhouse/dataloader/data_loader_split.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/data_loader_split.py
@@ -8,6 +8,7 @@ from functools import cached_property
 from itertools import chain
 from types import MappingProxyType
 
+from datafusion import SessionConfig
 from datafusion.context import SessionContext
 from pyarrow import RecordBatch
 from pyiceberg.io.pyarrow import ArrowScan
@@ -31,13 +32,17 @@ def to_sql_identifier(table_id: TableIdentifier) -> str:
 def _create_transform_session(
     table_id: TableIdentifier,
     udf_registry: UDFRegistry,
+    batch_size: int | None = None,
 ) -> SessionContext:
     """Create a DataFusion SessionContext for running split-level transforms.
 
     Returns a ready-to-query SessionContext where UDFs are registered and the
     target schema exists.
     """
-    session = SessionContext()
+    config = SessionConfig()
+    if batch_size is not None:
+        config = config.set("datafusion.execution.batch_size", str(batch_size))
+    session = SessionContext(config)
     udf_registry.register_udfs(session)
 
     session.sql(f"CREATE SCHEMA IF NOT EXISTS {_quote_identifier(table_id.database)}").collect()
@@ -161,7 +166,7 @@ class DataLoaderSplit:
             first = next(timed, None)
             if first is None:
                 return
-            session = _create_transform_session(self._scan_context.table_id, self._udf_registry)
+            session = _create_transform_session(self._scan_context.table_id, self._udf_registry, self._batch_size)
             yield from _timed_transform(chain([first], timed), split_id, session, self._apply_transform)
 
     def _apply_transform(self, session: SessionContext, batch: RecordBatch) -> Iterator[RecordBatch]:

--- a/integrations/python/dataloader/tests/test_data_loader_split.py
+++ b/integrations/python/dataloader/tests/test_data_loader_split.py
@@ -499,10 +499,8 @@ def test_split_batch_size_honored_with_transform(tmp_path):
     )
     batches = list(split)
 
-    assert sum(b.num_rows for b in batches) == num_rows
-    for batch in batches:
-        assert batch.num_rows <= num_rows
-    assert len(batches) == 1, f"Expected 1 batch of {num_rows} rows, got {[b.num_rows for b in batches]}"
+    assert len(batches) == 1
+    assert batches[0].num_rows == num_rows
 
 
 # --- multi-file split tests ---

--- a/integrations/python/dataloader/tests/test_data_loader_split.py
+++ b/integrations/python/dataloader/tests/test_data_loader_split.py
@@ -471,13 +471,15 @@ def test_split_batch_size_preserves_data(tmp_path):
 
 
 def test_split_batch_size_honored_with_transform(tmp_path):
-    """When batch_size > 8192 with a transform, DataFusion must not fragment batches.
+    """When batch_size exceeds DataFusion's default, transforms must not fragment batches.
 
-    DataFusion defaults to batch_size=8192. Without propagating the user's
-    batch_size to the SessionConfig, a 10_000-row input batch would be split
-    into [8192, 1808] by the transform step.
+    Without propagating the user's batch_size to the SessionConfig, DataFusion
+    splits output at its default boundary.
     """
-    num_rows = 10_000
+    from datafusion import Config
+
+    df_default = int(Config().get("datafusion.execution.batch_size"))
+    num_rows = df_default + 1000
     table = pa.table(
         {
             "id": pa.array(list(range(num_rows)), type=pa.int64()),
@@ -500,7 +502,6 @@ def test_split_batch_size_honored_with_transform(tmp_path):
     assert sum(b.num_rows for b in batches) == num_rows
     for batch in batches:
         assert batch.num_rows <= num_rows
-    # The key assertion: DataFusion should not fragment into sub-8192 chunks
     assert len(batches) == 1, f"Expected 1 batch of {num_rows} rows, got {[b.num_rows for b in batches]}"
 
 

--- a/integrations/python/dataloader/tests/test_data_loader_split.py
+++ b/integrations/python/dataloader/tests/test_data_loader_split.py
@@ -470,6 +470,40 @@ def test_split_batch_size_preserves_data(tmp_path):
     assert sorted(result.column("id").to_pylist()) == list(range(25))
 
 
+def test_split_batch_size_honored_with_transform(tmp_path):
+    """When batch_size > 8192 with a transform, DataFusion must not fragment batches.
+
+    DataFusion defaults to batch_size=8192. Without propagating the user's
+    batch_size to the SessionConfig, a 10_000-row input batch would be split
+    into [8192, 1808] by the transform step.
+    """
+    num_rows = 10_000
+    table = pa.table(
+        {
+            "id": pa.array(list(range(num_rows)), type=pa.int64()),
+            "name": pa.array([f"n{i}" for i in range(num_rows)], type=pa.string()),
+        }
+    )
+    identity_sql = f"SELECT id, name FROM {to_sql_identifier(_TABLE_ID)}"
+
+    split = _create_test_split(
+        tmp_path,
+        table,
+        FileFormat.PARQUET,
+        _TRANSFORM_SCHEMA,
+        transform_sql=identity_sql,
+        table_id=_TABLE_ID,
+        batch_size=num_rows,
+    )
+    batches = list(split)
+
+    assert sum(b.num_rows for b in batches) == num_rows
+    for batch in batches:
+        assert batch.num_rows <= num_rows
+    # The key assertion: DataFusion should not fragment into sub-8192 chunks
+    assert len(batches) == 1, f"Expected 1 batch of {num_rows} rows, got {[b.num_rows for b in batches]}"
+
+
 # --- multi-file split tests ---
 
 


### PR DESCRIPTION
## Summary

DataFusion defaults its internal `batch_size` to 8192. When a DataLoader user sets `batch_size` larger than 8192 and a table transformer is active, the DataFusion transform step silently fragments output batches at the 8192 boundary (e.g. a 10,000-row batch becomes `[8192, 1808]`). This PR propagates the user's `batch_size` to the DataFusion `SessionConfig` so output batches respect the requested size.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

`_create_transform_session` now accepts an optional `batch_size` parameter. When set, it configures `datafusion.execution.batch_size` on the `SessionConfig` before creating the `SessionContext`. The call site in `DataLoaderSplit.__iter__` passes through `self._batch_size`.

## Testing Done

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Added `test_split_batch_size_honored_with_transform`

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.