### PR TITLE
Fix multi-schema replication intermediates dropped on snapshots-endpoint commits

### DIFF
--- a/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
@@ -1,11 +1,14 @@
 package com.linkedin.openhouse.javaclient;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 import com.linkedin.openhouse.gen.tables.client.api.SnapshotApi;
 import com.linkedin.openhouse.gen.tables.client.api.TableApi;
 import com.linkedin.openhouse.gen.tables.client.model.CreateUpdateTableRequestBody;
 import com.linkedin.openhouse.gen.tables.client.model.History;
+import com.linkedin.openhouse.gen.tables.client.model.IcebergSnapshotsRequestBody;
 import com.linkedin.openhouse.gen.tables.client.model.Policies;
 import com.linkedin.openhouse.gen.tables.client.model.PolicyTag;
 import com.linkedin.openhouse.gen.tables.client.model.Retention;
@@ -32,6 +35,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 public class OpenHouseTableOperationsTest {
 
@@ -456,6 +460,116 @@ public class OpenHouseTableOperationsTest {
     Assertions.assertEquals(
         History.GranularityEnum.DAY, updatedPolicies.getHistory().getGranularity());
     Assertions.assertEquals(2, updatedPolicies.getHistory().getVersions());
+  }
+
+  /**
+   * Replication commits from cross-cluster can update both metadata (schema, properties) and
+   * snapshots in one commit. They must not be routed through the RTAS replace path because the
+   * server's replace branch treats the commit as a fresh table creation and does not preserve the
+   * multi-schema-delta intermediate-schemas plumbing. This test pins the dispatch fix that sends
+   * REPLICA_TABLE commits through {@code putSnapshots} (regular update) instead of {@code
+   * putSnapshotsForReplace} (RTAS).
+   */
+  @Test
+  public void testDoCommitRoutesReplicaTableThroughPutSnapshotsNotReplace() {
+    TableIdentifier id = TableIdentifier.of("a", "b");
+    FileIO mockFileIO = mock(FileIO.class);
+    TableApi mockTableApi = mock(TableApi.class);
+    SnapshotApi mockSnapshotApi = mock(SnapshotApi.class);
+    OpenHouseTableOperationsForTest openHouseTableOperations =
+        new OpenHouseTableOperationsForTest(
+            id, mockFileIO, mockTableApi, mockSnapshotApi, "cluster");
+
+    TableMetadata metadata = mock(TableMetadata.class);
+    TableMetadata base = mock(TableMetadata.class);
+
+    // schemas differ → isMetadataUpdated == true
+    when(metadata.schema()).thenReturn(mock(Schema.class));
+    when(base.schema()).thenReturn(mock(Schema.class));
+
+    // base = REPLICA_TABLE on dest cluster; metadata = PRIMARY_TABLE on src cluster (cross-cluster
+    // replication). This is what getTableType uses to detect a REPLICA commit.
+    Map<String, String> baseProps =
+        ImmutableMap.of(
+            "openhouse.tableType", "REPLICA_TABLE",
+            "openhouse.clusterId", "dest-cluster");
+    Map<String, String> metaProps =
+        ImmutableMap.of(
+            "openhouse.tableType", "PRIMARY_TABLE",
+            "openhouse.clusterId", "src-cluster");
+    when(base.properties()).thenReturn(baseProps);
+    when(metadata.properties()).thenReturn(metaProps);
+
+    // snapshots differ → areSnapshotsUpdated == true (so dispatch sees BOTH updated)
+    when(base.snapshots()).thenReturn(Collections.emptyList());
+    when(metadata.snapshots()).thenReturn(Collections.singletonList(mock(Snapshot.class)));
+    when(base.refs()).thenReturn(Collections.emptyMap());
+    when(metadata.refs()).thenReturn(Collections.emptyMap());
+
+    when(mockSnapshotApi.putSnapshotsV1(anyString(), anyString(), any())).thenReturn(Mono.empty());
+
+    openHouseTableOperations.doCommit(base, metadata);
+
+    ArgumentCaptor<IcebergSnapshotsRequestBody> bodyCaptor =
+        ArgumentCaptor.forClass(IcebergSnapshotsRequestBody.class);
+    verify(mockSnapshotApi).putSnapshotsV1(anyString(), anyString(), bodyCaptor.capture());
+    // putSnapshots (regular) sets replaceCommit=null/false; putSnapshotsForReplace would set true.
+    // Pre-fix, this dispatched to putSnapshotsForReplace and the server's replace branch lost the
+    // newIntermediateSchemas; the assertion below fails on the unfixed version.
+    Boolean replaceCommit =
+        bodyCaptor.getValue().getCreateUpdateTableRequestBody().getReplaceCommit();
+    Assertions.assertTrue(
+        replaceCommit == null || !replaceCommit,
+        "REPLICA_TABLE commits must route through putSnapshots, not putSnapshotsForReplace");
+  }
+
+  /**
+   * Companion to {@link #testDoCommitRoutesReplicaTableThroughPutSnapshotsNotReplace} — when the
+   * commit is NOT a replication commit (e.g. genuine RTAS where metadata.tableType is PRIMARY_TABLE
+   * and clusters match), the dispatch should still go through {@code putSnapshotsForReplace}. This
+   * pins the original behavior is preserved for actual RTAS use cases.
+   */
+  @Test
+  public void testDoCommitRoutesPrimaryRtasThroughPutSnapshotsForReplace() {
+    TableIdentifier id = TableIdentifier.of("a", "b");
+    FileIO mockFileIO = mock(FileIO.class);
+    TableApi mockTableApi = mock(TableApi.class);
+    SnapshotApi mockSnapshotApi = mock(SnapshotApi.class);
+    OpenHouseTableOperationsForTest openHouseTableOperations =
+        new OpenHouseTableOperationsForTest(
+            id, mockFileIO, mockTableApi, mockSnapshotApi, "cluster");
+
+    TableMetadata metadata = mock(TableMetadata.class);
+    TableMetadata base = mock(TableMetadata.class);
+
+    when(metadata.schema()).thenReturn(mock(Schema.class));
+    when(base.schema()).thenReturn(mock(Schema.class));
+
+    // RTAS: both base and metadata are PRIMARY_TABLE on the same cluster.
+    Map<String, String> sameClusterPrimary =
+        ImmutableMap.of(
+            "openhouse.tableType", "PRIMARY_TABLE",
+            "openhouse.clusterId", "cluster");
+    when(base.properties()).thenReturn(sameClusterPrimary);
+    when(metadata.properties()).thenReturn(sameClusterPrimary);
+
+    when(base.snapshots()).thenReturn(Collections.emptyList());
+    when(metadata.snapshots()).thenReturn(Collections.singletonList(mock(Snapshot.class)));
+    when(base.refs()).thenReturn(Collections.emptyMap());
+    when(metadata.refs()).thenReturn(Collections.emptyMap());
+
+    when(mockSnapshotApi.putSnapshotsV1(anyString(), anyString(), any())).thenReturn(Mono.empty());
+
+    openHouseTableOperations.doCommit(base, metadata);
+
+    ArgumentCaptor<IcebergSnapshotsRequestBody> bodyCaptor =
+        ArgumentCaptor.forClass(IcebergSnapshotsRequestBody.class);
+    verify(mockSnapshotApi).putSnapshotsV1(anyString(), anyString(), bodyCaptor.capture());
+    Boolean replaceCommit =
+        bodyCaptor.getValue().getCreateUpdateTableRequestBody().getReplaceCommit();
+    Assertions.assertTrue(
+        Boolean.TRUE.equals(replaceCommit),
+        "Genuine RTAS commit on a PRIMARY table must still route through putSnapshotsForReplace");
   }
 
   @Test

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -111,7 +111,15 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
     boolean metadataUpdated = isMetadataUpdated(base, metadata);
     boolean snapshotsUpdated = areSnapshotsUpdated(base, metadata);
     try {
-      if (metadataUpdated && snapshotsUpdated && base != null) {
+      // REPLICA_TABLE commits from cross-cluster replication can update both
+      // metadata (schema, properties) and snapshots in one commit. They must go through the
+      // regular putSnapshots path so the server's update branch can apply newIntermediateSchemas;
+      // the replace path treats the commit as a fresh table creation and does not preserve
+      // multi-schema delta semantics. Reserve putSnapshotsForReplace for genuine CTAS/RTAS, where
+      // the metadata being committed is PRIMARY (not a REPLICA_TABLE update).
+      boolean isReplicaCommit =
+          getTableType(base, metadata) == CreateUpdateTableRequestBody.TableTypeEnum.REPLICA_TABLE;
+      if (metadataUpdated && snapshotsUpdated && base != null && !isReplicaCommit) {
         // Only CTAS and RTAS can update both metadata and snapshots at the same time.
         // When the table exists, it will be a replace commit operation.
         putSnapshotsForReplace(base, metadata);
@@ -217,30 +225,36 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
 
   /**
    * If request is coming from replication process, createUpdateTableRequestBody.tableType should be
-   * REPLICA_TABLE Replication process requests are identified based on difference between table
-   * types and cluster_id between base, metadata
+   * REPLICA_TABLE. Replication process requests are identified based on difference between table
+   * types and cluster_id between base, metadata. Returns {@code null} when either side lacks the
+   * {@code openhouse.tableType} property — this matters for {@link #doCommit}'s dispatch which may
+   * be invoked very early (e.g. by replace transactions) before properties are populated.
    */
   @VisibleForTesting
   CreateUpdateTableRequestBody.TableTypeEnum getTableType(
       TableMetadata base, TableMetadata metadata) {
+    String metaTypeStr = metadata.properties().get(OPENHOUSE_TABLE_TYPE_KEY);
     if (base != null) {
-      CreateUpdateTableRequestBody.TableTypeEnum baseTableType =
-          CreateUpdateTableRequestBody.TableTypeEnum.valueOf(
-              base.properties().get(OPENHOUSE_TABLE_TYPE_KEY));
-      CreateUpdateTableRequestBody.TableTypeEnum metadataTableType =
-          CreateUpdateTableRequestBody.TableTypeEnum.valueOf(
-              metadata.properties().get(OPENHOUSE_TABLE_TYPE_KEY));
-      // check if commit request is from replication case
-      if (baseTableType == CreateUpdateTableRequestBody.TableTypeEnum.REPLICA_TABLE
-          && metadataTableType == CreateUpdateTableRequestBody.TableTypeEnum.PRIMARY_TABLE
-          && !base.properties()
-              .get(OPENHOUSE_CLUSTER_ID_KEY)
-              .equals(metadata.properties().get(OPENHOUSE_CLUSTER_ID_KEY))) {
-        return baseTableType;
+      String baseTypeStr = base.properties().get(OPENHOUSE_TABLE_TYPE_KEY);
+      if (baseTypeStr != null && metaTypeStr != null) {
+        CreateUpdateTableRequestBody.TableTypeEnum baseTableType =
+            CreateUpdateTableRequestBody.TableTypeEnum.valueOf(baseTypeStr);
+        CreateUpdateTableRequestBody.TableTypeEnum metadataTableType =
+            CreateUpdateTableRequestBody.TableTypeEnum.valueOf(metaTypeStr);
+        String baseCluster = base.properties().get(OPENHOUSE_CLUSTER_ID_KEY);
+        String metaCluster = metadata.properties().get(OPENHOUSE_CLUSTER_ID_KEY);
+        // check if commit request is from replication case
+        if (baseTableType == CreateUpdateTableRequestBody.TableTypeEnum.REPLICA_TABLE
+            && metadataTableType == CreateUpdateTableRequestBody.TableTypeEnum.PRIMARY_TABLE
+            && baseCluster != null
+            && !baseCluster.equals(metaCluster)) {
+          return baseTableType;
+        }
       }
     }
-    return CreateUpdateTableRequestBody.TableTypeEnum.valueOf(
-        metadata.properties().get(OPENHOUSE_TABLE_TYPE_KEY));
+    return metaTypeStr != null
+        ? CreateUpdateTableRequestBody.TableTypeEnum.valueOf(metaTypeStr)
+        : null;
   }
 
   @VisibleForTesting

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -119,12 +119,15 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
       // the metadata being committed is PRIMARY (not a REPLICA_TABLE update).
       boolean isReplicaCommit =
           getTableType(base, metadata) == CreateUpdateTableRequestBody.TableTypeEnum.REPLICA_TABLE;
-      if (metadataUpdated && snapshotsUpdated && base != null && !isReplicaCommit) {
+      if (isReplicaCommit) {
+        if (snapshotsUpdated) {
+          putSnapshots(base, metadata);
+        } else if (metadataUpdated) {
+          createUpdateTable(base, metadata);
+        }
+      } else if (metadataUpdated && snapshotsUpdated && base != null) {
         // Among PRIMARY-table commits, only CTAS and RTAS update both metadata and snapshots at
-        // the same time; when the table already exists this is an RTAS (replace) commit. REPLICA
-        // commits also touch both, but are excluded above via isReplicaCommit and handled by the
-        // regular putSnapshots path so the server preserves newIntermediateSchemas — the replace
-        // path would treat them as a fresh creation and drop the multi-schema deltas.
+        // the same time; when the table already exists this is an RTAS (replace) commit.
         putSnapshotsForReplace(base, metadata);
       } else if (snapshotsUpdated) {
         putSnapshots(base, metadata);

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -120,8 +120,11 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
       boolean isReplicaCommit =
           getTableType(base, metadata) == CreateUpdateTableRequestBody.TableTypeEnum.REPLICA_TABLE;
       if (metadataUpdated && snapshotsUpdated && base != null && !isReplicaCommit) {
-        // Only CTAS and RTAS can update both metadata and snapshots at the same time.
-        // When the table exists, it will be a replace commit operation.
+        // Among PRIMARY-table commits, only CTAS and RTAS update both metadata and snapshots at
+        // the same time; when the table already exists this is an RTAS (replace) commit. REPLICA
+        // commits also touch both, but are excluded above via isReplicaCommit and handled by the
+        // regular putSnapshots path so the server preserves newIntermediateSchemas — the replace
+        // path would treat them as a fresh creation and drop the multi-schema deltas.
         putSnapshotsForReplace(base, metadata);
       } else if (snapshotsUpdated) {
         putSnapshots(base, metadata);
@@ -225,10 +228,13 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
 
   /**
    * If request is coming from replication process, createUpdateTableRequestBody.tableType should be
-   * REPLICA_TABLE. Replication process requests are identified based on difference between table
-   * types and cluster_id between base, metadata. Returns {@code null} when either side lacks the
-   * {@code openhouse.tableType} property — this matters for {@link #doCommit}'s dispatch which may
-   * be invoked very early (e.g. by replace transactions) before properties are populated.
+   * REPLICA_TABLE Replication process requests are identified based on difference between table
+   * types and cluster_id between base, metadata.
+   *
+   * <p>Returns {@code null} when the {@code openhouse.tableType} property is absent. Legacy tables
+   * created before the property existed don't carry it (the server back-fills them to PRIMARY_TABLE
+   * on write — see OpenHouseInternalRepositoryImpl#checkIfTableTypeAdded), so callers must tolerate
+   * a null result rather than assuming the property is always present.
    */
   @VisibleForTesting
   CreateUpdateTableRequestBody.TableTypeEnum getTableType(

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/TablesMapper.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/TablesMapper.java
@@ -95,6 +95,9 @@ public interface TablesMapper {
         target = "tableVersion"), /* store base version to check later */
     @Mapping(source = "requestBody.createUpdateTableRequestBody.schema", target = "schema"),
     @Mapping(
+        source = "requestBody.createUpdateTableRequestBody.newIntermediateSchemas",
+        target = "newIntermediateSchemas"),
+    @Mapping(
         source = "requestBody.createUpdateTableRequestBody.tableProperties",
         target = "tableProperties"),
     @Mapping(

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/mapper/TablesMapperTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/mapper/TablesMapperTest.java
@@ -11,7 +11,9 @@ import com.linkedin.openhouse.tables.dto.mapper.TablesMapper;
 import com.linkedin.openhouse.tables.model.TableDto;
 import com.linkedin.openhouse.tables.model.TableDtoPrimaryKey;
 import com.linkedin.openhouse.tables.model.TableModelConstants;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Assertions;
@@ -219,5 +221,38 @@ public class TablesMapperTest {
     TableDtoPrimaryKey tableDtoPrimaryKey = tablesMapper.toTableDtoPrimaryKey(tableIdentifier);
     Assertions.assertEquals("d1", tableDtoPrimaryKey.getDatabaseId());
     Assertions.assertEquals("t1", tableDtoPrimaryKey.getTableId());
+  }
+
+  /**
+   * Pins that the snapshots-endpoint mapping carries {@code
+   * createUpdateTableRequestBody.newIntermediateSchemas} into {@code
+   * tableDto.newIntermediateSchemas}. Without it, multi-schema replication commits through {@code
+   * /iceberg/v2/snapshots} silently drop intermediates and the dest replica's snapshot.schema-id
+   * ends up outside {@code schemas[]}.
+   */
+  @Test
+  public void testToTableDtoWithPutSnapshotsPreservesNewIntermediateSchemas() {
+    List<String> intermediateSchemas =
+        Arrays.asList(
+            "{\"type\":\"struct\",\"schema-id\":1,\"fields\":["
+                + "{\"id\":1,\"name\":\"a\",\"required\":false,\"type\":\"string\"}]}",
+            "{\"type\":\"struct\",\"schema-id\":2,\"fields\":["
+                + "{\"id\":1,\"name\":\"a\",\"required\":false,\"type\":\"string\"},"
+                + "{\"id\":2,\"name\":\"b\",\"required\":false,\"type\":\"int\"}]}");
+    CreateUpdateTableRequestBody createUpdateRequestBody =
+        CREATE_TABLE_REQUEST_BODY_WITHIN_SNAPSHOTS_REQUEST
+            .toBuilder()
+            .newIntermediateSchemas(intermediateSchemas)
+            .build();
+    IcebergSnapshotsRequestBody icebergSnapshotsRequestBody =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion("v1")
+            .createUpdateTableRequestBody(createUpdateRequestBody)
+            .jsonSnapshots(Collections.singletonList("dummy"))
+            .build();
+
+    TableDto tableDto = tablesMapper.toTableDto(TABLE_DTO, icebergSnapshotsRequestBody);
+
+    Assertions.assertEquals(intermediateSchemas, tableDto.getNewIntermediateSchemas());
   }
 }


### PR DESCRIPTION
## Summary
Replication commits arriving through PUT /iceberg/v2/snapshots with multi-schema-jump intermediate schemas were silently losing them due to two issues that combine to leave the dest replica with a snapshot whose schema-id points at a schema not present in schemas[]. Trino strictly resolves snapshot schema-id against schemas[] and fails with "Cannot find schema with schema id N"; Spark falls back to current-schema-id and reads succeed.

Two fixes:

1. TablesMapper#toTableDto(TableDto, IcebergSnapshotsRequestBody) was missing the @Mapping for newIntermediateSchemas. The CreateUpdateTableRequestBody overload had it (added in #407), but the IcebergSnapshotsRequestBody overload used for the snapshots endpoint did not — so intermediates packed correctly by the client got dropped at the server-side DTO mapping step.

2. OpenHouseTableOperations#doCommit (after #524 introduced putSnapshotsForReplace) was routing cross-cluster REPLICA_TABLE replication commits through the RTAS replace path because they update both metadata and snapshots in one commit. The server's REPLACE branch treats the commit as a fresh table creation and uses CLIENT_TABLE_SCHEMA (bootstrap-era schema) as the final schema, not the request's actual target. This produces a different but related corruption pattern. Detect REPLICA commits (base REPLICA_TABLE + metadata PRIMARY_TABLE + different cluster IDs) and route them through the regular putSnapshots path so the intermediate-schemas plumbing fires.

Both fixes are needed in tandem: without (1), even the regular update branch drops intermediates; without (2), commits hitting the post-#524 client get routed around (1) entirely.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [X] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
