### PR TITLE
Retention: pre-flight empty-DELETE check to skip no-op spark.sql(DELETE)

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -312,6 +312,23 @@ public final class Operations implements AutoCloseable {
       boolean backupEnabled,
       String backupDir,
       ZonedDateTime now) {
+    // Pre-flight: plan files matching the retention filter. If none match, the DELETE is a
+    // no-op — skip spark.sql(DELETE) to avoid the full-table COW scan that Iceberg performs
+    // when the retention column doesn't align with the partition spec.
+    Table table = getTable(fqtn);
+    Expression filter =
+        SparkJobUtil.createDeleteFilter(columnName, columnPattern, granularity, count, now);
+    boolean hasMatchingFiles;
+    try (CloseableIterable<FileScanTask> filesIterable =
+        table.newScan().filter(filter).planFiles()) {
+      hasMatchingFiles = filesIterable.iterator().hasNext();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to plan files for retention pre-flight", e);
+    }
+    if (!hasMatchingFiles) {
+      log.info("Retention pre-flight: no files match filter for table {}, skipping DELETE", fqtn);
+      return;
+    }
     if (backupEnabled) {
       // Cache of manifests: partitionPath -> list of data file path
       Map<String, List<String>> manifestCache =

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -163,7 +163,7 @@ public class OperationsTest extends OpenHouseSparkITest {
   }
 
   @Test
-  public void testRetentionCreatesSnapshotsOnNoOpDelete() throws Exception {
+  public void testRetentionSkipsNoOpDelete() throws Exception {
     final String tableName = "db_test.test_retention_sql";
     try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
       prepareTable(ops, tableName);
@@ -174,7 +174,9 @@ public class OperationsTest extends OpenHouseSparkITest {
       ops.runRetention(tableName, "ts", "", "day", 2, false, "", ZonedDateTime.now());
       verifyRowCount(ops, tableName, 4);
       List<Long> snapshotsAfter = getSnapshotIds(ops, tableName);
-      Assertions.assertEquals(snapshots.size() + 1, snapshotsAfter.size());
+      // Pre-flight planFiles returns empty (all rows are from today, cutoff is 2 days ago),
+      // so spark.sql(DELETE) is skipped and no new snapshot is produced.
+      Assertions.assertEquals(snapshots.size(), snapshotsAfter.size());
     }
   }
 
@@ -306,6 +308,34 @@ public class OperationsTest extends OpenHouseSparkITest {
       }
       Assertions.assertEquals(
           table.location() + "/.backup", table.properties().get(AppConstants.BACKUP_DIR_KEY));
+    }
+  }
+
+  @Test
+  public void testRetentionNoOpDeleteSkipsBackupManifests() throws Exception {
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      String tableName = "db.test_noop_skip_backup";
+      String columnName = "ts";
+      String granularity = "DAY";
+      int count = 1;
+      // Only insert current-day rows; cutoff (1 day ago) leaves nothing to delete.
+      ops.spark()
+          .sql(
+              String.format(
+                  "create table %s (data string, ts timestamp) partitioned by (Days(ts))",
+                  tableName));
+      ops.spark().sql(String.format("insert into %s values ('a', current_timestamp())", tableName));
+      ZonedDateTime now = ZonedDateTime.now();
+      List<Long> snapshotsBefore = getSnapshotIds(ops, tableName);
+      ops.runRetention(tableName, columnName, "", granularity, count, true, ".backup", now);
+      // No backup manifests should be written and BACKUP_DIR_KEY should not be set.
+      Table table = ops.getTable(tableName);
+      Path backupRoot = new Path(table.location(), ".backup");
+      Assertions.assertFalse(ops.fs().exists(backupRoot));
+      Assertions.assertNull(table.properties().get(AppConstants.BACKUP_DIR_KEY));
+      // No DELETE snapshot should be appended.
+      List<Long> snapshotsAfter = getSnapshotIds(ops, tableName);
+      Assertions.assertEquals(snapshotsBefore.size(), snapshotsAfter.size());
     }
   }
 


### PR DESCRIPTION
## Summary

`Operations.runRetention` issues `spark.sql("DELETE FROM ... WHERE ...")` unconditionally. For retention runs where the filter matches zero files, this still pays the cost of Spark SQL parse + Catalyst planning + Iceberg's empty-snapshot commit. Iceberg's own planner already prunes to an empty file list in those cases; we're paying the SQL engine round-trip to discover that.

This PR short-circuits the round-trip. Before issuing the DELETE, call `table.newScan().filter(filter).planFiles()` with the same `Expression` the existing backup-manifest path builds. If the iterator is empty, log and return — skip the SQL DELETE, the backup-manifest writing, and the empty-snapshot commit.

The mechanism is purely Spark SQL engine overhead avoidance — no data file I/O is saved, because the no-op case wasn't reading data files to begin with. Iceberg's manifest-level min/max pruning already eliminated the file list before any Spark task would have launched.

### Out of scope

This PR does **not** catch the case where files match Iceberg's metadata filter (min/max overlaps the cutoff) but no rows actually match the row predicate — i.e., `planFiles()` returns non-empty, the COW path scans them, and the rewrite produces zero net file changes. That requires partition/policy remediation on the affected tables (typically aligning the retention column with the partition spec), not a code change here.

## Behavioral note

Today, every retention run produces an Iceberg snapshot — even when zero rows are deleted. This PR stops emitting that empty snapshot for the no-op bucket. The previous behavior was documented in commit `5719ff0` (April 2024) via the renamed test `testRetentionCreatesSnapshotsOnNoOpDelete`. I couldn't find a consumer in this repo that depends on the empty snapshot existing — `expireSnapshots` is time/version-based, `TableStatsCollectorUtil` uses `currentSnapshot()` without requiring retention specifically produced it, and no code filters `<table>.snapshots` by `operation = 'delete'` to gate downstream behavior. If you know of one outside this repo, please flag it.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [x] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

### Details

In `apps/spark/.../Operations.java`:

- `runRetention`: prepend a pre-flight block that loads the table, builds the retention filter via `SparkJobUtil.createDeleteFilter(...)`, and peeks `table.newScan().filter(filter).planFiles()`. If empty, log `"Retention pre-flight: no files match filter for table {}, skipping DELETE"` and return. Otherwise fall through to the existing backup-manifest + `spark.sql(DELETE)` flow unchanged.

No public API change.

## Testing Done

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

In `apps/spark/.../OperationsTest.java`:

- Renamed `testRetentionCreatesSnapshotsOnNoOpDelete` → `testRetentionSkipsNoOpDelete`. Flipped the snapshot-count assertion from `snapshots.size() + 1` to `snapshots.size()` — the pre-flight now short-circuits the no-op DELETE, so no new snapshot is appended.
- Added `testRetentionNoOpDeleteSkipsBackupManifests`: creates a partitioned table with only current-day rows, runs retention with `backupEnabled=true`, and asserts (a) the `.backup` directory is never created, (b) `BACKUP_DIR_KEY` table property stays `null`, (c) no new snapshot is appended.

Test suite run:

```
./gradlew :apps:openhouse-spark-apps_2.12:test \
  --tests "OperationsTest.testRetentionSkipsNoOpDelete" \
  --tests "OperationsTest.testRetentionNoOpDeleteSkipsBackupManifests" \
  --tests "OperationsTest.testRetentionSparkApp" \
  --tests "OperationsTest.testRetentionSparkAppWithStringPartitionColumns" \
  --tests "OperationsTest.testRetentionDataManifestWithTimestampPartitionedTable" \
  --tests "OperationsTest.testRetentionDataManifestWithStringDatePartitionedTable"
```

All six retention tests pass. The two existing backup-manifest tests still pass because they insert old data — `planFiles()` returns non-empty, the pre-flight passes through, and the backup path executes as before.

## Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.