### PR TITLE
Add tableProperties to TableAuditEvent

### DIFF
--- a/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
+++ b/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
@@ -13,7 +13,7 @@ task javadocJar(type: Jar) {
 }
 
 tasks.withType(GenerateModuleMetadata) {
-  enabled = false
+  enabled = project.version.toString().endsWith('-SNAPSHOT')
 }
 
 [jar, sourcesJar, javadocJar].each { task ->

--- a/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
+++ b/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
@@ -13,7 +13,7 @@ task javadocJar(type: Jar) {
 }
 
 tasks.withType(GenerateModuleMetadata) {
-  enabled = project.version.toString().endsWith('-SNAPSHOT')
+  enabled = false
 }
 
 [jar, sourcesJar, javadocJar].each { task ->

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
@@ -18,6 +18,7 @@ import com.linkedin.openhouse.tables.audit.model.OperationStatus;
 import com.linkedin.openhouse.tables.audit.model.OperationType;
 import com.linkedin.openhouse.tables.audit.model.TableAuditEvent;
 import com.linkedin.openhouse.tables.config.InternalCatalogProperties;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
@@ -543,24 +544,52 @@ public class TableAuditAspect {
 
   /**
    * Narrows the committed table properties down to the configured allowlist ({@code
-   * cluster.iceberg.tables.audit.table-properties-allowlist}). Returns {@code null} when there is
-   * nothing to emit so downstream audit handlers can skip the field entirely. Iterates the
-   * allowlist rather than the source so cost is O(|allowlist|) regardless of source size.
+   * cluster.iceberg.tables.audit.table-properties-allowlist}) and enforces two byte-size caps to
+   * keep the audit event within the Kafka producer's max.request.size budget: a per-value cap
+   * ({@code table-property-value-max-size}) and a combined-total cap ({@code
+   * table-properties-total-max-size}). Values exceeding either cap are skipped with a warning log.
+   * Returns {@code null} when there is nothing to emit so downstream audit handlers can skip the
+   * field entirely. Iterates the allowlist rather than the source so cost is O(|allowlist|)
+   * regardless of source size.
    */
   private Map<String, String> filterTableProperties(Map<String, String> source) {
     if (source == null || source.isEmpty()) {
       return null;
     }
-    List<String> allowlist = internalCatalogProperties.getAudit().getTablePropertiesAllowlist();
+    InternalCatalogProperties.Audit auditConfig = internalCatalogProperties.getAudit();
+    List<String> allowlist = auditConfig.getTablePropertiesAllowlist();
     if (allowlist == null || allowlist.isEmpty()) {
       return null;
     }
+    long maxValueBytes = auditConfig.getTablePropertyValueMaxSize().toBytes();
+    long maxTotalBytes = auditConfig.getTablePropertiesTotalMaxSize().toBytes();
     Map<String, String> filtered = new HashMap<>();
+    long totalBytes = 0;
     for (String key : allowlist) {
       String value = source.get(key);
-      if (value != null) {
-        filtered.put(key, value);
+      if (value == null) {
+        continue;
       }
+      long valueBytes = value.getBytes(StandardCharsets.UTF_8).length;
+      if (valueBytes > maxValueBytes) {
+        log.warn(
+            "Dropping audited table-property '{}': value size {} bytes exceeds per-value cap {} bytes",
+            key,
+            valueBytes,
+            maxValueBytes);
+        continue;
+      }
+      if (totalBytes + valueBytes > maxTotalBytes) {
+        log.warn(
+            "Dropping audited table-property '{}': including it would exceed total cap {} bytes "
+                + "(already accumulated {} bytes)",
+            key,
+            maxTotalBytes,
+            totalBytes);
+        continue;
+      }
+      filtered.put(key, value);
+      totalBytes += valueBytes;
     }
     return filtered.isEmpty() ? null : filtered;
   }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
@@ -371,12 +371,18 @@ public class TableAuditAspect {
     } else {
       operationType = OperationType.COMMIT;
     }
+    CreateUpdateTableRequestBody createUpdateTableRequestBody =
+        icebergSnapshotRequestBody.getCreateUpdateTableRequestBody();
     TableAuditEvent.TableAuditEventBuilder eventBuilder =
         TableAuditEvent.builder()
             .eventTimestamp(Instant.now())
             .databaseName(databaseId)
             .tableName(tableId)
-            .operationType(operationType);
+            .operationType(operationType)
+            .tableProperties(
+                createUpdateTableRequestBody == null
+                    ? null
+                    : createUpdateTableRequestBody.getTableProperties());
     extractSnapshotInfo(icebergSnapshotRequestBody, eventBuilder);
     TableAuditEvent event = eventBuilder.build();
     try {

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
@@ -17,7 +17,9 @@ import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
 import com.linkedin.openhouse.tables.audit.model.OperationStatus;
 import com.linkedin.openhouse.tables.audit.model.OperationType;
 import com.linkedin.openhouse.tables.audit.model.TableAuditEvent;
+import com.linkedin.openhouse.tables.config.InternalCatalogProperties;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -43,6 +45,8 @@ public class TableAuditAspect {
   @Autowired private ClusterProperties clusterProperties;
 
   @Autowired private AuditHandler<TableAuditEvent> tableAuditHandler;
+
+  @Autowired private InternalCatalogProperties internalCatalogProperties;
 
   /**
    * Install the Around advice for getTable() method in OpenHouseTablesApiHandler.
@@ -371,26 +375,27 @@ public class TableAuditAspect {
     } else {
       operationType = OperationType.COMMIT;
     }
-    CreateUpdateTableRequestBody createUpdateTableRequestBody =
-        icebergSnapshotRequestBody.getCreateUpdateTableRequestBody();
     TableAuditEvent.TableAuditEventBuilder eventBuilder =
         TableAuditEvent.builder()
             .eventTimestamp(Instant.now())
             .databaseName(databaseId)
             .tableName(tableId)
-            .operationType(operationType)
-            .tableProperties(
-                createUpdateTableRequestBody == null
-                    ? null
-                    : createUpdateTableRequestBody.getTableProperties());
+            .operationType(operationType);
     extractSnapshotInfo(icebergSnapshotRequestBody, eventBuilder);
-    TableAuditEvent event = eventBuilder.build();
     try {
       result = (ApiResponse<GetTableResponseBody>) point.proceed();
+      // Read tableProperties from the response, not the request body: OpenHouse mutates
+      // properties server-side during commit (e.g. openhouse.tableVersion,
+      // openhouse.lastModifiedTime), and the audit event should reflect the committed state.
+      TableAuditEvent event =
+          eventBuilder
+              .tableProperties(filterTableProperties(result.getResponseBody().getTableProperties()))
+              .build();
       buildAndSendEvent(
           event, OperationStatus.SUCCESS, result.getResponseBody().getTableLocation());
     } catch (Throwable t) {
-      buildAndSendEvent(event, OperationStatus.FAILED, null);
+      // On failure there is no committed state to read from, so tableProperties stays null.
+      buildAndSendEvent(eventBuilder.build(), OperationStatus.FAILED, null);
       throw t;
     }
     return result;
@@ -533,6 +538,30 @@ public class TableAuditAspect {
       throw t;
     }
     return result;
+  }
+
+  /**
+   * Narrows the request-body table properties down to the configured allowlist ({@code
+   * cluster.iceberg.tables.audit.table-properties-allowlist}). Returns {@code null} when there is
+   * nothing to emit so downstream audit handlers can skip the field entirely. Iterates the
+   * allowlist rather than the source so cost is O(|allowlist|) regardless of source size.
+   */
+  private Map<String, String> filterTableProperties(Map<String, String> source) {
+    if (source == null || source.isEmpty()) {
+      return null;
+    }
+    List<String> allowlist = internalCatalogProperties.getAudit().getTablePropertiesAllowlist();
+    if (allowlist == null || allowlist.isEmpty()) {
+      return null;
+    }
+    Map<String, String> filtered = new HashMap<>();
+    for (String key : allowlist) {
+      String value = source.get(key);
+      if (value != null) {
+        filtered.put(key, value);
+      }
+    }
+    return filtered.isEmpty() ? null : filtered;
   }
 
   private void buildAndSendEvent(

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
@@ -542,37 +542,24 @@ public class TableAuditAspect {
 
   /**
    * Narrows the committed table properties down to the configured allowlist ({@code
-   * cluster.iceberg.tables.audit.table-properties-allowlist}) and drops any value longer than
-   * {@code cluster.iceberg.tables.audit.table-property-value-max-length} characters. Returns {@code
-   * null} when there is nothing to emit so downstream audit handlers can skip the field entirely.
-   * Iterates the allowlist rather than the source so cost is O(|allowlist|) regardless of source
-   * size.
+   * cluster.iceberg.tables.audit.table-properties-allowlist}). Returns {@code null} when there is
+   * nothing to emit so downstream audit handlers can skip the field entirely. Iterates the
+   * allowlist rather than the source so cost is O(|allowlist|) regardless of source size.
    */
   private Map<String, String> filterTableProperties(Map<String, String> source) {
     if (source == null || source.isEmpty()) {
       return null;
     }
-    InternalCatalogProperties.Audit auditConfig = internalCatalogProperties.getAudit();
-    List<String> allowlist = auditConfig.getTablePropertiesAllowlist();
+    List<String> allowlist = internalCatalogProperties.getAudit().getTablePropertiesAllowlist();
     if (allowlist == null || allowlist.isEmpty()) {
       return null;
     }
-    int maxLength = auditConfig.getTablePropertyValueMaxLength();
     Map<String, String> filtered = new HashMap<>();
     for (String key : allowlist) {
       String value = source.get(key);
-      if (value == null) {
-        continue;
+      if (value != null) {
+        filtered.put(key, value);
       }
-      if (maxLength > 0 && value.length() > maxLength) {
-        log.warn(
-            "Dropping table-property '{}' from audit event: value length {} exceeds cap {}",
-            key,
-            value.length(),
-            maxLength);
-        continue;
-      }
-      filtered.put(key, value);
     }
     return filtered.isEmpty() ? null : filtered;
   }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
@@ -389,7 +389,8 @@ public class TableAuditAspect {
       // openhouse.lastModifiedTime), and the audit event should reflect the committed state.
       TableAuditEvent event =
           eventBuilder
-              .tableProperties(filterTableProperties(result.getResponseBody().getTableProperties()))
+              .auditedTableProperties(
+                  filterTableProperties(result.getResponseBody().getTableProperties()))
               .build();
       buildAndSendEvent(
           event, OperationStatus.SUCCESS, result.getResponseBody().getTableLocation());

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
@@ -541,25 +541,38 @@ public class TableAuditAspect {
   }
 
   /**
-   * Narrows the request-body table properties down to the configured allowlist ({@code
-   * cluster.iceberg.tables.audit.table-properties-allowlist}). Returns {@code null} when there is
-   * nothing to emit so downstream audit handlers can skip the field entirely. Iterates the
-   * allowlist rather than the source so cost is O(|allowlist|) regardless of source size.
+   * Narrows the committed table properties down to the configured allowlist ({@code
+   * cluster.iceberg.tables.audit.table-properties-allowlist}) and drops any value longer than
+   * {@code cluster.iceberg.tables.audit.table-property-value-max-length} characters. Returns {@code
+   * null} when there is nothing to emit so downstream audit handlers can skip the field entirely.
+   * Iterates the allowlist rather than the source so cost is O(|allowlist|) regardless of source
+   * size.
    */
   private Map<String, String> filterTableProperties(Map<String, String> source) {
     if (source == null || source.isEmpty()) {
       return null;
     }
-    List<String> allowlist = internalCatalogProperties.getAudit().getTablePropertiesAllowlist();
+    InternalCatalogProperties.Audit auditConfig = internalCatalogProperties.getAudit();
+    List<String> allowlist = auditConfig.getTablePropertiesAllowlist();
     if (allowlist == null || allowlist.isEmpty()) {
       return null;
     }
+    int maxLength = auditConfig.getTablePropertyValueMaxLength();
     Map<String, String> filtered = new HashMap<>();
     for (String key : allowlist) {
       String value = source.get(key);
-      if (value != null) {
-        filtered.put(key, value);
+      if (value == null) {
+        continue;
       }
+      if (maxLength > 0 && value.length() > maxLength) {
+        log.warn(
+            "Dropping table-property '{}' from audit event: value length {} exceeds cap {}",
+            key,
+            value.length(),
+            maxLength);
+        continue;
+      }
+      filtered.put(key, value);
     }
     return filtered.isEmpty() ? null : filtered;
   }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/model/TableAuditEvent.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/model/TableAuditEvent.java
@@ -2,6 +2,7 @@ package com.linkedin.openhouse.tables.audit.model;
 
 import com.linkedin.openhouse.common.audit.model.BaseAuditEvent;
 import java.time.Instant;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -40,4 +41,6 @@ public class TableAuditEvent extends BaseAuditEvent {
   private Long currentSnapshotId;
 
   private Long currentSnapshotTimestampMs;
+
+  private Map<String, String> tableProperties;
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/model/TableAuditEvent.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/model/TableAuditEvent.java
@@ -42,5 +42,6 @@ public class TableAuditEvent extends BaseAuditEvent {
 
   private Long currentSnapshotTimestampMs;
 
-  private Map<String, String> tableProperties;
+  /** Allowlisted subset of table properties at commit time, not the full property map. */
+  private Map<String, String> auditedTableProperties;
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/config/InternalCatalogProperties.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/config/InternalCatalogProperties.java
@@ -1,6 +1,8 @@
 package com.linkedin.openhouse.tables.config;
 
 import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -13,11 +15,19 @@ public class InternalCatalogProperties {
 
   private MetadataCache metadataCache = new MetadataCache();
 
+  private Audit audit = new Audit();
+
   @Getter
   @Setter
   public static class MetadataCache {
     private Boolean enabled;
     private Duration ttl;
     private DataSize maxWeight;
+  }
+
+  @Getter
+  @Setter
+  public static class Audit {
+    private List<String> tablePropertiesAllowlist = Collections.emptyList();
   }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/config/InternalCatalogProperties.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/config/InternalCatalogProperties.java
@@ -29,5 +29,17 @@ public class InternalCatalogProperties {
   @Setter
   public static class Audit {
     private List<String> tablePropertiesAllowlist = Collections.emptyList();
+
+    /**
+     * Maximum UTF-8 byte size of a single audited property value. Values larger than this are
+     * skipped.
+     */
+    private DataSize tablePropertyValueMaxSize = DataSize.ofKilobytes(256);
+
+    /**
+     * Maximum combined UTF-8 byte size of all audited property values. Once including the next
+     * property would exceed this, that property and any remaining ones are skipped.
+     */
+    private DataSize tablePropertiesTotalMaxSize = DataSize.ofKilobytes(512);
   }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/config/InternalCatalogProperties.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/config/InternalCatalogProperties.java
@@ -29,5 +29,13 @@ public class InternalCatalogProperties {
   @Setter
   public static class Audit {
     private List<String> tablePropertiesAllowlist = Collections.emptyList();
+
+    /**
+     * Maximum character length of a single allowlisted property value. Values exceeding this are
+     * dropped from the audit event (with a warning log) to prevent oversized events from blowing
+     * the Kafka producer's max.request.size budget or OOM-ing downstream consumers. {@code 0}
+     * disables the cap (current/legacy behavior).
+     */
+    private int tablePropertyValueMaxLength = 0;
   }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/config/InternalCatalogProperties.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/config/InternalCatalogProperties.java
@@ -29,13 +29,5 @@ public class InternalCatalogProperties {
   @Setter
   public static class Audit {
     private List<String> tablePropertiesAllowlist = Collections.emptyList();
-
-    /**
-     * Maximum character length of a single allowlisted property value. Values exceeding this are
-     * dropped from the audit event (with a warning log) to prevent oversized events from blowing
-     * the Kafka producer's max.request.size budget or OOM-ing downstream consumers. {@code 0}
-     * disables the cap (current/legacy behavior).
-     */
-    private int tablePropertyValueMaxLength = 0;
   }
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/MockIcebergSnapshotApiHandler.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/MockIcebergSnapshotApiHandler.java
@@ -26,9 +26,20 @@ public class MockIcebergSnapshotApiHandler implements IcebergSnapshotsApiHandler
             .responseBody(RequestConstants.TEST_GET_TABLE_RESPONSE_BODY)
             .build();
       case "d200":
+        // Echo the request's table properties on the response so the audit aspect can read
+        // committed state from result.getResponseBody().getTableProperties().
         return ApiResponse.<GetTableResponseBody>builder()
             .httpStatus(HttpStatus.OK)
-            .responseBody(RequestConstants.TEST_GET_TABLE_RESPONSE_BODY)
+            .responseBody(
+                RequestConstants.TEST_GET_TABLE_RESPONSE_BODY
+                    .toBuilder()
+                    .tableProperties(
+                        icebergSnapshotRequestBody.getCreateUpdateTableRequestBody() == null
+                            ? null
+                            : icebergSnapshotRequestBody
+                                .getCreateUpdateTableRequestBody()
+                                .getTableProperties())
+                    .build())
             .build();
       case "d400":
         throw new RequestValidationFailureException();

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
@@ -221,7 +221,7 @@ public class IcebergSnapshotsApiHandlerAuditTest {
     Map<String, String> expected = new HashMap<>();
     expected.put("openhouse.watermark", "100");
     expected.put("openhouse.tableType", "PRIMARY_TABLE");
-    assertEquals(expected, actualEvent.getTableProperties());
+    assertEquals(expected, actualEvent.getAuditedTableProperties());
   }
 
   @Test

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
@@ -35,7 +35,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @TestPropertySource(
     properties = {
       "cluster.iceberg.tables.audit.table-properties-allowlist[0]=openhouse.watermark",
-      "cluster.iceberg.tables.audit.table-properties-allowlist[1]=openhouse.tableType"
+      "cluster.iceberg.tables.audit.table-properties-allowlist[1]=openhouse.tableType",
+      "cluster.iceberg.tables.audit.table-property-value-max-length=20"
     })
 @WithMockUser(username = "testUser")
 public class IcebergSnapshotsApiHandlerAuditTest {
@@ -222,6 +223,40 @@ public class IcebergSnapshotsApiHandlerAuditTest {
     expected.put("openhouse.watermark", "100");
     expected.put("openhouse.tableType", "PRIMARY_TABLE");
     assertEquals(expected, actualEvent.getTableProperties());
+  }
+
+  @Test
+  public void testPutIcebergSnapshotsDropsOversizedTableProperty() throws Exception {
+    // Cap is 20 chars (set at class level). "openhouse.watermark"="100" stays;
+    // "openhouse.tableType" with a 30+ char value is dropped.
+    Map<String, String> requestProperties = new HashMap<>();
+    requestProperties.put("openhouse.watermark", "100");
+    requestProperties.put(
+        "openhouse.tableType", "THIS_VALUE_IS_DEFINITELY_LONGER_THAN_TWENTY_CHARS");
+    IcebergSnapshotsRequestBody base = RequestConstants.TEST_ICEBERG_SNAPSHOTS_REQUEST_BODY;
+    IcebergSnapshotsRequestBody requestBody =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion(base.getBaseTableVersion())
+            .jsonSnapshots(base.getJsonSnapshots())
+            .snapshotRefs(base.getSnapshotRefs())
+            .createUpdateTableRequestBody(
+                base.getCreateUpdateTableRequestBody()
+                    .toBuilder()
+                    .tableProperties(requestProperties)
+                    .build())
+            .build();
+    mvc.perform(
+        MockMvcRequestBuilders.put(
+                String.format(
+                    CURRENT_MAJOR_VERSION_PREFIX
+                        + "/databases/d200/tables/tb1/iceberg/v2/snapshots"))
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody.toJson()));
+    Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
+    TableAuditEvent actualEvent = argCaptor.getValue();
+    assertEquals(
+        Collections.singletonMap("openhouse.watermark", "100"), actualEvent.getTableProperties());
   }
 
   @Test

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
@@ -185,6 +185,37 @@ public class IcebergSnapshotsApiHandlerAuditTest {
   }
 
   @Test
+  public void testPutIcebergSnapshotsCarriesTableProperties() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("openhouse.watermark", "100");
+    properties.put("openhouse.tableType", "PRIMARY_TABLE");
+    properties.put("user.custom.key", "v");
+    IcebergSnapshotsRequestBody base = RequestConstants.TEST_ICEBERG_SNAPSHOTS_REQUEST_BODY;
+    IcebergSnapshotsRequestBody requestBody =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion(base.getBaseTableVersion())
+            .jsonSnapshots(base.getJsonSnapshots())
+            .snapshotRefs(base.getSnapshotRefs())
+            .createUpdateTableRequestBody(
+                base.getCreateUpdateTableRequestBody()
+                    .toBuilder()
+                    .tableProperties(properties)
+                    .build())
+            .build();
+    mvc.perform(
+        MockMvcRequestBuilders.put(
+                String.format(
+                    CURRENT_MAJOR_VERSION_PREFIX
+                        + "/databases/d200/tables/tb1/iceberg/v2/snapshots"))
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody.toJson()));
+    Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
+    TableAuditEvent actualEvent = argCaptor.getValue();
+    assertEquals(properties, actualEvent.getTableProperties());
+  }
+
+  @Test
   public void testCTASCommitPhase() throws Exception {
     mvc.perform(
         MockMvcRequestBuilders.put(

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
@@ -35,7 +35,14 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @TestPropertySource(
     properties = {
       "cluster.iceberg.tables.audit.table-properties-allowlist[0]=openhouse.watermark",
-      "cluster.iceberg.tables.audit.table-properties-allowlist[1]=openhouse.tableType"
+      "cluster.iceberg.tables.audit.table-properties-allowlist[1]=openhouse.tableType",
+      "cluster.iceberg.tables.audit.table-properties-allowlist[2]=openhouse.a",
+      "cluster.iceberg.tables.audit.table-properties-allowlist[3]=openhouse.b",
+      "cluster.iceberg.tables.audit.table-properties-allowlist[4]=openhouse.c",
+      // Small caps (bytes) so the size-limit tests stay readable; production defaults are
+      // 256KB/512KB.
+      "cluster.iceberg.tables.audit.table-property-value-max-size=256B",
+      "cluster.iceberg.tables.audit.table-properties-total-max-size=512B"
     })
 @WithMockUser(username = "testUser")
 public class IcebergSnapshotsApiHandlerAuditTest {
@@ -222,6 +229,61 @@ public class IcebergSnapshotsApiHandlerAuditTest {
     expected.put("openhouse.watermark", "100");
     expected.put("openhouse.tableType", "PRIMARY_TABLE");
     assertEquals(expected, actualEvent.getAuditedTableProperties());
+  }
+
+  @Test
+  public void testPutIcebergSnapshotsSkipsPropertyExceedingPerValueCap() throws Exception {
+    // Per-value cap is 256B (class-level). A 300-byte value is skipped; the small one survives.
+    Map<String, String> requestProperties = new HashMap<>();
+    requestProperties.put("openhouse.watermark", "100");
+    requestProperties.put("openhouse.a", "x".repeat(300));
+    TableAuditEvent actualEvent = putSnapshotsAndCapture(requestProperties);
+    assertEquals(
+        Collections.singletonMap("openhouse.watermark", "100"),
+        actualEvent.getAuditedTableProperties());
+  }
+
+  @Test
+  public void testPutIcebergSnapshotsSkipsPropertiesExceedingTotalCap() throws Exception {
+    // Each value passes the 256B per-value cap, but the 512B total cap admits only the first two
+    // (allowlist order: openhouse.a, openhouse.b, openhouse.c). 200 + 200 = 400 <= 512; adding the
+    // third (600) exceeds, so openhouse.c is skipped.
+    Map<String, String> requestProperties = new HashMap<>();
+    requestProperties.put("openhouse.a", "x".repeat(200));
+    requestProperties.put("openhouse.b", "y".repeat(200));
+    requestProperties.put("openhouse.c", "z".repeat(200));
+    TableAuditEvent actualEvent = putSnapshotsAndCapture(requestProperties);
+    Map<String, String> emitted = actualEvent.getAuditedTableProperties();
+    assertEquals(2, emitted.size());
+    assertEquals("x".repeat(200), emitted.get("openhouse.a"));
+    assertEquals("y".repeat(200), emitted.get("openhouse.b"));
+    assertNull(emitted.get("openhouse.c"));
+  }
+
+  private TableAuditEvent putSnapshotsAndCapture(Map<String, String> tableProperties)
+      throws Exception {
+    IcebergSnapshotsRequestBody base = RequestConstants.TEST_ICEBERG_SNAPSHOTS_REQUEST_BODY;
+    IcebergSnapshotsRequestBody requestBody =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion(base.getBaseTableVersion())
+            .jsonSnapshots(base.getJsonSnapshots())
+            .snapshotRefs(base.getSnapshotRefs())
+            .createUpdateTableRequestBody(
+                base.getCreateUpdateTableRequestBody()
+                    .toBuilder()
+                    .tableProperties(tableProperties)
+                    .build())
+            .build();
+    mvc.perform(
+        MockMvcRequestBuilders.put(
+                String.format(
+                    CURRENT_MAJOR_VERSION_PREFIX
+                        + "/databases/d200/tables/tb1/iceberg/v2/snapshots"))
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody.toJson()));
+    Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
+    return argCaptor.getValue();
   }
 
   @Test

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
@@ -35,8 +35,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @TestPropertySource(
     properties = {
       "cluster.iceberg.tables.audit.table-properties-allowlist[0]=openhouse.watermark",
-      "cluster.iceberg.tables.audit.table-properties-allowlist[1]=openhouse.tableType",
-      "cluster.iceberg.tables.audit.table-property-value-max-length=20"
+      "cluster.iceberg.tables.audit.table-properties-allowlist[1]=openhouse.tableType"
     })
 @WithMockUser(username = "testUser")
 public class IcebergSnapshotsApiHandlerAuditTest {
@@ -223,40 +222,6 @@ public class IcebergSnapshotsApiHandlerAuditTest {
     expected.put("openhouse.watermark", "100");
     expected.put("openhouse.tableType", "PRIMARY_TABLE");
     assertEquals(expected, actualEvent.getTableProperties());
-  }
-
-  @Test
-  public void testPutIcebergSnapshotsDropsOversizedTableProperty() throws Exception {
-    // Cap is 20 chars (set at class level). "openhouse.watermark"="100" stays;
-    // "openhouse.tableType" with a 30+ char value is dropped.
-    Map<String, String> requestProperties = new HashMap<>();
-    requestProperties.put("openhouse.watermark", "100");
-    requestProperties.put(
-        "openhouse.tableType", "THIS_VALUE_IS_DEFINITELY_LONGER_THAN_TWENTY_CHARS");
-    IcebergSnapshotsRequestBody base = RequestConstants.TEST_ICEBERG_SNAPSHOTS_REQUEST_BODY;
-    IcebergSnapshotsRequestBody requestBody =
-        IcebergSnapshotsRequestBody.builder()
-            .baseTableVersion(base.getBaseTableVersion())
-            .jsonSnapshots(base.getJsonSnapshots())
-            .snapshotRefs(base.getSnapshotRefs())
-            .createUpdateTableRequestBody(
-                base.getCreateUpdateTableRequestBody()
-                    .toBuilder()
-                    .tableProperties(requestProperties)
-                    .build())
-            .build();
-    mvc.perform(
-        MockMvcRequestBuilders.put(
-                String.format(
-                    CURRENT_MAJOR_VERSION_PREFIX
-                        + "/databases/d200/tables/tb1/iceberg/v2/snapshots"))
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(requestBody.toJson()));
-    Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
-    TableAuditEvent actualEvent = argCaptor.getValue();
-    assertEquals(
-        Collections.singletonMap("openhouse.watermark", "100"), actualEvent.getTableProperties());
   }
 
   @Test

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
@@ -25,12 +25,18 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @ContextConfiguration
+@TestPropertySource(
+    properties = {
+      "cluster.iceberg.tables.audit.table-properties-allowlist[0]=openhouse.watermark",
+      "cluster.iceberg.tables.audit.table-properties-allowlist[1]=openhouse.tableType"
+    })
 @WithMockUser(username = "testUser")
 public class IcebergSnapshotsApiHandlerAuditTest {
   @Autowired private MockMvc mvc;
@@ -185,11 +191,11 @@ public class IcebergSnapshotsApiHandlerAuditTest {
   }
 
   @Test
-  public void testPutIcebergSnapshotsCarriesTableProperties() throws Exception {
-    Map<String, String> properties = new HashMap<>();
-    properties.put("openhouse.watermark", "100");
-    properties.put("openhouse.tableType", "PRIMARY_TABLE");
-    properties.put("user.custom.key", "v");
+  public void testPutIcebergSnapshotsFiltersTablePropertiesToAllowlist() throws Exception {
+    Map<String, String> requestProperties = new HashMap<>();
+    requestProperties.put("openhouse.watermark", "100");
+    requestProperties.put("openhouse.tableType", "PRIMARY_TABLE");
+    requestProperties.put("user.custom.key", "v");
     IcebergSnapshotsRequestBody base = RequestConstants.TEST_ICEBERG_SNAPSHOTS_REQUEST_BODY;
     IcebergSnapshotsRequestBody requestBody =
         IcebergSnapshotsRequestBody.builder()
@@ -199,7 +205,7 @@ public class IcebergSnapshotsApiHandlerAuditTest {
             .createUpdateTableRequestBody(
                 base.getCreateUpdateTableRequestBody()
                     .toBuilder()
-                    .tableProperties(properties)
+                    .tableProperties(requestProperties)
                     .build())
             .build();
     mvc.perform(
@@ -212,7 +218,10 @@ public class IcebergSnapshotsApiHandlerAuditTest {
             .content(requestBody.toJson()));
     Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
     TableAuditEvent actualEvent = argCaptor.getValue();
-    assertEquals(properties, actualEvent.getTableProperties());
+    Map<String, String> expected = new HashMap<>();
+    expected.put("openhouse.watermark", "100");
+    expected.put("openhouse.tableType", "PRIMARY_TABLE");
+    assertEquals(expected, actualEvent.getTableProperties());
   }
 
   @Test


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

Surface a snapshot of Iceberg table properties on the per-commit TableAuditEvent.

Emission is gated by allowlist:

  | Config | Default | Purpose |
  |---|---|---|
  | `cluster.iceberg.tables.audit.table-properties-allowlist` | `[]` | Which keys are appropriate to audit. [] = nothing emitted. |
  | `cluster.iceberg.tables.audit.table-property-value-max-size` | `256KB` | Per-value byte cap; oversized values skipped. |
  | `cluster.iceberg.tables.audit.table-properties-total-max-size` | `512KB` | Combined byte cap; properties skipped once total would exceed. |

## Changes

- [x] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

./gradlew :services:tables:test --tests IcebergSnapshotsApiHandlerAuditTest

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
