### PR TITLE
Skip metadata.json parse in drop path

### DIFF
--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
@@ -161,12 +162,7 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
             .databaseId(identifier.namespace().toString())
             .tableId(identifier.name())
             .build();
-    // OpenHouse writes metadata.json directly in the table base directory (not under /metadata/
-    // as standard Iceberg does), so the parent of the metadata.json path is the base location
-    // that Table.location() would return. Same derivation as OpenHouseInternalRepositoryImpl#save
-    // (replace flow).
-    String metadataLocation = houseTable.getTableLocation();
-    String tableLocation = metadataLocation.substring(0, metadataLocation.lastIndexOf("/"));
+    String tableLocation = getTableBaseLocation(houseTable, identifier);
     FileIO fileIO = resolveFileIO(identifier);
     log.debug("Dropping table {}, purge:{}", tableLocation, purge);
     try {
@@ -189,6 +185,23 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
       }
     }
     return true;
+  }
+
+  /**
+   * Returns the table base directory derived from the HouseTable's metadata location. OpenHouse
+   * writes metadata.json directly under the table base subdir, so the parent of the metadata.json
+   * path is the same value that {@link org.apache.iceberg.Table#location()} would return.
+   */
+  private static String getTableBaseLocation(HouseTable houseTable, TableIdentifier identifier) {
+    String metadataLocation = houseTable.getTableLocation();
+    // Defensive check to avoid any unintentional deletion
+    if (!metadataLocation.endsWith(".metadata.json")) {
+      throw new IllegalStateException(
+          String.format(
+              "Refusing to drop %s: metadata_location does not look like a metadata.json file: %s",
+              identifier, metadataLocation));
+    }
+    return new Path(metadataLocation).getParent().toString();
   }
 
   @Override

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.Transaction;
 import org.apache.iceberg.UpdateProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.SupportsPrefixOperations;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -128,17 +129,47 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
     return houseTableRepository.findAllByDatabaseId(namespace.toString(), pageable);
   }
 
+  /**
+   * Direct HTS lookup that returns the {@link HouseTable} row without parsing metadata.json. Use
+   * this when only HTS-resident columns (e.g. tableUUID, tableLocation) are needed — for example,
+   * to authorize a drop without loading the full Iceberg table, which is important when the
+   * underlying metadata is corrupted and {@link #loadTable} would throw.
+   */
+  public Optional<HouseTable> findHouseTable(TableIdentifier identifier) {
+    HouseTablePrimaryKey primaryKey =
+        HouseTablePrimaryKey.builder()
+            .databaseId(identifier.namespace().toString())
+            .tableId(identifier.name())
+            .build();
+    try {
+      return houseTableRepository.findById(primaryKey);
+    } catch (HouseTableNotFoundException e) {
+      return Optional.empty();
+    }
+  }
+
   @Override
   public boolean dropTable(TableIdentifier identifier, boolean purge) {
-    String tableLocation = loadTable(identifier).location();
+    // Look up the HouseTable row directly instead of calling loadTable(), so drop works even when
+    // the table's metadata.json is corrupted and cannot be parsed by TableMetadataParser.
+    HouseTable houseTable =
+        findHouseTable(identifier)
+            .orElseThrow(() -> new NoSuchTableException("Table does not exist: %s", identifier));
+
+    HouseTablePrimaryKey primaryKey =
+        HouseTablePrimaryKey.builder()
+            .databaseId(identifier.namespace().toString())
+            .tableId(identifier.name())
+            .build();
+    // OpenHouse writes metadata.json directly in the table base directory (not under /metadata/
+    // as standard Iceberg does), so the parent of the metadata.json path is the base location
+    // that Table.location() would return. Same derivation as OpenHouseInternalRepositoryImpl#save
+    // (replace flow).
+    String metadataLocation = houseTable.getTableLocation();
+    String tableLocation = metadataLocation.substring(0, metadataLocation.lastIndexOf("/"));
     FileIO fileIO = resolveFileIO(identifier);
     log.debug("Dropping table {}, purge:{}", tableLocation, purge);
     try {
-      HouseTablePrimaryKey primaryKey =
-          HouseTablePrimaryKey.builder()
-              .databaseId(identifier.namespace().toString())
-              .tableId(identifier.name())
-              .build();
       houseTableRepository.deleteById(primaryKey, purge);
     } catch (HouseTableRepositoryException houseTableRepositoryException) {
       throw new RuntimeException(
@@ -146,7 +177,6 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
           houseTableRepositoryException);
     }
     if (purge) {
-      // Delete data and metadata files from storage.
       if (fileIO instanceof SupportsPrefixOperations) {
         log.debug("Deleting files for table {}", tableLocation);
         ((SupportsPrefixOperations) fileIO).deletePrefix(tableLocation);

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalogTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalogTest.java
@@ -103,6 +103,29 @@ public class OpenHouseInternalCatalogTest {
   }
 
   @Test
+  void dropTableRefusesWhenMetadataLocationIsNotAMetadataJsonFile() {
+    // Defensive: if metadata_location somehow points at a directory (bad migration, manual
+    // MySQL edit, future regression), the derived parent would be a level too high — e.g. the
+    // whole database directory — which deletePrefix would happily wipe. Refuse instead.
+    HouseTableRepository repo = mock(HouseTableRepository.class);
+    HouseTable row =
+        HouseTable.builder()
+            .databaseId(DB)
+            .tableId(TABLE)
+            .tableLocation("/data/openhouse/test_db/test_table-uuid") // directory, not file
+            .build();
+    when(repo.findById(any(HouseTablePrimaryKey.class))).thenReturn(Optional.of(row));
+    FileIO fileIO =
+        mock(FileIO.class, withSettings().extraInterfaces(SupportsPrefixOperations.class));
+    OpenHouseInternalCatalog catalog = new FixedFileIOCatalog(fileIO);
+    catalog.houseTableRepository = repo;
+
+    Assertions.assertThrows(IllegalStateException.class, () -> catalog.dropTable(IDENTIFIER, true));
+    verify(repo, never()).deleteById(any(), anyBoolean());
+    verify((SupportsPrefixOperations) fileIO, never()).deletePrefix(any());
+  }
+
+  @Test
   void dropTableWithoutPurgeSkipsPrefixDelete() {
     HouseTableRepository repo = mock(HouseTableRepository.class);
     HouseTable row =

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalogTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalogTest.java
@@ -1,10 +1,34 @@
 package com.linkedin.openhouse.internal.catalog;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import com.linkedin.openhouse.internal.catalog.model.HouseTable;
+import com.linkedin.openhouse.internal.catalog.model.HouseTablePrimaryKey;
+import com.linkedin.openhouse.internal.catalog.repository.HouseTableRepository;
+import com.linkedin.openhouse.internal.catalog.repository.exception.HouseTableNotFoundException;
+import java.util.Optional;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.SupportsPrefixOperations;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class OpenHouseInternalCatalogTest {
+
+  private static final String DB = "test_db";
+  private static final String TABLE = "test_table";
+  private static final TableIdentifier IDENTIFIER = TableIdentifier.of(DB, TABLE);
+  private static final String METADATA_LOCATION =
+      "/data/openhouse/test_db/test_table-uuid/00001-aaa.metadata.json";
+  private static final String EXPECTED_BASE = "/data/openhouse/test_db/test_table-uuid";
 
   @Test
   void testIsValidIdentifierRequiresDatabaseTableShape() {
@@ -17,8 +41,99 @@ public class OpenHouseInternalCatalogTest {
         catalog.isValidBaseIdentifier(TableIdentifier.of("db", "table", "partitions")));
   }
 
-  private static class TestOpenHouseInternalCatalog extends OpenHouseInternalCatalog {
+  @Test
+  void findHouseTableReturnsRowWhenPresent() {
+    HouseTableRepository repo = mock(HouseTableRepository.class);
+    HouseTable row = HouseTable.builder().databaseId(DB).tableId(TABLE).tableUUID("uuid").build();
+    when(repo.findById(any(HouseTablePrimaryKey.class))).thenReturn(Optional.of(row));
+    OpenHouseInternalCatalog catalog = new OpenHouseInternalCatalog();
+    catalog.houseTableRepository = repo;
 
+    Optional<HouseTable> result = catalog.findHouseTable(IDENTIFIER);
+
+    Assertions.assertTrue(result.isPresent());
+    Assertions.assertEquals("uuid", result.get().getTableUUID());
+  }
+
+  @Test
+  void findHouseTableReturnsEmptyOnNotFoundException() {
+    HouseTableRepository repo = mock(HouseTableRepository.class);
+    when(repo.findById(any(HouseTablePrimaryKey.class)))
+        .thenThrow(new HouseTableNotFoundException("missing", new RuntimeException()));
+    OpenHouseInternalCatalog catalog = new OpenHouseInternalCatalog();
+    catalog.houseTableRepository = repo;
+
+    Assertions.assertFalse(catalog.findHouseTable(IDENTIFIER).isPresent());
+  }
+
+  @Test
+  void dropTableThrowsNoSuchTableWhenHouseTableMissing() {
+    HouseTableRepository repo = mock(HouseTableRepository.class);
+    when(repo.findById(any(HouseTablePrimaryKey.class))).thenReturn(Optional.empty());
+    FileIO fileIO =
+        mock(FileIO.class, withSettings().extraInterfaces(SupportsPrefixOperations.class));
+    OpenHouseInternalCatalog catalog = new FixedFileIOCatalog(fileIO);
+    catalog.houseTableRepository = repo;
+
+    Assertions.assertThrows(NoSuchTableException.class, () -> catalog.dropTable(IDENTIFIER, true));
+    verify(repo, never()).deleteById(any(), anyBoolean());
+    verify((SupportsPrefixOperations) fileIO, never()).deletePrefix(any());
+  }
+
+  @Test
+  void dropTableWithPurgeDeletesHtsRowAndPrefix() {
+    HouseTableRepository repo = mock(HouseTableRepository.class);
+    HouseTable row =
+        HouseTable.builder()
+            .databaseId(DB)
+            .tableId(TABLE)
+            .tableUUID("uuid")
+            .tableLocation(METADATA_LOCATION)
+            .build();
+    when(repo.findById(any(HouseTablePrimaryKey.class))).thenReturn(Optional.of(row));
+    FileIO fileIO =
+        mock(FileIO.class, withSettings().extraInterfaces(SupportsPrefixOperations.class));
+    OpenHouseInternalCatalog catalog = new FixedFileIOCatalog(fileIO);
+    catalog.houseTableRepository = repo;
+
+    Assertions.assertTrue(catalog.dropTable(IDENTIFIER, true));
+
+    verify(repo).deleteById(any(HouseTablePrimaryKey.class), eq(true));
+    verify((SupportsPrefixOperations) fileIO).deletePrefix(EXPECTED_BASE);
+  }
+
+  @Test
+  void dropTableWithoutPurgeSkipsPrefixDelete() {
+    HouseTableRepository repo = mock(HouseTableRepository.class);
+    HouseTable row =
+        HouseTable.builder().databaseId(DB).tableId(TABLE).tableLocation(METADATA_LOCATION).build();
+    when(repo.findById(any(HouseTablePrimaryKey.class))).thenReturn(Optional.of(row));
+    FileIO fileIO =
+        mock(FileIO.class, withSettings().extraInterfaces(SupportsPrefixOperations.class));
+    OpenHouseInternalCatalog catalog = new FixedFileIOCatalog(fileIO);
+    catalog.houseTableRepository = repo;
+
+    Assertions.assertTrue(catalog.dropTable(IDENTIFIER, false));
+
+    verify(repo).deleteById(any(HouseTablePrimaryKey.class), eq(false));
+    verify((SupportsPrefixOperations) fileIO, never()).deletePrefix(any());
+  }
+
+  /** Test subclass that bypasses the real {@link OpenHouseInternalCatalog#resolveFileIO} wiring. */
+  private static class FixedFileIOCatalog extends OpenHouseInternalCatalog {
+    private final FileIO fileIO;
+
+    FixedFileIOCatalog(FileIO fileIO) {
+      this.fileIO = fileIO;
+    }
+
+    @Override
+    protected FileIO resolveFileIO(TableIdentifier identifier) {
+      return fileIO;
+    }
+  }
+
+  private static class TestOpenHouseInternalCatalog extends OpenHouseInternalCatalog {
     boolean isValidBaseIdentifier(TableIdentifier identifier) {
       return isValidIdentifier(identifier);
     }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/OpenHouseInternalRepository.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/OpenHouseInternalRepository.java
@@ -20,12 +20,13 @@ public interface OpenHouseInternalRepository
     extends PagingAndSortingRepository<TableDto, TableDtoPrimaryKey> {
 
   /**
-   * Returns a stub {@link TableDto} populated only with the fields needed for existence + auth
-   * checks (identifiers, tableUUID, tableLocation). Unlike {@link #findById}, this does not parse
-   * the table's metadata.json, so it succeeds even when the metadata is corrupted. Intended for
-   * paths (e.g. drop) that don't need full table state.
+   * Returns a lightweight {@link TableDto} that acts as a catalog-level reference to the table —
+   * populated only with the identifiers, tableUUID, and the metadata.json location. Unlike {@link
+   * #findById}, this does not parse the table's metadata.json, so it succeeds even when the
+   * metadata is corrupted. Intended for paths (e.g. drop) that need only the reference, not the
+   * full table state.
    */
-  Optional<TableDto> findStubById(TableDtoPrimaryKey tableDtoPrimaryKey);
+  Optional<TableDto> findTableRefById(TableDtoPrimaryKey tableDtoPrimaryKey);
 
   List<TableDtoPrimaryKey> findAllIds();
 

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/OpenHouseInternalRepository.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/OpenHouseInternalRepository.java
@@ -5,6 +5,7 @@ import com.linkedin.openhouse.internal.catalog.model.SoftDeletedTablePrimaryKey;
 import com.linkedin.openhouse.tables.model.TableDto;
 import com.linkedin.openhouse.tables.model.TableDtoPrimaryKey;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.PagingAndSortingRepository;
@@ -17,6 +18,15 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface OpenHouseInternalRepository
     extends PagingAndSortingRepository<TableDto, TableDtoPrimaryKey> {
+
+  /**
+   * Returns a stub {@link TableDto} populated only with the fields needed for existence + auth
+   * checks (identifiers, tableUUID, tableLocation). Unlike {@link #findById}, this does not parse
+   * the table's metadata.json, so it succeeds even when the metadata is corrupted. Intended for
+   * paths (e.g. drop) that don't need full table state.
+   */
+  Optional<TableDto> findStubById(TableDtoPrimaryKey tableDtoPrimaryKey);
+
   List<TableDtoPrimaryKey> findAllIds();
 
   Page<TableDtoPrimaryKey> findAllIds(Pageable pageable);

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -679,6 +679,25 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
             table, fileIOManager, partitionSpecMapper, policiesMapper, tableTypeMapper));
   }
 
+  @Override
+  public Optional<TableDto> findStubById(TableDtoPrimaryKey tableDtoPrimaryKey) {
+    if (!(catalog instanceof OpenHouseInternalCatalog)) {
+      throw new UnsupportedOperationException(
+          "findStubById is not supported for catalog type: " + catalog.getClass().getName());
+    }
+    return ((OpenHouseInternalCatalog) catalog)
+        .findHouseTable(
+            TableIdentifier.of(tableDtoPrimaryKey.getDatabaseId(), tableDtoPrimaryKey.getTableId()))
+        .map(
+            houseTable ->
+                TableDto.builder()
+                    .databaseId(houseTable.getDatabaseId())
+                    .tableId(houseTable.getTableId())
+                    .tableUUID(houseTable.getTableUUID())
+                    .tableLocation(houseTable.getTableLocation())
+                    .build());
+  }
+
   // FIXME: Likely need a cache layer to avoid expensive tableScan.
   @Timed(metricKey = MetricsConstant.REPO_TABLE_EXISTS_TIME)
   @Override

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -680,10 +680,10 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
   }
 
   @Override
-  public Optional<TableDto> findStubById(TableDtoPrimaryKey tableDtoPrimaryKey) {
+  public Optional<TableDto> findTableRefById(TableDtoPrimaryKey tableDtoPrimaryKey) {
     if (!(catalog instanceof OpenHouseInternalCatalog)) {
       throw new UnsupportedOperationException(
-          "findStubById is not supported for catalog type: " + catalog.getClass().getName());
+          "findTableRefById is not supported for catalog type: " + catalog.getClass().getName());
     }
     return ((OpenHouseInternalCatalog) catalog)
         .findHouseTable(

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
@@ -216,12 +216,14 @@ public class TablesServiceImpl implements TablesService {
     TableDtoPrimaryKey tableDtoPrimaryKey =
         TableDtoPrimaryKey.builder().databaseId(databaseId).tableId(tableId).build();
 
-    Optional<TableDto> tableDto = openHouseInternalRepository.findById(tableDtoPrimaryKey);
-    if (!tableDto.isPresent()) {
-      throw new NoSuchUserTableException(databaseId, tableId);
-    }
-    authorizationUtils.checkTableDropPrivilege(
-        tableDto.get(), actingPrincipal, Privileges.DELETE_TABLE);
+    // Stub lookup (no metadata.json parse) is enough here — drop only needs identifiers +
+    // tableUUID for the ACL check. Lets us drop tables whose metadata.json is corrupted.
+    TableDto tableDto =
+        openHouseInternalRepository
+            .findStubById(tableDtoPrimaryKey)
+            .orElseThrow(() -> new NoSuchUserTableException(databaseId, tableId));
+
+    authorizationUtils.checkTableDropPrivilege(tableDto, actingPrincipal, Privileges.DELETE_TABLE);
 
     openHouseInternalRepository.deleteById(tableDtoPrimaryKey);
   }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
@@ -216,11 +216,11 @@ public class TablesServiceImpl implements TablesService {
     TableDtoPrimaryKey tableDtoPrimaryKey =
         TableDtoPrimaryKey.builder().databaseId(databaseId).tableId(tableId).build();
 
-    // Stub lookup (no metadata.json parse) is enough here — drop only needs identifiers +
+    // Table-ref lookup (no metadata.json parse) is enough here — drop only needs identifiers +
     // tableUUID for the ACL check. Lets us drop tables whose metadata.json is corrupted.
     TableDto tableDto =
         openHouseInternalRepository
-            .findStubById(tableDtoPrimaryKey)
+            .findTableRefById(tableDtoPrimaryKey)
             .orElseThrow(() -> new NoSuchUserTableException(databaseId, tableId));
 
     authorizationUtils.checkTableDropPrivilege(tableDto, actingPrincipal, Privileges.DELETE_TABLE);

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
@@ -29,6 +29,8 @@ import com.linkedin.openhouse.tables.repository.OpenHouseInternalRepository;
 import com.linkedin.openhouse.tables.services.TablesService;
 import com.linkedin.openhouse.tables.utils.AuthorizationUtils;
 import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -261,6 +263,43 @@ public class TablesServiceTest {
   public void testTableDeleteAlreadyDeleted() {
     verifyPutTableRequest(TABLE_DTO, null, true);
     tablesService.deleteTable(TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER);
+    Assertions.assertThrows(
+        NoSuchUserTableException.class,
+        () ->
+            tablesService.deleteTable(
+                TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER));
+  }
+
+  /**
+   * Regression test for the corrupted-metadata drop path: even when metadata.json cannot be parsed
+   * (loadTable would throw), deleteTable must still succeed because it goes through the HTS-only
+   * findStubById lookup and avoids loadTable entirely.
+   */
+  @Test
+  public void testTableDeleteSucceedsWhenMetadataJsonIsCorrupted() throws IOException {
+    TableDto created = verifyPutTableRequest(TABLE_DTO, null, true);
+
+    // tableLocation on TableDto is the metadata.json path (file:/<base>/<filename>.metadata.json).
+    Path metadataPath = Paths.get(URI.create(created.getTableLocation()));
+    Assertions.assertTrue(
+        Files.exists(metadataPath),
+        "metadata.json should exist on disk after create: " + metadataPath);
+
+    // Corrupt the file so TableMetadataParser.read fails.
+    Files.write(metadataPath, "{\"not\":\"valid iceberg metadata\"}".getBytes());
+
+    // Sanity check: reading the table now fails because loadTable parses metadata.json.
+    Assertions.assertThrows(
+        Exception.class,
+        () -> tablesService.getTable(TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER));
+
+    // Drop should still succeed despite the corruption.
+    Assertions.assertDoesNotThrow(
+        () ->
+            tablesService.deleteTable(
+                TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER));
+
+    // Verify HTS row is gone — a second delete should now hit the not-found path.
     Assertions.assertThrows(
         NoSuchUserTableException.class,
         () ->

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
@@ -273,7 +273,7 @@ public class TablesServiceTest {
   /**
    * Regression test for the corrupted-metadata drop path: even when metadata.json cannot be parsed
    * (loadTable would throw), deleteTable must still succeed because it goes through the HTS-only
-   * findStubById lookup and avoids loadTable entirely.
+   * findTableRefById lookup and avoids loadTable entirely.
    */
   @Test
   public void testTableDeleteSucceedsWhenMetadataJsonIsCorrupted() throws IOException {

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImplTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImplTest.java
@@ -111,7 +111,7 @@ public class OpenHouseInternalRepositoryImplTest {
   }
 
   @Test
-  void findStubByIdReturnsPartialTableDto() {
+  void findTableRefByIdReturnsPartialTableDto() {
     HouseTable row =
         HouseTable.builder()
             .databaseId(DB_ID)
@@ -122,7 +122,7 @@ public class OpenHouseInternalRepositoryImplTest {
     when(catalog.findHouseTable(TableIdentifier.of(DB_ID, TABLE_ID))).thenReturn(Optional.of(row));
 
     Optional<TableDto> result =
-        openHouseInternalRepository.findStubById(
+        openHouseInternalRepository.findTableRefById(
             TableDtoPrimaryKey.builder().databaseId(DB_ID).tableId(TABLE_ID).build());
 
     Assertions.assertTrue(result.isPresent());
@@ -131,24 +131,24 @@ public class OpenHouseInternalRepositoryImplTest {
     Assertions.assertEquals(TABLE_ID, dto.getTableId());
     Assertions.assertEquals("uuid-1", dto.getTableUUID());
     Assertions.assertEquals("/base/db/table-uuid-1/00001-x.metadata.json", dto.getTableLocation());
-    // Fields not populated by the stub lookup should be null/default.
+    // Fields not populated by the table-ref lookup should be null/default.
     Assertions.assertNull(dto.getSchema());
     Assertions.assertNull(dto.getTableCreator());
   }
 
   @Test
-  void findStubByIdReturnsEmptyWhenHouseTableMissing() {
+  void findTableRefByIdReturnsEmptyWhenHouseTableMissing() {
     when(catalog.findHouseTable(any(TableIdentifier.class))).thenReturn(Optional.empty());
 
     Optional<TableDto> result =
-        openHouseInternalRepository.findStubById(
+        openHouseInternalRepository.findTableRefById(
             TableDtoPrimaryKey.builder().databaseId(DB_ID).tableId(TABLE_ID).build());
 
     Assertions.assertFalse(result.isPresent());
   }
 
   @Test
-  void findStubByIdThrowsWhenCatalogIsNotOpenHouseInternalCatalog() {
+  void findTableRefByIdThrowsWhenCatalogIsNotOpenHouseInternalCatalog() {
     // Build a fresh impl with a non-OpenHouseInternal Catalog wired in.
     OpenHouseInternalRepositoryImpl impl = new OpenHouseInternalRepositoryImpl();
     impl.catalog = mock(Catalog.class);
@@ -156,7 +156,7 @@ public class OpenHouseInternalRepositoryImplTest {
     Assertions.assertThrows(
         UnsupportedOperationException.class,
         () ->
-            impl.findStubById(
+            impl.findTableRefById(
                 TableDtoPrimaryKey.builder().databaseId(DB_ID).tableId(TABLE_ID).build()));
   }
 

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImplTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImplTest.java
@@ -6,16 +6,22 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.linkedin.openhouse.cluster.configs.ClusterProperties;
+import com.linkedin.openhouse.internal.catalog.OpenHouseInternalCatalog;
 import com.linkedin.openhouse.internal.catalog.mapper.HouseTableSerdeUtils;
+import com.linkedin.openhouse.internal.catalog.model.HouseTable;
 import com.linkedin.openhouse.tables.common.TableType;
 import com.linkedin.openhouse.tables.dto.mapper.iceberg.PoliciesSpecMapper;
 import com.linkedin.openhouse.tables.model.TableDto;
+import com.linkedin.openhouse.tables.model.TableDtoPrimaryKey;
 import com.linkedin.openhouse.tables.repository.PreservedKeyChecker;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,6 +40,7 @@ public class OpenHouseInternalRepositoryImplTest {
   @Mock private MeterRegistry meterRegistry;
   @Mock private ClusterProperties clusterProperties;
   @Mock private PreservedKeyChecker preservedKeyChecker;
+  @Mock private OpenHouseInternalCatalog catalog;
 
   @InjectMocks private OpenHouseInternalRepositoryImpl openHouseInternalRepository;
 
@@ -101,6 +108,56 @@ public class OpenHouseInternalRepositoryImplTest {
     Assertions.assertEquals(
         "/data/openhouse/db/table",
         actualProps.get(HouseTableSerdeUtils.getCanonicalFieldName("tableLocation")));
+  }
+
+  @Test
+  void findStubByIdReturnsPartialTableDto() {
+    HouseTable row =
+        HouseTable.builder()
+            .databaseId(DB_ID)
+            .tableId(TABLE_ID)
+            .tableUUID("uuid-1")
+            .tableLocation("/base/db/table-uuid-1/00001-x.metadata.json")
+            .build();
+    when(catalog.findHouseTable(TableIdentifier.of(DB_ID, TABLE_ID))).thenReturn(Optional.of(row));
+
+    Optional<TableDto> result =
+        openHouseInternalRepository.findStubById(
+            TableDtoPrimaryKey.builder().databaseId(DB_ID).tableId(TABLE_ID).build());
+
+    Assertions.assertTrue(result.isPresent());
+    TableDto dto = result.get();
+    Assertions.assertEquals(DB_ID, dto.getDatabaseId());
+    Assertions.assertEquals(TABLE_ID, dto.getTableId());
+    Assertions.assertEquals("uuid-1", dto.getTableUUID());
+    Assertions.assertEquals("/base/db/table-uuid-1/00001-x.metadata.json", dto.getTableLocation());
+    // Fields not populated by the stub lookup should be null/default.
+    Assertions.assertNull(dto.getSchema());
+    Assertions.assertNull(dto.getTableCreator());
+  }
+
+  @Test
+  void findStubByIdReturnsEmptyWhenHouseTableMissing() {
+    when(catalog.findHouseTable(any(TableIdentifier.class))).thenReturn(Optional.empty());
+
+    Optional<TableDto> result =
+        openHouseInternalRepository.findStubById(
+            TableDtoPrimaryKey.builder().databaseId(DB_ID).tableId(TABLE_ID).build());
+
+    Assertions.assertFalse(result.isPresent());
+  }
+
+  @Test
+  void findStubByIdThrowsWhenCatalogIsNotOpenHouseInternalCatalog() {
+    // Build a fresh impl with a non-OpenHouseInternal Catalog wired in.
+    OpenHouseInternalRepositoryImpl impl = new OpenHouseInternalRepositoryImpl();
+    impl.catalog = mock(Catalog.class);
+
+    Assertions.assertThrows(
+        UnsupportedOperationException.class,
+        () ->
+            impl.findStubById(
+                TableDtoPrimaryKey.builder().databaseId(DB_ID).tableId(TABLE_ID).build()));
   }
 
   private TableDto createTableDto(Map<String, String> properties) {


### PR DESCRIPTION
## Summary

Dropping a table currently goes through `catalog.loadTable` twice:
1. `TablesServiceImpl.deleteTable` → `findById` parses metadata.json to build a `TableDto` for the ACL check.
2. `OpenHouseInternalCatalog.dropTable` → `loadTable(id).location()` parses metadata.json again to get the table base directory for `fileIO.deletePrefix` on purge.

Both parses are redundant — everything drop needs (`databaseId`, `tableId`, `tableUUID`, the metadata.json path) is already on the HTS row. The redundant parses also make drop fragile: if metadata is semantically invalid (e.g. `Cannot find schema with current-schema-id=6 from schemas`), drop fails even though the HTS row and storage files are still well-formed.

This PR removes both `loadTable` calls from the drop path:

- **`OpenHouseInternalCatalog#findHouseTable(TableIdentifier)`** — HTS-only lookup that returns the `HouseTable` row, no metadata parse.
- **`OpenHouseInternalRepository#findStubById(TableDtoPrimaryKey)`** — returns  a partial `TableDto` (`databaseId`, `tableId`, `tableUUID`, `tableLocation`) built from the HTS row. Enough for the OPA auth check, which only uses db + UUID.
- **`TablesServiceImpl#deleteTable`** uses `findStubById` instead of `findById`.
- **`OpenHouseInternalCatalog#dropTable`** uses `findHouseTable` and derives the storage base location as the parent directory of the metadata.json path — same derivation `OpenHouseInternalRepositoryImpl#save` already uses in its replace flow, since OpenHouse writes `metadata.json` directly under `<base>/` (no `/metadata/` subdir).

A side benefit: corrupted-metadata tables can now be dropped end-to-end through the normal API.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [X] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [X] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
