### PR TITLE
(wip) docs(optimizer): @ApiResponses on controllers for OpenAPI spec

### DIFF
--- a/services/optimizer/src/main/java/com/linkedin/openhouse/optimizer/api/controller/TableOperationsController.java
+++ b/services/optimizer/src/main/java/com/linkedin/openhouse/optimizer/api/controller/TableOperationsController.java
@@ -6,6 +6,8 @@ import com.linkedin.openhouse.optimizer.api.spec.TableOperations;
 import com.linkedin.openhouse.optimizer.api.spec.TableOperationsHistory;
 import com.linkedin.openhouse.optimizer.api.spec.UpdateOperationRequest;
 import com.linkedin.openhouse.optimizer.service.OptimizerDataService;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -37,6 +39,12 @@ public class TableOperationsController {
    * operation row, writes a history entry with the operation's table metadata, and returns 201
    * Created with the history row, or 404 if the operation does not exist.
    */
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "201", description = "Operation UPDATE: CREATED"),
+        @ApiResponse(responseCode = "400", description = "Operation UPDATE: BAD_REQUEST"),
+        @ApiResponse(responseCode = "404", description = "Operation UPDATE: NOT_FOUND")
+      })
   @PostMapping("/{id}/update")
   public ResponseEntity<TableOperationsHistory> updateOperation(
       @PathVariable String id, @RequestBody UpdateOperationRequest request) {
@@ -66,6 +74,11 @@ public class TableOperationsController {
   }
 
   /** Fetch a single operation row by its ID, regardless of status. Returns 404 if not found. */
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "Operation GET: OK"),
+        @ApiResponse(responseCode = "404", description = "Operation GET: NOT_FOUND")
+      })
   @GetMapping("/{id}")
   public ResponseEntity<TableOperations> getTableOperation(@PathVariable String id) {
     return service
@@ -82,6 +95,11 @@ public class TableOperationsController {
    * List operations matching the given filters, capped at {@code limit} rows. Every filter is
    * optional; {@code limit} is required so callers always state how much they want back.
    */
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "Operation SEARCH: OK"),
+        @ApiResponse(responseCode = "400", description = "Operation SEARCH: BAD_REQUEST")
+      })
   @GetMapping
   public ResponseEntity<List<TableOperations>> listTableOperations(
       @RequestParam(required = false) OperationType operationType,

--- a/services/optimizer/src/main/java/com/linkedin/openhouse/optimizer/api/controller/TableOperationsHistoryController.java
+++ b/services/optimizer/src/main/java/com/linkedin/openhouse/optimizer/api/controller/TableOperationsHistoryController.java
@@ -2,6 +2,8 @@ package com.linkedin.openhouse.optimizer.api.controller;
 
 import com.linkedin.openhouse.optimizer.api.spec.TableOperationsHistory;
 import com.linkedin.openhouse.optimizer.service.OptimizerDataService;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +26,10 @@ public class TableOperationsHistoryController {
   private final OptimizerDataService service;
 
   /** Append a completed-job result. Called by the SparkJob after each run (success or failure). */
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "201", description = "OperationsHistory CREATE: CREATED")
+      })
   @PostMapping
   public ResponseEntity<TableOperationsHistory> appendHistory(
       @RequestBody TableOperationsHistory dto) {
@@ -35,6 +41,11 @@ public class TableOperationsHistoryController {
    * Return the most recent history for a table, newest first, capped at {@code limit} rows. {@code
    * limit} is required.
    */
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "OperationsHistory GET: OK"),
+        @ApiResponse(responseCode = "400", description = "OperationsHistory GET: BAD_REQUEST")
+      })
   @GetMapping("/{tableUuid}")
   public ResponseEntity<List<TableOperationsHistory>> getHistory(
       @PathVariable String tableUuid, @RequestParam int limit) {

--- a/services/optimizer/src/main/java/com/linkedin/openhouse/optimizer/api/controller/TableStatsController.java
+++ b/services/optimizer/src/main/java/com/linkedin/openhouse/optimizer/api/controller/TableStatsController.java
@@ -4,6 +4,8 @@ import com.linkedin.openhouse.optimizer.api.spec.TableStats;
 import com.linkedin.openhouse.optimizer.api.spec.TableStatsHistory;
 import com.linkedin.openhouse.optimizer.api.spec.UpsertTableStatsRequest;
 import com.linkedin.openhouse.optimizer.service.OptimizerDataService;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -32,6 +34,7 @@ public class TableStatsController {
    * Create or overwrite the stats row for {@code tableUuid}. Called by the Tables Service on every
    * Iceberg commit. Idempotent.
    */
+  @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Stats PUT: OK")})
   @PutMapping("/{tableUuid}")
   public ResponseEntity<TableStats> upsertTableStats(
       @PathVariable String tableUuid, @RequestBody UpsertTableStatsRequest request) {
@@ -40,6 +43,11 @@ public class TableStatsController {
   }
 
   /** Fetch the stats row for {@code tableUuid}. Returns 404 if no stats have been written yet. */
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "Stats GET: OK"),
+        @ApiResponse(responseCode = "404", description = "Stats GET: NOT_FOUND")
+      })
   @GetMapping("/{tableUuid}")
   public ResponseEntity<TableStats> getTableStats(@PathVariable String tableUuid) {
     return service
@@ -56,6 +64,11 @@ public class TableStatsController {
    * List stats rows matching the given filters, capped at {@code limit} rows. Every filter is
    * optional; {@code limit} is required so callers always state how much they want back.
    */
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "Stats SEARCH: OK"),
+        @ApiResponse(responseCode = "400", description = "Stats SEARCH: BAD_REQUEST")
+      })
   @GetMapping
   public ResponseEntity<List<TableStats>> listTableStats(
       @RequestParam(required = false) String databaseName,
@@ -79,6 +92,11 @@ public class TableStatsController {
    * Return per-commit stats history for {@code tableUuid}, newest first, capped at {@code limit}
    * rows. Optional {@code since} filter (inclusive). {@code limit} is required.
    */
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "StatsHistory GET: OK"),
+        @ApiResponse(responseCode = "400", description = "StatsHistory GET: BAD_REQUEST")
+      })
   @GetMapping("/{tableUuid}/history")
   public ResponseEntity<List<TableStatsHistory>> getStatsHistory(
       @PathVariable String tableUuid,


### PR DESCRIPTION
## Status

**(WIP)** — inspection branch on top of `mkuchenb/optimizer-2` (PR #531). Addresses [Abhishek's review comment](https://github.com/linkedin/openhouse/pull/531#discussion_r3291079232): list error codes in the API response via `@ApiResponses` per endpoint.

## Summary

Adds `@ApiResponses` annotations to every optimizer REST endpoint, following the same "Resource ACTION: STATUS" convention used by `services/tables`.

| Endpoint | Codes |
|---|---|
| `POST /v1/optimizer/operations/{id}/update` | 201, 400, 404 |
| `GET /v1/optimizer/operations/{id}` | 200, 404 |
| `GET /v1/optimizer/operations` | 200, 400 |
| `POST /v1/optimizer/operations-history` | 201 |
| `GET /v1/optimizer/operations-history/{tableUuid}` | 200, 400 |
| `PUT /v1/optimizer/stats/{tableUuid}` | 200 |
| `GET /v1/optimizer/stats/{tableUuid}` | 200, 404 |
| `GET /v1/optimizer/stats` | 200, 400 |
| `GET /v1/optimizer/stats/{tableUuid}/history` | 200, 400 |

Each endpoint lists only the codes it actually returns — no auth codes (no auth layer on this PR), no 500 (default catch-all behavior not user-facing contract).

## Changes

- 3 controllers, 9 endpoints, 9 `@ApiResponses` blocks.
- 2 new imports per controller (`io.swagger.v3.oas.annotations.responses.ApiResponse` + `ApiResponses`).
- `swagger-annotations:2.1.11` already on the classpath via `openhouse.springboot-conventions` — no dep change.

## Testing Done

- [x] No tests added — these are documentation annotations only.

`./gradlew :services:optimizer:test` — all green (existing 24 tests, no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)