### PR TITLE
[DataLoader] Support more literal types in filters DSL to DataFusion conversion

### DIFF
--- a/integrations/python/dataloader/src/openhouse/dataloader/filters.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/filters.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import typing
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from datetime import date, datetime
 from typing import Any
 
 from pyiceberg import expressions as ice
@@ -327,6 +328,12 @@ def _literal_to_sql(value: object) -> str:
         return exp.Literal.string(value).sql()
     if isinstance(value, bool):
         return exp.Boolean(this=True).sql() if value else exp.Boolean(this=False).sql()
+    if isinstance(value, datetime):
+        lit = exp.Literal.string(value.strftime("%Y-%m-%d %H:%M:%S"))
+        return exp.Cast(this=lit, to=exp.DataType.build("TIMESTAMP")).sql()
+    if isinstance(value, date):
+        lit = exp.Literal.string(value.isoformat())
+        return exp.Cast(this=lit, to=exp.DataType.build("DATE")).sql()
     if isinstance(value, (int, float)):
         return exp.Literal.number(value).sql()
     raise TypeError(f"Unsupported literal type: {type(value).__name__}")

--- a/integrations/python/dataloader/src/openhouse/dataloader/filters.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/filters.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import typing
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date, datetime, time
+from decimal import Decimal
 from typing import Any
+from uuid import UUID
 
 from pyiceberg import expressions as ice
 from sqlglot import exp
@@ -334,8 +336,15 @@ def _literal_to_sql(value: object) -> str:
     if isinstance(value, date):
         lit = exp.Literal.string(value.isoformat())
         return exp.Cast(this=lit, to=exp.DataType.build("DATE")).sql()
+    if isinstance(value, time):
+        lit = exp.Literal.string(value.strftime("%H:%M:%S"))
+        return exp.Cast(this=lit, to=exp.DataType.build("TIME")).sql()
     if isinstance(value, (int, float)):
         return exp.Literal.number(value).sql()
+    if isinstance(value, Decimal):
+        return exp.Literal.number(value).sql()
+    if isinstance(value, UUID):
+        return exp.Literal.string(str(value)).sql()
     raise TypeError(f"Unsupported literal type: {type(value).__name__}")
 
 

--- a/integrations/python/dataloader/src/openhouse/dataloader/filters.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/filters.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import typing
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -346,8 +347,12 @@ def _literal_to_sql(value: object) -> str:
         lit = exp.Literal.string(value.strftime("%H:%M:%S.%f"))
         return exp.Cast(this=lit, to=exp.DataType.build("TIME")).sql()
     if isinstance(value, (int, float)):
+        if isinstance(value, float) and not math.isfinite(value):
+            return exp.Cast(this=exp.Literal.string(str(value)), to=exp.DataType.build("DOUBLE")).sql()
         return exp.Literal.number(value).sql()
     if isinstance(value, Decimal):
+        if not value.is_finite():
+            return exp.Cast(this=exp.Literal.string(str(value)), to=exp.DataType.build("DOUBLE")).sql()
         return exp.Literal.number(value).sql()
     if isinstance(value, UUID):
         return exp.Literal.string(str(value)).sql()

--- a/integrations/python/dataloader/src/openhouse/dataloader/filters.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/filters.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from datetime import date, datetime, time
+from datetime import UTC, date, datetime, time
 from decimal import Decimal
 from typing import Any
 from uuid import UUID
@@ -337,6 +337,12 @@ def _literal_to_sql(value: object) -> str:
         lit = exp.Literal.string(value.isoformat())
         return exp.Cast(this=lit, to=exp.DataType.build("DATE")).sql()
     if isinstance(value, time):
+        # DataFusion does not support TIME WITH TIME ZONE (TIMETZ), so
+        # tz-aware values are converted to UTC before formatting.
+        if value.tzinfo is not None:
+            # Python can only convert timezones on a full datetime, so combine
+            # with an arbitrary date, convert to UTC, then extract the time back.
+            value = datetime.combine(date(2000, 1, 1), value).astimezone(UTC).time()
         lit = exp.Literal.string(value.strftime("%H:%M:%S.%f"))
         return exp.Cast(this=lit, to=exp.DataType.build("TIME")).sql()
     if isinstance(value, (int, float)):

--- a/integrations/python/dataloader/src/openhouse/dataloader/filters.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/filters.py
@@ -4,7 +4,7 @@ import math
 import typing
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from datetime import UTC, date, datetime, time
+from datetime import date, datetime, time
 from decimal import Decimal
 from typing import Any
 from uuid import UUID
@@ -338,12 +338,11 @@ def _literal_to_sql(value: object) -> str:
         lit = exp.Literal.string(value.isoformat())
         return exp.Cast(this=lit, to=exp.DataType.build("DATE")).sql()
     if isinstance(value, time):
-        # DataFusion does not support TIME WITH TIME ZONE (TIMETZ), so
-        # tz-aware values are converted to UTC before formatting.
         if value.tzinfo is not None:
-            # Python can only convert timezones on a full datetime, so combine
-            # with an arbitrary date, convert to UTC, then extract the time back.
-            value = datetime.combine(date(2000, 1, 1), value).astimezone(UTC).time()
+            raise TypeError(
+                "DataFusion does not support timezones for time data types. "
+                "The time should match the timezone used in the dataset."
+            )
         lit = exp.Literal.string(value.strftime("%H:%M:%S.%f"))
         return exp.Cast(this=lit, to=exp.DataType.build("TIME")).sql()
     if isinstance(value, (int, float)):

--- a/integrations/python/dataloader/src/openhouse/dataloader/filters.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/filters.py
@@ -331,13 +331,13 @@ def _literal_to_sql(value: object) -> str:
     if isinstance(value, bool):
         return exp.Boolean(this=True).sql() if value else exp.Boolean(this=False).sql()
     if isinstance(value, datetime):
-        lit = exp.Literal.string(value.strftime("%Y-%m-%d %H:%M:%S%z"))
+        lit = exp.Literal.string(value.strftime("%Y-%m-%d %H:%M:%S.%f%z"))
         return exp.Cast(this=lit, to=exp.DataType.build("TIMESTAMP")).sql()
     if isinstance(value, date):
         lit = exp.Literal.string(value.isoformat())
         return exp.Cast(this=lit, to=exp.DataType.build("DATE")).sql()
     if isinstance(value, time):
-        lit = exp.Literal.string(value.strftime("%H:%M:%S"))
+        lit = exp.Literal.string(value.strftime("%H:%M:%S.%f"))
         return exp.Cast(this=lit, to=exp.DataType.build("TIME")).sql()
     if isinstance(value, (int, float)):
         return exp.Literal.number(value).sql()

--- a/integrations/python/dataloader/src/openhouse/dataloader/filters.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/filters.py
@@ -331,7 +331,7 @@ def _literal_to_sql(value: object) -> str:
     if isinstance(value, bool):
         return exp.Boolean(this=True).sql() if value else exp.Boolean(this=False).sql()
     if isinstance(value, datetime):
-        lit = exp.Literal.string(value.strftime("%Y-%m-%d %H:%M:%S"))
+        lit = exp.Literal.string(value.strftime("%Y-%m-%d %H:%M:%S%z"))
         return exp.Cast(this=lit, to=exp.DataType.build("TIMESTAMP")).sql()
     if isinstance(value, date):
         lit = exp.Literal.string(value.isoformat())

--- a/integrations/python/dataloader/tests/test_filters.py
+++ b/integrations/python/dataloader/tests/test_filters.py
@@ -409,10 +409,10 @@ class TestDataFusionLiteralConversion:
         result = _to_datafusion_sql(col("event_time") == t)
         assert result == "\"event_time\" = CAST('14:30:00.500000' AS TIME)"
 
-    def test_time_with_timezone_converted_to_utc(self):
+    def test_time_with_timezone_rejected(self):
         t = time(14, 30, 0, tzinfo=timezone(timedelta(hours=5)))
-        result = _to_datafusion_sql(col("event_time") == t)
-        assert result == "\"event_time\" = CAST('09:30:00.000000' AS TIME)"
+        with pytest.raises(TypeError, match="does not support timezones for time"):
+            _to_datafusion_sql(col("event_time") == t)
 
     def test_decimal_greater_than(self):
         d = Decimal("99.95")
@@ -527,14 +527,6 @@ class TestDataFusionFilterExecution:
         table = self._query(ctx, where)
         assert table.num_rows == 1
         assert table.column("t")[0].as_py() == time(14, 30, 0)
-
-    def test_time_filter_with_timezone(self, ctx):
-        # 14:30:00+04:30 is 10:00:00 UTC — should match row 1, not row 2
-        t = time(14, 30, 0, tzinfo=timezone(timedelta(hours=4, minutes=30)))
-        where = _to_datafusion_sql(col("t") == t)
-        table = self._query(ctx, where)
-        assert table.num_rows == 1
-        assert table.column("t")[0].as_py() == time(10, 0, 0)
 
     def test_decimal_filter(self, ctx):
         where = _to_datafusion_sql(col("price") > Decimal("10.00"))

--- a/integrations/python/dataloader/tests/test_filters.py
+++ b/integrations/python/dataloader/tests/test_filters.py
@@ -436,43 +436,66 @@ class TestDataFusionFilterExecution:
         ctx.register_record_batches("t", [[batch]])
         return ctx
 
-    def _query(self, ctx, where: str) -> int:
-        return len(ctx.sql(f'SELECT * FROM "t" WHERE {where}').collect()[0])
+    def _query(self, ctx, where: str):
+        batches = ctx.sql(f'SELECT * FROM "t" WHERE {where}').collect()
+        import pyarrow as pa
+
+        return pa.Table.from_batches(batches)
 
     def test_datetime_filter(self, ctx):
         where = _to_datafusion_sql(col("ts") >= datetime(2026, 4, 27, tzinfo=UTC))
-        assert self._query(ctx, where) == 2
+        table = self._query(ctx, where)
+        assert table.num_rows == 2
+        ts_values = [v.as_py() for v in table.column("ts")]
+        assert ts_values == [datetime(2026, 4, 27, tzinfo=UTC), datetime(2026, 4, 29, tzinfo=UTC)]
 
     def test_datetime_less_than(self, ctx):
         where = _to_datafusion_sql(col("ts") < datetime(2026, 4, 27, tzinfo=UTC))
-        assert self._query(ctx, where) == 1
+        table = self._query(ctx, where)
+        assert table.num_rows == 1
+        assert table.column("ts")[0].as_py() == datetime(2026, 4, 25, tzinfo=UTC)
 
     def test_date_filter(self, ctx):
         where = _to_datafusion_sql(col("dt") >= date(2026, 4, 27))
-        assert self._query(ctx, where) == 2
+        table = self._query(ctx, where)
+        assert table.num_rows == 2
+        dt_values = [v.as_py() for v in table.column("dt")]
+        assert dt_values == [date(2026, 4, 27), date(2026, 4, 29)]
 
     def test_time_filter(self, ctx):
         where = _to_datafusion_sql(col("t") == time(14, 30, 0))
-        assert self._query(ctx, where) == 1
+        table = self._query(ctx, where)
+        assert table.num_rows == 1
+        assert table.column("t")[0].as_py() == time(14, 30, 0)
 
     def test_decimal_filter(self, ctx):
         where = _to_datafusion_sql(col("price") > Decimal("10.00"))
-        assert self._query(ctx, where) == 2
+        table = self._query(ctx, where)
+        assert table.num_rows == 2
+        price_values = [v.as_py() for v in table.column("price")]
+        assert price_values == [Decimal("49.99"), Decimal("99.99")]
 
     def test_uuid_filter(self, ctx):
         where = _to_datafusion_sql(col("id") == UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
-        assert self._query(ctx, where) == 1
+        table = self._query(ctx, where)
+        assert table.num_rows == 1
+        assert table.column("id")[0].as_py() == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 
     def test_datetime_between_filter(self, ctx):
         where = _to_datafusion_sql(
             col("ts").between(datetime(2026, 4, 26, tzinfo=UTC), datetime(2026, 4, 28, tzinfo=UTC))
         )
-        assert self._query(ctx, where) == 1
+        table = self._query(ctx, where)
+        assert table.num_rows == 1
+        assert table.column("ts")[0].as_py() == datetime(2026, 4, 27, tzinfo=UTC)
 
     def test_compound_filter(self, ctx):
         f = (col("ts") >= datetime(2026, 4, 27, tzinfo=UTC)) & (col("price") > Decimal("50.00"))
         where = _to_datafusion_sql(f)
-        assert self._query(ctx, where) == 1
+        table = self._query(ctx, where)
+        assert table.num_rows == 1
+        assert table.column("ts")[0].as_py() == datetime(2026, 4, 29, tzinfo=UTC)
+        assert table.column("price")[0].as_py() == Decimal("99.99")
 
 
 class TestPyIcebergUnsupportedType:

--- a/integrations/python/dataloader/tests/test_filters.py
+++ b/integrations/python/dataloader/tests/test_filters.py
@@ -1,3 +1,5 @@
+from datetime import UTC, date, datetime
+
 import pytest
 from pyiceberg import expressions as ice
 
@@ -97,6 +99,18 @@ class TestComparisonOperators:
         f = col("score") > 3.14
         assert isinstance(f, GreaterThan)
         assert f.value == 3.14
+
+    def test_comparison_with_datetime(self):
+        dt = datetime(2026, 4, 27, tzinfo=UTC)
+        f = col("datepartition") >= dt
+        assert isinstance(f, GreaterThanOrEqual)
+        assert f.value == dt
+
+    def test_comparison_with_date(self):
+        d = date(2026, 4, 27)
+        f = col("datepartition") >= d
+        assert isinstance(f, GreaterThanOrEqual)
+        assert f.value == d
 
 
 class TestNullAndNanChecks:
@@ -333,6 +347,38 @@ class TestNamespacedImport:
         assert isinstance(f, And)
         assert isinstance(f.left, GreaterThan)
         assert isinstance(f.right, EqualTo)
+
+
+class TestDataFusionDatetimeConversion:
+    def test_datetime_greater_than_or_equal(self):
+        dt = datetime(2026, 4, 27, tzinfo=UTC)
+        result = _to_datafusion_sql(col("datepartition") >= dt)
+        assert result == "\"datepartition\" >= CAST('2026-04-27 00:00:00' AS TIMESTAMP)"
+
+    def test_datetime_equal(self):
+        dt = datetime(2026, 4, 27, 12, 30, 45, tzinfo=UTC)
+        result = _to_datafusion_sql(col("ts") == dt)
+        assert result == "\"ts\" = CAST('2026-04-27 12:30:45' AS TIMESTAMP)"
+
+    def test_date_greater_than_or_equal(self):
+        d = date(2026, 4, 27)
+        result = _to_datafusion_sql(col("datepartition") >= d)
+        assert result == "\"datepartition\" >= CAST('2026-04-27' AS DATE)"
+
+    def test_datetime_between(self):
+        dt1 = datetime(2026, 4, 27, tzinfo=UTC)
+        dt2 = datetime(2026, 5, 1, tzinfo=UTC)
+        result = _to_datafusion_sql(col("ts").between(dt1, dt2))
+        assert result == (
+            "\"ts\" BETWEEN CAST('2026-04-27 00:00:00' AS TIMESTAMP) AND CAST('2026-05-01 00:00:00' AS TIMESTAMP)"
+        )
+
+    def test_datetime_in_compound_filter(self):
+        dt = datetime(2026, 4, 27, tzinfo=UTC)
+        f = (col("datepartition") >= dt) & (col("status") == "active")
+        result = _to_datafusion_sql(f)
+        assert "CAST('2026-04-27 00:00:00' AS TIMESTAMP)" in result
+        assert "\"status\" = 'active'" in result
 
 
 class TestPyIcebergUnsupportedType:

--- a/integrations/python/dataloader/tests/test_filters.py
+++ b/integrations/python/dataloader/tests/test_filters.py
@@ -408,6 +408,11 @@ class TestDataFusionLiteralConversion:
         result = _to_datafusion_sql(col("event_time") == t)
         assert result == "\"event_time\" = CAST('14:30:00.500000' AS TIME)"
 
+    def test_time_with_timezone_converted_to_utc(self):
+        t = time(14, 30, 0, tzinfo=timezone(timedelta(hours=5)))
+        result = _to_datafusion_sql(col("event_time") == t)
+        assert result == "\"event_time\" = CAST('09:30:00.000000' AS TIME)"
+
     def test_decimal_greater_than(self):
         d = Decimal("99.95")
         result = _to_datafusion_sql(col("price") > d)
@@ -497,6 +502,14 @@ class TestDataFusionFilterExecution:
         table = self._query(ctx, where)
         assert table.num_rows == 1
         assert table.column("t")[0].as_py() == time(14, 30, 0)
+
+    def test_time_filter_with_timezone(self, ctx):
+        # 14:30:00+04:30 is 10:00:00 UTC — should match row 1, not row 2
+        t = time(14, 30, 0, tzinfo=timezone(timedelta(hours=4, minutes=30)))
+        where = _to_datafusion_sql(col("t") == t)
+        table = self._query(ctx, where)
+        assert table.num_rows == 1
+        assert table.column("t")[0].as_py() == time(10, 0, 0)
 
     def test_decimal_filter(self, ctx):
         where = _to_datafusion_sql(col("price") > Decimal("10.00"))

--- a/integrations/python/dataloader/tests/test_filters.py
+++ b/integrations/python/dataloader/tests/test_filters.py
@@ -1,3 +1,4 @@
+import math
 from datetime import UTC, date, datetime, time, timedelta, timezone
 from decimal import Decimal
 from uuid import UUID
@@ -422,6 +423,30 @@ class TestDataFusionLiteralConversion:
         result = _to_datafusion_sql(col("price").between(Decimal("10.00"), Decimal("50.00")))
         assert result == '"price" BETWEEN 10.00 AND 50.00'
 
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (float("nan"), "CAST('nan' AS DOUBLE)"),
+            (float("inf"), "CAST('inf' AS DOUBLE)"),
+            (float("-inf"), "CAST('-inf' AS DOUBLE)"),
+        ],
+    )
+    def test_non_finite_float(self, value, expected):
+        result = _to_datafusion_sql(col("x") == value)
+        assert result == f'"x" = {expected}'
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (Decimal("NaN"), "CAST('NaN' AS DOUBLE)"),
+            (Decimal("Inf"), "CAST('Infinity' AS DOUBLE)"),
+            (Decimal("-Inf"), "CAST('-Infinity' AS DOUBLE)"),
+        ],
+    )
+    def test_non_finite_decimal(self, value, expected):
+        result = _to_datafusion_sql(col("x") == value)
+        assert result == f'"x" = {expected}'
+
     def test_uuid_equal(self):
         u = UUID("12345678-1234-5678-1234-567812345678")
         result = _to_datafusion_sql(col("id") == u)
@@ -517,6 +542,31 @@ class TestDataFusionFilterExecution:
         assert table.num_rows == 2
         price_values = [v.as_py() for v in table.column("price")]
         assert price_values == [Decimal("49.99"), Decimal("99.99")]
+
+    @pytest.mark.parametrize(
+        ("value", "expected_count", "check"),
+        [
+            (float("nan"), 1, lambda v: math.isnan(v)),
+            (float("inf"), 1, lambda v: v == float("inf")),
+            (float("-inf"), 1, lambda v: v == float("-inf")),
+            (Decimal("NaN"), 1, lambda v: math.isnan(v)),
+            (Decimal("Inf"), 1, lambda v: v == float("inf")),
+            (Decimal("-Inf"), 1, lambda v: v == float("-inf")),
+        ],
+    )
+    def test_non_finite_filter(self, value, expected_count, check):
+        import datafusion
+        import pyarrow as pa
+
+        ctx = datafusion.SessionContext()
+        batch = pa.record_batch({"x": pa.array([1.0, float("nan"), float("inf"), float("-inf"), 5.0])})
+        ctx.register_record_batches("t", [[batch]])
+
+        where = _to_datafusion_sql(col("x") == value)
+        batches = ctx.sql(f'SELECT * FROM "t" WHERE {where}').collect()
+        table = pa.Table.from_batches(batches)
+        assert table.num_rows == expected_count
+        assert check(table.column("x")[0].as_py())
 
     def test_high_precision_decimal_filter(self, ctx):
         where = _to_datafusion_sql(col("price") > Decimal("49.9899999999999999"))

--- a/integrations/python/dataloader/tests/test_filters.py
+++ b/integrations/python/dataloader/tests/test_filters.py
@@ -518,6 +518,12 @@ class TestDataFusionFilterExecution:
         price_values = [v.as_py() for v in table.column("price")]
         assert price_values == [Decimal("49.99"), Decimal("99.99")]
 
+    def test_high_precision_decimal_filter(self, ctx):
+        where = _to_datafusion_sql(col("price") > Decimal("49.9899999999999999"))
+        table = self._query(ctx, where)
+        assert table.num_rows == 1
+        assert table.column("price")[0].as_py() == Decimal("99.99")
+
     def test_uuid_filter(self, ctx):
         where = _to_datafusion_sql(col("id") == UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
         table = self._query(ctx, where)

--- a/integrations/python/dataloader/tests/test_filters.py
+++ b/integrations/python/dataloader/tests/test_filters.py
@@ -1,4 +1,6 @@
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, time
+from decimal import Decimal
+from uuid import UUID
 
 import pytest
 from pyiceberg import expressions as ice
@@ -349,7 +351,7 @@ class TestNamespacedImport:
         assert isinstance(f.right, EqualTo)
 
 
-class TestDataFusionDatetimeConversion:
+class TestDataFusionLiteralConversion:
     def test_datetime_greater_than_or_equal(self):
         dt = datetime(2026, 4, 27, tzinfo=UTC)
         result = _to_datafusion_sql(col("datepartition") >= dt)
@@ -379,6 +381,25 @@ class TestDataFusionDatetimeConversion:
         result = _to_datafusion_sql(f)
         assert "CAST('2026-04-27 00:00:00' AS TIMESTAMP)" in result
         assert "\"status\" = 'active'" in result
+
+    def test_time_equal(self):
+        t = time(14, 30, 0)
+        result = _to_datafusion_sql(col("event_time") == t)
+        assert result == "\"event_time\" = CAST('14:30:00' AS TIME)"
+
+    def test_decimal_greater_than(self):
+        d = Decimal("99.95")
+        result = _to_datafusion_sql(col("price") > d)
+        assert result == '"price" > 99.95'
+
+    def test_decimal_between(self):
+        result = _to_datafusion_sql(col("price").between(Decimal("10.00"), Decimal("50.00")))
+        assert result == '"price" BETWEEN 10.00 AND 50.00'
+
+    def test_uuid_equal(self):
+        u = UUID("12345678-1234-5678-1234-567812345678")
+        result = _to_datafusion_sql(col("id") == u)
+        assert result == "\"id\" = '12345678-1234-5678-1234-567812345678'"
 
 
 class TestPyIcebergUnsupportedType:

--- a/integrations/python/dataloader/tests/test_filters.py
+++ b/integrations/python/dataloader/tests/test_filters.py
@@ -1,4 +1,4 @@
-from datetime import UTC, date, datetime, time
+from datetime import UTC, date, datetime, time, timedelta, timezone
 from decimal import Decimal
 from uuid import UUID
 
@@ -355,12 +355,22 @@ class TestDataFusionLiteralConversion:
     def test_datetime_greater_than_or_equal(self):
         dt = datetime(2026, 4, 27, tzinfo=UTC)
         result = _to_datafusion_sql(col("datepartition") >= dt)
-        assert result == "\"datepartition\" >= CAST('2026-04-27 00:00:00' AS TIMESTAMP)"
+        assert result == "\"datepartition\" >= CAST('2026-04-27 00:00:00+0000' AS TIMESTAMP)"
 
     def test_datetime_equal(self):
         dt = datetime(2026, 4, 27, 12, 30, 45, tzinfo=UTC)
         result = _to_datafusion_sql(col("ts") == dt)
-        assert result == "\"ts\" = CAST('2026-04-27 12:30:45' AS TIMESTAMP)"
+        assert result == "\"ts\" = CAST('2026-04-27 12:30:45+0000' AS TIMESTAMP)"
+
+    def test_datetime_non_utc_timezone_preserved(self):
+        dt = datetime(2026, 4, 27, 12, 0, 0, tzinfo=timezone(timedelta(hours=5)))
+        result = _to_datafusion_sql(col("ts") >= dt)
+        assert result == "\"ts\" >= CAST('2026-04-27 12:00:00+0500' AS TIMESTAMP)"
+
+    def test_datetime_naive_no_offset(self):
+        dt = datetime(2026, 4, 27, 12, 0, 0)
+        result = _to_datafusion_sql(col("ts") >= dt)
+        assert result == "\"ts\" >= CAST('2026-04-27 12:00:00' AS TIMESTAMP)"
 
     def test_date_greater_than_or_equal(self):
         d = date(2026, 4, 27)
@@ -372,14 +382,15 @@ class TestDataFusionLiteralConversion:
         dt2 = datetime(2026, 5, 1, tzinfo=UTC)
         result = _to_datafusion_sql(col("ts").between(dt1, dt2))
         assert result == (
-            "\"ts\" BETWEEN CAST('2026-04-27 00:00:00' AS TIMESTAMP) AND CAST('2026-05-01 00:00:00' AS TIMESTAMP)"
+            "\"ts\" BETWEEN CAST('2026-04-27 00:00:00+0000' AS TIMESTAMP)"
+            " AND CAST('2026-05-01 00:00:00+0000' AS TIMESTAMP)"
         )
 
     def test_datetime_in_compound_filter(self):
         dt = datetime(2026, 4, 27, tzinfo=UTC)
         f = (col("datepartition") >= dt) & (col("status") == "active")
         result = _to_datafusion_sql(f)
-        assert "CAST('2026-04-27 00:00:00' AS TIMESTAMP)" in result
+        assert "CAST('2026-04-27 00:00:00+0000' AS TIMESTAMP)" in result
         assert "\"status\" = 'active'" in result
 
     def test_time_equal(self):
@@ -454,6 +465,15 @@ class TestDataFusionFilterExecution:
         table = self._query(ctx, where)
         assert table.num_rows == 1
         assert table.column("ts")[0].as_py() == datetime(2026, 4, 25, tzinfo=UTC)
+
+    def test_datetime_non_utc_timezone(self, ctx):
+        # 2026-04-27 05:00:00+05:00 == 2026-04-27 00:00:00 UTC, same as row 2
+        dt = datetime(2026, 4, 27, 5, 0, 0, tzinfo=timezone(timedelta(hours=5)))
+        where = _to_datafusion_sql(col("ts") >= dt)
+        table = self._query(ctx, where)
+        assert table.num_rows == 2
+        ts_values = [v.as_py() for v in table.column("ts")]
+        assert ts_values == [datetime(2026, 4, 27, tzinfo=UTC), datetime(2026, 4, 29, tzinfo=UTC)]
 
     def test_date_filter(self, ctx):
         where = _to_datafusion_sql(col("dt") >= date(2026, 4, 27))

--- a/integrations/python/dataloader/tests/test_filters.py
+++ b/integrations/python/dataloader/tests/test_filters.py
@@ -402,6 +402,79 @@ class TestDataFusionLiteralConversion:
         assert result == "\"id\" = '12345678-1234-5678-1234-567812345678'"
 
 
+class TestDataFusionFilterExecution:
+    """Execute generated filter SQL against a real DataFusion SessionContext."""
+
+    @pytest.fixture()
+    def ctx(self):
+        import datafusion
+        import pyarrow as pa
+
+        ctx = datafusion.SessionContext()
+        batch = pa.record_batch(
+            {
+                "ts": pa.array(
+                    [
+                        datetime(2026, 4, 25, tzinfo=UTC),
+                        datetime(2026, 4, 27, tzinfo=UTC),
+                        datetime(2026, 4, 29, tzinfo=UTC),
+                    ],
+                    type=pa.timestamp("us", tz="UTC"),
+                ),
+                "dt": pa.array([date(2026, 4, 25), date(2026, 4, 27), date(2026, 4, 29)]),
+                "t": pa.array([time(10, 0, 0), time(14, 30, 0), time(20, 0, 0)], type=pa.time64("ns")),
+                "price": pa.array([Decimal("9.99"), Decimal("49.99"), Decimal("99.99")], type=pa.decimal128(10, 2)),
+                "id": pa.array(
+                    [
+                        "12345678-1234-5678-1234-567812345678",
+                        "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                        "ffffffff-ffff-ffff-ffff-ffffffffffff",
+                    ]
+                ),
+            }
+        )
+        ctx.register_record_batches("t", [[batch]])
+        return ctx
+
+    def _query(self, ctx, where: str) -> int:
+        return len(ctx.sql(f'SELECT * FROM "t" WHERE {where}').collect()[0])
+
+    def test_datetime_filter(self, ctx):
+        where = _to_datafusion_sql(col("ts") >= datetime(2026, 4, 27, tzinfo=UTC))
+        assert self._query(ctx, where) == 2
+
+    def test_datetime_less_than(self, ctx):
+        where = _to_datafusion_sql(col("ts") < datetime(2026, 4, 27, tzinfo=UTC))
+        assert self._query(ctx, where) == 1
+
+    def test_date_filter(self, ctx):
+        where = _to_datafusion_sql(col("dt") >= date(2026, 4, 27))
+        assert self._query(ctx, where) == 2
+
+    def test_time_filter(self, ctx):
+        where = _to_datafusion_sql(col("t") == time(14, 30, 0))
+        assert self._query(ctx, where) == 1
+
+    def test_decimal_filter(self, ctx):
+        where = _to_datafusion_sql(col("price") > Decimal("10.00"))
+        assert self._query(ctx, where) == 2
+
+    def test_uuid_filter(self, ctx):
+        where = _to_datafusion_sql(col("id") == UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"))
+        assert self._query(ctx, where) == 1
+
+    def test_datetime_between_filter(self, ctx):
+        where = _to_datafusion_sql(
+            col("ts").between(datetime(2026, 4, 26, tzinfo=UTC), datetime(2026, 4, 28, tzinfo=UTC))
+        )
+        assert self._query(ctx, where) == 1
+
+    def test_compound_filter(self, ctx):
+        f = (col("ts") >= datetime(2026, 4, 27, tzinfo=UTC)) & (col("price") > Decimal("50.00"))
+        where = _to_datafusion_sql(f)
+        assert self._query(ctx, where) == 1
+
+
 class TestPyIcebergUnsupportedType:
     def test_raises_on_unknown_filter(self):
         class CustomFilter(Filter):

--- a/integrations/python/dataloader/tests/test_filters.py
+++ b/integrations/python/dataloader/tests/test_filters.py
@@ -355,22 +355,27 @@ class TestDataFusionLiteralConversion:
     def test_datetime_greater_than_or_equal(self):
         dt = datetime(2026, 4, 27, tzinfo=UTC)
         result = _to_datafusion_sql(col("datepartition") >= dt)
-        assert result == "\"datepartition\" >= CAST('2026-04-27 00:00:00+0000' AS TIMESTAMP)"
+        assert result == "\"datepartition\" >= CAST('2026-04-27 00:00:00.000000+0000' AS TIMESTAMP)"
 
     def test_datetime_equal(self):
         dt = datetime(2026, 4, 27, 12, 30, 45, tzinfo=UTC)
         result = _to_datafusion_sql(col("ts") == dt)
-        assert result == "\"ts\" = CAST('2026-04-27 12:30:45+0000' AS TIMESTAMP)"
+        assert result == "\"ts\" = CAST('2026-04-27 12:30:45.000000+0000' AS TIMESTAMP)"
+
+    def test_datetime_with_microseconds(self):
+        dt = datetime(2026, 4, 27, 12, 30, 45, 123456, tzinfo=UTC)
+        result = _to_datafusion_sql(col("ts") == dt)
+        assert result == "\"ts\" = CAST('2026-04-27 12:30:45.123456+0000' AS TIMESTAMP)"
 
     def test_datetime_non_utc_timezone_preserved(self):
         dt = datetime(2026, 4, 27, 12, 0, 0, tzinfo=timezone(timedelta(hours=5)))
         result = _to_datafusion_sql(col("ts") >= dt)
-        assert result == "\"ts\" >= CAST('2026-04-27 12:00:00+0500' AS TIMESTAMP)"
+        assert result == "\"ts\" >= CAST('2026-04-27 12:00:00.000000+0500' AS TIMESTAMP)"
 
     def test_datetime_naive_no_offset(self):
         dt = datetime(2026, 4, 27, 12, 0, 0)
         result = _to_datafusion_sql(col("ts") >= dt)
-        assert result == "\"ts\" >= CAST('2026-04-27 12:00:00' AS TIMESTAMP)"
+        assert result == "\"ts\" >= CAST('2026-04-27 12:00:00.000000' AS TIMESTAMP)"
 
     def test_date_greater_than_or_equal(self):
         d = date(2026, 4, 27)
@@ -382,21 +387,26 @@ class TestDataFusionLiteralConversion:
         dt2 = datetime(2026, 5, 1, tzinfo=UTC)
         result = _to_datafusion_sql(col("ts").between(dt1, dt2))
         assert result == (
-            "\"ts\" BETWEEN CAST('2026-04-27 00:00:00+0000' AS TIMESTAMP)"
-            " AND CAST('2026-05-01 00:00:00+0000' AS TIMESTAMP)"
+            "\"ts\" BETWEEN CAST('2026-04-27 00:00:00.000000+0000' AS TIMESTAMP)"
+            " AND CAST('2026-05-01 00:00:00.000000+0000' AS TIMESTAMP)"
         )
 
     def test_datetime_in_compound_filter(self):
         dt = datetime(2026, 4, 27, tzinfo=UTC)
         f = (col("datepartition") >= dt) & (col("status") == "active")
         result = _to_datafusion_sql(f)
-        assert "CAST('2026-04-27 00:00:00+0000' AS TIMESTAMP)" in result
+        assert "CAST('2026-04-27 00:00:00.000000+0000' AS TIMESTAMP)" in result
         assert "\"status\" = 'active'" in result
 
     def test_time_equal(self):
         t = time(14, 30, 0)
         result = _to_datafusion_sql(col("event_time") == t)
-        assert result == "\"event_time\" = CAST('14:30:00' AS TIME)"
+        assert result == "\"event_time\" = CAST('14:30:00.000000' AS TIME)"
+
+    def test_time_with_microseconds(self):
+        t = time(14, 30, 0, 500000)
+        result = _to_datafusion_sql(col("event_time") == t)
+        assert result == "\"event_time\" = CAST('14:30:00.500000' AS TIME)"
 
     def test_decimal_greater_than(self):
         d = Decimal("99.95")
@@ -516,6 +526,28 @@ class TestDataFusionFilterExecution:
         assert table.num_rows == 1
         assert table.column("ts")[0].as_py() == datetime(2026, 4, 29, tzinfo=UTC)
         assert table.column("price")[0].as_py() == Decimal("99.99")
+
+    def test_datetime_microseconds(self, ctx):
+        import pyarrow as pa
+
+        ctx2 = __import__("datafusion").SessionContext()
+        batch = pa.record_batch(
+            {
+                "ts": pa.array(
+                    [datetime(2026, 4, 27, 12, 0, 0, 500000, tzinfo=UTC)],
+                    type=pa.timestamp("us", tz="UTC"),
+                ),
+            }
+        )
+        ctx2.register_record_batches("t2", [[batch]])
+        where = _to_datafusion_sql(col("ts") == datetime(2026, 4, 27, 12, 0, 0, 500000, tzinfo=UTC))
+        table = ctx2.sql(f'SELECT * FROM "t2" WHERE {where}').collect()
+        assert len(table[0]) == 1
+        assert table[0].column("ts")[0].as_py() == datetime(2026, 4, 27, 12, 0, 0, 500000, tzinfo=UTC)
+
+        where_no_match = _to_datafusion_sql(col("ts") == datetime(2026, 4, 27, 12, 0, 0, tzinfo=UTC))
+        table2 = ctx2.sql(f'SELECT * FROM "t2" WHERE {where_no_match}').collect()
+        assert sum(len(b) for b in table2) == 0
 
 
 class TestPyIcebergUnsupportedType:


### PR DESCRIPTION
## Summary

Filter expressions using `datetime`, `date`, `time`, `Decimal`, or `UUID` values fail with `TypeError` when a `TableTransformer` is active because `_literal_to_sql()` only handled `str`, `bool`, `int`, and `float`. This extends support for other types.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

## Testing Done

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

All 234 tests pass. `make verify` clean.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.