### PR TITLE
(wip) feat(optimizer): bound list-API responses with configurable limit

### DIFF
--- a/services/optimizer/src/main/java/com/linkedin/openhouse/optimizer/OptimizerServiceApplication.java
+++ b/services/optimizer/src/main/java/com/linkedin/openhouse/optimizer/OptimizerServiceApplication.java
@@ -1,10 +1,13 @@
 package com.linkedin.openhouse.optimizer;
 
+import com.linkedin.openhouse.optimizer.api.spec.ApiListLimitProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 /** Spring Boot entry point for the Optimizer Service. */
 @SpringBootApplication
+@EnableConfigurationProperties(ApiListLimitProperties.class)
 public class OptimizerServiceApplication {
 
   public static void main(String[] args) {

--- a/services/optimizer/src/main/java/com/linkedin/openhouse/optimizer/api/controller/TableOperationsController.java
+++ b/services/optimizer/src/main/java/com/linkedin/openhouse/optimizer/api/controller/TableOperationsController.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.optimizer.api.controller;
 
+import com.linkedin.openhouse.optimizer.api.spec.ApiListLimitProperties;
 import com.linkedin.openhouse.optimizer.api.spec.OperationStatus;
 import com.linkedin.openhouse.optimizer.api.spec.OperationType;
 import com.linkedin.openhouse.optimizer.api.spec.TableOperations;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TableOperationsController {
 
   private final OptimizerDataService service;
+  private final ApiListLimitProperties limits;
 
   /**
    * Report an update to an operation. The body carries the {@code operationId} the caller is
@@ -59,8 +61,9 @@ public class TableOperationsController {
   }
 
   /**
-   * List operations matching the given filters. All parameters are optional — omit all to return
-   * every row.
+   * List operations matching the given filters. Every filter is optional. {@code limit} defaults to
+   * {@code optimizer.api.list.default-limit} (10) and is rejected with 400 outside {@code [1,
+   * optimizer.api.list.max-limit]} (1000).
    */
   @GetMapping
   public ResponseEntity<List<TableOperations>> listTableOperations(
@@ -68,7 +71,9 @@ public class TableOperationsController {
       @RequestParam(required = false) OperationStatus status,
       @RequestParam(required = false) String databaseName,
       @RequestParam(required = false) String tableName,
-      @RequestParam(required = false) String tableUuid) {
+      @RequestParam(required = false) String tableUuid,
+      @RequestParam(required = false) Integer limit) {
+    int effectiveLimit = limits.validateAndResolve(limit);
     List<TableOperations> result =
         service
             .listTableOperations(
@@ -76,7 +81,8 @@ public class TableOperationsController {
                 Optional.ofNullable(status).map(OperationStatus::toModel),
                 Optional.ofNullable(databaseName),
                 Optional.ofNullable(tableName),
-                Optional.ofNullable(tableUuid))
+                Optional.ofNullable(tableUuid),
+                effectiveLimit)
             .stream()
             .map(TableOperations::fromModel)
             .collect(Collectors.toList());

--- a/services/optimizer/src/main/java/com/linkedin/openhouse/optimizer/api/controller/TableOperationsHistoryController.java
+++ b/services/optimizer/src/main/java/com/linkedin/openhouse/optimizer/api/controller/TableOperationsHistoryController.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.optimizer.api.controller;
 
+import com.linkedin.openhouse.optimizer.api.spec.ApiListLimitProperties;
 import com.linkedin.openhouse.optimizer.api.spec.TableOperationsHistory;
 import com.linkedin.openhouse.optimizer.service.OptimizerDataService;
 import java.util.List;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TableOperationsHistoryController {
 
   private final OptimizerDataService service;
+  private final ApiListLimitProperties limits;
 
   /** Append a completed-job result. Called by the SparkJob after each run (success or failure). */
   @PostMapping
@@ -31,12 +33,17 @@ public class TableOperationsHistoryController {
         .body(TableOperationsHistory.fromModel(service.appendHistory(dto.toModel())));
   }
 
-  /** Return the most recent history for a table, newest first, up to {@code limit} rows. */
+  /**
+   * Return the most recent history for a table, newest first. {@code limit} defaults to {@code
+   * optimizer.api.list.default-limit} (10) and is rejected with 400 outside {@code [1,
+   * optimizer.api.list.max-limit]} (1000).
+   */
   @GetMapping("/{tableUuid}")
   public ResponseEntity<List<TableOperationsHistory>> getHistory(
-      @PathVariable String tableUuid, @RequestParam(defaultValue = "100") int limit) {
+      @PathVariable String tableUuid, @RequestParam(required = false) Integer limit) {
+    int effectiveLimit = limits.validateAndResolve(limit);
     List<TableOperationsHistory> result =
-        service.getHistory(tableUuid, limit).stream()
+        service.getHistory(tableUuid, effectiveLimit).stream()
             .map(TableOperationsHistory::fromModel)
             .collect(Collectors.toList());
     return ResponseEntity.ok(result);

--- a/services/optimizer/src/main/java/com/linkedin/openhouse/optimizer/api/controller/TableStatsController.java
+++ b/services/optimizer/src/main/java/com/linkedin/openhouse/optimizer/api/controller/TableStatsController.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.optimizer.api.controller;
 
+import com.linkedin.openhouse.optimizer.api.spec.ApiListLimitProperties;
 import com.linkedin.openhouse.optimizer.api.spec.TableStats;
 import com.linkedin.openhouse.optimizer.api.spec.TableStatsHistory;
 import com.linkedin.openhouse.optimizer.api.spec.UpsertTableStatsRequest;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TableStatsController {
 
   private final OptimizerDataService service;
+  private final ApiListLimitProperties limits;
 
   /**
    * Create or overwrite the stats row for {@code tableUuid}. Called by the Tables Service on every
@@ -48,20 +50,24 @@ public class TableStatsController {
   }
 
   /**
-   * List stats rows matching the given filters. All parameters are optional — omit all to return
-   * every row.
+   * List stats rows matching the given filters. Every filter is optional. {@code limit} defaults to
+   * {@code optimizer.api.list.default-limit} (10) and is rejected with 400 outside {@code [1,
+   * optimizer.api.list.max-limit]} (1000).
    */
   @GetMapping
   public ResponseEntity<List<TableStats>> listTableStats(
       @RequestParam(required = false) String databaseName,
       @RequestParam(required = false) String tableName,
-      @RequestParam(required = false) String tableUuid) {
+      @RequestParam(required = false) String tableUuid,
+      @RequestParam(required = false) Integer limit) {
+    int effectiveLimit = limits.validateAndResolve(limit);
     List<TableStats> result =
         service
             .listTableStats(
                 Optional.ofNullable(databaseName),
                 Optional.ofNullable(tableName),
-                Optional.ofNullable(tableUuid))
+                Optional.ofNullable(tableUuid),
+                effectiveLimit)
             .stream()
             .map(TableStats::fromModel)
             .collect(Collectors.toList());
@@ -69,16 +75,18 @@ public class TableStatsController {
   }
 
   /**
-   * Return per-commit stats history for {@code tableUuid}, newest first. Optionally filter by
-   * {@code since} (inclusive) and cap at {@code limit} rows.
+   * Return per-commit stats history for {@code tableUuid}, newest first. Optional {@code since}
+   * filter (inclusive). {@code limit} defaults to {@code optimizer.api.list.default-limit} (10) and
+   * is rejected with 400 outside {@code [1, optimizer.api.list.max-limit]} (1000).
    */
   @GetMapping("/{tableUuid}/history")
   public ResponseEntity<List<TableStatsHistory>> getStatsHistory(
       @PathVariable String tableUuid,
       @RequestParam(required = false) Instant since,
-      @RequestParam(defaultValue = "100") int limit) {
+      @RequestParam(required = false) Integer limit) {
+    int effectiveLimit = limits.validateAndResolve(limit);
     List<TableStatsHistory> result =
-        service.getStatsHistory(tableUuid, Optional.ofNullable(since), limit).stream()
+        service.getStatsHistory(tableUuid, Optional.ofNullable(since), effectiveLimit).stream()
             .map(TableStatsHistory::fromModel)
             .collect(Collectors.toList());
     return ResponseEntity.ok(result);

--- a/services/optimizer/src/main/java/com/linkedin/openhouse/optimizer/api/spec/ApiListLimitProperties.java
+++ b/services/optimizer/src/main/java/com/linkedin/openhouse/optimizer/api/spec/ApiListLimitProperties.java
@@ -1,0 +1,34 @@
+package com.linkedin.openhouse.optimizer.api.spec;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Bounds on list-style endpoints. Default applies when the caller omits {@code limit}; max is the
+ * hard cap — requests beyond it are rejected (400) rather than silently clamped, so callers don't
+ * get partial results without knowing.
+ */
+@ConfigurationProperties("optimizer.api.list")
+@Getter
+@Setter
+public class ApiListLimitProperties {
+  private int defaultLimit = 10;
+  private int maxLimit = 1000;
+
+  /**
+   * Resolve a caller-supplied {@code limit} against this configuration. Null falls back to {@link
+   * #defaultLimit}; out-of-range values throw {@link ResponseStatusException} carrying HTTP 400.
+   */
+  public int validateAndResolve(Integer limit) {
+    int effective = (limit == null) ? defaultLimit : limit;
+    if (effective < 1 || effective > maxLimit) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST,
+          "limit must be between 1 and " + maxLimit + " (got " + effective + ")");
+    }
+    return effective;
+  }
+}

--- a/services/optimizer/src/main/java/com/linkedin/openhouse/optimizer/service/OptimizerDataService.java
+++ b/services/optimizer/src/main/java/com/linkedin/openhouse/optimizer/service/OptimizerDataService.java
@@ -23,15 +23,16 @@ public interface OptimizerDataService {
   // --- TableOperations ---
 
   /**
-   * List operations matching the given filters. Every parameter is optional — pass {@link
-   * Optional#empty()} to skip that filter. No filters returns all rows.
+   * List operations matching the given filters, capped at {@code limit} rows. Every filter
+   * parameter is optional — pass {@link Optional#empty()} to skip that filter.
    */
   List<TableOperationDto> listTableOperations(
       Optional<OperationTypeDto> operationType,
       Optional<OperationStatusDto> status,
       Optional<String> databaseName,
       Optional<String> tableName,
-      Optional<String> tableUuid);
+      Optional<String> tableUuid,
+      int limit);
 
   /**
    * Update an operation by writing a history entry. Looks up the operation row by {@code
@@ -60,11 +61,14 @@ public interface OptimizerDataService {
   Optional<TableStatsDto> getTableStats(String tableUuid);
 
   /**
-   * List stats rows matching the given filters. Every parameter is optional — pass {@link
-   * Optional#empty()} to skip that filter. No filters returns all rows.
+   * List stats rows matching the given filters, capped at {@code limit} rows. Every filter
+   * parameter is optional — pass {@link Optional#empty()} to skip that filter.
    */
   List<TableStatsDto> listTableStats(
-      Optional<String> databaseName, Optional<String> tableName, Optional<String> tableUuid);
+      Optional<String> databaseName,
+      Optional<String> tableName,
+      Optional<String> tableUuid,
+      int limit);
 
   /**
    * Return per-commit stats history for {@code tableUuid}, newest first.

--- a/services/optimizer/src/main/java/com/linkedin/openhouse/optimizer/service/OptimizerDataServiceImpl.java
+++ b/services/optimizer/src/main/java/com/linkedin/openhouse/optimizer/service/OptimizerDataServiceImpl.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,9 +39,6 @@ public class OptimizerDataServiceImpl implements OptimizerDataService {
   private final TableStatsRepository statsRepository;
   private final TableStatsHistoryRepository statsHistoryRepository;
 
-  @Value("${optimizer.repo.default-limit:10000}")
-  private int defaultLimit;
-
   // --- TableOperations ---
 
   @Override
@@ -51,7 +47,8 @@ public class OptimizerDataServiceImpl implements OptimizerDataService {
       Optional<OperationStatusDto> status,
       Optional<String> databaseName,
       Optional<String> tableName,
-      Optional<String> tableUuid) {
+      Optional<String> tableUuid,
+      int limit) {
     return operationsRepository
         .find(
             operationType.map(OperationTypeDto::toDb),
@@ -61,7 +58,7 @@ public class OptimizerDataServiceImpl implements OptimizerDataService {
             tableName,
             Optional.empty(),
             Optional.empty(),
-            PageRequest.of(0, defaultLimit))
+            PageRequest.of(0, limit))
         .stream()
         .map(TableOperationDto::fromRow)
         .collect(Collectors.toList());
@@ -137,8 +134,11 @@ public class OptimizerDataServiceImpl implements OptimizerDataService {
 
   @Override
   public List<TableStatsDto> listTableStats(
-      Optional<String> databaseName, Optional<String> tableName, Optional<String> tableUuid) {
-    return statsRepository.find(databaseName, tableName, tableUuid, PageRequest.of(0, defaultLimit))
+      Optional<String> databaseName,
+      Optional<String> tableName,
+      Optional<String> tableUuid,
+      int limit) {
+    return statsRepository.find(databaseName, tableName, tableUuid, PageRequest.of(0, limit))
         .stream()
         .map(TableStatsDto::fromRow)
         .collect(Collectors.toList());

--- a/services/optimizer/src/main/resources/application.properties
+++ b/services/optimizer/src/main/resources/application.properties
@@ -16,7 +16,8 @@ spring.datasource.username=${OPTIMIZER_DB_USER:oh_user}
 spring.datasource.password=${OPTIMIZER_DB_PASSWORD:oh_password}
 spring.datasource.hikari.maximum-pool-size=20
 
-optimizer.repo.default-limit=10000
+optimizer.api.list.default-limit=10
+optimizer.api.list.max-limit=1000
 
 management.endpoints.web.exposure.include=health,prometheus
 management.endpoint.health.enabled=true

--- a/services/optimizer/src/test/java/com/linkedin/openhouse/optimizer/api/controller/ListLimitControllerTest.java
+++ b/services/optimizer/src/test/java/com/linkedin/openhouse/optimizer/api/controller/ListLimitControllerTest.java
@@ -1,0 +1,176 @@
+package com.linkedin.openhouse.optimizer.api.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.linkedin.openhouse.optimizer.db.OperationStatus;
+import com.linkedin.openhouse.optimizer.db.OperationType;
+import com.linkedin.openhouse.optimizer.db.TableOperationsHistoryRow;
+import com.linkedin.openhouse.optimizer.db.TableOperationsRow;
+import com.linkedin.openhouse.optimizer.db.TableStatsHistoryRow;
+import com.linkedin.openhouse.optimizer.db.TableStatsRow;
+import com.linkedin.openhouse.optimizer.repository.TableOperationsHistoryRepository;
+import com.linkedin.openhouse.optimizer.repository.TableOperationsRepository;
+import com.linkedin.openhouse.optimizer.repository.TableStatsHistoryRepository;
+import com.linkedin.openhouse.optimizer.repository.TableStatsRepository;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Exercises the limit param across all four list endpoints: default applies when omitted,
+ * out-of-range values are rejected with 400, and the {@code max-limit} bound is config-driven.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestPropertySource(
+    properties = {
+      "optimizer.api.list.default-limit=3",
+      "optimizer.api.list.max-limit=50",
+    })
+@Transactional
+class ListLimitControllerTest {
+
+  @Autowired MockMvc mockMvc;
+  @Autowired TableOperationsRepository operationsRepository;
+  @Autowired TableOperationsHistoryRepository historyRepository;
+  @Autowired TableStatsRepository statsRepository;
+  @Autowired TableStatsHistoryRepository statsHistoryRepository;
+
+  private String sharedTableUuid;
+
+  @BeforeEach
+  void seed() {
+    sharedTableUuid = UUID.randomUUID().toString();
+    for (int i = 0; i < 8; i++) {
+      operationsRepository.save(
+          TableOperationsRow.builder()
+              .id(UUID.randomUUID().toString())
+              .tableUuid(UUID.randomUUID().toString())
+              .databaseName("db1")
+              .tableName("tbl" + i)
+              .operationType(OperationType.ORPHAN_FILES_DELETION)
+              .status(OperationStatus.PENDING)
+              .createdAt(Instant.now())
+              .build());
+      statsRepository.save(
+          TableStatsRow.builder()
+              .tableUuid(UUID.randomUUID().toString())
+              .databaseName("db1")
+              .tableName("tbl" + i)
+              .updatedAt(Instant.now())
+              .build());
+      historyRepository.save(
+          TableOperationsHistoryRow.builder()
+              .id(UUID.randomUUID().toString())
+              .tableUuid(sharedTableUuid)
+              .databaseName("db1")
+              .tableName("tbl")
+              .operationType(OperationType.ORPHAN_FILES_DELETION)
+              .status(com.linkedin.openhouse.optimizer.db.HistoryStatus.SUCCESS)
+              .completedAt(Instant.now())
+              .build());
+      statsHistoryRepository.save(
+          TableStatsHistoryRow.builder()
+              .id(UUID.randomUUID().toString())
+              .tableUuid(sharedTableUuid)
+              .databaseName("db1")
+              .tableName("tbl")
+              .recordedAt(Instant.now())
+              .build());
+    }
+  }
+
+  // --- /operations ---
+
+  @Test
+  void listOperations_default_appliesConfiguredDefaultLimit() throws Exception {
+    mockMvc
+        .perform(get("/v1/optimizer/operations"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(3));
+  }
+
+  @Test
+  void listOperations_explicitLimit_honored() throws Exception {
+    mockMvc
+        .perform(get("/v1/optimizer/operations").param("limit", "5"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(5));
+  }
+
+  @Test
+  void listOperations_zeroLimit_returns400() throws Exception {
+    mockMvc
+        .perform(get("/v1/optimizer/operations").param("limit", "0"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void listOperations_overMax_returns400() throws Exception {
+    mockMvc
+        .perform(get("/v1/optimizer/operations").param("limit", "51"))
+        .andExpect(status().isBadRequest());
+  }
+
+  // --- /stats ---
+
+  @Test
+  void listStats_default_appliesConfiguredDefaultLimit() throws Exception {
+    mockMvc
+        .perform(get("/v1/optimizer/stats"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(3));
+  }
+
+  @Test
+  void listStats_overMax_returns400() throws Exception {
+    mockMvc
+        .perform(get("/v1/optimizer/stats").param("limit", "51"))
+        .andExpect(status().isBadRequest());
+  }
+
+  // --- /operations-history/{tableUuid} ---
+
+  @Test
+  void getOperationsHistory_default_appliesConfiguredDefaultLimit() throws Exception {
+    mockMvc
+        .perform(get("/v1/optimizer/operations-history/" + sharedTableUuid))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(3));
+  }
+
+  @Test
+  void getOperationsHistory_overMax_returns400() throws Exception {
+    mockMvc
+        .perform(get("/v1/optimizer/operations-history/" + sharedTableUuid).param("limit", "51"))
+        .andExpect(status().isBadRequest());
+  }
+
+  // --- /stats/{tableUuid}/history ---
+
+  @Test
+  void getStatsHistory_default_appliesConfiguredDefaultLimit() throws Exception {
+    mockMvc
+        .perform(get("/v1/optimizer/stats/" + sharedTableUuid + "/history"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(3));
+  }
+
+  @Test
+  void getStatsHistory_overMax_returns400() throws Exception {
+    mockMvc
+        .perform(get("/v1/optimizer/stats/" + sharedTableUuid + "/history").param("limit", "51"))
+        .andExpect(status().isBadRequest());
+  }
+}

--- a/services/optimizer/src/test/java/com/linkedin/openhouse/optimizer/service/OptimizerDataServiceImplTest.java
+++ b/services/optimizer/src/test/java/com/linkedin/openhouse/optimizer/service/OptimizerDataServiceImplTest.java
@@ -165,8 +165,52 @@ class OptimizerDataServiceImplTest {
                 Optional.of(OperationStatusDto.PENDING),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty()))
+                Optional.empty(),
+                100))
         .extracting(op -> op.getId())
         .containsExactly(pendingId);
+  }
+
+  @Test
+  void listTableOperations_respectsLimit() {
+    for (int i = 0; i < 15; i++) {
+      operationsRepository.save(
+          TableOperationsRow.builder()
+              .id(UUID.randomUUID().toString())
+              .tableUuid(UUID.randomUUID().toString())
+              .databaseName("db1")
+              .tableName("tbl" + i)
+              .operationType(
+                  com.linkedin.openhouse.optimizer.db.OperationType.ORPHAN_FILES_DELETION)
+              .status(com.linkedin.openhouse.optimizer.db.OperationStatus.PENDING)
+              .createdAt(Instant.now())
+              .build());
+    }
+
+    assertThat(
+            service.listTableOperations(
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                5))
+        .hasSize(5);
+  }
+
+  @Test
+  void listTableStats_respectsLimit() {
+    for (int i = 0; i < 15; i++) {
+      service.upsertTableStats(
+          TableStatsDto.builder()
+              .tableUuid(UUID.randomUUID().toString())
+              .databaseName("db1")
+              .tableName("tbl" + i)
+              .snapshot(TableStatsDto.SnapshotMetrics.builder().tableSizeBytes(1L).build())
+              .build());
+    }
+
+    assertThat(service.listTableStats(Optional.empty(), Optional.empty(), Optional.empty(), 7))
+        .hasSize(7);
   }
 }


### PR DESCRIPTION
## Status

**(WIP)** — inspection branch on top of `mkuchenb/optimizer-2` (PR #531). Open for review of the diff shape before folding into #531.

## Summary

All four list-style endpoints on the optimizer REST API now require a bounded `limit`. Default 10, max 1000, both configurable.

- `GET /v1/optimizer/operations`
- `GET /v1/optimizer/stats`
- `GET /v1/optimizer/operations-history/{tableUuid}`
- `GET /v1/optimizer/stats/{tableUuid}/history`

## Changes

- New `ApiListLimitProperties` (`@ConfigurationProperties("optimizer.api.list")`) — `defaultLimit=10`, `maxLimit=1000`, with a `validateAndResolve(Integer)` helper that throws `ResponseStatusException(BAD_REQUEST)` on out-of-range.
- Controllers accept `@RequestParam(required = false) Integer limit`, call `limits.validateAndResolve(limit)` at method entry.
- `OptimizerDataService` — `listTableOperations` and `listTableStats` gain `int limit` (the two history methods already had it).
- `OptimizerDataServiceImpl` — drops `@Value("${optimizer.repo.default-limit:10000}")`; threads the caller-supplied limit straight into `PageRequest.of(0, limit)`, which Spring Data translates to MySQL `LIMIT n`.
- `application.properties` — `optimizer.repo.default-limit=10000` removed; replaced with `optimizer.api.list.default-limit=10` + `max-limit=1000`.

## Design notes

- **No pagination.** Filters narrow the scope; the implicit `len(result) == limit` signal tells callers there may be more. Cursor-based pagination can land later if needed. Offset/limit pagination is deliberately avoided (deep-scan cost, skip/duplicate under concurrent writes).
- **Bounds are configurable, not constants.** Tests vary the cap via `@TestPropertySource` to confirm the bound is config-driven, not hard-coded.
- **400, not 500, on out-of-range.** Uses `ResponseStatusException(BAD_REQUEST)` rather than `IllegalArgumentException` because Spring does not auto-map the latter to 400.

## Testing Done

- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.

`./gradlew :services:optimizer:test` — all green.

New `ListLimitControllerTest` (10 MockMvc cases): default applies, explicit limit honored, `limit=0` → 400, `limit > max` → 400, across all four endpoints. `@TestPropertySource` sets `default-limit=3, max-limit=50` to verify config-driven behavior.

New service-layer cases: `listTableOperations_respectsLimit` and `listTableStats_respectsLimit` confirm the `PageRequest` cap reaches the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)