### PR TITLE
[Just for sharing] Abort commit when writer's declared base diverges from current

### DIFF
--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -265,8 +265,35 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
     try {
       // Now that we have metadataLocation we stamp it in metadata property.
       Map<String, String> properties = new HashMap<>(metadata.properties());
+
+      // Capture the writer's declared base BEFORE failIfRetryUpdate strips COMMIT_KEY. The value
+      // is the writer's request body's baseTableVersion (set on the transaction by
+      // OpenHouseInternalRepositoryImpl.save's `updateProperties.set(COMMIT_KEY, ...).commit()`),
+      // which equals the metadata file path the writer's local view was loaded from.
+      String writerClaimedBase = properties.get(CatalogConstants.COMMIT_KEY);
+
       failIfRetryUpdate(properties);
       restoreOverriddenProperties(properties);
+
+      // Abort if the transaction's base has advanced past what the writer claimed it was
+      // committing against. This catches the SNAPSHOTS_EXPIRATION race-orphan bug class:
+      // BaseTransaction.applyUpdates:497 silently refreshes the transaction's base mid-commit,
+      // which would otherwise cause the subtractive merge below (lines 336-343) to interpret
+      // racing-acquired snapshots as writer-intended removals and silently drop them.
+      //
+      // Analog of HiveTableOperations:210 and HadoopTableOperations:133 — visible failure on
+      // stale-base commits, surfacing through Iceberg's BaseMetastoreTableOperations.commit
+      // retry path to the application instead of corrupting silently.
+      if (base != null
+          && writerClaimedBase != null
+          && !CatalogConstants.INITIAL_VERSION.equals(writerClaimedBase)
+          && !isSameMetadataPath(writerClaimedBase, base.metadataFileLocation())) {
+        throw new CommitFailedException(
+            "Cannot commit: writer's declared base [%s] does not match the table's current base "
+                + "[%s] for table %s. The catalog advanced after the writer constructed its "
+                + "request. Refresh and retry.",
+            writerClaimedBase, base.metadataFileLocation(), tableIdentifier);
+      }
 
       properties.put(
           getCanonicalFieldName("tableVersion"),
@@ -580,6 +607,23 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
     }
 
     return builder.build();
+  }
+
+  /**
+   * Compare two metadata file paths ignoring URI scheme/authority. The writer's declared base may
+   * carry a scheme (e.g. {@code hdfs://cluster/...}) while internal Iceberg metadata locations are
+   * scheme-less, or vice versa, depending on the FileIO configuration. We compare on the underlying
+   * path component to avoid spurious mismatches.
+   */
+  private static boolean isSameMetadataPath(String a, String b) {
+    if (java.util.Objects.equals(a, b)) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return false;
+    }
+    return java.util.Objects.equals(
+        java.net.URI.create(a).getPath(), java.net.URI.create(b).getPath());
   }
 
   /**

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
@@ -30,6 +30,7 @@ import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -266,6 +267,104 @@ public class OpenHouseInternalTableOperationsTest {
 
       Assertions.assertTrue(updatedProperties.containsKey(getCanonicalFieldName("tableLocation")));
       Mockito.verify(mockHouseTableRepository, Mockito.times(1)).save(Mockito.eq(mockHouseTable));
+    }
+  }
+
+  /**
+   * Regression test for the SNAPSHOTS_EXPIRATION race-orphan bug class.
+   *
+   * <p>In production the failure pattern is:
+   *
+   * <ol>
+   *   <li>Spark expiration writer loads the table at T_X. Its body's {@code jsonSnapshots} is the
+   *       writer's keep-set computed against T_X's snapshots. {@code
+   *       OpenHouseInternalRepositoryImpl.save:188} stages {@code COMMIT_KEY = T_X} (the writer's
+   *       declared base) on the transaction.
+   *   <li>{@code OpenHouseInternalRepositoryImpl.versionCheck:336} passes because the catalog is
+   *       still at T_X when the server's initial {@code catalog.loadTable()} runs.
+   *   <li>A racing commit lands at HTS during server-side processing, advancing the catalog to T_Y
+   *       (which contains a snapshot the writer did not know about).
+   *   <li>{@code BaseTransaction.applyUpdates:497} silently refreshes the transaction's base to T_Y
+   *       and re-applies the staged PendingUpdates. The PropertiesUpdate re-sets the same writer
+   *       values (idempotent in V), so {@code SNAPSHOTS_JSON_KEY} stays stale but {@code
+   *       COMMIT_KEY} stays at T_X.
+   *   <li>{@code doCommit(base=T_Y, metadata=T_Y + writer's stale properties)} runs. Without the
+   *       abort check, the subtractive merge at lines 336-343 would compute {@code toRemove =
+   *       T_Y.snapshots() − writer's stale list = \{racing snap\}} and silently drop the racing
+   *       snap.
+   * </ol>
+   *
+   * <p>This test sets up the post-refresh inputs ({@code base} and {@code metadata}) and the staged
+   * {@code COMMIT_KEY = writer's claimed base} that {@code doCommit} would see after {@code
+   * applyUpdates}' refresh. It asserts that {@code doCommit} aborts with {@code
+   * CommitFailedException} — the analog of {@code HiveTableOperations:210} — instead of silently
+   * dropping the racing snapshot.
+   *
+   * <p>Without the abort check at {@code doCommit:259-275}, the request silently succeeds and the
+   * racing snapshot is dropped. With the abort, the writer gets a visible failure that propagates
+   * through Iceberg's commit-retry path to the application.
+   */
+  @Test
+  void testDoCommitAbortsOnStaleClaimedBase() throws IOException {
+    List<Snapshot> testSnapshots = IcebergTestUtil.getSnapshots();
+    Snapshot writerKnown1 = testSnapshots.get(0);
+    Snapshot writerKnown2 = testSnapshots.get(1);
+    Snapshot racingSnapshot = testSnapshots.get(2);
+
+    // Writer's claimed base path (T_X) — what its driver loaded at job start.
+    String writerClaimedBaseLocation =
+        "/test/openhouse/test_db/test_table/00001-writer-base.metadata.json";
+
+    // Post-refresh state (T_Y): catalog advanced to include the racing snapshot. The actual
+    // base.metadataFileLocation() will be null for an in-memory TableMetadata built via
+    // setBranchSnapshot, which is sufficient for the abort check — isSameMetadataPath returns
+    // false when comparing any non-null path against null, so the abort will fire on the
+    // (non-null COMMIT_KEY, null base.metadataFileLocation()) mismatch. In production both are
+    // non-null and the mismatch is between two different paths; the assertion semantics are the
+    // same either way.
+    TableMetadata postRefreshBase =
+        TableMetadata.buildFrom(BASE_TABLE_METADATA)
+            .setBranchSnapshot(writerKnown1, SnapshotRef.MAIN_BRANCH)
+            .setBranchSnapshot(writerKnown2, SnapshotRef.MAIN_BRANCH)
+            .setBranchSnapshot(racingSnapshot, SnapshotRef.MAIN_BRANCH)
+            .build();
+
+    // Writer's stale request body — jsonSnapshots reflects pre-race view; the racing snapshot
+    // is missing because it didn't exist when the writer's driver serialized the body.
+    List<Snapshot> writersStaleUniverse = Arrays.asList(writerKnown1, writerKnown2);
+
+    Map<String, String> properties = new HashMap<>();
+    properties.put(
+        CatalogConstants.SNAPSHOTS_JSON_KEY,
+        SnapshotsUtil.serializedSnapshots(writersStaleUniverse));
+    properties.put(
+        CatalogConstants.SNAPSHOTS_REFS_KEY,
+        SnapshotsUtil.serializeMap(IcebergTestUtil.createMainBranchRefPointingTo(writerKnown2)));
+    properties.put(getCanonicalFieldName("tableLocation"), TEST_LOCATION);
+    // COMMIT_KEY: writer's declared base (T_X) — what OpenHouseInternalRepositoryImpl.save:188
+    // would have staged. doCommit's abort check compares this against base.metadataFileLocation()
+    // (which is T_Y after applyUpdates refreshed).
+    properties.put(CatalogConstants.COMMIT_KEY, writerClaimedBaseLocation);
+
+    TableMetadata metadata = postRefreshBase.replaceProperties(properties);
+
+    try (MockedStatic<TableMetadataParser> ignoreWriteMock =
+        Mockito.mockStatic(TableMetadataParser.class)) {
+      CommitFailedException thrown =
+          Assertions.assertThrows(
+              CommitFailedException.class,
+              () -> openHouseInternalTableOperations.doCommit(postRefreshBase, metadata),
+              "doCommit must abort when the writer's declared COMMIT_KEY base does not match "
+                  + "the transaction's current base — otherwise the subtractive merge at "
+                  + "lines 336-343 would silently expire racing snapshots.");
+
+      Assertions.assertTrue(
+          thrown.getMessage().contains("Cannot commit"),
+          "Expected stale-base abort message, got: " + thrown.getMessage());
+
+      // Critically, the HTS save must NOT have run. If it had, the racing snapshot would already
+      // be orphaned in the catalog regardless of any retry behavior.
+      Mockito.verify(mockHouseTableRepository, Mockito.never()).save(Mockito.any());
     }
   }
 


### PR DESCRIPTION
Catalog commits arriving via the snapshots endpoint smuggle the writer's intended state in opaque properties (snapshotsJsonToBePut, commitKey). When two concurrent commits race, Iceberg's BaseTransaction.applyUpdates silently refresh-and-reapplies the property set against the post-race base, after which OpenHouse's subtractive merge cannot distinguish a writer-intended snapshot removal from a race-acquired snapshot, and the loser's commit is dropped on the floor (BaseTransaction:466 "Failed to load metadata for a committed snapshot, skipping clean-up" WARN).

doCommit now compares the writer's declared base (COMMIT_KEY) against the actual base loaded into the table operations. If they diverge, throw CommitFailedException instead of merging; the writer can refresh and retry against the current state. INITIAL_VERSION (table-create) and post-create paths where COMMIT_KEY is absent are unaffected.

## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
