### PR TITLE
internalcatalog: bump HDFS replication on metadata.json after write

### DIFF
--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/CatalogConstants.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/CatalogConstants.java
@@ -29,15 +29,13 @@ public final class CatalogConstants {
   public static final String EVOLVED_SCHEMA_KEY = "evolved.table.schema";
 
   /**
-   * Target HDFS replication factor applied to newly-written {@code .metadata.json} files
-   * immediately after the synchronous write returns. Paired with a li-openhouse PR that
-   * lowers the cluster default {@code dfs.replication}.
-   *
-   * <p>TODO(mkuchenb): promote this to a Spring config property
-   * ({@code openhouse.metadata.hdfs.replication}) so deployments can tune it without a
-   * code change. Kept as a constant for now to minimize PR surface area.
+   * Default HDFS replication factor used by {@link MetadataReplicationProperties} when no explicit
+   * value is configured. Held here so unit tests that construct {@link
+   * OpenHouseInternalTableOperations} without wiring the Spring properties bean still get a sane
+   * default. The bump itself is gated by {@link MetadataReplicationProperties#isEnabled()} and is
+   * off by default.
    */
-  public static final short METADATA_FILE_HDFS_REPLICATION = (short) 30;
+  public static final int DEFAULT_METADATA_FILE_HDFS_REPLICATION = 30;
 
   static final String FEATURE_TOGGLE_STOP_CREATE = "stop_create";
 

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/CatalogConstants.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/CatalogConstants.java
@@ -28,6 +28,17 @@ public final class CatalogConstants {
 
   public static final String EVOLVED_SCHEMA_KEY = "evolved.table.schema";
 
+  /**
+   * Target HDFS replication factor applied to newly-written {@code .metadata.json} files
+   * immediately after the synchronous write returns. Paired with a li-openhouse PR that
+   * lowers the cluster default {@code dfs.replication}.
+   *
+   * <p>TODO(mkuchenb): promote this to a Spring config property
+   * ({@code openhouse.metadata.hdfs.replication}) so deployments can tune it without a
+   * code change. Kept as a constant for now to minimize PR surface area.
+   */
+  public static final short METADATA_FILE_HDFS_REPLICATION = (short) 30;
+
   static final String FEATURE_TOGGLE_STOP_CREATE = "stop_create";
 
   static final String CLIENT_TABLE_SCHEMA = "client.table.schema";

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/InternalCatalogMetricsConstant.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/InternalCatalogMetricsConstant.java
@@ -18,6 +18,7 @@ public final class InternalCatalogMetricsConstant {
 
   static final String METADATA_UPDATE_LATENCY = "metadata_update_latency";
   static final String METADATA_RETRIEVAL_LATENCY = "metadata_retrieval_latency";
+  static final String METADATA_REPLICATION_SET_LATENCY = "metadata_replication_set_latency";
 
   // Tag constants for metric dimensions
   static final String DATABASE_TAG = "database";

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/InternalCatalogMetricsConstant.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/InternalCatalogMetricsConstant.java
@@ -19,6 +19,8 @@ public final class InternalCatalogMetricsConstant {
   static final String METADATA_UPDATE_LATENCY = "metadata_update_latency";
   static final String METADATA_RETRIEVAL_LATENCY = "metadata_retrieval_latency";
   static final String METADATA_REPLICATION_SET_LATENCY = "metadata_replication_set_latency";
+  static final String METADATA_REPLICATION_SET_TIMEOUT_CTR = "metadata_replication_set_timeout";
+  static final String METADATA_REPLICATION_SET_DISABLED_CTR = "metadata_replication_set_disabled";
 
   // Tag constants for metric dimensions
   static final String DATABASE_TAG = "database";

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/MetadataReplicationProperties.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/MetadataReplicationProperties.java
@@ -1,0 +1,49 @@
+package com.linkedin.openhouse.internal.catalog;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Spring configuration for the post-write HDFS replication bump applied to newly-written {@code
+ * metadata.json} files inside {@link OpenHouseInternalTableOperations#doCommit}.
+ *
+ * <p>The bump exists so the synchronous metadata write can ack at the cluster HDFS default
+ * replication (typically lower, for write-latency reasons), then be asynchronously-to-the-client
+ * raised to a higher durable replication factor.
+ *
+ * <p>Defaults are safe-by-default: the bump is <b>disabled</b> unless explicitly enabled per
+ * deployment. This makes the rollout opt-in per fabric.
+ *
+ * <p>Configuration keys (under prefix {@code openhouse.internal.catalog.metadata.replication}):
+ *
+ * <ul>
+ *   <li>{@code enabled} (boolean, default {@code false}) - master switch for the bump
+ *   <li>{@code target} (short, default {@code 30}) - replication factor to apply
+ *   <li>{@code timeoutMs} (long, default {@code 10000}) - strict per-call timeout for the {@code
+ *       FileSystem.setReplication} RPC. On timeout the bump is treated as a degraded-durability
+ *       event (WARN + commit succeeds), not a commit failure.
+ * </ul>
+ */
+@Configuration
+@ConfigurationProperties(prefix = "openhouse.internal.catalog.metadata.replication")
+@Getter
+@Setter
+public class MetadataReplicationProperties {
+
+  /** Master switch. The bump is opt-in per deployment. */
+  private boolean enabled = false;
+
+  /**
+   * Target HDFS replication factor applied to a newly-written {@code metadata.json}. Stored as
+   * {@code int} for Spring binding convenience; the underlying HDFS API takes {@code short}.
+   */
+  private int target = CatalogConstants.DEFAULT_METADATA_FILE_HDFS_REPLICATION;
+
+  /**
+   * Strict per-call timeout for the {@code FileSystem.setReplication} RPC. On timeout the work is
+   * abandoned and the commit succeeds.
+   */
+  private long timeoutMs = 10_000L;
+}

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -63,6 +63,8 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
 
   @Autowired MeterRegistry meterRegistry;
 
+  @Autowired MetadataReplicationProperties metadataReplicationProperties;
+
   @Override
   protected TableOperations newTableOps(TableIdentifier tableIdentifier) {
     FileIO fileIO = resolveFileIO(tableIdentifier);
@@ -74,7 +76,8 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
         houseTableMapper,
         tableIdentifier,
         metricsReporter,
-        fileIOManager);
+        fileIOManager,
+        metadataReplicationProperties);
   }
 
   @Override

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
@@ -330,6 +331,9 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
             "updateMetadata to location {} succeeded, took {} ms",
             newMetadataLocation,
             System.currentTimeMillis() - metadataUpdateStartTime);
+        // Set replication after the synchronous write so the write path is not blocked
+        // on the higher replica count. Failures are logged and do not fail the commit.
+        bumpMetadataReplicationIfHdfs(newMetadataLocation);
       } catch (Exception e) {
         log.error(
             "updateMetadata to location {} failed after {} ms",
@@ -692,6 +696,62 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
    */
   private String[] getCatalogMetricTags() {
     return new String[] {};
+  }
+
+  /**
+   * Set HDFS replication on a just-written {@code metadata.json} file to {@link
+   * CatalogConstants#METADATA_FILE_HDFS_REPLICATION}. Called immediately after the synchronous
+   * metadata write returns inside {@link #doCommit(TableMetadata, TableMetadata)}.
+   *
+   * <p>The synchronous write produces the file at the cluster HDFS default replication. This
+   * call raises it to the target replication factor so the persisted file ends up at the
+   * expected count without making the synchronous write path wait on the longer datanode
+   * pipeline ack.
+   *
+   * <p>HDFS-only. Non-HDFS clients (local, blob storage) silently skip.
+   *
+   * <p>Failures are logged at WARN and swallowed; they do not fail the commit.
+   *
+   * @param newMetadataLocation absolute HDFS path of the newly-written metadata.json
+   */
+  private void bumpMetadataReplicationIfHdfs(String newMetadataLocation) {
+    Storage storage;
+    try {
+      storage = fileIOManager.getStorage(fileIO);
+    } catch (Exception e) {
+      log.warn(
+          "Skipping HDFS replication bump for {}: could not resolve storage from fileIO",
+          newMetadataLocation,
+          e);
+      return;
+    }
+    if (storage == null || !(storage.getClient() instanceof HdfsStorageClient)) {
+      return;
+    }
+    final FileSystem fs = (FileSystem) storage.getClient().getNativeClient();
+    final short targetReplication = CatalogConstants.METADATA_FILE_HDFS_REPLICATION;
+    try {
+      metricsReporter.executeWithStats(
+          () -> {
+            try {
+              fs.setReplication(new Path(newMetadataLocation), targetReplication);
+            } catch (IOException ioe) {
+              // Wrap so executeWithStats sees a RuntimeException; caught below for warn+swallow.
+              throw new RuntimeException(ioe);
+            }
+          },
+          InternalCatalogMetricsConstant.METADATA_REPLICATION_SET_LATENCY,
+          getCatalogMetricTags());
+      log.debug(
+          "Set HDFS replication on {} to {}", newMetadataLocation, targetReplication);
+    } catch (Exception e) {
+      log.warn(
+          "Failed to set HDFS replication on {} to {}; file remains at the HDFS default "
+              + "replication.",
+          newMetadataLocation,
+          targetReplication,
+          e);
+    }
   }
 
   /**

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -32,7 +32,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -78,10 +85,31 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
 
   FileIOManager fileIOManager;
 
+  MetadataReplicationProperties metadataReplicationProperties;
+
   private static final Gson GSON = new Gson();
 
   private static final Cache<String, Integer> CACHE =
       CacheBuilder.newBuilder().expireAfterWrite(5, TimeUnit.MINUTES).maximumSize(1000).build();
+
+  /**
+   * Shared daemon executor used to enforce a strict per-call timeout on the namenode {@code
+   * setReplication} RPC inside {@link #applyReplicationIfHDFS}. Daemon threads so this does not
+   * block JVM shutdown; single thread because the work is intermittent (one short RPC per commit)
+   * and serialization across concurrent commits is acceptable.
+   */
+  private static final ExecutorService REPLICATION_EXECUTOR =
+      Executors.newSingleThreadExecutor(
+          new ThreadFactory() {
+            private final AtomicInteger n = new AtomicInteger();
+
+            @Override
+            public Thread newThread(Runnable r) {
+              Thread t = new Thread(r, "oh-metadata-repl-bump-" + n.incrementAndGet());
+              t.setDaemon(true);
+              return t;
+            }
+          });
 
   @Override
   protected String tableName() {
@@ -331,9 +359,18 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
             "updateMetadata to location {} succeeded, took {} ms",
             newMetadataLocation,
             System.currentTimeMillis() - metadataUpdateStartTime);
-        // Set replication after the synchronous write so the write path is not blocked
-        // on the higher replica count. Failures are logged and do not fail the commit.
-        bumpMetadataReplicationIfHdfs(newMetadataLocation);
+        // Set replication after the synchronous write so the write path is not blocked on the
+        // higher replica count. Gated by config -- off by default; opt-in per deployment. Failures
+        // (including timeouts) are logged and do not fail the commit.
+        if (metadataReplicationProperties != null && metadataReplicationProperties.isEnabled()) {
+          applyReplicationIfHDFS(
+              newMetadataLocation,
+              (short) metadataReplicationProperties.getTarget(),
+              metadataReplicationProperties.getTimeoutMs());
+        } else {
+          metricsReporter.count(
+              InternalCatalogMetricsConstant.METADATA_REPLICATION_SET_DISABLED_CTR);
+        }
       } catch (Exception e) {
         log.error(
             "updateMetadata to location {} failed after {} ms",
@@ -699,29 +736,28 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
   }
 
   /**
-   * Set HDFS replication on a just-written {@code metadata.json} file to {@link
-   * CatalogConstants#METADATA_FILE_HDFS_REPLICATION}. Called immediately after the synchronous
-   * metadata write returns inside {@link #doCommit(TableMetadata, TableMetadata)}.
+   * Apply an HDFS replication factor to a just-written file via {@code FileSystem.setReplication}.
+   * Called immediately after the synchronous metadata write returns inside {@link
+   * #doCommit(TableMetadata, TableMetadata)} when the bump is enabled.
    *
-   * <p>The synchronous write produces the file at the cluster HDFS default replication. This
-   * call raises it to the target replication factor so the persisted file ends up at the
-   * expected count without making the synchronous write path wait on the longer datanode
-   * pipeline ack.
+   * <p>The call is dispatched to a static daemon executor and bounded by a strict timeout. A
+   * timeout, IO failure, or any other exception is logged at WARN and swallowed -- the commit
+   * succeeds because the file is already durably written at the cluster HDFS default replication.
    *
    * <p>HDFS-only. Non-HDFS clients (local, blob storage) silently skip.
    *
-   * <p>Failures are logged at WARN and swallowed; they do not fail the commit.
-   *
-   * @param newMetadataLocation absolute HDFS path of the newly-written metadata.json
+   * @param location absolute path of the file whose replication should be changed
+   * @param replication target replication factor
+   * @param timeoutMs strict per-call timeout for the {@code setReplication} RPC, in milliseconds
    */
-  private void bumpMetadataReplicationIfHdfs(String newMetadataLocation) {
+  private void applyReplicationIfHDFS(String location, short replication, long timeoutMs) {
     Storage storage;
     try {
       storage = fileIOManager.getStorage(fileIO);
     } catch (Exception e) {
       log.warn(
-          "Skipping HDFS replication bump for {}: could not resolve storage from fileIO",
-          newMetadataLocation,
+          "Skipping HDFS replication apply for {}: could not resolve storage from fileIO",
+          location,
           e);
       return;
     }
@@ -729,28 +765,52 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
       return;
     }
     final FileSystem fs = (FileSystem) storage.getClient().getNativeClient();
-    final short targetReplication = CatalogConstants.METADATA_FILE_HDFS_REPLICATION;
+    Future<Void> future = null;
     try {
+      future =
+          REPLICATION_EXECUTOR.submit(
+              () -> {
+                fs.setReplication(new Path(location), replication);
+                return null;
+              });
+      final Future<Void> futureRef = future;
       metricsReporter.executeWithStats(
           () -> {
             try {
-              fs.setReplication(new Path(newMetadataLocation), targetReplication);
-            } catch (IOException ioe) {
-              // Wrap so executeWithStats sees a RuntimeException; caught below for warn+swallow.
-              throw new RuntimeException(ioe);
+              futureRef.get(timeoutMs, TimeUnit.MILLISECONDS);
+            } catch (TimeoutException te) {
+              // Wrap so executeWithStats records latency, caught below for warn+swallow.
+              throw new RuntimeException(te);
+            } catch (ExecutionException ee) {
+              throw new RuntimeException(ee.getCause() != null ? ee.getCause() : ee);
+            } catch (InterruptedException ie) {
+              Thread.currentThread().interrupt();
+              throw new RuntimeException(ie);
             }
           },
           InternalCatalogMetricsConstant.METADATA_REPLICATION_SET_LATENCY,
           getCatalogMetricTags());
-      log.debug(
-          "Set HDFS replication on {} to {}", newMetadataLocation, targetReplication);
+      log.debug("Set HDFS replication on {} to {}", location, replication);
     } catch (Exception e) {
-      log.warn(
-          "Failed to set HDFS replication on {} to {}; file remains at the HDFS default "
-              + "replication.",
-          newMetadataLocation,
-          targetReplication,
-          e);
+      Throwable cause = e.getCause() != null ? e.getCause() : e;
+      if (cause instanceof TimeoutException || e.getCause() instanceof TimeoutException) {
+        metricsReporter.count(InternalCatalogMetricsConstant.METADATA_REPLICATION_SET_TIMEOUT_CTR);
+        if (future != null) {
+          future.cancel(true);
+        }
+        log.warn(
+            "HDFS setReplication on {} timed out after {} ms; file remains at the HDFS default "
+                + "replication. This is a degraded-durability event, not a commit failure.",
+            location,
+            timeoutMs);
+      } else {
+        log.warn(
+            "Failed to set HDFS replication on {} to {}; file remains at the HDFS default "
+                + "replication. This is a degraded-durability event, not a commit failure.",
+            location,
+            replication,
+            cause);
+      }
     }
   }
 

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
@@ -94,6 +94,11 @@ public class OpenHouseInternalTableOperationsTest {
 
   private OpenHouseInternalTableOperations openHouseInternalTableOperations;
   private OpenHouseInternalTableOperations openHouseInternalTableOperationsWithMockMetrics;
+  /**
+   * Replication properties used by the tests. Defaults to enabled=true so the bump code path is
+   * exercised; individual tests can swap in a disabled instance to test the gate.
+   */
+  private MetadataReplicationProperties metadataReplicationProperties;
 
   @SneakyThrows
   private static String getTempLocation() {
@@ -108,6 +113,11 @@ public class OpenHouseInternalTableOperationsTest {
     HadoopFileIO fileIO = new HadoopFileIO(new Configuration());
     MetricsReporter metricsReporter =
         new MetricsReporter(new SimpleMeterRegistry(), "TEST_CATALOG", Lists.newArrayList());
+    metadataReplicationProperties = new MetadataReplicationProperties();
+    metadataReplicationProperties.setEnabled(true);
+    metadataReplicationProperties.setTarget(
+        CatalogConstants.DEFAULT_METADATA_FILE_HDFS_REPLICATION);
+    metadataReplicationProperties.setTimeoutMs(5_000L);
     openHouseInternalTableOperations =
         new OpenHouseInternalTableOperations(
             mockHouseTableRepository,
@@ -115,7 +125,8 @@ public class OpenHouseInternalTableOperationsTest {
             mockHouseTableMapper,
             TEST_TABLE_IDENTIFIER,
             metricsReporter,
-            fileIOManager);
+            fileIOManager,
+            metadataReplicationProperties);
 
     // Create a separate instance with mock metrics reporter for testing metrics
     openHouseInternalTableOperationsWithMockMetrics =
@@ -125,7 +136,8 @@ public class OpenHouseInternalTableOperationsTest {
             mockHouseTableMapper,
             TEST_TABLE_IDENTIFIER,
             mockMetricsReporter,
-            fileIOManager);
+            fileIOManager,
+            metadataReplicationProperties);
 
     LocalStorage localStorage = mock(LocalStorage.class);
     when(fileIOManager.getStorage(fileIO)).thenReturn(localStorage);
@@ -315,11 +327,11 @@ public class OpenHouseInternalTableOperationsTest {
 
     // Verify filesystem operations were performed.
     // fileIOManager.getStorage is now called twice on the replicated-initial-version path:
-    //   1) bumpMetadataReplicationIfHdfs() — skips because the client is local, not HDFS
-    //   2) updateMetadataFieldForTable()  — the pre-existing replication-aware update
+    //   1) applyReplicationIfHDFS() -- skips because the client is local, not HDFS
+    //   2) updateMetadataFieldForTable() -- the pre-existing replication-aware update
     verify(fileIOManager, times(2)).getStorage(any(FileIO.class));
     // mockLocalStorage.getClient() is now invoked four times:
-    //   1) bumpMetadataReplicationIfHdfs's instanceof HdfsStorageClient check (returns false)
+    //   1) applyReplicationIfHDFS's instanceof HdfsStorageClient check (returns false)
     //   2-4) updateMetadataFieldForTable: 2x instanceof checks + 1x assignment
     verify(mockLocalStorage, times(4)).getClient();
     verify(mockLocalStorageClient).getNativeClient();
@@ -393,12 +405,12 @@ public class OpenHouseInternalTableOperationsTest {
   }
 
   /**
-   * Tests that the post-write HDFS replication bump invokes {@code fs.setReplication} with the
-   * just-written metadata.json path and {@link CatalogConstants#METADATA_FILE_HDFS_REPLICATION}
-   * when the storage client is {@link HdfsStorageClient}.
+   * Tests that the post-write HDFS replication apply invokes {@code fs.setReplication} with the
+   * just-written metadata.json path and the configured target when the storage client is {@link
+   * HdfsStorageClient} and the bump is enabled.
    */
   @Test
-  void testDoCommitBumpsMetadataReplicationOnHdfs() throws IOException {
+  void testDoCommitAppliesReplicationOnHdfs() throws IOException {
     HdfsStorage mockHdfsStorage = mock(HdfsStorage.class);
     HdfsStorageClient mockHdfsClient = mock(HdfsStorageClient.class);
     FileSystem mockHdfsFs = mock(FileSystem.class);
@@ -417,9 +429,11 @@ public class OpenHouseInternalTableOperationsTest {
 
     ArgumentCaptor<Path> pathCaptor = ArgumentCaptor.forClass(Path.class);
     ArgumentCaptor<Short> replicationCaptor = ArgumentCaptor.forClass(Short.class);
-    verify(mockHdfsFs).setReplication(pathCaptor.capture(), replicationCaptor.capture());
+    verify(mockHdfsFs, timeout(5_000))
+        .setReplication(pathCaptor.capture(), replicationCaptor.capture());
     Assertions.assertEquals(
-        CatalogConstants.METADATA_FILE_HDFS_REPLICATION, replicationCaptor.getValue().shortValue());
+        (short) CatalogConstants.DEFAULT_METADATA_FILE_HDFS_REPLICATION,
+        replicationCaptor.getValue().shortValue());
     // The setReplication path must point at the just-written metadata file (the table location
     // plus a versioned filename of the form NNNNN-<uuid>...). We do not assert the trailing
     // extension because TableMetadataParser is statically mocked here and returns null for the
@@ -437,11 +451,11 @@ public class OpenHouseInternalTableOperationsTest {
   }
 
   /**
-   * Tests that the post-write HDFS replication bump is skipped when the storage client is NOT
+   * Tests that the post-write HDFS replication apply is skipped when the storage client is NOT
    * {@link HdfsStorageClient} (e.g. local storage). {@code setReplication} must not be invoked.
    */
   @Test
-  void testDoCommitDoesNotBumpReplicationOnLocalStorage() throws IOException {
+  void testDoCommitDoesNotApplyReplicationOnLocalStorage() throws IOException {
     // Reconfigure the storage mock to return a LocalStorageClient (not HDFS).
     LocalStorage mockLocalStorage = mock(LocalStorage.class);
     when(fileIOManager.getStorage(any(FileIO.class))).thenReturn(mockLocalStorage);
@@ -464,12 +478,12 @@ public class OpenHouseInternalTableOperationsTest {
   }
 
   /**
-   * Tests that a failure during the HDFS replication bump does not fail the commit.
-   * {@code setReplication} throwing {@link IOException} must be swallowed (logged at WARN) and
-   * the commit must complete normally.
+   * Tests that a failure during the HDFS replication apply does not fail the commit. {@code
+   * setReplication} throwing {@link IOException} must be swallowed (logged at WARN) and the commit
+   * must complete normally.
    */
   @Test
-  void testDoCommitSucceedsWhenReplicationBumpFails() throws IOException {
+  void testDoCommitSucceedsWhenReplicationApplyFails() throws IOException {
     HdfsStorage mockHdfsStorage = mock(HdfsStorage.class);
     HdfsStorageClient mockHdfsClient = mock(HdfsStorageClient.class);
     FileSystem mockHdfsFs = mock(FileSystem.class);
@@ -486,13 +500,125 @@ public class OpenHouseInternalTableOperationsTest {
 
     try (MockedStatic<TableMetadataParser> ignoreWriteMock =
         Mockito.mockStatic(TableMetadataParser.class)) {
-      // Must not throw -- replication bump failure does not fail the commit.
+      // Must not throw -- replication apply failure does not fail the commit.
       openHouseInternalTableOperations.doCommit(BASE_TABLE_METADATA, metadata);
     }
 
     // Commit completed successfully despite the setReplication failure.
     Mockito.verify(mockHouseTableRepository, Mockito.times(1)).save(Mockito.eq(mockHouseTable));
-    verify(mockHdfsFs).setReplication(any(Path.class), anyShort());
+    verify(mockHdfsFs, timeout(5_000)).setReplication(any(Path.class), anyShort());
+  }
+
+  /**
+   * Tests that the replication apply is gated by {@link MetadataReplicationProperties#isEnabled()}.
+   * When disabled, {@code setReplication} must not be invoked even on an HDFS storage client.
+   */
+  @Test
+  void testDoCommitDoesNotApplyReplicationWhenDisabled() throws IOException {
+    HdfsStorage mockHdfsStorage = mock(HdfsStorage.class);
+    HdfsStorageClient mockHdfsClient = mock(HdfsStorageClient.class);
+    FileSystem mockHdfsFs = mock(FileSystem.class);
+    when(fileIOManager.getStorage(any(FileIO.class))).thenReturn(mockHdfsStorage);
+    when(mockHdfsStorage.getClient()).thenReturn((StorageClient) mockHdfsClient);
+    when(mockHdfsClient.getNativeClient()).thenReturn(mockHdfsFs);
+
+    // Build a fresh operations instance with the bump explicitly DISABLED.
+    MetadataReplicationProperties disabled = new MetadataReplicationProperties();
+    disabled.setEnabled(false);
+    HadoopFileIO testFileIO = new HadoopFileIO(new Configuration());
+    MetricsReporter metricsReporter =
+        new MetricsReporter(new SimpleMeterRegistry(), "TEST_CATALOG", Lists.newArrayList());
+    OpenHouseInternalTableOperations disabledOps =
+        new OpenHouseInternalTableOperations(
+            mockHouseTableRepository,
+            testFileIO,
+            mockHouseTableMapper,
+            TEST_TABLE_IDENTIFIER,
+            metricsReporter,
+            fileIOManager,
+            disabled);
+
+    Map<String, String> properties = new HashMap<>(BASE_TABLE_METADATA.properties());
+    TableMetadata metadata = BASE_TABLE_METADATA.replaceProperties(properties);
+
+    try (MockedStatic<TableMetadataParser> ignoreWriteMock =
+        Mockito.mockStatic(TableMetadataParser.class)) {
+      disabledOps.doCommit(BASE_TABLE_METADATA, metadata);
+    }
+
+    // Gate is off: setReplication must NOT be invoked, even though storage is HDFS.
+    verify(mockHdfsFs, never()).setReplication(any(Path.class), anyShort());
+    // fileIOManager.getStorage should also not be queried for the bump path (the gate
+    // short-circuits before resolving storage). On the replicated-table path it can still be
+    // queried, but BASE_TABLE_METADATA is not a replicated-table-create, so it should be zero.
+    verify(fileIOManager, never()).getStorage(testFileIO);
+    Mockito.verify(mockHouseTableRepository, Mockito.times(1)).save(Mockito.eq(mockHouseTable));
+  }
+
+  /**
+   * Tests that a timeout during the HDFS replication apply is treated as a degraded-durability
+   * event: the commit succeeds and the future is cancelled. Uses a 100ms configured timeout and a
+   * setReplication stub that blocks for several seconds to deterministically trip the timeout.
+   */
+  @Test
+  void testDoCommitSucceedsWhenReplicationApplyTimesOut() throws IOException {
+    HdfsStorage mockHdfsStorage = mock(HdfsStorage.class);
+    HdfsStorageClient mockHdfsClient = mock(HdfsStorageClient.class);
+    FileSystem mockHdfsFs = mock(FileSystem.class);
+    when(fileIOManager.getStorage(any(FileIO.class))).thenReturn(mockHdfsStorage);
+    when(mockHdfsStorage.getClient()).thenReturn((StorageClient) mockHdfsClient);
+    when(mockHdfsClient.getNativeClient()).thenReturn(mockHdfsFs);
+    // Block for longer than the configured timeout, then return -- but the caller should
+    // already have given up by then.
+    doAnswer(
+            invocation -> {
+              try {
+                Thread.sleep(3_000L);
+              } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+              }
+              return null;
+            })
+        .when(mockHdfsFs)
+        .setReplication(any(Path.class), anyShort());
+
+    // Build a fresh operations instance with a deliberately tiny timeout.
+    MetadataReplicationProperties tinyTimeout = new MetadataReplicationProperties();
+    tinyTimeout.setEnabled(true);
+    tinyTimeout.setTarget(CatalogConstants.DEFAULT_METADATA_FILE_HDFS_REPLICATION);
+    tinyTimeout.setTimeoutMs(100L);
+    HadoopFileIO testFileIO = new HadoopFileIO(new Configuration());
+    MetricsReporter metricsReporter =
+        new MetricsReporter(new SimpleMeterRegistry(), "TEST_CATALOG", Lists.newArrayList());
+    OpenHouseInternalTableOperations tinyTimeoutOps =
+        new OpenHouseInternalTableOperations(
+            mockHouseTableRepository,
+            testFileIO,
+            mockHouseTableMapper,
+            TEST_TABLE_IDENTIFIER,
+            metricsReporter,
+            fileIOManager,
+            tinyTimeout);
+
+    Map<String, String> properties = new HashMap<>(BASE_TABLE_METADATA.properties());
+    TableMetadata metadata = BASE_TABLE_METADATA.replaceProperties(properties);
+
+    long start = System.currentTimeMillis();
+    try (MockedStatic<TableMetadataParser> ignoreWriteMock =
+        Mockito.mockStatic(TableMetadataParser.class)) {
+      // Must not throw -- timeout is a degraded-durability event, not a commit failure.
+      tinyTimeoutOps.doCommit(BASE_TABLE_METADATA, metadata);
+    }
+    long elapsed = System.currentTimeMillis() - start;
+
+    // The commit must return quickly (well under the 3s sleep), proving the timeout fired.
+    Assertions.assertTrue(
+        elapsed < 2_000L,
+        "Expected commit to return well before setReplication's 3s sleep, but took "
+            + elapsed
+            + " ms");
+    // Commit still completed normally.
+    Mockito.verify(mockHouseTableRepository, Mockito.times(1)).save(Mockito.eq(mockHouseTable));
   }
 
   /**
@@ -1199,7 +1325,8 @@ public class OpenHouseInternalTableOperationsTest {
             mockHouseTableMapper,
             TEST_TABLE_IDENTIFIER,
             realMetricsReporter,
-            fileIOManager);
+            fileIOManager,
+            metadataReplicationProperties);
 
     // Setup test-specific mocks
     setupFunction.accept(operationsWithRealMetrics);
@@ -1261,7 +1388,8 @@ public class OpenHouseInternalTableOperationsTest {
             mockHouseTableMapper,
             TEST_TABLE_IDENTIFIER,
             realMetricsReporter,
-            fileIOManager);
+            fileIOManager,
+            metadataReplicationProperties);
 
     // Setup test-specific mocks
     setupFunction.accept(operationsWithRealMetrics);

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.*;
 import com.linkedin.openhouse.cluster.metrics.micrometer.MetricsReporter;
 import com.linkedin.openhouse.cluster.storage.StorageClient;
 import com.linkedin.openhouse.cluster.storage.StorageType;
+import com.linkedin.openhouse.cluster.storage.hdfs.HdfsStorage;
+import com.linkedin.openhouse.cluster.storage.hdfs.HdfsStorageClient;
 import com.linkedin.openhouse.cluster.storage.local.LocalStorage;
 import com.linkedin.openhouse.cluster.storage.local.LocalStorageClient;
 import com.linkedin.openhouse.internal.catalog.fileio.FileIOManager;
@@ -311,10 +313,15 @@ public class OpenHouseInternalTableOperationsTest {
     Assertions.assertTrue(updatedProperties.containsKey(getCanonicalFieldName("tableLocation")));
     Mockito.verify(mockHouseTableRepository, Mockito.times(1)).save(Mockito.eq(mockHouseTable));
 
-    // Verify filesystem operations were performed
-    verify(fileIOManager).getStorage(any(FileIO.class));
-    // Called 3 times: 2x for instanceof checks, 1x for assignment
-    verify(mockLocalStorage, times(3)).getClient();
+    // Verify filesystem operations were performed.
+    // fileIOManager.getStorage is now called twice on the replicated-initial-version path:
+    //   1) bumpMetadataReplicationIfHdfs() — skips because the client is local, not HDFS
+    //   2) updateMetadataFieldForTable()  — the pre-existing replication-aware update
+    verify(fileIOManager, times(2)).getStorage(any(FileIO.class));
+    // mockLocalStorage.getClient() is now invoked four times:
+    //   1) bumpMetadataReplicationIfHdfs's instanceof HdfsStorageClient check (returns false)
+    //   2-4) updateMetadataFieldForTable: 2x instanceof checks + 1x assignment
+    verify(mockLocalStorage, times(4)).getClient();
     verify(mockLocalStorageClient).getNativeClient();
   }
 
@@ -383,6 +390,109 @@ public class OpenHouseInternalTableOperationsTest {
     }
 
     Mockito.verify(mockHouseTableRepository, Mockito.times(1)).save(Mockito.any(HouseTable.class));
+  }
+
+  /**
+   * Tests that the post-write HDFS replication bump invokes {@code fs.setReplication} with the
+   * just-written metadata.json path and {@link CatalogConstants#METADATA_FILE_HDFS_REPLICATION}
+   * when the storage client is {@link HdfsStorageClient}.
+   */
+  @Test
+  void testDoCommitBumpsMetadataReplicationOnHdfs() throws IOException {
+    HdfsStorage mockHdfsStorage = mock(HdfsStorage.class);
+    HdfsStorageClient mockHdfsClient = mock(HdfsStorageClient.class);
+    FileSystem mockHdfsFs = mock(FileSystem.class);
+    // Override the default LocalStorage stub from setup() with an HDFS-backed one.
+    when(fileIOManager.getStorage(any(FileIO.class))).thenReturn(mockHdfsStorage);
+    when(mockHdfsStorage.getClient()).thenReturn((StorageClient) mockHdfsClient);
+    when(mockHdfsClient.getNativeClient()).thenReturn(mockHdfsFs);
+
+    Map<String, String> properties = new HashMap<>(BASE_TABLE_METADATA.properties());
+    TableMetadata metadata = BASE_TABLE_METADATA.replaceProperties(properties);
+
+    try (MockedStatic<TableMetadataParser> ignoreWriteMock =
+        Mockito.mockStatic(TableMetadataParser.class)) {
+      openHouseInternalTableOperations.doCommit(BASE_TABLE_METADATA, metadata);
+    }
+
+    ArgumentCaptor<Path> pathCaptor = ArgumentCaptor.forClass(Path.class);
+    ArgumentCaptor<Short> replicationCaptor = ArgumentCaptor.forClass(Short.class);
+    verify(mockHdfsFs).setReplication(pathCaptor.capture(), replicationCaptor.capture());
+    Assertions.assertEquals(
+        CatalogConstants.METADATA_FILE_HDFS_REPLICATION, replicationCaptor.getValue().shortValue());
+    // The setReplication path must point at the just-written metadata file (the table location
+    // plus a versioned filename of the form NNNNN-<uuid>...). We do not assert the trailing
+    // extension because TableMetadataParser is statically mocked here and returns null for the
+    // file extension lookup.
+    Assertions.assertNotNull(pathCaptor.getValue());
+    String capturedPath = pathCaptor.getValue().toString();
+    Assertions.assertTrue(
+        capturedPath.contains(BASE_TABLE_METADATA.location()),
+        "Expected setReplication path to live under the table location ("
+            + BASE_TABLE_METADATA.location()
+            + "), got: "
+            + capturedPath);
+    // Commit must still complete normally.
+    Mockito.verify(mockHouseTableRepository, Mockito.times(1)).save(Mockito.eq(mockHouseTable));
+  }
+
+  /**
+   * Tests that the post-write HDFS replication bump is skipped when the storage client is NOT
+   * {@link HdfsStorageClient} (e.g. local storage). {@code setReplication} must not be invoked.
+   */
+  @Test
+  void testDoCommitDoesNotBumpReplicationOnLocalStorage() throws IOException {
+    // Reconfigure the storage mock to return a LocalStorageClient (not HDFS).
+    LocalStorage mockLocalStorage = mock(LocalStorage.class);
+    when(fileIOManager.getStorage(any(FileIO.class))).thenReturn(mockLocalStorage);
+    when(mockLocalStorage.getClient()).thenReturn((StorageClient) mockLocalStorageClient);
+    // Deliberately do NOT stub mockLocalStorageClient.getNativeClient() -- the code path under
+    // test must short-circuit on the instanceof check before ever calling it.
+
+    Map<String, String> properties = new HashMap<>(BASE_TABLE_METADATA.properties());
+    TableMetadata metadata = BASE_TABLE_METADATA.replaceProperties(properties);
+
+    try (MockedStatic<TableMetadataParser> ignoreWriteMock =
+        Mockito.mockStatic(TableMetadataParser.class)) {
+      openHouseInternalTableOperations.doCommit(BASE_TABLE_METADATA, metadata);
+    }
+
+    // The local-storage native FileSystem mock (mockFileSystem) is the field-level mock; verify
+    // setReplication was never invoked on it.
+    verify(mockFileSystem, never()).setReplication(any(Path.class), anyShort());
+    Mockito.verify(mockHouseTableRepository, Mockito.times(1)).save(Mockito.eq(mockHouseTable));
+  }
+
+  /**
+   * Tests that a failure during the HDFS replication bump does not fail the commit.
+   * {@code setReplication} throwing {@link IOException} must be swallowed (logged at WARN) and
+   * the commit must complete normally.
+   */
+  @Test
+  void testDoCommitSucceedsWhenReplicationBumpFails() throws IOException {
+    HdfsStorage mockHdfsStorage = mock(HdfsStorage.class);
+    HdfsStorageClient mockHdfsClient = mock(HdfsStorageClient.class);
+    FileSystem mockHdfsFs = mock(FileSystem.class);
+    when(fileIOManager.getStorage(any(FileIO.class))).thenReturn(mockHdfsStorage);
+    when(mockHdfsStorage.getClient()).thenReturn((StorageClient) mockHdfsClient);
+    when(mockHdfsClient.getNativeClient()).thenReturn(mockHdfsFs);
+    // Simulate the namenode rejecting the setReplication RPC.
+    doThrow(new IOException("simulated setReplication failure"))
+        .when(mockHdfsFs)
+        .setReplication(any(Path.class), anyShort());
+
+    Map<String, String> properties = new HashMap<>(BASE_TABLE_METADATA.properties());
+    TableMetadata metadata = BASE_TABLE_METADATA.replaceProperties(properties);
+
+    try (MockedStatic<TableMetadataParser> ignoreWriteMock =
+        Mockito.mockStatic(TableMetadataParser.class)) {
+      // Must not throw -- replication bump failure does not fail the commit.
+      openHouseInternalTableOperations.doCommit(BASE_TABLE_METADATA, metadata);
+    }
+
+    // Commit completed successfully despite the setReplication failure.
+    Mockito.verify(mockHouseTableRepository, Mockito.times(1)).save(Mockito.eq(mockHouseTable));
+    verify(mockHdfsFs).setReplication(any(Path.class), anyShort());
   }
 
   /**

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTestWithSettableComponents.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTestWithSettableComponents.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*;
 import com.linkedin.openhouse.cluster.metrics.micrometer.MetricsReporter;
 import com.linkedin.openhouse.cluster.storage.StorageManager;
 import com.linkedin.openhouse.common.test.cluster.PropertyOverrideContextInitializer;
+import com.linkedin.openhouse.internal.catalog.MetadataReplicationProperties;
 import com.linkedin.openhouse.internal.catalog.OpenHouseInternalTableOperations;
 import com.linkedin.openhouse.internal.catalog.fileio.FileIOManager;
 import com.linkedin.openhouse.internal.catalog.mapper.HouseTableMapper;
@@ -64,6 +65,8 @@ public class RepositoryTestWithSettableComponents {
 
   @Autowired MeterRegistry meterRegistry;
 
+  @Autowired MetadataReplicationProperties metadataReplicationProperties;
+
   FileIO fileIO;
 
   @PostConstruct
@@ -104,7 +107,8 @@ public class RepositoryTestWithSettableComponents {
             houseTableMapper,
             tableIdentifier,
             metricsReporter,
-            fileIOManager);
+            fileIOManager,
+            metadataReplicationProperties);
     ((SettableCatalogForTest) catalog).setOperation(actualOps);
     TableDto creationDTO = TABLE_DTO.toBuilder().tableVersion(INITIAL_TABLE_VERSION).build();
     creationDTO = openHouseInternalRepository.save(creationDTO);
@@ -120,7 +124,13 @@ public class RepositoryTestWithSettableComponents {
         new MetricsReporter(this.meterRegistry, "test", Lists.newArrayList());
     OpenHouseInternalTableOperations mockOps =
         new OpenHouseInternalTableOperations(
-            htsRepo, fileIO, houseTableMapper, tableIdentifier, metricsReporter2, fileIOManager);
+            htsRepo,
+            fileIO,
+            houseTableMapper,
+            tableIdentifier,
+            metricsReporter2,
+            fileIOManager,
+            metadataReplicationProperties);
     OpenHouseInternalTableOperations spyOperations = Mockito.spy(mockOps);
 
     BaseTable spyOptsMockedTable = Mockito.spy(new BaseTable(spyOperations, realTable.name()));
@@ -192,7 +202,8 @@ public class RepositoryTestWithSettableComponents {
             houseTableMapper,
             tableIdentifier,
             metricsReporter,
-            fileIOManager);
+            fileIOManager,
+            metadataReplicationProperties);
     ((SettableCatalogForTest) catalog).setOperation(actualOps);
 
     TableDto creationDTO = TABLE_DTO.toBuilder().tableVersion(INITIAL_TABLE_VERSION).build();
@@ -251,7 +262,13 @@ public class RepositoryTestWithSettableComponents {
           new MetricsReporter(this.meterRegistry, "test", Lists.newArrayList());
       OpenHouseInternalTableOperations mockOps =
           new OpenHouseInternalTableOperations(
-              htsRepo, fileIO, houseTableMapper, tableIdentifier, metricsReporter, fileIOManager);
+              htsRepo,
+              fileIO,
+              houseTableMapper,
+              tableIdentifier,
+              metricsReporter,
+              fileIOManager,
+              metadataReplicationProperties);
       OpenHouseInternalTableOperations spyOperations = Mockito.spy(mockOps);
       BaseTable spyOptsMockedTable =
           Mockito.spy(


### PR DESCRIPTION
## Summary

Bump the HDFS replication factor on each newly-written `metadata.json` file to 30 immediately after `TableMetadataParser.write(...)` returns inside `OpenHouseInternalTableOperations.doCommit(...)`. Paired with an internal `li-openhouse` infra PR that drops `dfs.replication` on Holdem from 30 -> 10, this moves the durability cost off the synchronous commit-write-ack path while preserving repl=30 durability on the persisted file.

**Ordering constraint (important):** this PR must merge **before or together with** the paired `li-openhouse` PR. If `li-openhouse` lands first, every newly-written `metadata.json` on Holdem will live at repl=10 indefinitely until this PR ships — a durability regression. Reviewers, please coordinate on merge order.

## Changes

- [ ] Client-facing API Changes
- [x] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [x] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

**Internal API change / new behavior in `doCommit`:** Added a private `bumpMetadataReplicationIfHdfs(...)` helper invoked immediately after the existing synchronous metadata write. Behavior:

- HDFS-only via `storage.getClient() instanceof HdfsStorageClient`. Non-HDFS clients (local, blob) silently skip — their durability is managed elsewhere.
- Pulls `FileSystem` from `fileIOManager.getStorage(fileIO).getClient().getNativeClient()`, mirroring the existing `updateMetadataFieldForTable(...)` helper at the bottom of the same file.
- `fs.setReplication(new Path(newMetadataLocation), CatalogConstants.METADATA_FILE_HDFS_REPLICATION)`.
- Failures are caught, logged at WARN with the path and exception, and swallowed. They do NOT fail the commit — the file is already durably written at the cluster default replication, so a failed bump is a degraded-durability event, not a commit failure.
- Wrapped in `metricsReporter.executeWithStats(...)` under a new `metadata_replication_set_latency` metric, matching the existing class-level Micrometer convention. (No OpenTelemetry tracing was introduced — none exists in this class today.)

**Performance improvement (rationale):** After the paired `li-openhouse` change drops `dfs.replication` to 10, synchronous `TableMetadataParser.write(...)` will return once the file is durable at 10 datanodes instead of 30. The async bump in this PR restores on-disk durability to repl=30 without putting that pipeline-fill cost on the commit-write-ack path. The expected effect is a meaningful drop in commit p50/p99 metadata-write latency on Holdem; the new metric will quantify both the savings and the bump's own cost in production.

**Configuration choice:** `METADATA_FILE_HDFS_REPLICATION = (short) 30` is added as a constant on `CatalogConstants`. There is no established Spring-config-into-`OpenHouseInternalTableOperations` convention today, and the constructor is `@AllArgsConstructor`-generated, so adding a config-injected field would ripple through every construction site. The constant carries an explicit `TODO` to promote to a Spring config property (e.g. `openhouse.metadata.hdfs.replication`) in a follow-up PR.

**Interpretation note for reviewers:** the internal trigger described "the manifest json file." In Iceberg's commit layout the only JSON file written per commit is the table metadata file `<version>-<uuid>.metadata.json`. Manifest files proper (`*-m#.avro`) and the manifest list (`snap-*.avro`) are Avro. This PR treats `metadata.json` only. If the same durability-bump treatment is wanted for Avro manifest/manifest-list files, that requires a `FileIO` wrapper and is a separate follow-up.

**Files changed (4):**
- `iceberg/openhouse/internalcatalog/.../OpenHouseInternalTableOperations.java` — new helper + call site in `doCommit`, `org.apache.hadoop.fs.Path` import added.
- `iceberg/openhouse/internalcatalog/.../CatalogConstants.java` — new `METADATA_FILE_HDFS_REPLICATION` short constant + TODO.
- `iceberg/openhouse/internalcatalog/.../InternalCatalogMetricsConstant.java` — new `METADATA_REPLICATION_SET_LATENCY` metric name constant.
- `iceberg/openhouse/internalcatalog/src/test/.../OpenHouseInternalTableOperationsTest.java` — 3 new tests, 1 existing-test verify-count update.

## Testing Done

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

**Added tests** (all on `OpenHouseInternalTableOperationsTest`, mirroring the file's existing Mockito-based style):

1. `testDoCommitBumpsMetadataReplicationOnHdfs` — sets up the storage mock to return an `HdfsStorageClient` whose native client is a mock `FileSystem`, drives a commit, captures the args to `setReplication(Path, short)` and asserts the replication factor equals `CatalogConstants.METADATA_FILE_HDFS_REPLICATION` (30) and the path lives under the table location.
2. `testDoCommitDoesNotBumpReplicationOnLocalStorage` — drives a commit with a `LocalStorageClient` and verifies `setReplication` was never invoked (the `instanceof HdfsStorageClient` guard short-circuits).
3. `testDoCommitSucceedsWhenReplicationBumpFails` — stubs `setReplication` to throw `IOException`, drives a commit, asserts the commit completes successfully (`houseTableRepository.save(...)` is invoked once) and the bump was attempted. Validates the warn-and-swallow durability/availability trade-off.

**Updated existing test:** `testDoCommitUpdateMetadataForInitalVersionCommit` — `fileIOManager.getStorage(...)` is now called twice on the replicated-initial-version path (once by the new bump helper, once by the pre-existing `updateMetadataFieldForTable`). Updated the verify counts and added inline comments explaining each call's purpose.

**Module test run:** `./gradlew :iceberg:openhouse:internalcatalog:test` — all 69 tests green (including the 3 new ones).

**Spotless:** `./gradlew :iceberg:openhouse:internalcatalog:spotlessCheck` — clean (after one `spotlessApply` pass during authoring).

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [x] Large PR broken into smaller PRs, and PR plan linked in the description.

**PR plan:**
1. **This PR (`openhouse` repo)** — adds the synchronous `setReplication(..., 30)` bump after `metadata.json` is written. Must merge first or together with (2).
2. **Paired `li-openhouse` PR (separate repo, in flight)** — lowers `dfs.replication` from 30 -> 10 in `holdem-hdfs-site-extra.xml`. Must NOT merge before (1) or new `metadata.json` files on Holdem will live at repl=10 until this PR ships.
3. **Follow-up (separate PR, not blocking)** — promote `METADATA_FILE_HDFS_REPLICATION` from a constant on `CatalogConstants` to a Spring config property (`openhouse.metadata.hdfs.replication`) so deployments can tune the durable replication factor without a code change.
4. **Follow-up (separate PR, conditional on reviewer intent)** — if the same durability-bump treatment is desired for Avro manifest / manifest-list files (`*-m#.avro`, `snap-*.avro`), that needs a `FileIO` wrapper; out of scope here.