### PR TITLE
Add all-modules aggregate for simplified ELR onboarding

### DIFF
--- a/all-modules/build.gradle
+++ b/all-modules/build.gradle
@@ -1,0 +1,14 @@
+plugins {
+  id 'openhouse.java-conventions'
+  id 'openhouse.maven-publish'
+}
+
+// This module depends on all other OpenHouse modules. Its primary purpose is to allow downstream
+// consumers to track a single artifact in ELR instead of enumerating every module individually.
+dependencies {
+  rootProject.subprojects.each { subproject ->
+    if (subproject.path != project.path && subproject.subprojects.isEmpty()) {
+      implementation project(subproject.path)
+    }
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -62,6 +62,8 @@ include ':cluster:metrics'
 
 include ':scripts:java:tools:dummytokens'
 
+include ':all-modules'
+
 project(':integrations:spark:spark-3.1:openhouse-spark-runtime').name = 'openhouse-spark-runtime_2.12'
 project(':apps:spark').name = 'openhouse-spark-apps_2.12'
 project(':apps:spark-3.5').name = 'openhouse-spark-apps-1.5_2.12'


### PR DESCRIPTION
## Summary

Introduce an `all-modules` aggregate module that transitively depends on every published OpenHouse module.

**Problem:** ELR (External Library Registry) at LinkedIn requires onboarding and monitoring each artifact individually. With 24+ OpenHouse modules per release, all 24 ELR checks must pass before a dependency bump can proceed. This creates operational overhead and makes non-happy-path failures harder to isolate and track.

**Solution:** `all-modules` provides a single artifact that covers the full OpenHouse module set via transitive dependency resolution.

**How it is used in practice:** In our downstream LinkedIn dependency (`li-openhouse`), `all-modules` is declared in the `external` block of `product-spec.json` — the registry ELR scans to enumerate tracked artifacts. ELR resolves `all-modules` transitively and sees all OpenHouse modules through that single entry. The individual 24 ELR registrations (e.g. `openhouse_tables-test-fixtures`, `openhouse_storage`, etc.) can then be decommissioned.

During build time, `all-modules` is **not** placed on any classpath. Submodules continue to resolve their specific OpenHouse dependencies directly by GAV coordinate. The separation is intentional: `all-modules` is a tracking artifact for ELR, not a runtime dependency.

## Changes

- [x] New Features

`all-modules/build.gradle` — new aggregate module that dynamically depends on all leaf subprojects, following the same pattern used by the [Venice](https://github.com/linkedin/venice) project.  
`settings.gradle` — registers `:all-modules` as a Gradle subproject.

## Testing Done

- [x] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.

This change adds a Gradle configuration module only. There is no production logic to test. The module is verified by the existing Gradle build resolving all subproject dependencies correctly at configuration time.

# Additional Information

- No breaking changes, deprecations, or large PR splits required.