### PR TITLE
Collapse repeated collectAsList in DataLayoutStrategyGenerator

### DIFF
--- a/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGenerator.java
+++ b/libs/datalayout/src/main/java/com/linkedin/openhouse/datalayout/generator/OpenHouseDataLayoutStrategyGenerator.java
@@ -10,17 +10,15 @@ import com.linkedin.openhouse.datalayout.datasource.TableSnapshotStats;
 import com.linkedin.openhouse.datalayout.strategy.DataLayoutStrategy;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import org.apache.iceberg.FileContent;
 import org.apache.spark.api.java.function.FilterFunction;
-import org.apache.spark.api.java.function.MapFunction;
 import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Encoders;
 import scala.Tuple3;
 
 /**
@@ -116,28 +114,34 @@ public class OpenHouseDataLayoutStrategyGenerator implements DataLayoutStrategyG
       String partitionValues,
       String partitionColumns) {
 
-    Dataset<FileStat> dataFiles =
-        fileStats.filter((FilterFunction<FileStat>) file -> file.getContent() == FileContent.DATA);
+    // Single Spark action: collect all files once, then partition/aggregate in driver memory.
+    // Replaces 4 separate Spark actions (count + 3x collectAsList) with 1.
+    List<FileStat> allFiles = fileStats.collectAsList();
 
-    Dataset<FileStat> filteredDataFiles =
-        dataFiles.filter(
-            (FilterFunction<FileStat>)
-                file ->
-                    file.getSizeInBytes()
-                        < TARGET_BYTES_SIZE * DataCompactionConfig.MIN_BYTE_SIZE_RATIO_DEFAULT);
+    long minByteSize =
+        (long) (TARGET_BYTES_SIZE * DataCompactionConfig.MIN_BYTE_SIZE_RATIO_DEFAULT);
 
-    // Check whether we have anything to map/reduce on for cost computation, this is only the case
-    // if we have small files that need to be compacted.
-    if (filteredDataFiles.count() == 0) {
+    Tuple3<Long, Integer, Long> filteredDataFileStats =
+        aggregateInMemory(
+            allFiles, f -> f.getContent() == FileContent.DATA && f.getSizeInBytes() < minByteSize);
+
+    // Early-return if no small data files to compact.
+    if (filteredDataFileStats._2() == 0) {
       return Optional.empty();
     }
 
-    Tuple3<Long, Integer, Long> filteredDataFileStats =
-        computeFileStats(filteredDataFiles, FileContent.DATA);
     Tuple3<Long, Integer, Long> posDeleteStats =
-        computeFileStats(fileStats, FileContent.POSITION_DELETES);
+        aggregateInMemory(allFiles, f -> f.getContent() == FileContent.POSITION_DELETES);
     Tuple3<Long, Integer, Long> eqDeleteStats =
-        computeFileStats(fileStats, FileContent.EQUALITY_DELETES);
+        aggregateInMemory(allFiles, f -> f.getContent() == FileContent.EQUALITY_DELETES);
+
+    // Derive DATA file sizes (used by computeEntropy) from the same in-memory list instead of
+    // issuing another Spark action.
+    List<Long> dataFileSizes =
+        allFiles.stream()
+            .filter(f -> f.getContent() == FileContent.DATA)
+            .map(FileStat::getSizeInBytes)
+            .collect(Collectors.toList());
 
     long rewriteFileBytes = filteredDataFileStats._1();
     int rewriteFileCount = filteredDataFileStats._2();
@@ -161,10 +165,7 @@ public class OpenHouseDataLayoutStrategyGenerator implements DataLayoutStrategyG
             .cost(computeGbHr)
             .gain(reducedFileCount)
             .score(reducedFileCountPerComputeGbHr)
-            .entropy(
-                computeEntropy(
-                    dataFiles.map(
-                        (MapFunction<FileStat, Long>) FileStat::getSizeInBytes, Encoders.LONG())))
+            .entropy(computeEntropy(dataFileSizes))
             .partitionId(partitionValues)
             .partitionColumns(partitionColumns)
             .posDeleteFileBytes(posDeleteStats._1())
@@ -236,39 +237,37 @@ public class OpenHouseDataLayoutStrategyGenerator implements DataLayoutStrategyG
     return rewriteHours * EXECUTOR_MEMORY_GB + COMPUTE_STARTUP_COST_GB_HR;
   }
 
-  /** Computes the file entropy as the difference of a set of file's target and actual file size. */
-  private double computeEntropy(Dataset<Long> fileSizes) {
-    // If no files available, MSE is 0.
-    if (fileSizes.count() == 0) {
+  /**
+   * Computes file entropy as mean-squared error from TARGET_BYTES_SIZE over a pre-collected list.
+   */
+  private double computeEntropy(List<Long> fileSizes) {
+    if (fileSizes.isEmpty()) {
       return 0;
     }
-    // Compute the mean-squared error.
     double mse = 0.0;
-    Iterator<Long> itr = fileSizes.toLocalIterator();
-    while (itr.hasNext()) {
-      mse += Math.pow(TARGET_BYTES_SIZE - itr.next(), 2);
+    for (long size : fileSizes) {
+      double diff = TARGET_BYTES_SIZE - (double) size;
+      mse += diff * diff;
     }
-    // Normalize.
-    return mse / fileSizes.count();
+    return mse / fileSizes.size();
   }
 
   /**
-   * Computes statistics for files of a content type, including total bytes, file count, and record
-   * count.
-   *
-   * @param files Dataset of FileStat objects
-   * @param content a type of file in iceberg
-   * @return A Tuple3 containing (totalBytes, fileCount, recordCount)
+   * Aggregates a (totalBytes, count, totalRecords) tuple from a pre-collected list of FileStats
+   * matching the given predicate. Pure driver-side; issues no Spark actions.
    */
-  private Tuple3<Long, Integer, Long> computeFileStats(
-      Dataset<FileStat> files, FileContent content) {
-    Stream<FileStat> filesOfContent =
-        files.collectAsList().stream().filter(file -> file.getContent().equals(content));
-
-    return filesOfContent
-        .map(file -> new Tuple3<>(file.getSizeInBytes(), 1, file.getRecordCount()))
-        .reduce(
-            new Tuple3<>(0L, 0, 0L), // Default value for empty collection
-            (a, b) -> new Tuple3<>(a._1() + b._1(), a._2() + b._2(), a._3() + b._3()));
+  private Tuple3<Long, Integer, Long> aggregateInMemory(
+      List<FileStat> files, Predicate<FileStat> predicate) {
+    long totalBytes = 0L;
+    int count = 0;
+    long totalRecords = 0L;
+    for (FileStat f : files) {
+      if (predicate.test(f)) {
+        totalBytes += f.getSizeInBytes();
+        count++;
+        totalRecords += f.getRecordCount();
+      }
+    }
+    return new Tuple3<>(totalBytes, count, totalRecords);
   }
 }


### PR DESCRIPTION
## Summary

`buildDataLayoutStrategy` in `OpenHouseDataLayoutStrategyGenerator` issues 4 Spark actions to characterize the file mix (one `count` + three `collectAsList` via `computeFileStats`), and `computeEntropy` issues 3 more (`count` + `toLocalIterator` + `count`). Each action has Spark scheduling overhead even when the underlying data is cached.

This PR collects the `Dataset<FileStat>` once per `buildDataLayoutStrategy` call and aggregates in driver memory, replacing 7 actions with 1.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [x] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [ ] Tests

### Details

In `OpenHouseDataLayoutStrategyGenerator.java`:

- New `aggregateInMemory(List<FileStat>, Predicate<FileStat>)` helper sums `(totalBytes, count, totalRecords)` over rows matching a predicate. Pure driver-side, no Spark action.
- `buildDataLayoutStrategy` now does a single `fileStats.collectAsList()` and feeds it to three `aggregateInMemory` calls for DATA-small, POSITION_DELETES, EQUALITY_DELETES tuples.
- `computeEntropy(Dataset<Long>)` -> `computeEntropy(List<Long>)`: single in-memory pass, eliminates the prior 3 actions.
- `dataFileSizes` (used by `computeEntropy`) is derived from the same collected list instead of issuing `dataFiles.map(...)` separately.
- Drop now-unused imports (`Iterator`, `Stream`, `MapFunction`, `Encoders`); add `Predicate`, `Collectors`.

### Action-count impact (per `buildDataLayoutStrategy`)

| | Before | After |
|---|---:|---:|
| `count` actions | 1 | 0 |
| `collectAsList` actions | 3 (in `computeFileStats`) | 1 |
| `computeEntropy` actions | 3 (`count` + `toLocalIterator` + `count`) | 0 |
| Total | **7** | **1** |

### Driver memory

The aggregation runs entirely in driver memory after `collectAsList`. The peak footprint equals one `List<FileStat>` - which is the same as today, since the old code already invoked `collectAsList` three times on the same Dataset. No new OOM mode is introduced. Tables that already fit comfortably in the driver continue to; tables that didn't fail at the same point as before.

## Testing Done

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [x] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

The change is intended to be functionally equivalent. Public API and every observable output (every `DataLayoutStrategy` field: `gain`, `cost`, `score`, `entropy`, delete-file bytes/counts/records, `fileCountReductionPenalty`, `config`) are unchanged and exercised by the existing suite:

- `./gradlew :libs:datalayout:test` - all 17 tests pass, including:
  - `OpenHouseDataLayoutStrategyGeneratorTest.testTableLevelStrategy`
  - `OpenHouseDataLayoutStrategyGeneratorTest.testTableLevelStrategyPartitioned`
  - `OpenHouseDataLayoutStrategyGeneratorTest.testPartitionLevelStrategy`
  - `IntegrationTest.testCompactionStrategyGenerationNonPartitioned`
  - `IntegrationTest.testCompactionStrategyGenerationWithPersistencePartitioned`

## Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.