### PR TITLE
[DataLoader] Add unique id property to OpenHouseDataLoader

### DIFF
--- a/integrations/python/dataloader/src/openhouse/dataloader/data_loader.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/data_loader.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import uuid
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from functools import cached_property
@@ -163,6 +164,7 @@ class OpenHouseDataLoader:
         self._max_attempts = max_attempts
         self._batch_size = batch_size
         self._files_per_split = files_per_split
+        self._id = str(uuid.uuid4())
 
         if self._context.jvm_config is not None and self._context.jvm_config.planner_args is not None:
             apply_libhdfs_opts(self._context.jvm_config.planner_args)
@@ -174,6 +176,11 @@ class OpenHouseDataLoader:
             label=f"load_table {self._table_id}",
             max_attempts=self._max_attempts,
         )
+
+    @property
+    def id(self) -> str:
+        """Unique identifier for this data loader instance, generated at construction."""
+        return self._id
 
     @property
     def table_properties(self) -> Mapping[str, str]:

--- a/integrations/python/dataloader/src/openhouse/dataloader/data_loader.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/data_loader.py
@@ -164,7 +164,7 @@ class OpenHouseDataLoader:
         self._max_attempts = max_attempts
         self._batch_size = batch_size
         self._files_per_split = files_per_split
-        self._id = str(uuid.uuid4())
+        self._id = f"dataloader-{uuid.uuid4()}"
 
         if self._context.jvm_config is not None and self._context.jvm_config.planner_args is not None:
             apply_libhdfs_opts(self._context.jvm_config.planner_args)

--- a/integrations/python/dataloader/tests/test_data_loader.py
+++ b/integrations/python/dataloader/tests/test_data_loader.py
@@ -125,6 +125,17 @@ def test_table_properties_returns_metadata_properties(tmp_path):
     assert loader.table_properties["custom.key"] == "myvalue"
 
 
+def test_id_is_unique_per_loader_instance(tmp_path):
+    catalog = _make_real_catalog(tmp_path)
+
+    loader_a = OpenHouseDataLoader(catalog=catalog, database="db", table="tbl")
+    loader_b = OpenHouseDataLoader(catalog=catalog, database="db", table="tbl")
+
+    assert isinstance(loader_a.id, str)
+    assert loader_a.id == loader_a.id
+    assert loader_a.id != loader_b.id
+
+
 def test_snapshot_id_returns_current_snapshot_id(tmp_path):
     catalog = _make_real_catalog(tmp_path)
 

--- a/integrations/python/dataloader/tests/test_data_loader.py
+++ b/integrations/python/dataloader/tests/test_data_loader.py
@@ -132,6 +132,7 @@ def test_id_is_unique_per_loader_instance(tmp_path):
     loader_b = OpenHouseDataLoader(catalog=catalog, database="db", table="tbl")
 
     assert isinstance(loader_a.id, str)
+    assert loader_a.id.startswith("dataloader-")
     assert loader_a.id == loader_a.id
     assert loader_a.id != loader_b.id
 


### PR DESCRIPTION
## Summary

Adds an `id` property to `OpenHouseDataLoader`. Each instance gets a unique `dataloader-<uuid>` id at construction, useful for logging and correlation.

## Changes

- [x] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

## Testing Done

- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

`make verify` passes (lint, format, mypy, 264 pytest).

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.