### PR TITLE
Reduce metadata refresh retries from 20 to 3

### DIFF
--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -93,9 +93,7 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
   /**
    * Overrides Iceberg's {@code BaseMetastoreTableOperations.META_DATA_REFRESH_RETRIES} (20). The
    * underlying {@code refreshFromMetadataLocation} retries with exponential backoff capped at 5s,
-   * so 20 retries can stretch a single failing refresh to ~90 seconds. HTS already returns the
-   * authoritative metadata pointer, so a high retry budget mostly serves to absorb object-store
-   * read-after-write races, where a much smaller value suffices.
+   * so 20 retries can stretch a single failing refresh to ~90 seconds.
    */
   private static final int METADATA_REFRESH_RETRIES = 3;
 

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -90,6 +90,15 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
   private static final Cache<String, Integer> CACHE =
       CacheBuilder.newBuilder().expireAfterWrite(5, TimeUnit.MINUTES).maximumSize(1000).build();
 
+  /**
+   * Overrides Iceberg's {@code BaseMetastoreTableOperations.META_DATA_REFRESH_RETRIES} (20). The
+   * underlying {@code refreshFromMetadataLocation} retries with exponential backoff capped at 5s,
+   * so 20 retries can stretch a single failing refresh to ~90 seconds. HTS already returns the
+   * authoritative metadata pointer, so a high retry budget mostly serves to absorb object-store
+   * read-after-write races, where a much smaller value suffices.
+   */
+  private static final int METADATA_REFRESH_RETRIES = 3;
+
   @Override
   protected String tableName() {
     return this.tableIdentifier.toString();
@@ -133,7 +142,7 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
   protected void refreshMetadata(final String metadataLoc) {
     long startTime = System.currentTimeMillis();
     boolean needToReload = !Objects.equal(currentMetadataLocation(), metadataLoc);
-    Runnable r = () -> super.refreshFromMetadataLocation(metadataLoc);
+    Runnable r = () -> super.refreshFromMetadataLocation(metadataLoc, METADATA_REFRESH_RETRIES);
     try {
       if (needToReload) {
         metricsReporter.executeWithStats(
@@ -405,7 +414,7 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
          * "forced refresh" in {@link OpenHouseInternalTableOperations#commit(TableMetadata,
          * TableMetadata)}
          */
-        refreshFromMetadataLocation(newMetadataLocation);
+        refreshFromMetadataLocation(newMetadataLocation, METADATA_REFRESH_RETRIES);
       }
       if (isReplicatedTableCreate(properties)) {
         updateMetadataFieldForTable(metadata, newMetadataLocation);


### PR DESCRIPTION
## Summary
The select statement on some malformed tables will stuck for 60s, timeout, and throws a 504 error. However, the underlying server shows a different error. Take `u_openhouse.test_rohit2` as an example. It is a replica table with a wrongly-ordered snapshot logs. So `refreshFromMetadataLocation` failed for `Invalid update timestamp 1738457438373: before last snapshot log entry at 1738534225676`, and retried 20 times (iceberg's default config). The total time spent on retry is 90s which causes the client to timeout. The same pattern of retrying 20 times for 90s will happen to all tables with a bad metadata. So I want to reduce the retry number to acheive 2 things:
1. Avoid a wrong error code on the client side.
2. Fast fail at parsing the metadata to reduce waste of computing resources.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [x] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [x] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
