### PR TITLE
Cache tableFileStats Dataset to reuse across Spark actions

### DIFF
--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGenerator.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGenerator.java
@@ -63,12 +63,18 @@ public class OpenHouseDataLayoutStrategyGenerator implements DataLayoutStrategyG
    */
   @Override
   public List<DataLayoutStrategy> generateTableLevelStrategies() {
-    // Retrieve file sizes of all data files.
-    Dataset<FileStat> fileStats = tableFileStats.get();
-    long partitionCount = tablePartitionStats.get().count();
-    Optional<DataLayoutStrategy> strategy =
-        buildDataLayoutStrategy(fileStats, partitionCount, null, null);
-    return strategy.map(Collections::singletonList).orElse(Collections.emptyList());
+    // Cache the Dataset so the underlying Iceberg manifest scan executes once; the downstream
+    // count/collectAsList/toLocalIterator actions inside buildDataLayoutStrategy reuse the cached
+    // partitions instead of re-scanning system.files for each terminal action.
+    Dataset<FileStat> fileStats = tableFileStats.get().cache();
+    try {
+      long partitionCount = tablePartitionStats.get().count();
+      Optional<DataLayoutStrategy> strategy =
+          buildDataLayoutStrategy(fileStats, partitionCount, null, null);
+      return strategy.map(Collections::singletonList).orElse(Collections.emptyList());
+    } finally {
+      fileStats.unpersist();
+    }
   }
 
   /**
@@ -78,25 +84,30 @@ public class OpenHouseDataLayoutStrategyGenerator implements DataLayoutStrategyG
   @Override
   public List<DataLayoutStrategy> generatePartitionLevelStrategies() {
     List<DataLayoutStrategy> strategies = new ArrayList<>();
-    List<PartitionStat> partitionStatsList = tablePartitionStats.get().collectAsList();
-    String partitionColumns = String.join(", ", tablePartitionStats.getPartitionColumns());
-    // For each partition, generate a compaction strategy
-    partitionStatsList.forEach(
-        partitionStat -> {
-          String partitionValues = String.join(", ", partitionStat.getValues());
-          Dataset<FileStat> fileStats =
-              tableFileStats
-                  .get()
-                  .filter(
-                      (FilterFunction<FileStat>)
-                          fileStat ->
-                              String.join(", ", fileStat.getPartitionValues())
-                                  .equals(partitionValues));
-          Optional<DataLayoutStrategy> strategy =
-              buildDataLayoutStrategy(fileStats, 1L, partitionValues, partitionColumns);
-          strategy.ifPresent(strategies::add);
-        });
-    return strategies;
+    // Cache the unfiltered Dataset once; each per-partition filter operates on the cached rows,
+    // so the Iceberg manifest scan does not re-execute for every partition.
+    Dataset<FileStat> cachedFileStats = tableFileStats.get().cache();
+    try {
+      List<PartitionStat> partitionStatsList = tablePartitionStats.get().collectAsList();
+      String partitionColumns = String.join(", ", tablePartitionStats.getPartitionColumns());
+      // For each partition, generate a compaction strategy
+      partitionStatsList.forEach(
+          partitionStat -> {
+            String partitionValues = String.join(", ", partitionStat.getValues());
+            Dataset<FileStat> fileStats =
+                cachedFileStats.filter(
+                    (FilterFunction<FileStat>)
+                        fileStat ->
+                            String.join(", ", fileStat.getPartitionValues())
+                                .equals(partitionValues));
+            Optional<DataLayoutStrategy> strategy =
+                buildDataLayoutStrategy(fileStats, 1L, partitionValues, partitionColumns);
+            strategy.ifPresent(strategies::add);
+          });
+      return strategies;
+    } finally {
+      cachedFileStats.unpersist();
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

`OpenHouseDataLayoutStrategyGenerator` invokes several Spark terminal actions (`count`, `collectAsList`, `toLocalIterator`) on the lazy `Dataset<FileStat>` returned by `tableFileStats.get()`. Without caching, every action independently materializes the Dataset by re-reading the underlying Iceberg `system.files` manifest. In `generateTableLevelStrategies`, that's 5-7 manifest reads per app run; in `generatePartitionLevelStrategies` it's that figure multiplied by partition count, since the loop calls `tableFileStats.get()` fresh per partition.

This PR adds `.cache()` so the Dataset is materialized once and subsequent actions read from the cached partitions instead of re-reading the manifest. The action count is unchanged - this only makes each action faster by eliminating the redundant scan work.

A try/finally `unpersist()` bounds the cache lifetime to the generator invocation so the cached blocks are released promptly.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [x] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

### Details

In `OpenHouseDataLayoutStrategyGenerator.java`:

- `generateTableLevelStrategies`: wrap `tableFileStats.get()` with `.cache()`, add `try/finally unpersist()`.
- `generatePartitionLevelStrategies`: cache the unfiltered Dataset **outside** the per-partition loop; each per-partition filter now derives from the cached Dataset rather than calling `tableFileStats.get()` again.

No other logic changed. No API change.

## Testing Done

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [x] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

The change is a transparent performance hint - the public API and every observable output (every `DataLayoutStrategy` field) is unchanged. Verified by running the existing suite:

- `./gradlew :libs:datalayout:test` - all 17 tests pass, including:
  - `OpenHouseDataLayoutStrategyGeneratorTest.testTableLevelStrategy`
  - `OpenHouseDataLayoutStrategyGeneratorTest.testTableLevelStrategyPartitioned`
  - `OpenHouseDataLayoutStrategyGeneratorTest.testPartitionLevelStrategy`
  - `IntegrationTest.testCompactionStrategyGenerationNonPartitioned`
  - `IntegrationTest.testCompactionStrategyGenerationWithPersistencePartitioned`

No new tests added because there is no new behavior to assert. The win is reduced per-action wall time, which only manifests against a real Spark cluster.

## Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.