### PR TITLE
(wip) feat(tables): in-process Iceberg REST Catalog adapter

### DIFF
--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/rest/adapter/CommitAdapter.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/rest/adapter/CommitAdapter.java
@@ -1,0 +1,67 @@
+package com.linkedin.openhouse.tables.rest.adapter;
+
+import com.linkedin.openhouse.cluster.configs.ClusterProperties;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
+import com.linkedin.openhouse.tables.common.TableType;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.SortOrderParser;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.catalog.Namespace;
+import org.springframework.stereotype.Component;
+
+/**
+ * Builds an OpenHouse {@link CreateUpdateTableRequestBody} from an Iceberg {@link TableMetadata}
+ * produced by a REST commit (i.e. base + MetadataUpdates replayed).
+ *
+ * <p>v0 simplifications:
+ *
+ * <ul>
+ *   <li>timePartitioning / clustering — null (OpenHouse stores the spec inside the metadata file
+ *       directly; the REST adapter does not synthesize OpenHouse's extra hints)
+ *   <li>newIntermediateSchemas — null
+ *   <li>policies — null
+ *   <li>tableType — PRIMARY_TABLE always; replicas are not writable via REST
+ * </ul>
+ */
+@Component
+@RequiredArgsConstructor
+public class CommitAdapter {
+
+  private final ClusterProperties clusterProperties;
+
+  /**
+   * @param namespace OpenHouse database namespace (depth 1)
+   * @param tableName table name within the namespace
+   * @param newMetadata the post-update Iceberg metadata
+   * @param baseTableVersion {@code base.metadataFileLocation()} for updates, or {@code null} on
+   *     create — in which case "INITIAL_VERSION" is used
+   */
+  public CreateUpdateTableRequestBody buildCreateUpdateBody(
+      Namespace namespace, String tableName, TableMetadata newMetadata, String baseTableVersion) {
+    NamespaceUtilRest.requireDepthOne(namespace);
+
+    Map<String, String> tableProperties = new HashMap<>();
+    if (newMetadata.properties() != null) {
+      for (Map.Entry<String, String> e : newMetadata.properties().entrySet()) {
+        if (e.getKey() != null && e.getValue() != null) {
+          tableProperties.put(e.getKey(), e.getValue());
+        }
+      }
+    }
+
+    return CreateUpdateTableRequestBody.builder()
+        .tableId(tableName)
+        .databaseId(namespace.level(0))
+        .clusterId(clusterProperties.getClusterName())
+        .schema(SchemaParser.toJson(newMetadata.schema(), false))
+        .sortOrder(SortOrderParser.toJson(newMetadata.sortOrder()))
+        .baseTableVersion(baseTableVersion == null ? "INITIAL_VERSION" : baseTableVersion)
+        .tableProperties(tableProperties)
+        .tableType(TableType.PRIMARY_TABLE)
+        // v0: timePartitioning / clustering / policies / newIntermediateSchemas left null
+        .build();
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/rest/adapter/CreateTableRequestAdapter.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/rest/adapter/CreateTableRequestAdapter.java
@@ -1,0 +1,63 @@
+package com.linkedin.openhouse.tables.rest.adapter;
+
+import com.linkedin.openhouse.cluster.configs.ClusterProperties;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
+import com.linkedin.openhouse.tables.common.TableType;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.SortOrderParser;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.springframework.stereotype.Component;
+
+/**
+ * Adapter from Iceberg REST {@link CreateTableRequest} to OpenHouse {@link
+ * CreateUpdateTableRequestBody}.
+ *
+ * <p>v0: partition-spec / clustering / policies are not propagated separately — OpenHouse stores
+ * the Iceberg PartitionSpec inside its own metadata file. Stage-create requests are rejected at the
+ * controller layer.
+ */
+@Component
+@RequiredArgsConstructor
+public class CreateTableRequestAdapter {
+
+  private final ClusterProperties clusterProperties;
+
+  public CreateUpdateTableRequestBody buildFromCreate(Namespace namespace, CreateTableRequest req) {
+    NamespaceUtilRest.requireDepthOne(namespace);
+
+    Map<String, String> tableProperties = new HashMap<>();
+    Map<String, String> incoming =
+        req.properties() == null ? Collections.emptyMap() : req.properties();
+    for (Map.Entry<String, String> e : incoming.entrySet()) {
+      if (e.getKey() != null && e.getValue() != null) {
+        tableProperties.put(e.getKey(), e.getValue());
+      }
+    }
+
+    String sortOrderJson;
+    if (req.writeOrder() != null) {
+      sortOrderJson = SortOrderParser.toJson(req.writeOrder());
+    } else {
+      sortOrderJson = SortOrderParser.toJson(SortOrder.unsorted());
+    }
+
+    return CreateUpdateTableRequestBody.builder()
+        .tableId(req.name())
+        .databaseId(namespace.level(0))
+        .clusterId(clusterProperties.getClusterName())
+        .schema(SchemaParser.toJson(req.schema(), false))
+        .sortOrder(sortOrderJson)
+        .baseTableVersion("INITIAL_VERSION")
+        .tableProperties(tableProperties)
+        .tableType(TableType.PRIMARY_TABLE)
+        .stageCreate(false)
+        // v0: timePartitioning / clustering / policies / newIntermediateSchemas left null
+        .build();
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/rest/adapter/IcebergRestJson.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/rest/adapter/IcebergRestJson.java
@@ -1,0 +1,39 @@
+package com.linkedin.openhouse.tables.rest.adapter;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.apache.iceberg.rest.RESTSerializers;
+
+/**
+ * Project-local replacement for Iceberg's package-private {@code RESTObjectMapper}. Builds a
+ * Jackson {@link ObjectMapper} configured with Iceberg REST request/response (de)serializers via
+ * {@link RESTSerializers#registerAll(ObjectMapper)}. Use this for parsing inbound bodies and
+ * rendering outbound bodies on all {@code /iceberg/v1/*} endpoints.
+ */
+public final class IcebergRestJson {
+
+  private static final ObjectMapper MAPPER;
+
+  static {
+    ObjectMapper m = new ObjectMapper();
+    // Iceberg's REST response types (ListNamespacesResponse, LoadTableResponse, ...) have
+    // private fields and method-style accessors like `namespaces()` — not getters.
+    // Without FIELD visibility ANY, Jackson sees no properties and emits {}.
+    m.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+    m.setPropertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE);
+    m.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+    m.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+    m.setSerializationInclusion(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL);
+    RESTSerializers.registerAll(m);
+    MAPPER = m;
+  }
+
+  private IcebergRestJson() {}
+
+  public static ObjectMapper mapper() {
+    return MAPPER;
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/rest/adapter/NamespaceUtilRest.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/rest/adapter/NamespaceUtilRest.java
@@ -1,0 +1,52 @@
+package com.linkedin.openhouse.tables.rest.adapter;
+
+import com.linkedin.openhouse.common.exception.RequestValidationFailureException;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.rest.RESTUtil;
+
+/**
+ * Helpers for translating between Iceberg REST namespace path variables and {@link Namespace}
+ * objects. OpenHouse only supports single-level namespaces ("databases"); this helper enforces
+ * that.
+ */
+public final class NamespaceUtilRest {
+
+  private NamespaceUtilRest() {}
+
+  /** Decode an Iceberg REST path-variable (unit-separator delimited) into a {@link Namespace}. */
+  public static Namespace decode(String pathVariable) {
+    if (pathVariable == null || pathVariable.isEmpty()) {
+      throw new RequestValidationFailureException("namespace path variable is empty");
+    }
+    return RESTUtil.decodeNamespace(pathVariable);
+  }
+
+  /** Encode a {@link Namespace} back to a path-variable string. */
+  public static String encode(Namespace ns) {
+    return RESTUtil.encodeNamespace(ns);
+  }
+
+  /**
+   * Reject multi-level namespaces — OpenHouse uses a single database level. Empty namespaces are
+   * also rejected.
+   */
+  public static void requireDepthOne(Namespace ns) {
+    if (ns == null || ns.isEmpty()) {
+      throw new RequestValidationFailureException(
+          "namespace must have exactly one level; got empty namespace");
+    }
+    if (ns.length() > 1) {
+      throw new RequestValidationFailureException(
+          "multi-level namespaces are not supported; depth=" + ns.length());
+    }
+  }
+
+  /**
+   * Return the single database level. Caller must have run {@link #requireDepthOne(Namespace)}
+   * first; this method does so defensively as well.
+   */
+  public static String singleLevelDb(Namespace ns) {
+    requireDepthOne(ns);
+    return ns.level(0);
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/rest/adapter/TableLoadAdapter.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/rest/adapter/TableLoadAdapter.java
@@ -1,0 +1,39 @@
+package com.linkedin.openhouse.tables.rest.adapter;
+
+import com.linkedin.openhouse.internal.catalog.OpenHouseInternalCatalog;
+import lombok.RequiredArgsConstructor;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.springframework.stereotype.Component;
+
+/**
+ * Loads an OpenHouse-backed Iceberg table via {@link OpenHouseInternalCatalog} and wraps it into an
+ * Iceberg REST {@link LoadTableResponse}. The metadata-location field of the response is filled
+ * from {@link TableMetadata#metadataFileLocation()} by the Iceberg builder.
+ */
+@Component
+@RequiredArgsConstructor
+public class TableLoadAdapter {
+
+  private final OpenHouseInternalCatalog openHouseInternalCatalog;
+
+  public LoadTableResponse buildLoadTableResponse(String databaseId, String tableId) {
+    TableIdentifier id = TableIdentifier.of(Namespace.of(databaseId), tableId);
+    Table table = openHouseInternalCatalog.loadTable(id);
+    BaseTable baseTable = (BaseTable) table;
+    TableMetadata metadata = baseTable.operations().current();
+    return LoadTableResponse.builder().withTableMetadata(metadata).build();
+  }
+
+  /** Convenience: also returns the underlying metadata, for callers that need both. */
+  public TableMetadata loadMetadata(String databaseId, String tableId) {
+    TableIdentifier id = TableIdentifier.of(Namespace.of(databaseId), tableId);
+    Table table = openHouseInternalCatalog.loadTable(id);
+    BaseTable baseTable = (BaseTable) table;
+    return baseTable.operations().current();
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/rest/config/IcebergRestPaths.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/rest/config/IcebergRestPaths.java
@@ -1,0 +1,10 @@
+package com.linkedin.openhouse.tables.rest.config;
+
+/** URL roots for the Iceberg REST Catalog adapter. */
+public final class IcebergRestPaths {
+  private IcebergRestPaths() {}
+
+  public static final String BASE = "/iceberg";
+  public static final String V1 = BASE + "/v1";
+  public static final String CONFIG = V1 + "/config";
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/rest/controller/IcebergConfigController.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/rest/controller/IcebergConfigController.java
@@ -1,0 +1,42 @@
+package com.linkedin.openhouse.tables.rest.controller;
+
+import com.linkedin.openhouse.tables.rest.adapter.IcebergRestJson;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.iceberg.rest.responses.ConfigResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Iceberg REST Catalog {@code GET /v1/config} endpoint.
+ *
+ * <p>Iceberg 1.5.2 {@link ConfigResponse.Builder} does not expose a {@code withEndpoints(...)}
+ * method (endpoint advertisement was added in newer Iceberg). Clients will probe each call instead
+ * and 404s for unsupported endpoints are tolerated by Spark/Flink REST catalog clients.
+ */
+@RestController
+@Slf4j
+public class IcebergConfigController {
+
+  @GetMapping(value = "/iceberg/v1/config", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<String> getConfig(
+      @RequestParam(value = "warehouse", required = false) String warehouse) throws Exception {
+    // Echo the caller's warehouse name back as `overrides.prefix` so the Iceberg
+    // REST client routes every subsequent call through /v1/{prefix}/... — that is
+    // the URL shape this adapter's namespace/table controllers serve.
+    Map<String, String> overrides = new HashMap<>();
+    overrides.put("prefix", warehouse == null || warehouse.isEmpty() ? "openhouse" : warehouse);
+    ConfigResponse response =
+        ConfigResponse.builder()
+            .withDefaults(Collections.emptyMap())
+            .withOverrides(overrides)
+            .build();
+    String json = IcebergRestJson.mapper().writeValueAsString(response);
+    return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(json);
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/rest/controller/IcebergNamespacesController.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/rest/controller/IcebergNamespacesController.java
@@ -1,0 +1,165 @@
+package com.linkedin.openhouse.tables.rest.controller;
+
+import com.linkedin.openhouse.common.api.spec.ApiResponse;
+import com.linkedin.openhouse.common.exception.NoSuchEntityException;
+import com.linkedin.openhouse.tables.api.handler.DatabasesApiHandler;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllDatabasesResponseBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetDatabaseResponseBody;
+import com.linkedin.openhouse.tables.rest.adapter.IcebergRestJson;
+import com.linkedin.openhouse.tables.rest.adapter.NamespaceUtilRest;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
+import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
+import org.apache.iceberg.rest.responses.GetNamespaceResponse;
+import org.apache.iceberg.rest.responses.ListNamespacesResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Iceberg REST Catalog namespace endpoints under {@code /iceberg/v1/{prefix}/namespaces/...}.
+ *
+ * <p>OpenHouse namespaces are implicit — they spring into existence when their first table is
+ * created and stop existing when their last table is dropped. We surface them via {@link
+ * DatabasesApiHandler#getAllDatabases()} for listing and existence checks. Creation is a no-op
+ * success (we don't pre-create), and deletion is accepted as a no-op success because OpenHouse has
+ * no explicit drop-namespace operation.
+ *
+ * <p>Only single-level namespaces are supported; deeper paths return 400.
+ */
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/iceberg/v1/{prefix}")
+public class IcebergNamespacesController {
+
+  private final DatabasesApiHandler databasesApiHandler;
+
+  // ----------------------------------------------------------------------------------------------
+  // GET /namespaces
+  // ----------------------------------------------------------------------------------------------
+  @GetMapping(value = "/namespaces", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<String> listNamespaces(@PathVariable("prefix") String prefix)
+      throws Exception {
+    ApiResponse<GetAllDatabasesResponseBody> resp = databasesApiHandler.getAllDatabases();
+    List<GetDatabaseResponseBody> dbs =
+        resp.getResponseBody() == null || resp.getResponseBody().getResults() == null
+            ? Collections.emptyList()
+            : resp.getResponseBody().getResults();
+
+    List<Namespace> namespaces = new ArrayList<>(dbs.size());
+    for (GetDatabaseResponseBody db : dbs) {
+      namespaces.add(Namespace.of(db.getDatabaseId()));
+    }
+    ListNamespacesResponse out = ListNamespacesResponse.builder().addAll(namespaces).build();
+    return ResponseEntity.ok()
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(IcebergRestJson.mapper().writeValueAsString(out));
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // POST /namespaces — accept, but no-op (OpenHouse namespaces are auto-created on first table)
+  // ----------------------------------------------------------------------------------------------
+  @PostMapping(
+      value = "/namespaces",
+      consumes = MediaType.APPLICATION_JSON_VALUE,
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<String> createNamespace(
+      @PathVariable("prefix") String prefix, @RequestBody String requestBody) throws Exception {
+    CreateNamespaceRequest req =
+        IcebergRestJson.mapper().readValue(requestBody, CreateNamespaceRequest.class);
+    Namespace ns = req.namespace();
+    NamespaceUtilRest.requireDepthOne(ns);
+
+    // OpenHouse doesn't pre-create namespaces; we return success and silently drop properties.
+    CreateNamespaceResponse out =
+        CreateNamespaceResponse.builder()
+            .withNamespace(ns)
+            .setProperties(Collections.emptyMap())
+            .build();
+    return ResponseEntity.ok()
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(IcebergRestJson.mapper().writeValueAsString(out));
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // GET /namespaces/{namespace}
+  // ----------------------------------------------------------------------------------------------
+  @GetMapping(value = "/namespaces/{namespace}", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<String> loadNamespace(
+      @PathVariable("prefix") String prefix, @PathVariable("namespace") String namespacePath)
+      throws Exception {
+    Namespace ns = NamespaceUtilRest.decode(namespacePath);
+    NamespaceUtilRest.requireDepthOne(ns);
+
+    if (!namespaceExists(ns)) {
+      throw new NoSuchEntityException("Namespace", ns.toString());
+    }
+
+    GetNamespaceResponse out =
+        GetNamespaceResponse.builder()
+            .withNamespace(ns)
+            .setProperties(Collections.emptyMap())
+            .build();
+    return ResponseEntity.ok()
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(IcebergRestJson.mapper().writeValueAsString(out));
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // HEAD /namespaces/{namespace}
+  // ----------------------------------------------------------------------------------------------
+  @RequestMapping(value = "/namespaces/{namespace}", method = RequestMethod.HEAD)
+  public ResponseEntity<Void> namespaceExistsHead(
+      @PathVariable("prefix") String prefix, @PathVariable("namespace") String namespacePath) {
+    Namespace ns = NamespaceUtilRest.decode(namespacePath);
+    NamespaceUtilRest.requireDepthOne(ns);
+
+    if (!namespaceExists(ns)) {
+      // Let the exception handler render the 404 ErrorResponse for consistency.
+      throw new NoSuchEntityException("Namespace", ns.toString());
+    }
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // DELETE /namespaces/{namespace} — OpenHouse has no drop-namespace; accept as no-op.
+  // ----------------------------------------------------------------------------------------------
+  @DeleteMapping(value = "/namespaces/{namespace}")
+  public ResponseEntity<Void> dropNamespace(
+      @PathVariable("prefix") String prefix, @PathVariable("namespace") String namespacePath) {
+    Namespace ns = NamespaceUtilRest.decode(namespacePath);
+    NamespaceUtilRest.requireDepthOne(ns);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // helpers
+  // ----------------------------------------------------------------------------------------------
+  private boolean namespaceExists(Namespace ns) {
+    ApiResponse<GetAllDatabasesResponseBody> resp = databasesApiHandler.getAllDatabases();
+    if (resp.getResponseBody() == null || resp.getResponseBody().getResults() == null) {
+      return false;
+    }
+    String dbId = ns.level(0);
+    for (GetDatabaseResponseBody db : resp.getResponseBody().getResults()) {
+      if (dbId.equals(db.getDatabaseId())) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/rest/controller/IcebergRestExceptionHandler.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/rest/controller/IcebergRestExceptionHandler.java
@@ -1,0 +1,166 @@
+package com.linkedin.openhouse.tables.rest.controller;
+
+import com.linkedin.openhouse.common.exception.AlreadyExistsException;
+import com.linkedin.openhouse.common.exception.EntityConcurrentModificationException;
+import com.linkedin.openhouse.common.exception.InvalidSchemaEvolutionException;
+import com.linkedin.openhouse.common.exception.InvalidTableMetadataException;
+import com.linkedin.openhouse.common.exception.NoSuchEntityException;
+import com.linkedin.openhouse.common.exception.NoSuchSoftDeletedUserTableException;
+import com.linkedin.openhouse.common.exception.NoSuchUserTableException;
+import com.linkedin.openhouse.common.exception.RequestValidationFailureException;
+import com.linkedin.openhouse.common.exception.UnsupportedClientOperationException;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.ErrorResponseParser;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+
+/**
+ * Spring REST controller advice scoped to {@code com.linkedin.openhouse.tables.rest}: translates
+ * OpenHouse internal exceptions and Iceberg exceptions to Iceberg's wire-format {@link
+ * ErrorResponse} JSON ({@code { "error": { "message": "...", "type": "...", "code": N } } }).
+ *
+ * <p>The {@code basePackages} attribute is critical — it scopes this advice ONLY to the new REST
+ * adapter controllers so we don't clobber the existing OpenHouse exception handler for the native
+ * {@code /v1/databases/...} surface.
+ */
+@RestControllerAdvice(basePackages = "com.linkedin.openhouse.tables.rest")
+@Slf4j
+public class IcebergRestExceptionHandler {
+
+  // --------------------------------------------------------------------------------------------
+  // OpenHouse common exceptions
+  // --------------------------------------------------------------------------------------------
+
+  @ExceptionHandler(NoSuchEntityException.class)
+  public ResponseEntity<String> handleNoSuchEntity(NoSuchEntityException ex, WebRequest req) {
+    String type = isTablePath(req) ? "NoSuchTableException" : "NoSuchNamespaceException";
+    return render(HttpStatus.NOT_FOUND, type, safeMessage(ex));
+  }
+
+  @ExceptionHandler(NoSuchUserTableException.class)
+  public ResponseEntity<String> handleNoSuchUserTable(NoSuchUserTableException ex) {
+    return render(HttpStatus.NOT_FOUND, "NoSuchTableException", safeMessage(ex));
+  }
+
+  @ExceptionHandler(NoSuchSoftDeletedUserTableException.class)
+  public ResponseEntity<String> handleNoSuchSoftDeleted(NoSuchSoftDeletedUserTableException ex) {
+    return render(HttpStatus.NOT_FOUND, "NoSuchTableException", safeMessage(ex));
+  }
+
+  /**
+   * Catch-all for {@link java.util.NoSuchElementException} (parent of OpenHouse's
+   * NoSuchUserTableException). Some OpenHouse code paths throw the raw parent class.
+   */
+  @ExceptionHandler(java.util.NoSuchElementException.class)
+  public ResponseEntity<String> handleNoSuchElement(
+      java.util.NoSuchElementException ex, WebRequest req) {
+    String type = isTablePath(req) ? "NoSuchTableException" : "NoSuchNamespaceException";
+    return render(HttpStatus.NOT_FOUND, type, safeMessage(ex));
+  }
+
+  @ExceptionHandler(AlreadyExistsException.class)
+  public ResponseEntity<String> handleAlreadyExists(AlreadyExistsException ex) {
+    return render(HttpStatus.CONFLICT, "AlreadyExistsException", safeMessage(ex));
+  }
+
+  @ExceptionHandler(EntityConcurrentModificationException.class)
+  public ResponseEntity<String> handleConcurrentModification(
+      EntityConcurrentModificationException ex) {
+    return render(HttpStatus.CONFLICT, "CommitFailedException", safeMessage(ex));
+  }
+
+  @ExceptionHandler(RequestValidationFailureException.class)
+  public ResponseEntity<String> handleRequestValidation(RequestValidationFailureException ex) {
+    return render(HttpStatus.BAD_REQUEST, "BadRequestException", safeMessage(ex));
+  }
+
+  @ExceptionHandler(InvalidSchemaEvolutionException.class)
+  public ResponseEntity<String> handleSchemaEvolution(InvalidSchemaEvolutionException ex) {
+    return render(HttpStatus.BAD_REQUEST, "BadRequestException", safeMessage(ex));
+  }
+
+  @ExceptionHandler(InvalidTableMetadataException.class)
+  public ResponseEntity<String> handleInvalidTableMetadata(InvalidTableMetadataException ex) {
+    return render(HttpStatus.BAD_REQUEST, "BadRequestException", safeMessage(ex));
+  }
+
+  @ExceptionHandler(UnsupportedClientOperationException.class)
+  public ResponseEntity<String> handleUnsupportedClient(UnsupportedClientOperationException ex) {
+    return render(HttpStatus.BAD_REQUEST, "BadRequestException", safeMessage(ex));
+  }
+
+  // --------------------------------------------------------------------------------------------
+  // Iceberg-native exceptions (in case a handler unwraps and rethrows raw)
+  // --------------------------------------------------------------------------------------------
+
+  @ExceptionHandler(CommitFailedException.class)
+  public ResponseEntity<String> handleCommitFailed(CommitFailedException ex) {
+    return render(HttpStatus.CONFLICT, "CommitFailedException", safeMessage(ex));
+  }
+
+  @ExceptionHandler(org.apache.iceberg.exceptions.NoSuchTableException.class)
+  public ResponseEntity<String> handleIcebergNoSuchTable(
+      org.apache.iceberg.exceptions.NoSuchTableException ex) {
+    return render(HttpStatus.NOT_FOUND, "NoSuchTableException", safeMessage(ex));
+  }
+
+  @ExceptionHandler(org.apache.iceberg.exceptions.NoSuchNamespaceException.class)
+  public ResponseEntity<String> handleIcebergNoSuchNamespace(
+      org.apache.iceberg.exceptions.NoSuchNamespaceException ex) {
+    return render(HttpStatus.NOT_FOUND, "NoSuchNamespaceException", safeMessage(ex));
+  }
+
+  @ExceptionHandler(org.apache.iceberg.exceptions.AlreadyExistsException.class)
+  public ResponseEntity<String> handleIcebergAlreadyExists(
+      org.apache.iceberg.exceptions.AlreadyExistsException ex) {
+    return render(HttpStatus.CONFLICT, "AlreadyExistsException", safeMessage(ex));
+  }
+
+  // --------------------------------------------------------------------------------------------
+  // Generic fallbacks
+  // --------------------------------------------------------------------------------------------
+
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<String> handleIllegalArgument(IllegalArgumentException ex) {
+    return render(HttpStatus.BAD_REQUEST, "BadRequestException", safeMessage(ex));
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<String> handleAny(Exception ex) {
+    log.warn("Unhandled exception in Iceberg REST adapter", ex);
+    return render(HttpStatus.INTERNAL_SERVER_ERROR, "InternalServerError", safeMessage(ex));
+  }
+
+  // --------------------------------------------------------------------------------------------
+  // helpers
+  // --------------------------------------------------------------------------------------------
+
+  private static ResponseEntity<String> render(HttpStatus status, String type, String message) {
+    ErrorResponse err =
+        ErrorResponse.builder()
+            .withMessage(message == null ? "" : message)
+            .withType(type)
+            .responseCode(status.value())
+            .build();
+    String json = ErrorResponseParser.toJson(err);
+    return ResponseEntity.status(status).contentType(MediaType.APPLICATION_JSON).body(json);
+  }
+
+  private static String safeMessage(Throwable t) {
+    return t.getMessage() == null ? t.getClass().getSimpleName() : t.getMessage();
+  }
+
+  private static boolean isTablePath(WebRequest req) {
+    if (req == null) {
+      return false;
+    }
+    String desc = req.getDescription(false);
+    return desc != null && desc.contains("/tables/");
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/rest/controller/IcebergTablesController.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/rest/controller/IcebergTablesController.java
@@ -1,0 +1,314 @@
+package com.linkedin.openhouse.tables.rest.controller;
+
+import static com.linkedin.openhouse.common.security.AuthenticationUtils.extractAuthenticatedUserPrincipal;
+
+import com.linkedin.openhouse.common.api.spec.ApiResponse;
+import com.linkedin.openhouse.tables.api.handler.IcebergSnapshotsApiHandler;
+import com.linkedin.openhouse.tables.api.handler.TablesApiHandler;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.request.IcebergSnapshotsRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllTablesResponseBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
+import com.linkedin.openhouse.tables.rest.adapter.CommitAdapter;
+import com.linkedin.openhouse.tables.rest.adapter.CreateTableRequestAdapter;
+import com.linkedin.openhouse.tables.rest.adapter.IcebergRestJson;
+import com.linkedin.openhouse.tables.rest.adapter.NamespaceUtilRest;
+import com.linkedin.openhouse.tables.rest.adapter.TableLoadAdapter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotParser;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.SnapshotRefParser;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.UpdateRequirement;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.ListTablesResponse;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Iceberg REST Catalog table endpoints under {@code /iceberg/v1/{prefix}/namespaces/...}.
+ *
+ * <p>Reads are delegated to {@link TablesApiHandler} for ACL + existence and then to {@link
+ * TableLoadAdapter} (backed by {@code OpenHouseInternalCatalog}) for the live Iceberg metadata.
+ *
+ * <p>Commits replay the inbound {@code MetadataUpdate}s on top of the current metadata, then route
+ * the result to either {@link IcebergSnapshotsApiHandler#putIcebergSnapshots} (when snapshots
+ * changed) or {@link TablesApiHandler#updateTable} (metadata-only commit) so OpenHouse's normal
+ * write path runs.
+ *
+ * <p>{@link org.apache.iceberg.rest.responses.LoadTableResponse} is used for both create and commit
+ * responses — Iceberg's commit response is structurally identical and {@code CommitTableResponse}
+ * does not exist in iceberg-core 1.5.2.
+ */
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/iceberg/v1/{prefix}")
+public class IcebergTablesController {
+
+  private final TablesApiHandler tablesApiHandler;
+  private final IcebergSnapshotsApiHandler icebergSnapshotsApiHandler;
+  private final CommitAdapter commitAdapter;
+  private final CreateTableRequestAdapter createTableRequestAdapter;
+  private final TableLoadAdapter tableLoadAdapter;
+
+  // ----------------------------------------------------------------------------------------------
+  // GET /namespaces/{namespace}/tables
+  // ----------------------------------------------------------------------------------------------
+  @GetMapping(value = "/namespaces/{namespace}/tables", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<String> listTables(
+      @PathVariable("prefix") String prefix, @PathVariable("namespace") String namespacePath)
+      throws Exception {
+    Namespace ns = NamespaceUtilRest.decode(namespacePath);
+    String databaseId = NamespaceUtilRest.singleLevelDb(ns);
+
+    ApiResponse<GetAllTablesResponseBody> resp = tablesApiHandler.searchTables(databaseId);
+    List<GetTableResponseBody> tables =
+        resp.getResponseBody() == null || resp.getResponseBody().getResults() == null
+            ? Collections.emptyList()
+            : resp.getResponseBody().getResults();
+
+    ListTablesResponse.Builder builder = ListTablesResponse.builder();
+    for (GetTableResponseBody t : tables) {
+      builder.add(
+          org.apache.iceberg.catalog.TableIdentifier.of(
+              Namespace.of(t.getDatabaseId()), t.getTableId()));
+    }
+    return ResponseEntity.ok()
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(IcebergRestJson.mapper().writeValueAsString(builder.build()));
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // GET /namespaces/{namespace}/tables/{table}
+  // ----------------------------------------------------------------------------------------------
+  @GetMapping(
+      value = "/namespaces/{namespace}/tables/{table}",
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<String> loadTable(
+      @PathVariable("prefix") String prefix,
+      @PathVariable("namespace") String namespacePath,
+      @PathVariable("table") String tableId)
+      throws Exception {
+    Namespace ns = NamespaceUtilRest.decode(namespacePath);
+    String databaseId = NamespaceUtilRest.singleLevelDb(ns);
+    String principal = extractAuthenticatedUserPrincipal();
+
+    // existence + ACL check via OpenHouse handler; throws NoSuchEntityException -> 404
+    tablesApiHandler.getTable(databaseId, tableId, principal);
+
+    LoadTableResponse response = tableLoadAdapter.buildLoadTableResponse(databaseId, tableId);
+    return ResponseEntity.ok()
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(IcebergRestJson.mapper().writeValueAsString(response));
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // HEAD /namespaces/{namespace}/tables/{table}
+  // ----------------------------------------------------------------------------------------------
+  @RequestMapping(value = "/namespaces/{namespace}/tables/{table}", method = RequestMethod.HEAD)
+  public ResponseEntity<Void> tableExistsHead(
+      @PathVariable("prefix") String prefix,
+      @PathVariable("namespace") String namespacePath,
+      @PathVariable("table") String tableId) {
+    Namespace ns = NamespaceUtilRest.decode(namespacePath);
+    String databaseId = NamespaceUtilRest.singleLevelDb(ns);
+    String principal = extractAuthenticatedUserPrincipal();
+
+    // Throws NoSuchEntityException -> 404 via exception handler.
+    tablesApiHandler.getTable(databaseId, tableId, principal);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // POST /namespaces/{namespace}/tables — create
+  // ----------------------------------------------------------------------------------------------
+  @PostMapping(
+      value = "/namespaces/{namespace}/tables",
+      consumes = MediaType.APPLICATION_JSON_VALUE,
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<String> createTable(
+      @PathVariable("prefix") String prefix,
+      @PathVariable("namespace") String namespacePath,
+      @RequestBody String requestBody)
+      throws Exception {
+    Namespace ns = NamespaceUtilRest.decode(namespacePath);
+    String databaseId = NamespaceUtilRest.singleLevelDb(ns);
+    String principal = extractAuthenticatedUserPrincipal();
+
+    CreateTableRequest req =
+        IcebergRestJson.mapper().readValue(requestBody, CreateTableRequest.class);
+    if (req.stageCreate()) {
+      // v0 limitation: staged-create (CTAS) requires separate stage + commit handling.
+      return errorResponse(
+          HttpStatus.NOT_IMPLEMENTED,
+          "BadRequestException",
+          "stage-create (CTAS) is not supported by the OpenHouse Iceberg REST adapter v0");
+    }
+
+    CreateUpdateTableRequestBody body = createTableRequestAdapter.buildFromCreate(ns, req);
+    tablesApiHandler.createTable(databaseId, body, principal);
+
+    // Re-load the freshly-created table to produce a LoadTableResponse with current metadata.
+    LoadTableResponse response = tableLoadAdapter.buildLoadTableResponse(databaseId, req.name());
+    return ResponseEntity.ok()
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(IcebergRestJson.mapper().writeValueAsString(response));
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // POST /namespaces/{namespace}/tables/{table} — commit (updateTable)
+  // ----------------------------------------------------------------------------------------------
+  @PostMapping(
+      value = "/namespaces/{namespace}/tables/{table}",
+      consumes = MediaType.APPLICATION_JSON_VALUE,
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<String> commitTable(
+      @PathVariable("prefix") String prefix,
+      @PathVariable("namespace") String namespacePath,
+      @PathVariable("table") String tableId,
+      @RequestBody String requestBody)
+      throws Exception {
+    Namespace ns = NamespaceUtilRest.decode(namespacePath);
+    String databaseId = NamespaceUtilRest.singleLevelDb(ns);
+    String principal = extractAuthenticatedUserPrincipal();
+
+    UpdateTableRequest req =
+        IcebergRestJson.mapper().readValue(requestBody, UpdateTableRequest.class);
+
+    // 1. Load current metadata
+    TableMetadata currentMetadata = tableLoadAdapter.loadMetadata(databaseId, tableId);
+
+    // 2. Validate every requirement against current metadata (throws CommitFailedException -> 409)
+    if (req.requirements() != null) {
+      for (UpdateRequirement requirement : req.requirements()) {
+        requirement.validate(currentMetadata);
+      }
+    }
+
+    // 3. Replay updates to produce post-commit metadata
+    TableMetadata.Builder mdBuilder = TableMetadata.buildFrom(currentMetadata);
+    if (req.updates() != null) {
+      for (MetadataUpdate u : req.updates()) {
+        u.applyTo(mdBuilder);
+      }
+    }
+    TableMetadata newMetadata = mdBuilder.build();
+
+    // 4. Build the OpenHouse request body
+    String baseTableVersion = currentMetadata.metadataFileLocation();
+    CreateUpdateTableRequestBody body =
+        commitAdapter.buildCreateUpdateBody(ns, tableId, newMetadata, baseTableVersion);
+
+    // 5. Discriminate snapshot-changing vs metadata-only commits
+    boolean snapshotsChanged =
+        !safeEquals(currentMetadata.snapshots(), newMetadata.snapshots())
+            || !safeEquals(currentMetadata.refs(), newMetadata.refs());
+
+    if (snapshotsChanged) {
+      List<String> jsonSnapshots = new ArrayList<>();
+      if (newMetadata.snapshots() != null) {
+        for (Snapshot s : newMetadata.snapshots()) {
+          jsonSnapshots.add(SnapshotParser.toJson(s));
+        }
+      }
+      Map<String, String> jsonRefs = new LinkedHashMap<>();
+      if (newMetadata.refs() != null) {
+        for (Map.Entry<String, SnapshotRef> e : newMetadata.refs().entrySet()) {
+          jsonRefs.put(e.getKey(), SnapshotRefParser.toJson(e.getValue()));
+        }
+      }
+      IcebergSnapshotsRequestBody snapBody =
+          IcebergSnapshotsRequestBody.builder()
+              .baseTableVersion(baseTableVersion)
+              .jsonSnapshots(jsonSnapshots)
+              .snapshotRefs(jsonRefs)
+              .createUpdateTableRequestBody(body)
+              .build();
+      icebergSnapshotsApiHandler.putIcebergSnapshots(databaseId, tableId, snapBody, principal);
+    } else {
+      tablesApiHandler.updateTable(databaseId, tableId, body, principal);
+    }
+
+    // 6. Re-load to produce the committed LoadTableResponse
+    LoadTableResponse response = tableLoadAdapter.buildLoadTableResponse(databaseId, tableId);
+    return ResponseEntity.ok()
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(IcebergRestJson.mapper().writeValueAsString(response));
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // DELETE /namespaces/{namespace}/tables/{table} — drop
+  // ----------------------------------------------------------------------------------------------
+  @DeleteMapping(value = "/namespaces/{namespace}/tables/{table}")
+  public ResponseEntity<Void> dropTable(
+      @PathVariable("prefix") String prefix,
+      @PathVariable("namespace") String namespacePath,
+      @PathVariable("table") String tableId,
+      @RequestParam(value = "purgeRequested", required = false, defaultValue = "false")
+          boolean purgeRequested) {
+    Namespace ns = NamespaceUtilRest.decode(namespacePath);
+    String databaseId = NamespaceUtilRest.singleLevelDb(ns);
+    String principal = extractAuthenticatedUserPrincipal();
+
+    // v0: ignore purgeRequested — OpenHouse soft-deletes by default.
+    tablesApiHandler.deleteTable(databaseId, tableId, principal);
+    return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // helpers
+  // ----------------------------------------------------------------------------------------------
+
+  /** Null-safe equality wrapper for {@code List#equals} / {@code Map#equals}. */
+  private static boolean safeEquals(Object a, Object b) {
+    if (a == null && b == null) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return false;
+    }
+    return a.equals(b);
+  }
+
+  /** Render a minimal Iceberg ErrorResponse JSON inline (used for special-case 501 below). */
+  private ResponseEntity<String> errorResponse(HttpStatus status, String type, String message)
+      throws Exception {
+    org.apache.iceberg.rest.responses.ErrorResponse err =
+        org.apache.iceberg.rest.responses.ErrorResponse.builder()
+            .withMessage(message)
+            .withType(type)
+            .responseCode(status.value())
+            .build();
+    String json = org.apache.iceberg.rest.responses.ErrorResponseParser.toJson(err);
+    return ResponseEntity.status(status).contentType(MediaType.APPLICATION_JSON).body(json);
+  }
+
+  // Avoid an unused import warning if CommitFailedException is referenced only in javadoc.
+  @SuppressWarnings("unused")
+  private static Class<?> unusedCommitFailed() {
+    return CommitFailedException.class;
+  }
+}


### PR DESCRIPTION
## Summary

Adds an **in-process Iceberg REST Catalog facade** in front of the existing Tables Service. The new `com.linkedin.openhouse.tables.rest` package is picked up by the existing `TablesSpringApplication` component scan — no Spring-app wiring changes required. Any client that speaks the Apache Iceberg REST wire protocol (Spark, Trino, PyIceberg, Flink, …) can now read and write OpenHouse tables without an OpenHouse-specific plugin.

The new package contributes ~960 lines of new Java, **zero** changes to existing files. It reuses `TablesApiHandler`, `IcebergSnapshotsApiHandler`, `DatabasesApiHandler`, and `OpenHouseInternalCatalog` via constructor injection. Server-side metadata authorship and the existing two-stage CAS (path-string version check + HouseTables `@Version` JPA lock) are preserved unchanged — REST clients reach the same `OpenHouseInternalTableOperations.doCommit` path the existing OpenHouse Java client already uses.

## Changes

- [x] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

### Client-facing API: new endpoints under `/iceberg/v1/...`

All endpoints accept and return Iceberg's standard REST wire format.

| Method   | Path                                                           | Backed by |
|----------|----------------------------------------------------------------|-----------|
| `GET`    | `/v1/config`                                                   | static — echoes `?warehouse=` back as `overrides.prefix` |
| `GET`    | `/v1/{prefix}/namespaces`                                      | `DatabasesApiHandler.getAllDatabases` |
| `POST`   | `/v1/{prefix}/namespaces`                                      | accepted as success (OpenHouse auto-creates on first table) |
| `GET`    | `/v1/{prefix}/namespaces/{namespace}`                          | existence check via `DatabasesApiHandler` |
| `HEAD`   | `/v1/{prefix}/namespaces/{namespace}`                          | same |
| `DELETE` | `/v1/{prefix}/namespaces/{namespace}`                          | accepted as 204 (no native drop-namespace) |
| `GET`    | `/v1/{prefix}/namespaces/{namespace}/tables`                   | `TablesApiHandler.searchTables` |
| `POST`   | `/v1/{prefix}/namespaces/{namespace}/tables`                   | `TablesApiHandler.createTable` |
| `GET`    | `/v1/{prefix}/namespaces/{namespace}/tables/{table}`           | `TablesApiHandler.getTable` + `OpenHouseInternalCatalog.loadTable` |
| `HEAD`   | `/v1/{prefix}/namespaces/{namespace}/tables/{table}`           | same |
| `POST`   | `/v1/{prefix}/namespaces/{namespace}/tables/{table}` (commit)  | `IcebergSnapshotsApiHandler.putIcebergSnapshots` or `TablesApiHandler.updateTable` |
| `DELETE` | `/v1/{prefix}/namespaces/{namespace}/tables/{table}`           | `TablesApiHandler.deleteTable` |

The commit endpoint replays the Iceberg `requirements + updates` payload via `MetadataUpdate.applyTo(TableMetadata.Builder)`, pre-checks each `UpdateRequirement`, then discriminates: snapshot changes route to `IcebergSnapshotsApiHandler.putIcebergSnapshots`; metadata-only commits route to `TablesApiHandler.updateTable`.

### New Features

Lets any stock Iceberg REST client (Spark `org.apache.iceberg.rest.RESTCatalog`, PyIceberg `RestCatalog`, Trino `iceberg-rest` connector, Flink) talk to OpenHouse without per-engine catalog code.

A `@RestControllerAdvice(basePackages = "com.linkedin.openhouse.tables.rest")` maps OpenHouse internal exceptions to Iceberg's wire-format `ErrorResponse` JSON. The advice is **package-scoped** so OpenHouse's existing exception handler for the native `/v1/databases/...` surface is unaffected.

### MVP scope notes (intentional)

- **Single-level namespaces only** (depth > 1 → 400). Rejection chosen over flatten-encoding so a future multi-level migration is purely additive (no HDFS path rewrites). Spark, Trino, and PyIceberg all work depth-1 when the warehouse is configured that way.
- **Out of scope for this PR**: views, multi-table transactions, server-side scan planning, credential vending, remote signing. These are simply not advertised — clients gracefully skip them.
- **No new external dependencies** — Iceberg wire types (`UpdateTableRequest`, `LoadTableResponse`, `ConfigResponse`, `ErrorResponse`, …) come from `iceberg-core` 1.5.2 already on the Tables Service classpath.

## Testing Done

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

End-to-end smoke against the `oh-hadoop-spark` docker recipe. **Stock** Iceberg `RESTCatalog` client; **no** OpenHouse plugin activated.

\`\`\`bash
./gradlew :services:tables:bootJar
cd infra/recipes/docker-compose/oh-hadoop-spark
docker compose build openhouse-tables
docker compose up -d
\`\`\`

Spark session config (catalog `oh` is stock Iceberg):

\`\`\`
spark.sql.catalog.oh                = org.apache.iceberg.spark.SparkCatalog
spark.sql.catalog.oh.catalog-impl   = org.apache.iceberg.rest.RESTCatalog
spark.sql.catalog.oh.uri            = http://openhouse-tables:8080/iceberg/
spark.sql.catalog.oh.token          = <openhouse JWT>
spark.sql.catalog.oh.warehouse      = oh
\`\`\`

SQL script executed:

\`\`\`sql
SHOW NAMESPACES IN oh;
CREATE NAMESPACE IF NOT EXISTS oh.smoke;
DROP TABLE IF EXISTS oh.smoke.t1;
CREATE TABLE oh.smoke.t1 (id bigint, name string) USING iceberg;
SHOW TABLES IN oh.smoke;
INSERT INTO oh.smoke.t1 VALUES (1,'alice'),(2,'bob'),(3,'carol');
SELECT count(*) FROM oh.smoke.t1;
SELECT * FROM oh.smoke.t1 ORDER BY id;
INSERT INTO oh.smoke.t1 VALUES (4,'dave');
SELECT count(*) FROM oh.smoke.t1;
SELECT * FROM oh.smoke.t1 ORDER BY id;
DROP TABLE oh.smoke.t1;
SHOW TABLES IN oh.smoke;
\`\`\`

Result (trimmed):

\`\`\`
smoke   t1
Time taken: 0.595 seconds, Fetched 1 row(s)
Time taken: 6.497 seconds
3
1   alice
2   bob
3   carol
Time taken: 1.093 seconds, Fetched 3 row(s)
Time taken: 2.57 seconds
4
1   alice
2   bob
3   carol
4   dave
Time taken: 0.351 seconds, Fetched 4 row(s)
\`\`\`

All commands succeed end-to-end. Spark uses the stock Iceberg `RESTCatalog`; the adapter translates each request, delegates to existing OpenHouse handlers, and translates the response back. The new `metadata.json` files are written server-side by `OpenHouseInternalTableOperations.doCommit` (unchanged), and Spark reads them back via the standard Iceberg path.

Follow-up work intentionally not in this PR:

- Unit + Spring `@WebMvcTest` coverage for each controller
- `@SpringBootTest` with the upstream `RESTCatalog` Java client against an H2 Tables Service
- CI smoke that runs the docker SQL round-trip on every PR
- Configuration knob to enable/disable the adapter (currently always on)
- Credential vending (`LoadTableResponse.storage-credentials`)
- Multi-table transactions, views, multi-level namespaces

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

No breaking changes. The new package is additive; the existing `/v1/databases/...` surface is untouched. The new `@RestControllerAdvice` is scoped via `basePackages = "com.linkedin.openhouse.tables.rest"` so OpenHouse's existing exception handler keeps owning everything else.