### PR TITLE
Integrate batched orphan files deletion with the existing schedule workflow

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -618,6 +618,40 @@ docker compose --profile with_jobs_scheduler run openhouse-jobs-scheduler - \
 > Try HTTP plugin in IntelliJ to trigger /jobs service local endpoint in local mode by running HTTP scripts in
 services/jobs/src/test/http/.
 
+### Test batched orphan file deletion through job-scheduler
+
+The batched OFD scheduler runs orphan-files-deletion across multiple tables in a single Spark job, bin-packed per database. Builds on top of the table you created in [Test through Spark-shell](#test-through-spark-shell).
+
+1. **Manufacture an orphan file** that's older than the default OFD TTL (7 days). From the spark-shell session:
+   ```scala
+   scala> val fs = org.apache.hadoop.fs.FileSystem.get(spark.sparkContext.hadoopConfiguration)
+   scala> val orphan = new org.apache.hadoop.fs.Path("/data/openhouse/db/tb/data/test_orphan.orc")
+   scala> fs.createNewFile(orphan)
+   scala> fs.setTimes(orphan, System.currentTimeMillis() - 8L*24L*3600L*1000L, -1)  // 8 days old
+   ```
+
+2. **Build and run the batched scheduler.**
+   ```
+   docker compose --profile with_jobs_scheduler build
+   docker compose --profile with_jobs_scheduler run openhouse-jobs-scheduler - \
+       --type ORPHAN_FILES_DELETION_BATCH --cluster local \
+       --tablesURL http://openhouse-tables:8080 --jobsURL http://openhouse-jobs:8080 \
+       --batchMaxItems 5 \
+       --tableMinAgeThresholdHours 0 --taskPollIntervalMs 5000
+   ```
+
+> [!NOTE]
+> The orphan file at `/data/openhouse/db/tb/data/test_orphan.orc` should be gone after the job completes. Check the scheduler logs for `Packed N eligible tables into M batches` and the Spark app logs for `OFD success: fqtn=db.tb orphansDetected=1`.
+
+> [!NOTE]
+> The scheduler groups tables by database before bin-packing — no batch ever crosses a database. `--batchMaxItems` caps tables per batch (default 25; the Spark app enforces a hard ceiling of `MAX_BATCH_SIZE=200`).
+
+> [!NOTE]
+> To list files under the table from the HDFS namenode container:
+> ```
+> docker exec -it local.namenode hdfs dfs -ls -R /data/openhouse/db/tb
+> ```
+
 ## FAQs
 
 ### Q. My docker setup fails to create LLB definition.

--- a/apps/spark-3.5/build.gradle
+++ b/apps/spark-3.5/build.gradle
@@ -30,6 +30,10 @@ dependencies {
     implementation(project(':libs:datalayout')) {
         exclude group: 'com.linkedin.iceberg', module: 'iceberg-spark-runtime-3.1_2.12'
     }
+    // Exclude log4j-slf4j2-impl: incompatible with the log4j-slf4j-impl (1.x) bridge this app ships.
+    implementation(project(':libs:optimizer:binpack')) {
+        exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j2-impl'
+    }
     implementation ('org.apache.spark:spark-core_2.12:' + sparkVersion) {
         exclude group: 'io.netty'
         exclude group: 'org.apache.hadoop', module: 'hadoop-common'

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
@@ -752,9 +752,15 @@ public class JobsScheduler {
           cmdLine.getOptionValue(OperationTasksBuilder.MAX_STRATEGIES_COUNT));
     }
     if (cmdLine.hasOption(OperationTasksBuilder.BATCH_MAX_ITEMS)) {
-      result.setProperty(
-          OperationTasksBuilder.BATCH_MAX_ITEMS,
-          cmdLine.getOptionValue(OperationTasksBuilder.BATCH_MAX_ITEMS));
+      String raw = cmdLine.getOptionValue(OperationTasksBuilder.BATCH_MAX_ITEMS);
+      int parsed = Integer.parseInt(raw);
+      if (parsed > AppConstants.OFD_MAX_BATCH_SIZE) {
+        throw new IllegalArgumentException(
+            String.format(
+                "--%s=%d exceeds Spark-app ceiling OFD_MAX_BATCH_SIZE=%d",
+                OperationTasksBuilder.BATCH_MAX_ITEMS, parsed, AppConstants.OFD_MAX_BATCH_SIZE));
+      }
+      result.setProperty(OperationTasksBuilder.BATCH_MAX_ITEMS, raw);
     }
     return result;
   }

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
@@ -587,6 +587,13 @@ public class JobsScheduler {
         Option.builder(null)
             .required(false)
             .hasArg()
+            .longOpt(OperationTasksBuilder.BATCH_MAX_ITEMS)
+            .desc("Max tables per batched OFD job (ORPHAN_FILES_DELETION_BATCH only)")
+            .build());
+    options.addOption(
+        Option.builder(null)
+            .required(false)
+            .hasArg()
             .longOpt("parallelMetadataFetchMode")
             .desc("Turn on/off parallel metadata fetch mode")
             .build());
@@ -743,6 +750,11 @@ public class JobsScheduler {
       result.setProperty(
           OperationTasksBuilder.MAX_STRATEGIES_COUNT,
           cmdLine.getOptionValue(OperationTasksBuilder.MAX_STRATEGIES_COUNT));
+    }
+    if (cmdLine.hasOption(OperationTasksBuilder.BATCH_MAX_ITEMS)) {
+      result.setProperty(
+          OperationTasksBuilder.BATCH_MAX_ITEMS,
+          cmdLine.getOptionValue(OperationTasksBuilder.BATCH_MAX_ITEMS));
     }
     return result;
   }

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/BatchedTableOrphanFilesDeletionTask.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/BatchedTableOrphanFilesDeletionTask.java
@@ -66,6 +66,9 @@ public class BatchedTableOrphanFilesDeletionTask extends OperationTask<TableMeta
 
   @Override
   protected boolean launchJob() {
+    // Job name format: <JOB_TYPE>_<dbName>_<tableCount>
+    // e.g. ORPHAN_FILES_DELETION_BATCH_warehouse_25 for a 25-table batch in the "warehouse" db.
+    // dbName is shared across all entries in the batch (the scheduler never crosses db boundaries).
     String jobName =
         String.format("%s_%s_%d", getType(), metadata.getDbName(), metadata.getTables().size());
     Map<String, String> executionProperties = Collections.emptyMap();

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/BatchedTableOrphanFilesDeletionTask.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/BatchedTableOrphanFilesDeletionTask.java
@@ -1,0 +1,79 @@
+package com.linkedin.openhouse.jobs.scheduler.tasks;
+
+import com.linkedin.openhouse.jobs.client.JobsClient;
+import com.linkedin.openhouse.jobs.client.TablesClient;
+import com.linkedin.openhouse.jobs.client.model.JobConf;
+import com.linkedin.openhouse.jobs.util.TableMetadata;
+import com.linkedin.openhouse.jobs.util.TableMetadataBatch;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A task to remove orphan files from a batch of tables in a single Spark job. Pairs with {@code
+ * com.linkedin.openhouse.jobs.spark.BatchedOrphanFilesDeletionSparkApp} via the {@link
+ * JobConf.JobTypeEnum#ORPHAN_FILES_DELETION_BATCH} JobType.
+ *
+ * <p>The legacy {@link com.linkedin.openhouse.jobs.scheduler.JobsScheduler} pre-dates the optimizer
+ * service, so this task omits the optimizer-only CLI flags ({@code --resultsEndpoint}, {@code
+ * --operationIds}, {@code --tableUuids}). The Spark app treats them as optional and falls back to
+ * HTS-only lifecycle tracking when they are absent.
+ *
+ * @see <a href="https://iceberg.apache.org/docs/latest/maintenance/#delete-orphan-files">Delete
+ *     orphan files</a>
+ */
+@Slf4j
+@Getter
+public class BatchedTableOrphanFilesDeletionTask extends OperationTask<TableMetadataBatch> {
+  public static final JobConf.JobTypeEnum OPERATION_TYPE =
+      JobConf.JobTypeEnum.ORPHAN_FILES_DELETION_BATCH;
+
+  public BatchedTableOrphanFilesDeletionTask(
+      JobsClient jobsClient,
+      TablesClient tablesClient,
+      TableMetadataBatch metadata,
+      long pollIntervalMs,
+      long queuedTimeoutMs,
+      long taskTimeoutMs) {
+    super(jobsClient, tablesClient, metadata, pollIntervalMs, queuedTimeoutMs, taskTimeoutMs);
+  }
+
+  public BatchedTableOrphanFilesDeletionTask(
+      JobsClient jobsClient, TablesClient tablesClient, TableMetadataBatch metadata) {
+    super(jobsClient, tablesClient, metadata);
+  }
+
+  @Override
+  public JobConf.JobTypeEnum getType() {
+    return OPERATION_TYPE;
+  }
+
+  @Override
+  protected List<String> getArgs() {
+    String tableNames =
+        metadata.getTables().stream().map(TableMetadata::fqtn).collect(Collectors.joining(","));
+    return Arrays.asList("--tableNames", tableNames);
+  }
+
+  @Override
+  protected boolean shouldRun() {
+    return !metadata.getTables().isEmpty();
+  }
+
+  @Override
+  protected boolean launchJob() {
+    String jobName =
+        String.format("%s_%s_%d", getType(), metadata.getDbName(), metadata.getTables().size());
+    Map<String, String> executionProperties = Collections.emptyMap();
+    String proxyUser = metadata.getTables().get(0).getCreator();
+    jobId =
+        jobsClient
+            .launch(jobName, getType(), proxyUser, executionProperties, getArgs())
+            .orElse(null);
+    return jobId != null;
+  }
+}

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
@@ -18,9 +18,10 @@ import com.linkedin.openhouse.jobs.util.Metadata;
 import com.linkedin.openhouse.jobs.util.TableDataLayoutMetadata;
 import com.linkedin.openhouse.jobs.util.TableMetadata;
 import com.linkedin.openhouse.jobs.util.TableMetadataBatch;
-import com.linkedin.openhouse.jobs.util.binpack.Bin;
-import com.linkedin.openhouse.jobs.util.binpack.BinItem;
-import com.linkedin.openhouse.jobs.util.binpack.FirstFitDecreasingBinPacker;
+import com.linkedin.openhouse.optimizer.binpack.BinItem;
+import com.linkedin.openhouse.optimizer.binpack.FirstFitDecreasingBinPacker;
+import com.linkedin.openhouse.optimizer.model.TableOperationDto;
+import com.linkedin.openhouse.optimizer.model.TableStatsDto;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import java.util.ArrayList;
@@ -102,13 +103,10 @@ public class OperationTasksBuilder {
         eligible.size(),
         maxItemsPerBin);
 
-    FirstFitDecreasingBinPacker packer =
-        FirstFitDecreasingBinPacker.builder()
-            .maxItemsPerBin(maxItemsPerBin)
-            // Item-count cap only; weight/size dimensions disabled until table_stats is wired in.
-            .maxWeightPerBin(0)
-            .maxSizeBytesPerBin(0)
-            .build();
+    // Item-count cap only; the libs default maxWeightPerBin (1_000_000) is effectively unbounded
+    // for weight=1 items, so item-count is the active constraint until table_stats is wired in.
+    FirstFitDecreasingBinPacker<BinItem> packer =
+        FirstFitDecreasingBinPacker.<BinItem>builder().maxItemsPerBin(maxItemsPerBin).build();
 
     Map<String, List<TableMetadata>> byDb =
         eligible.stream().collect(Collectors.groupingBy(TableMetadata::getDbName));
@@ -118,25 +116,15 @@ public class OperationTasksBuilder {
       String dbName = dbGroup.getKey();
       List<BinItem> items =
           dbGroup.getValue().stream()
-              .map(
-                  t ->
-                      BinItem.builder()
-                          .fqtn(t.fqtn())
-                          .operationId("")
-                          .tableUuid("")
-                          .databaseName(t.getDbName())
-                          .tableName(t.getTableName())
-                          .weight(1L)
-                          .sizeBytes(0L)
-                          .build())
+              .map(t -> (BinItem) new FqtnBinItem(t.fqtn()))
               .collect(Collectors.toList());
-      for (Bin bin : packer.pack(items)) {
+      for (List<BinItem> group : packer.pack(items)) {
         List<TableMetadata> tablesForBin =
-            bin.items().stream()
+            group.stream()
                 .map(
                     item ->
                         dbGroup.getValue().stream()
-                            .filter(t -> t.fqtn().equals(item.getFqtn()))
+                            .filter(t -> t.fqtn().equals(item.getFullyQualifiedTableName()))
                             .findFirst()
                             .orElseThrow(() -> new IllegalStateException("missing table for bin")))
                 .collect(Collectors.toList());
@@ -538,5 +526,38 @@ public class OperationTasksBuilder {
                   jobType);
             })
         .subscribe();
+  }
+
+  /**
+   * Minimal {@link BinItem} for the legacy scheduler path: every item has weight 1, so packing is
+   * driven purely by {@code maxItemsPerBin}. {@code fromOpAndStats} is unreachable here because we
+   * call {@code packer.pack(List<BinItem>)} (the pre-projected overload), not the projection path.
+   */
+  private static final class FqtnBinItem implements BinItem {
+    private final String fqtn;
+
+    FqtnBinItem(String fqtn) {
+      this.fqtn = fqtn;
+    }
+
+    @Override
+    public long getWeight() {
+      return 1L;
+    }
+
+    @Override
+    public String getFullyQualifiedTableName() {
+      return fqtn;
+    }
+
+    @Override
+    public String getOperationId() {
+      return "";
+    }
+
+    @Override
+    public BinItem fromOpAndStats(TableOperationDto op, TableStatsDto stats) {
+      return this;
+    }
   }
 }

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
@@ -26,7 +26,6 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
@@ -52,7 +51,14 @@ public class OperationTasksBuilder {
   private static final double COMPACTION_GAIN_WEIGHT_DEFAULT = 0.7;
   private static final double MAX_COST_BUDGET_GB_HRS_DEFAULT = 1000.0;
   private static final int MAX_STRATEGIES_COUNT_DEFAULT = 10;
-  private static final int BATCH_MAX_ITEMS_DEFAULT = 25;
+  /**
+   * Default value for the {@code --batchMaxItems} CLI option (operator-tunable). Not a hard limit:
+   * the Spark-app side enforces the actual ceiling via {@link
+   * BatchedOrphanFilesDeletionSparkApp#MAX_BATCH_SIZE}, and {@link
+   * #prepareBatchedOrphanFilesDeletionTaskList} rejects any operator-supplied value above it.
+   */
+  private static final int DEFAULT_BATCH_MAX_ITEMS = 25;
+
   private static final String METRICS_SCOPE = JobsScheduler.class.getName();
 
   private final OperationTaskFactory<? extends OperationTask<?>> taskFactory;
@@ -78,7 +84,7 @@ public class OperationTasksBuilder {
    * Builds one {@link BatchedTableOrphanFilesDeletionTask} per database-scoped bin. Groups eligible
    * tables by database (batches never cross databases), then applies the first-fit-decreasing bin
    * packer with a per-bin item cap from {@code properties} (defaults to {@value
-   * #BATCH_MAX_ITEMS_DEFAULT}). Tables with the maintenance op disabled are filtered out before
+   * #DEFAULT_BATCH_MAX_ITEMS}). Tables with the maintenance op disabled are filtered out before
    * grouping.
    */
   private List<OperationTask<?>> prepareBatchedOrphanFilesDeletionTaskList(
@@ -87,51 +93,47 @@ public class OperationTasksBuilder {
       OperationMode operationMode,
       OtelEmitter otelEmitter) {
     int maxItemsPerBin =
-        NumberUtils.toInt(properties.getProperty(BATCH_MAX_ITEMS), BATCH_MAX_ITEMS_DEFAULT);
+        NumberUtils.toInt(properties.getProperty(BATCH_MAX_ITEMS), DEFAULT_BATCH_MAX_ITEMS);
     if (maxItemsPerBin > BatchedOrphanFilesDeletionSparkApp.MAX_BATCH_SIZE) {
       throw new IllegalArgumentException(
           String.format(
               "--%s=%d exceeds Spark-app ceiling MAX_BATCH_SIZE=%d",
               BATCH_MAX_ITEMS, maxItemsPerBin, BatchedOrphanFilesDeletionSparkApp.MAX_BATCH_SIZE));
     }
-    List<TableMetadata> eligible =
-        tablesClient.getTableMetadataList().stream()
-            .filter(t -> !t.isMaintenanceJobDisabled(jobType))
-            .collect(Collectors.toList());
-    log.info(
-        "Fetched metadata for {} batched-OFD-eligible tables; binMaxItems={}",
-        eligible.size(),
-        maxItemsPerBin);
-
     // Item-count cap only; the libs default maxWeightPerBin (1_000_000) is effectively unbounded
     // for weight=1 items, so item-count is the active constraint until table_stats is wired in.
     FirstFitDecreasingBinPacker<BinItem> packer =
         FirstFitDecreasingBinPacker.<BinItem>builder().maxItemsPerBin(maxItemsPerBin).build();
 
-    Map<String, List<TableMetadata>> byDb =
-        eligible.stream().collect(Collectors.groupingBy(TableMetadata::getDbName));
-
-    List<TableMetadataBatch> batches = new ArrayList<>();
-    for (Map.Entry<String, List<TableMetadata>> dbGroup : byDb.entrySet()) {
-      String dbName = dbGroup.getKey();
-      List<BinItem> items =
-          dbGroup.getValue().stream()
-              .map(t -> (BinItem) new FqtnBinItem(t.fqtn()))
-              .collect(Collectors.toList());
-      for (List<BinItem> group : packer.pack(items)) {
-        List<TableMetadata> tablesForBin =
-            group.stream()
-                .map(
-                    item ->
-                        dbGroup.getValue().stream()
-                            .filter(t -> t.fqtn().equals(item.getFullyQualifiedTableName()))
-                            .findFirst()
-                            .orElseThrow(() -> new IllegalStateException("missing table for bin")))
-                .collect(Collectors.toList());
-        batches.add(TableMetadataBatch.builder().dbName(dbName).tables(tablesForBin).build());
-      }
-    }
-    log.info("Packed {} eligible tables into {} batches", eligible.size(), batches.size());
+    // Note: groupingBy materializes the full eligible-table list in driver memory and serializes
+    // the pipeline at that point — acceptable for the O(thousands) tables we expect, but worth
+    // revisiting if the bound grows.
+    List<TableMetadataBatch> batches =
+        tablesClient.getTableMetadataList().stream()
+            .filter(t -> !t.isMaintenanceJobDisabled(jobType))
+            .collect(Collectors.groupingBy(TableMetadata::getDbName))
+            .entrySet()
+            .stream()
+            .flatMap(
+                dbGroup -> {
+                  List<BinItem> items =
+                      dbGroup.getValue().stream()
+                          .map(t -> (BinItem) new TableMetadataBinItem(t))
+                          .collect(Collectors.toList());
+                  return packer.pack(items).stream()
+                      .map(
+                          group ->
+                              TableMetadataBatch.builder()
+                                  .dbName(dbGroup.getKey())
+                                  .tables(
+                                      group.stream()
+                                          .map(item -> ((TableMetadataBinItem) item).getMetadata())
+                                          .collect(Collectors.toList()))
+                                  .build());
+                })
+            .collect(Collectors.toList());
+    log.info(
+        "Packed eligible tables into {} batches; binMaxItems={}", batches.size(), maxItemsPerBin);
     return processMetadataList(batches, jobType, operationMode, otelEmitter);
   }
 
@@ -529,15 +531,17 @@ public class OperationTasksBuilder {
   }
 
   /**
-   * Minimal {@link BinItem} for the legacy scheduler path: every item has weight 1, so packing is
-   * driven purely by {@code maxItemsPerBin}. {@code fromOpAndStats} is unreachable here because we
-   * call {@code packer.pack(List<BinItem>)} (the pre-projected overload), not the projection path.
+   * Minimal {@link BinItem} for the legacy scheduler path. Carries the full {@link TableMetadata}
+   * so the caller can reconstruct each bin's table list directly from the packer's output without a
+   * fqtn → metadata lookup. Every item has weight 1, so packing is driven purely by {@code
+   * maxItemsPerBin}. {@code fromOpAndStats} is unreachable here because we call {@code
+   * packer.pack(List<BinItem>)} (the pre-projected overload), not the projection path.
    */
-  private static final class FqtnBinItem implements BinItem {
-    private final String fqtn;
+  private static final class TableMetadataBinItem implements BinItem {
+    @Getter private final TableMetadata metadata;
 
-    FqtnBinItem(String fqtn) {
-      this.fqtn = fqtn;
+    TableMetadataBinItem(TableMetadata metadata) {
+      this.metadata = metadata;
     }
 
     @Override
@@ -547,9 +551,13 @@ public class OperationTasksBuilder {
 
     @Override
     public String getFullyQualifiedTableName() {
-      return fqtn;
+      return metadata.fqtn();
     }
 
+    /**
+     * Legacy scheduler has no optimizer-side operation ID. The libs {@link BinItem} interface
+     * requires {@code String} (not {@code Optional}) so we return empty to satisfy the contract.
+     */
     @Override
     public String getOperationId() {
       return "";

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
@@ -9,7 +9,6 @@ import com.linkedin.openhouse.datalayout.ranker.SimpleWeightedSumDataLayoutStrat
 import com.linkedin.openhouse.jobs.client.TablesClient;
 import com.linkedin.openhouse.jobs.client.model.JobConf;
 import com.linkedin.openhouse.jobs.scheduler.JobsScheduler;
-import com.linkedin.openhouse.jobs.spark.BatchedOrphanFilesDeletionSparkApp;
 import com.linkedin.openhouse.jobs.util.AppConstants;
 import com.linkedin.openhouse.jobs.util.DataLayoutUtil;
 import com.linkedin.openhouse.jobs.util.DatabaseMetadata;
@@ -53,9 +52,8 @@ public class OperationTasksBuilder {
   private static final int MAX_STRATEGIES_COUNT_DEFAULT = 10;
   /**
    * Default value for the {@code --batchMaxItems} CLI option (operator-tunable). Not a hard limit:
-   * the Spark-app side enforces the actual ceiling via {@link
-   * BatchedOrphanFilesDeletionSparkApp#MAX_BATCH_SIZE}, and {@link
-   * #prepareBatchedOrphanFilesDeletionTaskList} rejects any operator-supplied value above it.
+   * the Spark-app side enforces the actual ceiling via {@link AppConstants#OFD_MAX_BATCH_SIZE}, and
+   * {@link JobsScheduler#getAdditionalProperties} rejects any operator-supplied value above it.
    */
   private static final int DEFAULT_BATCH_MAX_ITEMS = 25;
 
@@ -92,14 +90,10 @@ public class OperationTasksBuilder {
       Properties properties,
       OperationMode operationMode,
       OtelEmitter otelEmitter) {
+    // Bounds (maxItemsPerBin <= AppConstants.OFD_MAX_BATCH_SIZE) are enforced at the CLI parsing
+    // boundary in JobsScheduler.getAdditionalProperties; this method assumes validated input.
     int maxItemsPerBin =
         NumberUtils.toInt(properties.getProperty(BATCH_MAX_ITEMS), DEFAULT_BATCH_MAX_ITEMS);
-    if (maxItemsPerBin > BatchedOrphanFilesDeletionSparkApp.MAX_BATCH_SIZE) {
-      throw new IllegalArgumentException(
-          String.format(
-              "--%s=%d exceeds Spark-app ceiling MAX_BATCH_SIZE=%d",
-              BATCH_MAX_ITEMS, maxItemsPerBin, BatchedOrphanFilesDeletionSparkApp.MAX_BATCH_SIZE));
-    }
     // Item-count cap only; the libs default maxWeightPerBin (1_000_000) is effectively unbounded
     // for weight=1 items, so item-count is the active constraint until table_stats is wired in.
     FirstFitDecreasingBinPacker<BinItem> packer =
@@ -115,22 +109,22 @@ public class OperationTasksBuilder {
             .entrySet()
             .stream()
             .flatMap(
-                dbGroup -> {
-                  List<BinItem> items =
-                      dbGroup.getValue().stream()
-                          .map(t -> (BinItem) new TableMetadataBinItem(t))
-                          .collect(Collectors.toList());
-                  return packer.pack(items).stream()
-                      .map(
-                          group ->
-                              TableMetadataBatch.builder()
-                                  .dbName(dbGroup.getKey())
-                                  .tables(
-                                      group.stream()
-                                          .map(item -> ((TableMetadataBinItem) item).getMetadata())
-                                          .collect(Collectors.toList()))
-                                  .build());
-                })
+                dbGroup ->
+                    packer
+                        .pack(
+                            dbGroup.getValue().stream()
+                                .<BinItem>map(TableMetadataBinItem::new)
+                                .collect(Collectors.toList()))
+                        .stream()
+                        .map(
+                            group ->
+                                TableMetadataBatch.builder()
+                                    .dbName(dbGroup.getKey())
+                                    .tables(
+                                        group.stream()
+                                            .map(TableMetadataBinItem::extract)
+                                            .collect(Collectors.toList()))
+                                    .build()))
             .collect(Collectors.toList());
     log.info(
         "Packed eligible tables into {} batches; binMaxItems={}", batches.size(), maxItemsPerBin);
@@ -542,6 +536,15 @@ public class OperationTasksBuilder {
 
     TableMetadataBinItem(TableMetadata metadata) {
       this.metadata = metadata;
+    }
+
+    /**
+     * Named cast helper so call sites can use {@code TableMetadataBinItem::extract} as a method
+     * reference and the unchecked downcast lives in one place. Throws {@link ClassCastException} if
+     * a foreign {@link BinItem} ever leaks through — which would be a packer/caller bug.
+     */
+    static TableMetadata extract(BinItem item) {
+      return ((TableMetadataBinItem) item).metadata;
     }
 
     @Override

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
@@ -9,6 +9,7 @@ import com.linkedin.openhouse.datalayout.ranker.SimpleWeightedSumDataLayoutStrat
 import com.linkedin.openhouse.jobs.client.TablesClient;
 import com.linkedin.openhouse.jobs.client.model.JobConf;
 import com.linkedin.openhouse.jobs.scheduler.JobsScheduler;
+import com.linkedin.openhouse.jobs.spark.BatchedOrphanFilesDeletionSparkApp;
 import com.linkedin.openhouse.jobs.util.AppConstants;
 import com.linkedin.openhouse.jobs.util.DataLayoutUtil;
 import com.linkedin.openhouse.jobs.util.DatabaseMetadata;
@@ -16,10 +17,15 @@ import com.linkedin.openhouse.jobs.util.DirectoryMetadata;
 import com.linkedin.openhouse.jobs.util.Metadata;
 import com.linkedin.openhouse.jobs.util.TableDataLayoutMetadata;
 import com.linkedin.openhouse.jobs.util.TableMetadata;
+import com.linkedin.openhouse.jobs.util.TableMetadataBatch;
+import com.linkedin.openhouse.jobs.util.binpack.Bin;
+import com.linkedin.openhouse.jobs.util.binpack.BinItem;
+import com.linkedin.openhouse.jobs.util.binpack.FirstFitDecreasingBinPacker;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
@@ -40,10 +46,12 @@ import reactor.core.scheduler.Schedulers;
 public class OperationTasksBuilder {
   public static final String MAX_COST_BUDGET_GB_HRS = "maxCostBudgetGbHrs";
   public static final String MAX_STRATEGIES_COUNT = "maxStrategiesCount";
+  public static final String BATCH_MAX_ITEMS = "batchMaxItems";
   private static final double COMPUTE_COST_WEIGHT_DEFAULT = 0.3;
   private static final double COMPACTION_GAIN_WEIGHT_DEFAULT = 0.7;
   private static final double MAX_COST_BUDGET_GB_HRS_DEFAULT = 1000.0;
   private static final int MAX_STRATEGIES_COUNT_DEFAULT = 10;
+  private static final int BATCH_MAX_ITEMS_DEFAULT = 25;
   private static final String METRICS_SCOPE = JobsScheduler.class.getName();
 
   private final OperationTaskFactory<? extends OperationTask<?>> taskFactory;
@@ -63,6 +71,80 @@ public class OperationTasksBuilder {
     List<TableMetadata> tableMetadataList = tablesClient.getTableMetadataList();
     log.info("Fetched metadata for {} tables", tableMetadataList.size());
     return processMetadataList(tableMetadataList, jobType, operationMode, otelEmitter);
+  }
+
+  /**
+   * Builds one {@link BatchedTableOrphanFilesDeletionTask} per database-scoped bin. Groups eligible
+   * tables by database (batches never cross databases), then applies the first-fit-decreasing bin
+   * packer with a per-bin item cap from {@code properties} (defaults to {@value
+   * #BATCH_MAX_ITEMS_DEFAULT}). Tables with the maintenance op disabled are filtered out before
+   * grouping.
+   */
+  private List<OperationTask<?>> prepareBatchedOrphanFilesDeletionTaskList(
+      JobConf.JobTypeEnum jobType,
+      Properties properties,
+      OperationMode operationMode,
+      OtelEmitter otelEmitter) {
+    int maxItemsPerBin =
+        NumberUtils.toInt(properties.getProperty(BATCH_MAX_ITEMS), BATCH_MAX_ITEMS_DEFAULT);
+    if (maxItemsPerBin > BatchedOrphanFilesDeletionSparkApp.MAX_BATCH_SIZE) {
+      throw new IllegalArgumentException(
+          String.format(
+              "--%s=%d exceeds Spark-app ceiling MAX_BATCH_SIZE=%d",
+              BATCH_MAX_ITEMS, maxItemsPerBin, BatchedOrphanFilesDeletionSparkApp.MAX_BATCH_SIZE));
+    }
+    List<TableMetadata> eligible =
+        tablesClient.getTableMetadataList().stream()
+            .filter(t -> !t.isMaintenanceJobDisabled(jobType))
+            .collect(Collectors.toList());
+    log.info(
+        "Fetched metadata for {} batched-OFD-eligible tables; binMaxItems={}",
+        eligible.size(),
+        maxItemsPerBin);
+
+    FirstFitDecreasingBinPacker packer =
+        FirstFitDecreasingBinPacker.builder()
+            .maxItemsPerBin(maxItemsPerBin)
+            // Item-count cap only; weight/size dimensions disabled until table_stats is wired in.
+            .maxWeightPerBin(0)
+            .maxSizeBytesPerBin(0)
+            .build();
+
+    Map<String, List<TableMetadata>> byDb =
+        eligible.stream().collect(Collectors.groupingBy(TableMetadata::getDbName));
+
+    List<TableMetadataBatch> batches = new ArrayList<>();
+    for (Map.Entry<String, List<TableMetadata>> dbGroup : byDb.entrySet()) {
+      String dbName = dbGroup.getKey();
+      List<BinItem> items =
+          dbGroup.getValue().stream()
+              .map(
+                  t ->
+                      BinItem.builder()
+                          .fqtn(t.fqtn())
+                          .operationId("")
+                          .tableUuid("")
+                          .databaseName(t.getDbName())
+                          .tableName(t.getTableName())
+                          .weight(1L)
+                          .sizeBytes(0L)
+                          .build())
+              .collect(Collectors.toList());
+      for (Bin bin : packer.pack(items)) {
+        List<TableMetadata> tablesForBin =
+            bin.items().stream()
+                .map(
+                    item ->
+                        dbGroup.getValue().stream()
+                            .filter(t -> t.fqtn().equals(item.getFqtn()))
+                            .findFirst()
+                            .orElseThrow(() -> new IllegalStateException("missing table for bin")))
+                .collect(Collectors.toList());
+        batches.add(TableMetadataBatch.builder().dbName(dbName).tables(tablesForBin).build());
+      }
+    }
+    log.info("Packed {} eligible tables into {} batches", eligible.size(), batches.size());
+    return processMetadataList(batches, jobType, operationMode, otelEmitter);
   }
 
   private List<OperationTask<?>> prepareReplicationOperationTaskList(
@@ -272,6 +354,9 @@ public class OperationTasksBuilder {
       case DATA_LAYOUT_STRATEGY_GENERATION:
       case SORT_STATS_COLLECTION:
         return prepareTableOperationTaskList(jobType, operationMode, otelEmitter);
+      case ORPHAN_FILES_DELETION_BATCH:
+        return prepareBatchedOrphanFilesDeletionTaskList(
+            jobType, properties, operationMode, otelEmitter);
       case REPLICATION:
         return prepareReplicationOperationTaskList(jobType, operationMode, otelEmitter);
       case DATA_LAYOUT_STRATEGY_EXECUTION:
@@ -300,6 +385,22 @@ public class OperationTasksBuilder {
       buildDataLayoutOperationTaskListInParallel(jobType, properties, operationMode, otelEmitter);
     } else if (jobType == JobConf.JobTypeEnum.TABLE_DIRECTORY_DELETION) {
       buildDatabaseLevelOperationTasksInParallel(jobType, operationMode, otelEmitter);
+    } else if (jobType == JobConf.JobTypeEnum.ORPHAN_FILES_DELETION_BATCH) {
+      // Batched OFD needs the full table set in hand before it can group-by-db and bin-pack,
+      // so we use the synchronous fetch path then enqueue the tasks in bulk.
+      List<OperationTask<?>> tasks =
+          prepareBatchedOrphanFilesDeletionTaskList(
+              jobType, properties, operationMode, otelEmitter);
+      for (OperationTask<?> task : tasks) {
+        try {
+          operationTaskManager.addData(task);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          log.warn("Interrupted while enqueueing batched OFD task", e);
+        }
+      }
+      operationTaskManager.updateDataGenerationCompletion();
+      log.info("Enqueued {} batched OFD tasks for job type: {}", tasks.size(), jobType);
     } else {
       buildOperationTaskListInParallelInternal(jobType, operationMode, otelEmitter);
     }

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
@@ -113,7 +113,7 @@ public class OperationTasksBuilder {
                     packer
                         .pack(
                             dbGroup.getValue().stream()
-                                .<BinItem>map(TableMetadataBinItem::new)
+                                .map(TableMetadataBinItem::new)
                                 .collect(Collectors.toList()))
                         .stream()
                         .map(
@@ -122,7 +122,7 @@ public class OperationTasksBuilder {
                                     .dbName(dbGroup.getKey())
                                     .tables(
                                         group.stream()
-                                            .map(TableMetadataBinItem::extract)
+                                            .map(TableMetadataBinItem::getMetadata)
                                             .collect(Collectors.toList()))
                                     .build()))
             .collect(Collectors.toList());
@@ -536,15 +536,6 @@ public class OperationTasksBuilder {
 
     TableMetadataBinItem(TableMetadata metadata) {
       this.metadata = metadata;
-    }
-
-    /**
-     * Named cast helper so call sites can use {@code TableMetadataBinItem::extract} as a method
-     * reference and the unchecked downcast lives in one place. Throws {@link ClassCastException} if
-     * a foreign {@link BinItem} ever leaks through — which would be a packer/caller bug.
-     */
-    static TableMetadata extract(BinItem item) {
-      return ((TableMetadataBinItem) item).metadata;
     }
 
     @Override

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/BatchedOrphanFilesDeletionSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/BatchedOrphanFilesDeletionSparkApp.java
@@ -62,17 +62,6 @@ public class BatchedOrphanFilesDeletionSparkApp extends BaseSparkApp {
   private static final int DEFAULT_MAX_ORPHAN_FILE_SAMPLE_SIZE = 20000;
   private static final int DEFAULT_MIN_OFD_TTL_IN_DAYS = 3;
 
-  /**
-   * Hard ceiling on the number of tables a single batched job can carry. The wire path is parallel
-   * CSV CLI args (see {@link #buildEntries}); at ~120 chars per entry (36-char UUID × 3 lists) this
-   * gives ~24 KB on the command line, well under the typical Linux {@code ARG_MAX} of 128 KB but
-   * leaves headroom for the {@code spark-submit} envelope and JVM flags. The scheduler-driven path
-   * uses a smaller per-entry footprint but inherits the same cap for defense in depth. Operators
-   * tune the per-job batch size with {@code --batchMaxItems} (default {@code 25}); this constant is
-   * a footgun stop, not the operating point.
-   */
-  public static final int MAX_BATCH_SIZE = 200;
-
   private final List<BatchEntry> entries;
   private final String resultsEndpoint;
   private final int driverParallelism;
@@ -422,11 +411,11 @@ public class BatchedOrphanFilesDeletionSparkApp extends BaseSparkApp {
       throw new IllegalArgumentException("--tableNames is required and must be non-empty");
     }
     String[] tables = tableNames.split(",");
-    if (tables.length > MAX_BATCH_SIZE) {
+    if (tables.length > AppConstants.OFD_MAX_BATCH_SIZE) {
       throw new IllegalArgumentException(
           String.format(
-              "Batch size %d exceeds MAX_BATCH_SIZE=%d; reduce --batchMaxItems on the scheduler",
-              tables.length, MAX_BATCH_SIZE));
+              "Batch size %d exceeds OFD_MAX_BATCH_SIZE=%d; reduce --batchMaxItems on the scheduler",
+              tables.length, AppConstants.OFD_MAX_BATCH_SIZE));
     }
     String[] ops = StringUtils.isBlank(operationIds) ? null : operationIds.split(",");
     String[] uuids = StringUtils.isBlank(tableUuids) ? null : tableUuids.split(",");

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/BatchedOrphanFilesDeletionSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/BatchedOrphanFilesDeletionSparkApp.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -116,7 +117,7 @@ public class BatchedOrphanFilesDeletionSparkApp extends BaseSparkApp {
       return;
     }
 
-    OptimizerServiceClient client = newOptimizerClient();
+    Optional<OptimizerServiceClient> client = newOptimizerClient();
     int successCount = runBatch(ops, client);
 
     int failureCount = entries.size() - successCount;
@@ -132,7 +133,7 @@ public class BatchedOrphanFilesDeletionSparkApp extends BaseSparkApp {
     }
   }
 
-  private int runBatch(Operations ops, OptimizerServiceClient client) {
+  private int runBatch(Operations ops, Optional<OptimizerServiceClient> client) {
     ExecutorService pool = Executors.newFixedThreadPool(driverParallelism);
     try {
       // Two-phase pipeline: submit every worker first (so they run concurrently), then await each.
@@ -152,7 +153,8 @@ public class BatchedOrphanFilesDeletionSparkApp extends BaseSparkApp {
     }
   }
 
-  private int awaitOne(BatchEntry entry, Future<Boolean> future, OptimizerServiceClient client) {
+  private int awaitOne(
+      BatchEntry entry, Future<Boolean> future, Optional<OptimizerServiceClient> client) {
     try {
       return Boolean.TRUE.equals(future.get()) ? 1 : 0;
     } catch (InterruptedException e) {
@@ -190,38 +192,44 @@ public class BatchedOrphanFilesDeletionSparkApp extends BaseSparkApp {
   }
 
   /**
-   * Returns a client bound to {@link #resultsEndpoint}, or {@code null} when the endpoint was not
+   * Returns a client bound to {@link #resultsEndpoint}, or empty when the endpoint was not
    * configured — in that case the legacy {@link
    * com.linkedin.openhouse.jobs.scheduler.JobsScheduler} is the caller and reports lifecycle via
    * HTS; the per-operation optimizer callback is skipped.
    */
-  protected OptimizerServiceClient newOptimizerClient() {
-    return resultsEndpoint == null ? null : new OptimizerServiceClient(resultsEndpoint);
+  protected Optional<OptimizerServiceClient> newOptimizerClient() {
+    return Optional.ofNullable(resultsEndpoint).map(OptimizerServiceClient::new);
   }
 
   /**
-   * POST the per-operation outcome to the Optimizer Service via the generated client. The wrapper
-   * returns {@link java.util.Optional#empty()} when the call exhausts retries — we log + count and
-   * leave the operation row at SCHEDULED so the Analyzer's stale-timeout can re-queue it.
+   * POST the per-operation outcome to the Optimizer Service via the generated client. No-op when
+   * {@code client} is empty (the legacy scheduler-driven path; lifecycle is already tracked via
+   * HTS). When the call exhausts retries we log + count and leave the operation row at SCHEDULED so
+   * the Analyzer's stale-timeout can re-queue it.
    *
    * <p>{@code status} is passed in as a {@link UpdateOperationRequest.StatusEnum} rather than a
    * boolean so the caller's intent is unambiguous and new terminal states (e.g. CANCELED) can be
    * plumbed in without changing the signature.
    */
   private void reportResult(
-      BatchEntry entry, UpdateOperationRequest.StatusEnum status, OptimizerServiceClient client) {
+      BatchEntry entry,
+      UpdateOperationRequest.StatusEnum status,
+      Optional<OptimizerServiceClient> client) {
+    if (!client.isPresent()) {
+      return;
+    }
     UpdateOperationRequest body =
         new UpdateOperationRequest()
-            .operationId(entry.getOperationId())
+            .operationId(entry.getOperationId().orElse(null))
             .status(status)
-            .tableUuid(entry.getTableUuid())
+            .tableUuid(entry.getTableUuid().orElse(null))
             .databaseName(entry.getDatabaseName())
             .tableName(entry.getTableName())
             .operationType(UpdateOperationRequest.OperationTypeEnum.ORPHAN_FILES_DELETION);
-    if (!client.updateOperation(entry.getOperationId(), body).isPresent()) {
+    if (!client.get().updateOperation(entry.getOperationId().orElse(null), body).isPresent()) {
       log.error(
           "Failed to report operation result after retries; row will stay SCHEDULED until stale-timeout: operationId={} fqtn={}",
-          entry.getOperationId(),
+          entry.getOperationId().orElse(null),
           entry.getFqtn());
       otelEmitter.count(
           METRICS_SCOPE,
@@ -235,9 +243,9 @@ public class BatchedOrphanFilesDeletionSparkApp extends BaseSparkApp {
   private final class TableWorker implements Callable<Boolean> {
     private final Operations ops;
     private final BatchEntry entry;
-    private final OptimizerServiceClient client;
+    private final Optional<OptimizerServiceClient> client;
 
-    TableWorker(Operations ops, BatchEntry entry, OptimizerServiceClient client) {
+    TableWorker(Operations ops, BatchEntry entry, Optional<OptimizerServiceClient> client) {
       this.ops = ops;
       this.entry = entry;
       this.client = client;
@@ -248,7 +256,7 @@ public class BatchedOrphanFilesDeletionSparkApp extends BaseSparkApp {
       String fqtn = entry.getFqtn();
       UpdateOperationRequest.StatusEnum status = UpdateOperationRequest.StatusEnum.FAILED;
       try {
-        log.info("OFD start: fqtn={} operationId={}", fqtn, entry.getOperationId());
+        log.info("OFD start: fqtn={} operationId={}", fqtn, entry.getOperationId().orElse(""));
         Table table = ops.getTable(fqtn);
         long olderThanTimestampMillis =
             System.currentTimeMillis() - TimeUnit.SECONDS.toMillis(resolveTtlSeconds(table));
@@ -275,7 +283,7 @@ public class BatchedOrphanFilesDeletionSparkApp extends BaseSparkApp {
         status = UpdateOperationRequest.StatusEnum.SUCCESS;
         log.info("OFD success: fqtn={} orphansDetected={}", fqtn, orphanCount);
       } catch (Throwable t) {
-        log.error("OFD failed: fqtn={} operationId={}", fqtn, entry.getOperationId(), t);
+        log.error("OFD failed: fqtn={} operationId={}", fqtn, entry.getOperationId().orElse(""), t);
       } finally {
         // Defensive: reportResult must not throw out of the finally block, since that would mask
         // the original failure and propagate up to awaitOne, which would then report FAILED again.
@@ -333,17 +341,28 @@ public class BatchedOrphanFilesDeletionSparkApp extends BaseSparkApp {
     }
   }
 
-  /** Per-table inputs for one operation row inside a bin. */
+  /**
+   * Per-table inputs for one operation row inside a bin. {@code operationId} and {@code tableUuid}
+   * are exposed as {@link Optional} because the legacy scheduler path leaves them unset (no
+   * optimizer-service context); the optimizer-service path always populates them.
+   */
   @lombok.AllArgsConstructor
   @lombok.Builder
-  @lombok.Getter
   @lombok.ToString
   public static class BatchEntry {
-    private final String fqtn;
+    @lombok.Getter private final String fqtn;
     private final String operationId;
     private final String tableUuid;
-    private final String databaseName;
-    private final String tableName;
+    @lombok.Getter private final String databaseName;
+    @lombok.Getter private final String tableName;
+
+    public Optional<String> getOperationId() {
+      return Optional.ofNullable(operationId);
+    }
+
+    public Optional<String> getTableUuid() {
+      return Optional.ofNullable(tableUuid);
+    }
   }
 
   public static void main(String[] args) {

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/BatchedOrphanFilesDeletionSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/BatchedOrphanFilesDeletionSparkApp.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
@@ -427,8 +428,8 @@ public class BatchedOrphanFilesDeletionSparkApp extends BaseSparkApp {
               "Batch size %d exceeds MAX_BATCH_SIZE=%d; reduce --batchMaxItems on the scheduler",
               tables.length, MAX_BATCH_SIZE));
     }
-    String[] ops = isBlank(operationIds) ? null : operationIds.split(",");
-    String[] uuids = isBlank(tableUuids) ? null : tableUuids.split(",");
+    String[] ops = StringUtils.isBlank(operationIds) ? null : operationIds.split(",");
+    String[] uuids = StringUtils.isBlank(tableUuids) ? null : tableUuids.split(",");
     if (ops != null && ops.length != tables.length) {
       throw new IllegalArgumentException(
           String.format(
@@ -459,10 +460,6 @@ public class BatchedOrphanFilesDeletionSparkApp extends BaseSparkApp {
               .build());
     }
     return entries;
-  }
-
-  private static boolean isBlank(String s) {
-    return s == null || s.isEmpty();
   }
 
   private static String requireOption(CommandLine cmdLine, String name) {

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/BatchedOrphanFilesDeletionSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/BatchedOrphanFilesDeletionSparkApp.java
@@ -57,9 +57,6 @@ import org.apache.iceberg.actions.DeleteOrphanFiles;
 @Slf4j
 public class BatchedOrphanFilesDeletionSparkApp extends BaseSparkApp {
 
-  private static final String OPERATION_TYPE = "ORPHAN_FILES_DELETION";
-  private static final String STATUS_SUCCESS = "SUCCESS";
-  private static final String STATUS_FAILED = "FAILED";
   private static final int DEFAULT_MAX_ORPHAN_FILE_SAMPLE_SIZE = 20000;
   private static final int DEFAULT_MIN_OFD_TTL_IN_DAYS = 3;
 

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/BatchedOrphanFilesDeletionSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/BatchedOrphanFilesDeletionSparkApp.java
@@ -57,8 +57,22 @@ import org.apache.iceberg.actions.DeleteOrphanFiles;
 @Slf4j
 public class BatchedOrphanFilesDeletionSparkApp extends BaseSparkApp {
 
+  private static final String OPERATION_TYPE = "ORPHAN_FILES_DELETION";
+  private static final String STATUS_SUCCESS = "SUCCESS";
+  private static final String STATUS_FAILED = "FAILED";
   private static final int DEFAULT_MAX_ORPHAN_FILE_SAMPLE_SIZE = 20000;
   private static final int DEFAULT_MIN_OFD_TTL_IN_DAYS = 3;
+
+  /**
+   * Hard ceiling on the number of tables a single batched job can carry. The wire path is parallel
+   * CSV CLI args (see {@link #buildEntries}); at ~120 chars per entry (36-char UUID × 3 lists) this
+   * gives ~24 KB on the command line, well under the typical Linux {@code ARG_MAX} of 128 KB but
+   * leaves headroom for the {@code spark-submit} envelope and JVM flags. The scheduler-driven path
+   * uses a smaller per-entry footprint but inherits the same cap for defense in depth. Operators
+   * tune the per-job batch size with {@code --batchMaxItems} (default {@code 25}); this constant is
+   * a footgun stop, not the operating point.
+   */
+  public static final int MAX_BATCH_SIZE = 200;
 
   private final List<BatchEntry> entries;
   private final String resultsEndpoint;
@@ -178,8 +192,14 @@ public class BatchedOrphanFilesDeletionSparkApp extends BaseSparkApp {
     }
   }
 
+  /**
+   * Returns a client bound to {@link #resultsEndpoint}, or {@code null} when the endpoint was not
+   * configured — in that case the legacy {@link
+   * com.linkedin.openhouse.jobs.scheduler.JobsScheduler} is the caller and reports lifecycle via
+   * HTS; the per-operation optimizer callback is skipped.
+   */
   protected OptimizerServiceClient newOptimizerClient() {
-    return new OptimizerServiceClient(resultsEndpoint);
+    return resultsEndpoint == null ? null : new OptimizerServiceClient(resultsEndpoint);
   }
 
   /**
@@ -381,23 +401,29 @@ public class BatchedOrphanFilesDeletionSparkApp extends BaseSparkApp {
   }
 
   static List<BatchEntry> buildEntries(String tableNames, String operationIds, String tableUuids) {
-    if (tableNames == null
-        || operationIds == null
-        || tableUuids == null
-        || tableNames.isEmpty()
-        || operationIds.isEmpty()
-        || tableUuids.isEmpty()) {
-      throw new IllegalArgumentException(
-          "--tableNames, --operationIds, and --tableUuids are all required and must be non-empty");
+    if (tableNames == null || tableNames.isEmpty()) {
+      throw new IllegalArgumentException("--tableNames is required and must be non-empty");
     }
     String[] tables = tableNames.split(",");
-    String[] ops = operationIds.split(",");
-    String[] uuids = tableUuids.split(",");
-    if (tables.length != ops.length || tables.length != uuids.length) {
+    if (tables.length > MAX_BATCH_SIZE) {
       throw new IllegalArgumentException(
           String.format(
-              "Parallel-list length mismatch: tableNames=%d operationIds=%d tableUuids=%d",
-              tables.length, ops.length, uuids.length));
+              "Batch size %d exceeds MAX_BATCH_SIZE=%d; reduce --batchMaxItems on the scheduler",
+              tables.length, MAX_BATCH_SIZE));
+    }
+    String[] ops = isBlank(operationIds) ? null : operationIds.split(",");
+    String[] uuids = isBlank(tableUuids) ? null : tableUuids.split(",");
+    if (ops != null && ops.length != tables.length) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Parallel-list length mismatch: tableNames=%d operationIds=%d",
+              tables.length, ops.length));
+    }
+    if (uuids != null && uuids.length != tables.length) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Parallel-list length mismatch: tableNames=%d tableUuids=%d",
+              tables.length, uuids.length));
     }
     List<BatchEntry> entries = new ArrayList<>(tables.length);
     for (int i = 0; i < tables.length; i++) {
@@ -410,13 +436,17 @@ public class BatchedOrphanFilesDeletionSparkApp extends BaseSparkApp {
       entries.add(
           BatchEntry.builder()
               .fqtn(fqtn)
-              .operationId(ops[i].trim())
-              .tableUuid(uuids[i].trim())
+              .operationId(ops == null ? null : ops[i].trim())
+              .tableUuid(uuids == null ? null : uuids[i].trim())
               .databaseName(dbAndTable[0])
               .tableName(dbAndTable[1])
               .build());
     }
     return entries;
+  }
+
+  private static boolean isBlank(String s) {
+    return s == null || s.isEmpty();
   }
 
   private static String requireOption(CommandLine cmdLine, String name) {

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/AppConstants.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/AppConstants.java
@@ -61,5 +61,16 @@ public final class AppConstants {
   public static final String TABLE_TYPE_REPLICA = "REPLICA_TABLE";
   public static final String OFD_ONE_DAY_TTL_ENABLED_KEY = "ofd.one_day_ttl.enabled";
 
+  /**
+   * Hard ceiling on the number of tables a single batched OFD job can carry. Wire path is parallel
+   * CSV CLI args (see {@code BatchedOrphanFilesDeletionSparkApp#buildEntries}); at ~120 chars per
+   * entry (36-char UUID × 3 lists) this gives ~24 KB on the command line, well under the typical
+   * Linux {@code ARG_MAX} of 128 KB but leaves headroom for the {@code spark-submit} envelope and
+   * JVM flags. The scheduler-driven path uses a smaller per-entry footprint but inherits the same
+   * cap for defense in depth. Operators tune the per-job batch size with {@code --batchMaxItems}
+   * (default {@code 25}); this constant is a footgun stop, not the operating point.
+   */
+  public static final int OFD_MAX_BATCH_SIZE = 200;
+
   private AppConstants() {}
 }

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableMetadataBatch.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableMetadataBatch.java
@@ -14,7 +14,7 @@ import lombok.experimental.SuperBuilder;
  *
  * <p>By design the scheduler never crosses database boundaries when bin-packing — every table in
  * {@link #tables} has the same {@link #dbName}. The {@link
- * com.linkedin.openhouse.jobs.util.binpack.FirstFitDecreasingBinPacker} is invoked per-database;
+ * com.linkedin.openhouse.optimizer.binpack.FirstFitDecreasingBinPacker} is invoked per-database;
  * each emitted bin becomes one {@code TableMetadataBatch}.
  */
 @Getter

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableMetadataBatch.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/TableMetadataBatch.java
@@ -1,0 +1,42 @@
+package com.linkedin.openhouse.jobs.util;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * A group of {@link TableMetadata} that share a database and will be processed in a single batched
+ * Spark job (e.g. {@code BatchedOrphanFilesDeletionSparkApp}).
+ *
+ * <p>By design the scheduler never crosses database boundaries when bin-packing — every table in
+ * {@link #tables} has the same {@link #dbName}. The {@link
+ * com.linkedin.openhouse.jobs.util.binpack.FirstFitDecreasingBinPacker} is invoked per-database;
+ * each emitted bin becomes one {@code TableMetadataBatch}.
+ */
+@Getter
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class TableMetadataBatch extends Metadata {
+  @NonNull protected String dbName;
+  @NonNull protected List<TableMetadata> tables;
+
+  /**
+   * Identifier used in metrics and the Jobs Service {@code jobName} — combines the database with
+   * the bin size so logs/dashboards distinguish bins of different fan-outs without exposing every
+   * fqtn.
+   */
+  @Override
+  public String getEntityName() {
+    return String.format("%s[%d]", dbName, tables.size());
+  }
+
+  /** Unmodifiable view of the underlying tables list. */
+  public List<TableMetadata> getTables() {
+    return Collections.unmodifiableList(tables);
+  }
+}

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/scheduler/tasks/BatchedTableOrphanFilesDeletionTaskTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/scheduler/tasks/BatchedTableOrphanFilesDeletionTaskTest.java
@@ -1,0 +1,91 @@
+package com.linkedin.openhouse.jobs.scheduler.tasks;
+
+import com.linkedin.openhouse.jobs.client.JobsClient;
+import com.linkedin.openhouse.jobs.client.TablesClient;
+import com.linkedin.openhouse.jobs.client.model.JobConf;
+import com.linkedin.openhouse.jobs.util.TableMetadata;
+import com.linkedin.openhouse.jobs.util.TableMetadataBatch;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+public class BatchedTableOrphanFilesDeletionTaskTest {
+
+  @Test
+  public void operationTypeIsBatchedOfd() {
+    Assertions.assertEquals(
+        JobConf.JobTypeEnum.ORPHAN_FILES_DELETION_BATCH,
+        BatchedTableOrphanFilesDeletionTask.OPERATION_TYPE);
+  }
+
+  @Test
+  public void getArgsBuildsCsvOfFqtns() {
+    TableMetadataBatch batch =
+        TableMetadataBatch.builder()
+            .dbName("db")
+            .tables(Arrays.asList(table("db", "t1"), table("db", "t2"), table("db", "t3")))
+            .build();
+    BatchedTableOrphanFilesDeletionTask task =
+        new BatchedTableOrphanFilesDeletionTask(
+            Mockito.mock(JobsClient.class), Mockito.mock(TablesClient.class), batch);
+
+    Assertions.assertEquals(Arrays.asList("--tableNames", "db.t1,db.t2,db.t3"), task.getArgs());
+  }
+
+  @Test
+  public void shouldRunFalseForEmptyBatch() {
+    TableMetadataBatch batch =
+        TableMetadataBatch.builder().dbName("db").tables(Collections.emptyList()).build();
+    BatchedTableOrphanFilesDeletionTask task =
+        new BatchedTableOrphanFilesDeletionTask(
+            Mockito.mock(JobsClient.class), Mockito.mock(TablesClient.class), batch);
+
+    Assertions.assertFalse(task.shouldRun());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void launchJobUsesBatchScopedJobName() {
+    JobsClient jobsClient = Mockito.mock(JobsClient.class);
+    Mockito.when(
+            jobsClient.launch(
+                Mockito.anyString(),
+                Mockito.eq(JobConf.JobTypeEnum.ORPHAN_FILES_DELETION_BATCH),
+                Mockito.anyString(),
+                Mockito.anyMap(),
+                Mockito.anyList()))
+        .thenReturn(Optional.of("job-42"));
+
+    TableMetadataBatch batch =
+        TableMetadataBatch.builder()
+            .dbName("warehouse")
+            .tables(Arrays.asList(table("warehouse", "a"), table("warehouse", "b")))
+            .build();
+    BatchedTableOrphanFilesDeletionTask task =
+        new BatchedTableOrphanFilesDeletionTask(
+            jobsClient, Mockito.mock(TablesClient.class), batch);
+
+    boolean launched = task.launchJob();
+
+    Assertions.assertTrue(launched);
+    Assertions.assertEquals("job-42", task.getJobId());
+    ArgumentCaptor<String> jobNameCaptor = ArgumentCaptor.forClass(String.class);
+    Mockito.verify(jobsClient)
+        .launch(
+            jobNameCaptor.capture(),
+            Mockito.eq(JobConf.JobTypeEnum.ORPHAN_FILES_DELETION_BATCH),
+            Mockito.anyString(),
+            Mockito.anyMap(),
+            Mockito.anyList());
+    // Job name carries db + batch size; nothing per-table is embedded so the string stays bounded.
+    Assertions.assertEquals("ORPHAN_FILES_DELETION_BATCH_warehouse_2", jobNameCaptor.getValue());
+  }
+
+  private static TableMetadata table(String db, String name) {
+    return TableMetadata.builder().dbName(db).tableName(name).creator("test-user").build();
+  }
+}

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/BatchedOrphanFilesDeletionSparkAppArgsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/BatchedOrphanFilesDeletionSparkAppArgsTest.java
@@ -46,23 +46,34 @@ public class BatchedOrphanFilesDeletionSparkAppArgsTest {
   }
 
   @Test
-  public void buildEntriesRejectsNullArguments() {
+  public void buildEntriesRejectsNullOrEmptyTableNames() {
     Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> BatchedOrphanFilesDeletionSparkApp.buildEntries(null, "op-1", "uuid-1"));
     Assertions.assertThrows(
         IllegalArgumentException.class,
-        () -> BatchedOrphanFilesDeletionSparkApp.buildEntries("db.a", null, "uuid-1"));
-    Assertions.assertThrows(
-        IllegalArgumentException.class,
-        () -> BatchedOrphanFilesDeletionSparkApp.buildEntries("db.a", "op-1", null));
+        () -> BatchedOrphanFilesDeletionSparkApp.buildEntries("", "op-1", "uuid-1"));
   }
 
   @Test
-  public void buildEntriesRejectsEmptyStrings() {
-    Assertions.assertThrows(
-        IllegalArgumentException.class,
-        () -> BatchedOrphanFilesDeletionSparkApp.buildEntries("", "op-1", "uuid-1"));
+  public void buildEntriesAllowsAbsentOperationIdsAndTableUuids() {
+    // The legacy JobsScheduler path doesn't know about optimizer-service operationIds or table
+    // UUIDs — it just passes the tables. Both null and empty should produce entries with null
+    // optional fields, no exception.
+    List<BatchedOrphanFilesDeletionSparkApp.BatchEntry> entriesNull =
+        BatchedOrphanFilesDeletionSparkApp.buildEntries("db.a,db.b", null, null);
+    List<BatchedOrphanFilesDeletionSparkApp.BatchEntry> entriesEmpty =
+        BatchedOrphanFilesDeletionSparkApp.buildEntries("db.a,db.b", "", "");
+
+    for (List<BatchedOrphanFilesDeletionSparkApp.BatchEntry> entries :
+        java.util.Arrays.asList(entriesNull, entriesEmpty)) {
+      Assertions.assertEquals(2, entries.size());
+      Assertions.assertEquals("db.a", entries.get(0).getFqtn());
+      Assertions.assertNull(entries.get(0).getOperationId());
+      Assertions.assertNull(entries.get(0).getTableUuid());
+      Assertions.assertEquals("db.b", entries.get(1).getFqtn());
+      Assertions.assertNull(entries.get(1).getOperationId());
+    }
   }
 
   @Test
@@ -70,5 +81,33 @@ public class BatchedOrphanFilesDeletionSparkAppArgsTest {
     Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> BatchedOrphanFilesDeletionSparkApp.buildEntries("just_a_table", "op-1", "uuid-1"));
+  }
+
+  @Test
+  public void buildEntriesAcceptsAtMaxBatchSize() {
+    String tableNames = generateFqtnCsv(BatchedOrphanFilesDeletionSparkApp.MAX_BATCH_SIZE);
+    List<BatchedOrphanFilesDeletionSparkApp.BatchEntry> entries =
+        BatchedOrphanFilesDeletionSparkApp.buildEntries(tableNames, null, null);
+    Assertions.assertEquals(BatchedOrphanFilesDeletionSparkApp.MAX_BATCH_SIZE, entries.size());
+  }
+
+  @Test
+  public void buildEntriesRejectsAboveMaxBatchSize() {
+    String tableNames = generateFqtnCsv(BatchedOrphanFilesDeletionSparkApp.MAX_BATCH_SIZE + 1);
+    IllegalArgumentException ex =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> BatchedOrphanFilesDeletionSparkApp.buildEntries(tableNames, null, null));
+    Assertions.assertTrue(
+        ex.getMessage().contains("MAX_BATCH_SIZE"), "error should reference the constant name");
+  }
+
+  private static String generateFqtnCsv(int n) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < n; i++) {
+      if (i > 0) sb.append(',');
+      sb.append("db.t").append(i);
+    }
+    return sb.toString();
   }
 }

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/BatchedOrphanFilesDeletionSparkAppArgsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/BatchedOrphanFilesDeletionSparkAppArgsTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.openhouse.jobs.spark;
 
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -20,10 +21,10 @@ public class BatchedOrphanFilesDeletionSparkAppArgsTest {
     Assertions.assertEquals("db1.t1", entries.get(0).getFqtn());
     Assertions.assertEquals("db1", entries.get(0).getDatabaseName());
     Assertions.assertEquals("t1", entries.get(0).getTableName());
-    Assertions.assertEquals("op-1", entries.get(0).getOperationId());
-    Assertions.assertEquals("uuid-1", entries.get(0).getTableUuid());
+    Assertions.assertEquals(Optional.of("op-1"), entries.get(0).getOperationId());
+    Assertions.assertEquals(Optional.of("uuid-1"), entries.get(0).getTableUuid());
     Assertions.assertEquals("db2.t2", entries.get(1).getFqtn());
-    Assertions.assertEquals("op-2", entries.get(1).getOperationId());
+    Assertions.assertEquals(Optional.of("op-2"), entries.get(1).getOperationId());
   }
 
   @Test
@@ -33,8 +34,8 @@ public class BatchedOrphanFilesDeletionSparkAppArgsTest {
             " db1.t1 , db2.t2 ", " op-1 , op-2 ", " uuid-1 , uuid-2 ");
 
     Assertions.assertEquals("db1.t1", entries.get(0).getFqtn());
-    Assertions.assertEquals("op-1", entries.get(0).getOperationId());
-    Assertions.assertEquals("uuid-1", entries.get(0).getTableUuid());
+    Assertions.assertEquals(Optional.of("op-1"), entries.get(0).getOperationId());
+    Assertions.assertEquals(Optional.of("uuid-1"), entries.get(0).getTableUuid());
   }
 
   @Test
@@ -69,10 +70,10 @@ public class BatchedOrphanFilesDeletionSparkAppArgsTest {
         java.util.Arrays.asList(entriesNull, entriesEmpty)) {
       Assertions.assertEquals(2, entries.size());
       Assertions.assertEquals("db.a", entries.get(0).getFqtn());
-      Assertions.assertNull(entries.get(0).getOperationId());
-      Assertions.assertNull(entries.get(0).getTableUuid());
+      Assertions.assertFalse(entries.get(0).getOperationId().isPresent());
+      Assertions.assertFalse(entries.get(0).getTableUuid().isPresent());
       Assertions.assertEquals("db.b", entries.get(1).getFqtn());
-      Assertions.assertNull(entries.get(1).getOperationId());
+      Assertions.assertFalse(entries.get(1).getOperationId().isPresent());
     }
   }
 

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/BatchedOrphanFilesDeletionSparkAppArgsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/BatchedOrphanFilesDeletionSparkAppArgsTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.jobs.spark;
 
+import com.linkedin.openhouse.jobs.util.AppConstants;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
@@ -86,21 +87,21 @@ public class BatchedOrphanFilesDeletionSparkAppArgsTest {
 
   @Test
   public void buildEntriesAcceptsAtMaxBatchSize() {
-    String tableNames = generateFqtnCsv(BatchedOrphanFilesDeletionSparkApp.MAX_BATCH_SIZE);
+    String tableNames = generateFqtnCsv(AppConstants.OFD_MAX_BATCH_SIZE);
     List<BatchedOrphanFilesDeletionSparkApp.BatchEntry> entries =
         BatchedOrphanFilesDeletionSparkApp.buildEntries(tableNames, null, null);
-    Assertions.assertEquals(BatchedOrphanFilesDeletionSparkApp.MAX_BATCH_SIZE, entries.size());
+    Assertions.assertEquals(AppConstants.OFD_MAX_BATCH_SIZE, entries.size());
   }
 
   @Test
   public void buildEntriesRejectsAboveMaxBatchSize() {
-    String tableNames = generateFqtnCsv(BatchedOrphanFilesDeletionSparkApp.MAX_BATCH_SIZE + 1);
+    String tableNames = generateFqtnCsv(AppConstants.OFD_MAX_BATCH_SIZE + 1);
     IllegalArgumentException ex =
         Assertions.assertThrows(
             IllegalArgumentException.class,
             () -> BatchedOrphanFilesDeletionSparkApp.buildEntries(tableNames, null, null));
     Assertions.assertTrue(
-        ex.getMessage().contains("MAX_BATCH_SIZE"), "error should reference the constant name");
+        ex.getMessage().contains("OFD_MAX_BATCH_SIZE"), "error should reference the constant name");
   }
 
   private static String generateFqtnCsv(int n) {

--- a/infra/recipes/docker-compose/oh-hadoop-spark/jobs.yaml
+++ b/infra/recipes/docker-compose/oh-hadoop-spark/jobs.yaml
@@ -58,6 +58,14 @@ jobs:
           <<: *spark-defaults
           "spark.driver.memory": "2g"
         << : *livy-engine
+      - type: ORPHAN_FILES_DELETION_BATCH
+        class-name: com.linkedin.openhouse.jobs.spark.BatchedOrphanFilesDeletionSparkApp
+        args: ["--backupDir", ".backup"]
+        <<: *apps-defaults
+        spark-properties:
+          <<: *spark-defaults
+          "spark.driver.memory": "2g"
+        << : *livy-engine
       - type: STAGED_FILES_DELETION
         class-name: com.linkedin.openhouse.jobs.spark.StagedFilesDeletionSparkApp
         args: ["--trashDir", ".trash", "--daysOld", "10", "--recursive", "true"]

--- a/libs/optimizer/binpack/src/main/java/com/linkedin/openhouse/optimizer/binpack/FirstFitDecreasingBinPacker.java
+++ b/libs/optimizer/binpack/src/main/java/com/linkedin/openhouse/optimizer/binpack/FirstFitDecreasingBinPacker.java
@@ -30,7 +30,8 @@ import lombok.extern.slf4j.Slf4j;
  *       row, returns the resulting groupings. Operations whose {@code tableUuid} has no entry in
  *       {@code statsByTableUuid} are dropped. Requires {@code binItemSupplier}.
  *   <li><b>Pre-projected raw groupings</b> ({@link #pack(List)}) — caller has already projected
- *       items; packer returns {@code List<List<BinItem>>}.
+ *       items; packer returns {@code List<List<U>>} preserving the caller's concrete item type so
+ *       no downcast is needed at the call site.
  *   <li><b>Pre-projected tagged bins</b> ({@link #pack(List, OperationTypeDto)}) — caller has
  *       already projected items; packer wraps each grouping in a {@link Bin} tagged with the
  *       supplied operation type. Use this when the bins flow directly to a scheduler that expects
@@ -75,9 +76,14 @@ public class FirstFitDecreasingBinPacker<T extends BinItem> implements BinPacker
     return groupings;
   }
 
-  /** Pre-projected items; returns raw groupings. */
-  public List<List<BinItem>> pack(List<BinItem> items) {
-    List<List<BinItem>> groupings = packCore(items);
+  /**
+   * Pre-projected items; returns raw groupings preserving the caller's concrete item type. The type
+   * parameter {@code U} is independent of the class-level {@code T} (which is bound to {@code
+   * binItemSupplier} for the projection path), so pre-projected callers can pack any concrete
+   * {@link BinItem} subtype without configuring the class's {@code T}.
+   */
+  public <U extends BinItem> List<List<U>> pack(List<U> items) {
+    List<List<U>> groupings = packCore(items);
     log.info(
         "Packed {} pre-projected items into {} groupings",
         items == null ? 0 : items.size(),
@@ -86,46 +92,46 @@ public class FirstFitDecreasingBinPacker<T extends BinItem> implements BinPacker
   }
 
   /** Pre-projected items; returns {@link Bin}s each tagged with {@code operationType}. */
-  public List<Bin> pack(List<BinItem> items, OperationTypeDto operationType) {
-    return pack(items).stream()
-        .map(group -> new Bin(operationType, group))
+  public <U extends BinItem> List<Bin> pack(List<U> items, OperationTypeDto operationType) {
+    return packCore(items).stream()
+        .map(group -> new Bin(operationType, new ArrayList<>(group)))
         .collect(Collectors.toList());
   }
 
-  private List<List<BinItem>> packCore(List<BinItem> items) {
+  private <U extends BinItem> List<List<U>> packCore(List<U> items) {
     if (items == null || items.isEmpty()) {
       return new ArrayList<>();
     }
-    List<PackingBin> packingBins =
+    List<PackingBin<U>> packingBins =
         items.stream()
             .sorted(Comparator.comparingLong(BinItem::getWeight).reversed())
             .collect(ArrayList::new, this::placeItem, List::addAll);
     return packingBins.stream().map(pb -> pb.items).collect(Collectors.toList());
   }
 
-  private void placeItem(List<PackingBin> bins, BinItem item) {
+  private <U extends BinItem> void placeItem(List<PackingBin<U>> bins, U item) {
     bins.stream()
         .filter(b -> b.fits(item, maxWeightPerBin, maxItemsPerBin))
         .findFirst()
         .ifPresentOrElse(
             b -> b.add(item),
             () -> {
-              PackingBin fresh = new PackingBin();
+              PackingBin<U> fresh = new PackingBin<>();
               fresh.add(item);
               bins.add(fresh);
             });
   }
 
   /** Running-totals helper used during the fold. */
-  private static class PackingBin {
-    final List<BinItem> items = new ArrayList<>();
+  private static class PackingBin<U extends BinItem> {
+    final List<U> items = new ArrayList<>();
     long totalWeight;
 
     boolean fits(BinItem item, long maxWeight, int maxItems) {
       return items.size() < maxItems && totalWeight + item.getWeight() <= maxWeight;
     }
 
-    void add(BinItem item) {
+    void add(U item) {
       items.add(item);
       totalWeight += item.getWeight();
     }

--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/model/JobConf.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/model/JobConf.java
@@ -27,6 +27,12 @@ public class JobConf {
     SQL_TEST,
     RETENTION,
     ORPHAN_FILES_DELETION,
+    /**
+     * Multi-table orphan-files-deletion. One Spark job processes a list of tables grouped by
+     * database — bin-packing happens scheduler-side. See {@code
+     * BatchedOrphanFilesDeletionSparkApp}.
+     */
+    ORPHAN_FILES_DELETION_BATCH,
     SNAPSHOTS_EXPIRATION,
     STAGED_FILES_DELETION,
     DATA_COMPACTION,


### PR DESCRIPTION
## Summary
 Wires the new `BatchedOrphanFilesDeletionSparkApp` (from #599) into the **existing** `JobsScheduler` flow so operators can amortize Spark startup over many tables today, without waiting for the optimizer-service stack to land. Batched OFD is opt-in via a new JobType — the existing single-table `ORPHAN_FILES_DELETION` path is untouched.

  ### How it works

  ```sh
  java JobsScheduler \
    --type ORPHAN_FILES_DELETION_BATCH \
    --tablesURL ... --jobsURL ... --cluster ... \
    --batchMaxItems 25
 ```

  1. JobsScheduler fetches all eligible tables (existing fetch path).
  2. New builder method groups by database (batches never cross databases) and runs FirstFitDecreasingBinPacker per group with an item-count cap from --batchMaxItems (default 25).
  3. Each bin becomes one BatchedTableOrphanFilesDeletionTask whose getArgs() returns ["--tableNames", "db.t1,db.t2,…"].
  4. The Jobs Service maps the new ORPHAN_FILES_DELETION_BATCH JobType to BatchedOrphanFilesDeletionSparkApp via jobs.yaml.
  5. The Spark app processes each table in a worker-thread pool, reusing Operations.deleteOrphanFiles(...) per table.

  **Key design choices**

  - Additive, opt-in. Existing ORPHAN_FILES_DELETION JobType + OrphanFilesDeletionSparkApp keep working unchanged. Operators choose mode at scheduler launch via --type.
  - No optimizer service required. BatchedOrphanFilesDeletionSparkApp now treats --resultsEndpoint, --operationIds, --tableUuids as optional. When absent (the legacy scheduler path), the per-operation optimizer callback is skipped entirely; HTS StateManager still tracks the Spark job's lifecycle as before.
  - Batches never cross databases. Grouping happens before bin-packing, not after.
  - Item-count cap only for now. Weight (numCurrentFiles) and sizeBytes dimensions are disabled in this PR — the legacy scheduler doesn't have table_stats. Future PR can layer in Iceberg-snapshot-based sizing without touching the wire.
  - MAX_BATCH_SIZE = 200 hard ceiling. Footgun stop, not the operating point. At ~120 chars per entry (3 parallel CSVs of 36-char UUIDs in the optimizer path), 200 tables ≈ 24 KB on the command line — well under Linux ARG_MAX = 128 KB with
  headroom for the spark-submit envelope. Enforced at both the Spark app boundary (buildEntries) and the scheduler boundary (fail-fast on --batchMaxItems > 200).

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests
  
**Service contract (services/jobs)**
  - JobConf.java — added ORPHAN_FILES_DELETION_BATCH to JobType. Codegen regenerates JobConf.JobTypeEnum in client/jobsclient automatically.

  **Scheduler (apps/spark)**
  - util/TableMetadataBatch.java (new) — Metadata subclass: dbName + List<TableMetadata>. getEntityName() returns "db[N]" for metrics granularity.
  - scheduler/tasks/BatchedTableOrphanFilesDeletionTask.java (new) — OperationTask<TableMetadataBatch>; auto-discovered by JobsScheduler's reflection registry. jobName = "ORPHAN_FILES_DELETION_BATCH_<db>_<N>".
  - scheduler/tasks/OperationTasksBuilder.java — new prepareBatchedOrphanFilesDeletionTaskList: filter eligible → groupBy(dbName) → FFD pack → emit one task per bin. Wired into both buildOperationTaskList (sync) and
  buildOperationTaskListInParallel (bulk-enqueue path because batching needs all metadata in hand first).
  - scheduler/JobsScheduler.java — --batchMaxItems CLI option threaded through getAdditionalProperties.

  **Spark app changes from #599**
  - --resultsEndpoint, --operationIds, --tableUuids now optional. BatchEntry.operationId/tableUuid nullable. newOptimizerClient() returns null when endpoint is absent; reportResult() short-circuits.
  - MAX_BATCH_SIZE = 200 constant + guards.

  **Bin-packer generification (libs/optimizer/binpack)**

  - FirstFitDecreasingBinPacker.java — pack(List<BinItem>) → <U extends BinItem> pack(List<U>) returning List<List<U>>. Caller's concrete item type is preserved through the packer, so consumers no longer need a downcast. pack(List<BinItem>, 
  OperationTypeDto) similarly generic. Internal PackingBin becomes PackingBin<U>. Strictly more permissive — existing callers passing List<BinItem> continue to work (U = BinItem).
  - OperationTasksBuilder.TableMetadataBinItem — no more extract(BinItem) cast helper; the call site uses TableMetadataBinItem::getMetadata as a method reference because the stream is Stream<TableMetadataBinItem> end-to-end.

**Rollout plan**
  - Phase 1 — merge this PR. ORPHAN_FILES_DELETION_BATCH is registered but no scheduler is launched with it. Zero behavior change for existing deployments.
  - Phase 2 — pick one cluster + a small database set, launch a parallel scheduler with --type ORPHAN_FILES_DELETION_BATCH --batchMaxItems 5. Compare success rate and total runtime against the single-table scheduler.
  - Phase 3 — raise --batchMaxItems (10 → 25 → 50) and broaden DB coverage. Drop the single-table scheduler for OFD once the batched one matches or beats it.
  - Rollback at any time: flip the scheduler back to --type ORPHAN_FILES_DELETION. Both paths coexist.


For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Tested on local docker
```
anath1@anath1-mn4233 oh-hadoop-spark % docker compose --profile with_jobs_scheduler run openhouse-jobs-scheduler - \
      --type ORPHAN_FILES_DELETION_BATCH --cluster local \
      --tablesURL http://openhouse-tables:8080 --jobsURL http://openhouse-jobs:8080 \
      --batchMaxItems 5 \
      --tableMinAgeThresholdHours 0 --taskPollIntervalMs 5000
WARN[0000] /Users/anath1/IdeaProjects/openhouse/infra/recipes/docker-compose/oh-hadoop-spark/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
[+] Creating 9/9
 ✔ Container local.jaeger                  Running                                                                                                                                                                                             0.0s 
 ✔ Container oh-hadoop-spark-prometheus-1  Running                                                                                                                                                                                             0.0s 
 ✔ Container local.datanode                Running                                                                                                                                                                                             0.0s 
 ✔ Container local.opa                     Running                                                                                                                                                                                             0.0s 
 ✔ Container local.mysql                   Running                                                                                                                                                                                             0.0s 
 ✔ Container local.namenode                Running                                                                                                                                                                                             0.0s 
 ✔ Container local.openhouse-housetables   Running                                                                                                                                                                                             0.0s 
 ✔ Container local.openhouse-tables        Running                                                                                                                                                                                             0.0s 
 ✔ Container local.openhouse-jobs          Running                                                                                                                                                                                             0.0s 
2026-06-11 02:17:38 INFO  Reflections:219 - Reflections took 67 ms to scan 1 urls, producing 8 keys and 20 values
2026-06-11 02:17:38 INFO  JobsScheduler:188 - Starting scheduler
2026-06-11 02:17:38 INFO  WebClientFactory:121 - Using connection pool strategy
2026-06-11 02:17:38 INFO  WebClientFactory:218 - Creating custom connection provider
2026-06-11 02:17:38 INFO  WebClientFactory:196 - Client session id: 787d65ac-dfe4-4937-9ac0-fc3dd263adfb
2026-06-11 02:17:38 INFO  WebClientFactory:209 - Client name: null
2026-06-11 02:17:38 INFO  WebClientFactory:121 - Using connection pool strategy
2026-06-11 02:17:38 INFO  WebClientFactory:218 - Creating custom connection provider
2026-06-11 02:17:38 INFO  WebClientFactory:196 - Client session id: 3f74cbee-4e92-4211-8edd-d49dd6bc240a
2026-06-11 02:17:38 INFO  WebClientFactory:209 - Client name: null
2026-06-11 02:17:38 INFO  DefaultOtelConfig:79 - initializing open-telemetry sdk (no agent detected)
2026-06-11 02:17:38 INFO  JobsScheduler:301 - Fetching task list based on the job type: ORPHAN_FILES_DELETION_BATCH
2026-06-11 02:17:39 INFO  OperationTasksBuilder:101 - Fetched metadata for 12 batched-OFD-eligible tables; binMaxItems=5
2026-06-11 02:17:39 INFO  FirstFitDecreasingBinPacker:81 - Packed 5 pre-projected items into 1 groupings
2026-06-11 02:17:39 INFO  FirstFitDecreasingBinPacker:81 - Packed 5 pre-projected items into 1 groupings
2026-06-11 02:17:39 INFO  FirstFitDecreasingBinPacker:81 - Packed 2 pre-projected items into 1 groupings
2026-06-11 02:17:39 INFO  OperationTasksBuilder:134 - Packed 12 eligible tables into 3 batches
2026-06-11 02:17:39 INFO  OperationTasksBuilder:238 - Found metadata TableMetadataBatch(super=Metadata(creator=), dbName=d1, tables=[TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t1, creationTimeMs=1781142262532, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t2, creationTimeMs=1781142286398, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t3, creationTimeMs=1781142305610, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t4, creationTimeMs=1781142316354, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t5, creationTimeMs=1781142326737, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null)])
2026-06-11 02:17:39 INFO  OperationTasksBuilder:238 - Found metadata TableMetadataBatch(super=Metadata(creator=), dbName=d2, tables=[TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t10, creationTimeMs=1781142392651, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t6, creationTimeMs=1781142352669, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t7, creationTimeMs=1781142364195, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t8, creationTimeMs=1781142375093, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t9, creationTimeMs=1781142384531, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null)])
2026-06-11 02:17:39 INFO  OperationTasksBuilder:238 - Found metadata TableMetadataBatch(super=Metadata(creator=), dbName=d3, tables=[TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d3, tableName=t2, creationTimeMs=1774646046137, isPrimary=true, isTimePartitioned=false, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d3, tableName=t3, creationTimeMs=1775245640368, isPrimary=true, isTimePartitioned=false, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null)])
2026-06-11 02:17:39 INFO  JobsScheduler:370 - Submitting and running 3 jobs based on the job type: ORPHAN_FILES_DELETION_BATCH
2026-06-11 02:17:39 INFO  OperationTask:149 - Launching job for TableMetadataBatch(super=Metadata(creator=), dbName=d2, tables=[TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t10, creationTimeMs=1781142392651, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t6, creationTimeMs=1781142352669, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t7, creationTimeMs=1781142364195, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t8, creationTimeMs=1781142375093, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t9, creationTimeMs=1781142384531, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null)])
2026-06-11 02:17:39 INFO  OperationTask:149 - Launching job for TableMetadataBatch(super=Metadata(creator=), dbName=d3, tables=[TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d3, tableName=t2, creationTimeMs=1774646046137, isPrimary=true, isTimePartitioned=false, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d3, tableName=t3, creationTimeMs=1775245640368, isPrimary=true, isTimePartitioned=false, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null)])
2026-06-11 02:17:39 INFO  OperationTask:149 - Launching job for TableMetadataBatch(super=Metadata(creator=), dbName=d1, tables=[TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t1, creationTimeMs=1781142262532, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t2, creationTimeMs=1781142286398, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t3, creationTimeMs=1781142305610, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t4, creationTimeMs=1781142316354, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t5, creationTimeMs=1781142326737, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null)])
2026-06-11 02:17:40 INFO  OperationTask:167 - Launched a job with id ORPHAN_FILES_DELETION_BATCH_d2_5_eae0ba6d-bff8-4f85-ad33-4a4f399e93c3 for TableMetadataBatch(super=Metadata(creator=), dbName=d2, tables=[TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t10, creationTimeMs=1781142392651, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t6, creationTimeMs=1781142352669, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t7, creationTimeMs=1781142364195, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t8, creationTimeMs=1781142375093, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t9, creationTimeMs=1781142384531, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null)])
2026-06-11 02:17:40 INFO  OperationTask:167 - Launched a job with id ORPHAN_FILES_DELETION_BATCH_d3_2_082ed2fc-07da-49d5-b92e-1aa6d215e9a7 for TableMetadataBatch(super=Metadata(creator=), dbName=d3, tables=[TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d3, tableName=t2, creationTimeMs=1774646046137, isPrimary=true, isTimePartitioned=false, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d3, tableName=t3, creationTimeMs=1775245640368, isPrimary=true, isTimePartitioned=false, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null)])
2026-06-11 02:17:40 INFO  OperationTask:167 - Launched a job with id ORPHAN_FILES_DELETION_BATCH_d1_5_25dedd5e-499b-484f-b49a-32936caa2d2a for TableMetadataBatch(super=Metadata(creator=), dbName=d1, tables=[TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t1, creationTimeMs=1781142262532, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t2, creationTimeMs=1781142286398, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t3, creationTimeMs=1781142305610, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t4, creationTimeMs=1781142316354, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t5, creationTimeMs=1781142326737, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null)])
---------------------------------------------------------------------------------------
2026-06-11 02:27:43 INFO  OperationTask:181 - Exiting status check for ORPHAN_FILES_DELETION_BATCH for TableMetadataBatch(super=Metadata(creator=), dbName=d2, tables=[TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t10, creationTimeMs=1781142392651, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t6, creationTimeMs=1781142352669, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t7, creationTimeMs=1781142364195, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t8, creationTimeMs=1781142375093, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t9, creationTimeMs=1781142384531, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null)]) due to queued timeout
2026-06-11 02:27:43 INFO  OperationTask:181 - Exiting status check for ORPHAN_FILES_DELETION_BATCH for TableMetadataBatch(super=Metadata(creator=), dbName=d1, tables=[TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t1, creationTimeMs=1781142262532, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t2, creationTimeMs=1781142286398, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t3, creationTimeMs=1781142305610, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t4, creationTimeMs=1781142316354, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t5, creationTimeMs=1781142326737, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null)]) due to queued timeout
2026-06-11 02:27:43 INFO  OperationTask:181 - Exiting status check for ORPHAN_FILES_DELETION_BATCH for TableMetadataBatch(super=Metadata(creator=), dbName=d3, tables=[TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d3, tableName=t2, creationTimeMs=1774646046137, isPrimary=true, isTimePartitioned=false, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d3, tableName=t3, creationTimeMs=1775245640368, isPrimary=true, isTimePartitioned=false, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null)]) due to queued timeout
2026-06-11 02:27:43 INFO  OperationTask:236 - Finished job for entity TableMetadataBatch(super=Metadata(creator=), dbName=d1, tables=[TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t1, creationTimeMs=1781142262532, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t2, creationTimeMs=1781142286398, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t3, creationTimeMs=1781142305610, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t4, creationTimeMs=1781142316354, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d1, tableName=t5, creationTimeMs=1781142326737, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null)]): JobId ORPHAN_FILES_DELETION_BATCH_d1_5_25dedd5e-499b-484f-b49a-32936caa2d2a, executionId 2, runTime -1781144260595, queuedTime -1781144260595, state QUEUED
2026-06-11 02:27:43 INFO  OperationTask:236 - Finished job for entity TableMetadataBatch(super=Metadata(creator=), dbName=d2, tables=[TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t10, creationTimeMs=1781142392651, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t6, creationTimeMs=1781142352669, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t7, creationTimeMs=1781142364195, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t8, creationTimeMs=1781142375093, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d2, tableName=t9, creationTimeMs=1781142384531, isPrimary=true, isTimePartitioned=true, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null)]): JobId ORPHAN_FILES_DELETION_BATCH_d2_5_eae0ba6d-bff8-4f85-ad33-4a4f399e93c3, executionId 0, runTime -1781144259215, queuedTime -1781144259215, state QUEUED
2026-06-11 02:27:43 INFO  OperationTask:236 - Finished job for entity TableMetadataBatch(super=Metadata(creator=), dbName=d3, tables=[TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d3, tableName=t2, creationTimeMs=1774646046137, isPrimary=true, isTimePartitioned=false, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null), TableMetadata(super=Metadata(creator=DUMMY_ANONYMOUS_USER), dbName=d3, tableName=t3, creationTimeMs=1775245640368, isPrimary=true, isTimePartitioned=false, isClustered=true, jobExecutionProperties={}, retentionConfig=null, historyConfig=null, replicationConfig=null)]): JobId ORPHAN_FILES_DELETION_BATCH_d3_2_082ed2fc-07da-49d5-b92e-1aa6d215e9a7, executionId 1, runTime -1781144260505, queuedTime -1781144260505, state QUEUED
2026-06-11 02:27:43 INFO  JobsScheduler:1166 - Collected job state for task ORPHAN_FILES_DELETION_BATCH_d3_2_082ed2fc-07da-49d5-b92e-1aa6d215e9a7: QUEUED
2026-06-11 02:27:43 INFO  JobsScheduler:1166 - Collected job state for task ORPHAN_FILES_DELETION_BATCH_d1_5_25dedd5e-499b-484f-b49a-32936caa2d2a: QUEUED
2026-06-11 02:27:43 INFO  JobsScheduler:1166 - Collected job state for task ORPHAN_FILES_DELETION_BATCH_d2_5_eae0ba6d-bff8-4f85-ad33-4a4f399e93c3: QUEUED
2026-06-11 02:27:43 INFO  JobsScheduler:1183 - Completed collecting jobs state on futures for job type ORPHAN_FILES_DELETION_BATCH
2026-06-11 02:27:43 INFO  JobsScheduler:387 - Finishing scheduler for job type ORPHAN_FILES_DELETION_BATCH, tasks stats: 3 created, 0 succeeded, 0 running, 3 queued 0 cancelled (scheduler timeout), 0 failed, 0 skipped (no state)
2026-06-11 02:27:43 INFO  JobsScheduler:401 - The total run duration of job scheduler for job type ORPHAN_FILES_DELETION_BATCH is : 00:10 hours (HH:mm format)
2026-06-11 02:27:43 INFO  JobsScheduler:259 - SIGTERM received, initiating graceful shutdown of scheduler...
2026-06-11 02:27:43 INFO  JobsScheduler:178 - Initiating graceful shutdown of scheduler...
2026-06-11 02:27:43 INFO  JobsScheduler:266 - Shutdown hook completed.
```

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
