### PR TITLE
Bump linkedin/iceberg to 1.2.0.15 / 1.5.2.11 (CachingCatalog metadata-table-name fix)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,8 @@ ext {
   spark_version = "3.1.1"
   ok_http3_version = "4.11.0"
   junit_version = "5.11.0"
-  iceberg_1_2_version = "1.2.0.13"
-  iceberg_1_5_version = "1.5.2.10"
+  iceberg_1_2_version = "1.2.0.15"
+  iceberg_1_5_version = "1.5.2.11"
   otel_agent_version = "2.12.0" // Bundles OTel SDK 1.47.0
   otel_annotations_version = "2.12.0" // Match agent version
 }


### PR DESCRIPTION
## Summary

Bumps OpenHouse's pinned iceberg fork versions:

- \`iceberg_1_2_version\`: \`1.2.0.13\` → \`1.2.0.15\`
- \`iceberg_1_5_version\`: \`1.5.2.10\` → \`1.5.2.11\`

This pulls in cherry-picks of upstream Apache Iceberg PR [#11738](https://github.com/apache/iceberg/pull/11738) ("Core: Fix loading a table in CachingCatalog with Metadata table name") that landed on \`linkedin/iceberg\` as [#240](https://github.com/linkedin/iceberg/pull/240) (\`openhouse-1.2.0\` → \`v1.2.0.15\`) and [#241](https://github.com/linkedin/iceberg/pull/241) (\`openhouse-1.5.2\` → \`v1.5.2.11\`).

### What the fix addresses

When a user creates a table whose name matches an Iceberg \`MetadataTableType\` (e.g. \`db.history\`, \`db.partitions\`, \`db.snapshots\`), \`CachingCatalog.loadTable\` previously assumed the identifier referred to a metadata-table access. It computed a collapsed-base origin identifier with an empty namespace and asked the underlying catalog to load it. For OpenHouse's single-level-namespace shape that collapsed identifier is invalid, so the underlying load threw \`NoSuchTableException\` (or, on staging, hit a 503 on a malformed \`GET /databases//tables/<X>\` request). The exception propagated out of \`CachingCatalog\` and Spark surfaced \"Table or view not found\" — making any cross-session read of such a table impossible.

The upstream fix flips the algorithm in \`CachingCatalog.loadTable\`: load the original identifier first, then check \`if (table instanceof BaseMetadataTable)\`. Catalogs that don't return a \`BaseMetadataTable\` from a normal load (OpenHouse never does) get back the user's primary \`BaseTable\` directly. The metadata-table-view branch only fires for catalogs that legitimately resolve metadata identifiers via direct load.

### Relationship to PR #538

PR [#538](https://github.com/linkedin/openhouse/pull/538) (\`f921014e\`, Christian Bush) overrode \`isValidIdentifier\` in \`OpenHouseCatalog\` and \`OpenHouseInternalCatalog\` to short-circuit \`BaseMetastoreCatalog.loadMetadataTable\` (BMC's *lazy* metadata-fallback that fires after a primary load returns null). That fix is correct and consistent with \`HiveCatalog\`'s long-standing override of the same hook — but it operates one layer deeper than the failure path users actually hit. The user-visible regression is \`CachingCatalog\`'s *eager* hijack at \`CachingCatalog.loadTable:146\`, which fires on identifier name before any load attempt and ignores \`isValidIdentifier\`. This bump (#11738) fixes that layer.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

Bug fix only — two version-string bumps in \`build.gradle\`. The actual fix is implemented in \`linkedin/iceberg\` PRs #240 and #241; this PR only changes which iceberg version OpenHouse resolves at build time.

## Testing Done

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [x] Some other form of testing like staging or soak time in production. Please explain.

**Iceberg-side regression tests (already merged in linkedin/iceberg #240/#241):** the upstream PR ships two new test methods in \`TestCachingCatalog\`:

- \`testNonExistingTable\` — asserts \`NoSuchTableException\` with the correct (uncollapsed) identifier when a missing table is loaded.
- \`testTableWithMetadataTableName\` — creates a primary table named \`partitions\`, invalidates the cache, asserts the subsequent load returns the primary table (not a metadata view) and caches under the right key. Then loads the legitimate metadata-view (\`db.partitions.partitions\`) and asserts it returns a \`BaseMetadataTable\` cached under its own key.

Both tests pass locally on the cherry-picked branches (JDK 11). They also pass in CI on the merged PRs (#240, #241).

**Local snapshot build:** built \`com.linkedin.iceberg:*:1.2.0.15-SNAPSHOT\` from the cherry-picked branch and \`com.linkedin.openhouse:*:0.5.411-SNAPSHOT\` from this commit's tip pinned at the snapshot, both into \`~/.m2/repository\`. All 28 OpenHouse modules built cleanly against the bumped iceberg.

**Wire-level reproduction (pre-fix vs post-fix):** without the fix, a fresh-JVM Spark session calling \`SELECT * FROM openhouse.u_openhouse.partitions\` against a stranded staging table emits \`GET /v1/databases//tables/u_openhouse\` → 503 from the gateway. With a bare \`LiOpenHouseCatalog\` (no CachingCatalog wrap) pointing at the same staging cluster, the same identifier resolves to the user's primary \`[id, name]\` schema. The cherry-picked CachingCatalog fix puts the wrapped path on the same footing as the bare path — confirmed by stepping through the algorithm change at \`CachingCatalog.loadTable:140-170\`.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

No breaking changes. The fix is strictly a behavior repair for a previously-broken case (reserved-named primary tables) and changes nothing for the common case (table names that don't collide with \`MetadataTableType\`). \`CachingCatalog\`'s metadata-view caching contract is preserved; only the eager identifier-name hijack is removed.