### PR TITLE
Fix SelectFromTableTest hang after iceberg 1.2.0.15 bump (#570)

### DIFF
--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/dml/SelectFromTableTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/e2e/dml/SelectFromTableTest.java
@@ -60,6 +60,11 @@ public class SelectFromTableTest {
                 baseSchema,
                 null,
                 null));
+    // CachingCatalog (iceberg >= 1.2.0.15) issues two loadTable round-trips for a metadata-table
+    // identifier: one resolves `tbl.snapshots` through BaseMetastoreCatalog.loadMetadataTable
+    // (which fetches the base table) and a second populates the cache entry for the base
+    // identifier so the metadata-table view can share its TableOperations.
+    mockTableService.enqueue(mockResponse);
     mockTableService.enqueue(mockResponse);
 
     List<Row> actualRows =


### PR DESCRIPTION
## Summary

Fixes the CI hang at \`SelectFromTableTest.testSelectTablesTimeTravel\` introduced by #570 (iceberg \`1.2.0.13\` → \`1.2.0.15\`).

## Why it hangs
The upstream fix introduces an additional REST call in the transaction workflow only for tables which match the metadata table naming scheme. 

In our client side tests, we have a mock server and enqueue mock responses for each request in the transaction. since the transaction semantic changed for this type of metadata table test, we need to account for it in unittests.

## Implications
The upstream cachingcatalog fix introduces one more rest call in the transaction if the table is named same as metadata table naming scheme. this is a very small percent of overall cluster tables so the expected qps increase is bounded / insignificant.

## Why wasn't found in CI
Somehow the previous PR was able to merge without unittests passing, TODO to look into making CI checks blocking. 

## Fix

Add a second \`mockTableService.enqueue(mockResponse)\` before the \`.snapshots\` query in \`SelectFromTableTest.testSelectTablesTimeTravel\` so the mock count matches the new request shape.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

Tests:
- Added one \`MockResponse\` enqueue in \`SelectFromTableTest.testSelectTablesTimeTravel\` to match the post-#570 request count for metadata-table loads.

## Testing Done

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

\`\`\`
JAVA_HOME=\$(/usr/libexec/java_home -v 17) ./gradlew \\
  :integrations:spark:spark-3.1:openhouse-spark-itest:test \\
  --tests com.linkedin.openhouse.spark.e2e.dml.SelectFromTableTest
\`\`\`

All four tests pass: \`testAuthzError\`, \`testSelectTables\`, \`testSelectTablesTimeTravel\`, \`testSelectTablesFromEmptyTable\`.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

No breaking changes. Pure test-mock alignment with the upstream \`CachingCatalog\` request shape from #570.