### PR TITLE
Add branchRefName to TableAuditEvent

### DIFF
--- a/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
+++ b/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
@@ -13,7 +13,7 @@ task javadocJar(type: Jar) {
 }
 
 tasks.withType(GenerateModuleMetadata) {
-  enabled = false
+  enabled = project.version.toString().endsWith('-SNAPSHOT')
 }
 
 [jar, sourcesJar, javadocJar].each { task ->

--- a/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
+++ b/buildSrc/src/main/groovy/openhouse.maven-publish.gradle
@@ -13,7 +13,7 @@ task javadocJar(type: Jar) {
 }
 
 tasks.withType(GenerateModuleMetadata) {
-  enabled = project.version.toString().endsWith('-SNAPSHOT')
+  enabled = false
 }
 
 [jar, sourcesJar, javadocJar].each { task ->

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
@@ -371,12 +371,18 @@ public class TableAuditAspect {
     } else {
       operationType = OperationType.COMMIT;
     }
+    CreateUpdateTableRequestBody createUpdateTableRequestBody =
+        icebergSnapshotRequestBody.getCreateUpdateTableRequestBody();
     TableAuditEvent.TableAuditEventBuilder eventBuilder =
         TableAuditEvent.builder()
             .eventTimestamp(Instant.now())
             .databaseName(databaseId)
             .tableName(tableId)
-            .operationType(operationType);
+            .operationType(operationType)
+            .tableProperties(
+                createUpdateTableRequestBody == null
+                    ? null
+                    : createUpdateTableRequestBody.getTableProperties());
     extractSnapshotInfo(icebergSnapshotRequestBody, eventBuilder);
     TableAuditEvent event = eventBuilder.build();
     try {

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
@@ -17,7 +17,9 @@ import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
 import com.linkedin.openhouse.tables.audit.model.OperationStatus;
 import com.linkedin.openhouse.tables.audit.model.OperationType;
 import com.linkedin.openhouse.tables.audit.model.TableAuditEvent;
+import com.linkedin.openhouse.tables.config.InternalCatalogProperties;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -43,6 +45,8 @@ public class TableAuditAspect {
   @Autowired private ClusterProperties clusterProperties;
 
   @Autowired private AuditHandler<TableAuditEvent> tableAuditHandler;
+
+  @Autowired private InternalCatalogProperties internalCatalogProperties;
 
   /**
    * Install the Around advice for getTable() method in OpenHouseTablesApiHandler.
@@ -371,26 +375,27 @@ public class TableAuditAspect {
     } else {
       operationType = OperationType.COMMIT;
     }
-    CreateUpdateTableRequestBody createUpdateTableRequestBody =
-        icebergSnapshotRequestBody.getCreateUpdateTableRequestBody();
     TableAuditEvent.TableAuditEventBuilder eventBuilder =
         TableAuditEvent.builder()
             .eventTimestamp(Instant.now())
             .databaseName(databaseId)
             .tableName(tableId)
-            .operationType(operationType)
-            .tableProperties(
-                createUpdateTableRequestBody == null
-                    ? null
-                    : createUpdateTableRequestBody.getTableProperties());
+            .operationType(operationType);
     extractSnapshotInfo(icebergSnapshotRequestBody, eventBuilder);
-    TableAuditEvent event = eventBuilder.build();
     try {
       result = (ApiResponse<GetTableResponseBody>) point.proceed();
+      // Read tableProperties from the response, not the request body: OpenHouse mutates
+      // properties server-side during commit (e.g. openhouse.tableVersion,
+      // openhouse.lastModifiedTime), and the audit event should reflect the committed state.
+      TableAuditEvent event =
+          eventBuilder
+              .tableProperties(filterTableProperties(result.getResponseBody().getTableProperties()))
+              .build();
       buildAndSendEvent(
           event, OperationStatus.SUCCESS, result.getResponseBody().getTableLocation());
     } catch (Throwable t) {
-      buildAndSendEvent(event, OperationStatus.FAILED, null);
+      // On failure there is no committed state to read from, so tableProperties stays null.
+      buildAndSendEvent(eventBuilder.build(), OperationStatus.FAILED, null);
       throw t;
     }
     return result;
@@ -533,6 +538,30 @@ public class TableAuditAspect {
       throw t;
     }
     return result;
+  }
+
+  /**
+   * Narrows the request-body table properties down to the configured allowlist ({@code
+   * cluster.iceberg.tables.audit.table-properties-allowlist}). Returns {@code null} when there is
+   * nothing to emit so downstream audit handlers can skip the field entirely. Iterates the
+   * allowlist rather than the source so cost is O(|allowlist|) regardless of source size.
+   */
+  private Map<String, String> filterTableProperties(Map<String, String> source) {
+    if (source == null || source.isEmpty()) {
+      return null;
+    }
+    List<String> allowlist = internalCatalogProperties.getAudit().getTablePropertiesAllowlist();
+    if (allowlist == null || allowlist.isEmpty()) {
+      return null;
+    }
+    Map<String, String> filtered = new HashMap<>();
+    for (String key : allowlist) {
+      String value = source.get(key);
+      if (value != null) {
+        filtered.put(key, value);
+      }
+    }
+    return filtered.isEmpty() ? null : filtered;
   }
 
   private void buildAndSendEvent(

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
@@ -542,37 +542,24 @@ public class TableAuditAspect {
 
   /**
    * Narrows the committed table properties down to the configured allowlist ({@code
-   * cluster.iceberg.tables.audit.table-properties-allowlist}) and drops any value longer than
-   * {@code cluster.iceberg.tables.audit.table-property-value-max-length} characters. Returns {@code
-   * null} when there is nothing to emit so downstream audit handlers can skip the field entirely.
-   * Iterates the allowlist rather than the source so cost is O(|allowlist|) regardless of source
-   * size.
+   * cluster.iceberg.tables.audit.table-properties-allowlist}). Returns {@code null} when there is
+   * nothing to emit so downstream audit handlers can skip the field entirely. Iterates the
+   * allowlist rather than the source so cost is O(|allowlist|) regardless of source size.
    */
   private Map<String, String> filterTableProperties(Map<String, String> source) {
     if (source == null || source.isEmpty()) {
       return null;
     }
-    InternalCatalogProperties.Audit auditConfig = internalCatalogProperties.getAudit();
-    List<String> allowlist = auditConfig.getTablePropertiesAllowlist();
+    List<String> allowlist = internalCatalogProperties.getAudit().getTablePropertiesAllowlist();
     if (allowlist == null || allowlist.isEmpty()) {
       return null;
     }
-    int maxLength = auditConfig.getTablePropertyValueMaxLength();
     Map<String, String> filtered = new HashMap<>();
     for (String key : allowlist) {
       String value = source.get(key);
-      if (value == null) {
-        continue;
+      if (value != null) {
+        filtered.put(key, value);
       }
-      if (maxLength > 0 && value.length() > maxLength) {
-        log.warn(
-            "Dropping table-property '{}' from audit event: value length {} exceeds cap {}",
-            key,
-            value.length(),
-            maxLength);
-        continue;
-      }
-      filtered.put(key, value);
     }
     return filtered.isEmpty() ? null : filtered;
   }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
@@ -541,25 +541,38 @@ public class TableAuditAspect {
   }
 
   /**
-   * Narrows the request-body table properties down to the configured allowlist ({@code
-   * cluster.iceberg.tables.audit.table-properties-allowlist}). Returns {@code null} when there is
-   * nothing to emit so downstream audit handlers can skip the field entirely. Iterates the
-   * allowlist rather than the source so cost is O(|allowlist|) regardless of source size.
+   * Narrows the committed table properties down to the configured allowlist ({@code
+   * cluster.iceberg.tables.audit.table-properties-allowlist}) and drops any value longer than
+   * {@code cluster.iceberg.tables.audit.table-property-value-max-length} characters. Returns {@code
+   * null} when there is nothing to emit so downstream audit handlers can skip the field entirely.
+   * Iterates the allowlist rather than the source so cost is O(|allowlist|) regardless of source
+   * size.
    */
   private Map<String, String> filterTableProperties(Map<String, String> source) {
     if (source == null || source.isEmpty()) {
       return null;
     }
-    List<String> allowlist = internalCatalogProperties.getAudit().getTablePropertiesAllowlist();
+    InternalCatalogProperties.Audit auditConfig = internalCatalogProperties.getAudit();
+    List<String> allowlist = auditConfig.getTablePropertiesAllowlist();
     if (allowlist == null || allowlist.isEmpty()) {
       return null;
     }
+    int maxLength = auditConfig.getTablePropertyValueMaxLength();
     Map<String, String> filtered = new HashMap<>();
     for (String key : allowlist) {
       String value = source.get(key);
-      if (value != null) {
-        filtered.put(key, value);
+      if (value == null) {
+        continue;
       }
+      if (maxLength > 0 && value.length() > maxLength) {
+        log.warn(
+            "Dropping table-property '{}' from audit event: value length {} exceeds cap {}",
+            key,
+            value.length(),
+            maxLength);
+        continue;
+      }
+      filtered.put(key, value);
     }
     return filtered.isEmpty() ? null : filtered;
   }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
@@ -402,22 +402,38 @@ public class TableAuditAspect {
   }
 
   /**
-   * Extracts snapshot ID and timestamp of the main branch from the request body. The snapshotRefs
-   * map contains branch name to JSON-serialized SnapshotRef. We read the main branch's snapshot-id
-   * (this is what Iceberg treats as current-snapshot-id — see TableMetadata.Builder.setRef()) and
-   * then find the matching snapshot in jsonSnapshots to get its timestamp-ms.
+   * Extracts snapshot ID, timestamp, and branch ref name from the request body.
    *
-   * <p>Leaves both fields null if the main branch ref is absent (e.g. branch-only commits where
-   * main didn't advance, or non-commit operations) or if the matching snapshot can't be found.
+   * <p>branchRefName is the ref whose snapshot-id matches the last snapshot in jsonSnapshots.
+   * Iceberg appends snapshots chronologically, so the last one is always the newly-committed
+   * snapshot, and the ref pointing to it is the branch that was written.
+   *
+   * <p>currentSnapshotId and currentSnapshotTimestampMs track the main branch ref for backwards
+   * compatibility. They are null when main is absent from snapshotRefs.
    */
   private void extractSnapshotInfo(
       IcebergSnapshotsRequestBody requestBody,
       TableAuditEvent.TableAuditEventBuilder eventBuilder) {
     try {
       Map<String, String> snapshotRefs = requestBody.getSnapshotRefs();
-      if (snapshotRefs == null) {
+      List<String> jsonSnapshots = requestBody.getJsonSnapshots();
+      if (snapshotRefs == null || jsonSnapshots == null || jsonSnapshots.isEmpty()) {
         return;
       }
+
+      // The last snapshot in the list is the one being committed (Iceberg appends chronologically).
+      // Find which ref points to it — that is the branch being written.
+      long lastSnapshotId =
+          SnapshotParser.fromJson(jsonSnapshots.get(jsonSnapshots.size() - 1)).snapshotId();
+      for (Map.Entry<String, String> entry : snapshotRefs.entrySet()) {
+        if (SnapshotRefParser.fromJson(entry.getValue()).snapshotId() == lastSnapshotId) {
+          eventBuilder.branchRefName(entry.getKey());
+          break;
+        }
+      }
+
+      // Extract snapshot ID and timestamp for main branch (backwards-compatible).
+      // Iterate jsonSnapshots in reverse: main's snapshot is typically the most recent.
       String mainRefJson = snapshotRefs.get(SnapshotRef.MAIN_BRANCH);
       if (mainRefJson == null) {
         return;
@@ -425,14 +441,6 @@ public class TableAuditAspect {
       long mainSnapshotId = SnapshotRefParser.fromJson(mainRefJson).snapshotId();
       eventBuilder.currentSnapshotId(mainSnapshotId);
 
-      // Find the matching snapshot in jsonSnapshots to get its timestamp-ms. Iterate in reverse
-      // because Iceberg appends snapshots chronologically and main's snapshot is typically the
-      // most recent. Skip snapshots whose JSON doesn't contain the target id as a cheap
-      // pre-filter before invoking the JSON parser.
-      List<String> jsonSnapshots = requestBody.getJsonSnapshots();
-      if (jsonSnapshots == null) {
-        return;
-      }
       String mainSnapshotIdStr = Long.toString(mainSnapshotId);
       for (int i = jsonSnapshots.size() - 1; i >= 0; i--) {
         String snapshotJson = jsonSnapshots.get(i);

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/model/TableAuditEvent.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/model/TableAuditEvent.java
@@ -2,6 +2,7 @@ package com.linkedin.openhouse.tables.audit.model;
 
 import com.linkedin.openhouse.common.audit.model.BaseAuditEvent;
 import java.time.Instant;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -40,4 +41,6 @@ public class TableAuditEvent extends BaseAuditEvent {
   private Long currentSnapshotId;
 
   private Long currentSnapshotTimestampMs;
+
+  private Map<String, String> tableProperties;
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/model/TableAuditEvent.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/model/TableAuditEvent.java
@@ -42,5 +42,7 @@ public class TableAuditEvent extends BaseAuditEvent {
 
   private Long currentSnapshotTimestampMs;
 
+  private String branchRefName;
+
   private Map<String, String> tableProperties;
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/config/InternalCatalogProperties.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/config/InternalCatalogProperties.java
@@ -1,6 +1,8 @@
 package com.linkedin.openhouse.tables.config;
 
 import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -13,11 +15,19 @@ public class InternalCatalogProperties {
 
   private MetadataCache metadataCache = new MetadataCache();
 
+  private Audit audit = new Audit();
+
   @Getter
   @Setter
   public static class MetadataCache {
     private Boolean enabled;
     private Duration ttl;
     private DataSize maxWeight;
+  }
+
+  @Getter
+  @Setter
+  public static class Audit {
+    private List<String> tablePropertiesAllowlist = Collections.emptyList();
   }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/config/InternalCatalogProperties.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/config/InternalCatalogProperties.java
@@ -29,5 +29,13 @@ public class InternalCatalogProperties {
   @Setter
   public static class Audit {
     private List<String> tablePropertiesAllowlist = Collections.emptyList();
+
+    /**
+     * Maximum character length of a single allowlisted property value. Values exceeding this are
+     * dropped from the audit event (with a warning log) to prevent oversized events from blowing
+     * the Kafka producer's max.request.size budget or OOM-ing downstream consumers. {@code 0}
+     * disables the cap (current/legacy behavior).
+     */
+    private int tablePropertyValueMaxLength = 0;
   }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/config/InternalCatalogProperties.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/config/InternalCatalogProperties.java
@@ -29,13 +29,5 @@ public class InternalCatalogProperties {
   @Setter
   public static class Audit {
     private List<String> tablePropertiesAllowlist = Collections.emptyList();
-
-    /**
-     * Maximum character length of a single allowlisted property value. Values exceeding this are
-     * dropped from the audit event (with a warning log) to prevent oversized events from blowing
-     * the Kafka producer's max.request.size budget or OOM-ing downstream consumers. {@code 0}
-     * disables the cap (current/legacy behavior).
-     */
-    private int tablePropertyValueMaxLength = 0;
   }
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/MockIcebergSnapshotApiHandler.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/MockIcebergSnapshotApiHandler.java
@@ -26,9 +26,20 @@ public class MockIcebergSnapshotApiHandler implements IcebergSnapshotsApiHandler
             .responseBody(RequestConstants.TEST_GET_TABLE_RESPONSE_BODY)
             .build();
       case "d200":
+        // Echo the request's table properties on the response so the audit aspect can read
+        // committed state from result.getResponseBody().getTableProperties().
         return ApiResponse.<GetTableResponseBody>builder()
             .httpStatus(HttpStatus.OK)
-            .responseBody(RequestConstants.TEST_GET_TABLE_RESPONSE_BODY)
+            .responseBody(
+                RequestConstants.TEST_GET_TABLE_RESPONSE_BODY
+                    .toBuilder()
+                    .tableProperties(
+                        icebergSnapshotRequestBody.getCreateUpdateTableRequestBody() == null
+                            ? null
+                            : icebergSnapshotRequestBody
+                                .getCreateUpdateTableRequestBody()
+                                .getTableProperties())
+                    .build())
             .build();
       case "d400":
         throw new RequestValidationFailureException();

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
@@ -114,10 +114,64 @@ public class IcebergSnapshotsApiHandlerAuditTest {
   }
 
   @Test
+  public void testPutIcebergSnapshotsMainCommitSetsBranchRefNameToMain() throws Exception {
+    mvc.perform(
+        MockMvcRequestBuilders.put(
+                String.format(
+                    CURRENT_MAJOR_VERSION_PREFIX
+                        + "/databases/d200/tables/tb1/iceberg/v2/snapshots"))
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(RequestConstants.TEST_ICEBERG_SNAPSHOTS_REQUEST_BODY.toJson()));
+    Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
+    assertEquals("main", argCaptor.getValue().getBranchRefName());
+  }
+
+  @Test
+  public void testPutIcebergSnapshotsNamedBranchCommitSetsBranchRefName() throws Exception {
+    // Realistic named-branch commit: main ref exists but its snapshot is NOT in jsonSnapshots
+    // (main didn't advance). Only the feature branch got a new snapshot.
+    String newSnapshotJson =
+        "{\n"
+            + "  \"snapshot-id\" : 999,\n"
+            + "  \"timestamp-ms\" : 5000,\n"
+            + "  \"summary\" : {\"operation\": \"append\"},\n"
+            + "  \"manifest-list\" : \"/tmp/feature.avro\",\n"
+            + "  \"schema-id\" : 0\n"
+            + "}";
+    Map<String, String> refs = new HashMap<>();
+    refs.put("main", "{\"snapshot-id\":100,\"type\":\"branch\"}"); // main stayed at old snapshot
+    refs.put("feature", "{\"snapshot-id\":999,\"type\":\"branch\"}"); // feature got new snapshot
+
+    IcebergSnapshotsRequestBody requestBody =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion("v1")
+            .jsonSnapshots(Collections.singletonList(newSnapshotJson))
+            .snapshotRefs(refs)
+            .createUpdateTableRequestBody(RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY)
+            .build();
+
+    mvc.perform(
+        MockMvcRequestBuilders.put(
+                String.format(
+                    CURRENT_MAJOR_VERSION_PREFIX
+                        + "/databases/d200/tables/tb1/iceberg/v2/snapshots"))
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody.toJson()));
+    Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
+    TableAuditEvent actualEvent = argCaptor.getValue();
+    assertEquals("feature", actualEvent.getBranchRefName());
+    // main didn't advance, so currentSnapshotId is main's old snapshot and timestamp is null
+    assertEquals(100L, actualEvent.getCurrentSnapshotId().longValue());
+    assertNull(actualEvent.getCurrentSnapshotTimestampMs());
+  }
+
+  @Test
   public void testPutIcebergSnapshotsBranchOnlyCommitLeavesSnapshotInfoNull() throws Exception {
-    // Simulate a branch-only commit where main is absent from snapshotRefs.
-    // In this case the main branch ref doesn't exist, so currentSnapshotId /
-    // currentSnapshotTimestampMs should be null.
+    // Simulate a branch-only commit where main is absent from snapshotRefs entirely.
+    // currentSnapshotId / currentSnapshotTimestampMs are null (no main), but branchRefName
+    // is still populated from the ref that received the new snapshot.
     IcebergSnapshotsRequestBody branchOnlyRequestBody =
         IcebergSnapshotsRequestBody.builder()
             .baseTableVersion("v1")
@@ -138,6 +192,7 @@ public class IcebergSnapshotsApiHandlerAuditTest {
             .content(branchOnlyRequestBody.toJson()));
     Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
     TableAuditEvent actualEvent = argCaptor.getValue();
+    assertEquals("my_branch", actualEvent.getBranchRefName());
     assertNull(actualEvent.getCurrentSnapshotId());
     assertNull(actualEvent.getCurrentSnapshotTimestampMs());
   }
@@ -188,6 +243,8 @@ public class IcebergSnapshotsApiHandlerAuditTest {
     TableAuditEvent actualEvent = argCaptor.getValue();
     assertEquals(100L, actualEvent.getCurrentSnapshotId().longValue());
     assertEquals(1000L, actualEvent.getCurrentSnapshotTimestampMs().longValue());
+    // The last snapshot (200) belongs to feature — that is the committed branch.
+    assertEquals("feature", actualEvent.getBranchRefName());
   }
 
   @Test

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
@@ -35,7 +35,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @TestPropertySource(
     properties = {
       "cluster.iceberg.tables.audit.table-properties-allowlist[0]=openhouse.watermark",
-      "cluster.iceberg.tables.audit.table-properties-allowlist[1]=openhouse.tableType"
+      "cluster.iceberg.tables.audit.table-properties-allowlist[1]=openhouse.tableType",
+      "cluster.iceberg.tables.audit.table-property-value-max-length=20"
     })
 @WithMockUser(username = "testUser")
 public class IcebergSnapshotsApiHandlerAuditTest {
@@ -222,6 +223,40 @@ public class IcebergSnapshotsApiHandlerAuditTest {
     expected.put("openhouse.watermark", "100");
     expected.put("openhouse.tableType", "PRIMARY_TABLE");
     assertEquals(expected, actualEvent.getTableProperties());
+  }
+
+  @Test
+  public void testPutIcebergSnapshotsDropsOversizedTableProperty() throws Exception {
+    // Cap is 20 chars (set at class level). "openhouse.watermark"="100" stays;
+    // "openhouse.tableType" with a 30+ char value is dropped.
+    Map<String, String> requestProperties = new HashMap<>();
+    requestProperties.put("openhouse.watermark", "100");
+    requestProperties.put(
+        "openhouse.tableType", "THIS_VALUE_IS_DEFINITELY_LONGER_THAN_TWENTY_CHARS");
+    IcebergSnapshotsRequestBody base = RequestConstants.TEST_ICEBERG_SNAPSHOTS_REQUEST_BODY;
+    IcebergSnapshotsRequestBody requestBody =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion(base.getBaseTableVersion())
+            .jsonSnapshots(base.getJsonSnapshots())
+            .snapshotRefs(base.getSnapshotRefs())
+            .createUpdateTableRequestBody(
+                base.getCreateUpdateTableRequestBody()
+                    .toBuilder()
+                    .tableProperties(requestProperties)
+                    .build())
+            .build();
+    mvc.perform(
+        MockMvcRequestBuilders.put(
+                String.format(
+                    CURRENT_MAJOR_VERSION_PREFIX
+                        + "/databases/d200/tables/tb1/iceberg/v2/snapshots"))
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody.toJson()));
+    Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
+    TableAuditEvent actualEvent = argCaptor.getValue();
+    assertEquals(
+        Collections.singletonMap("openhouse.watermark", "100"), actualEvent.getTableProperties());
   }
 
   @Test

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
@@ -185,6 +185,37 @@ public class IcebergSnapshotsApiHandlerAuditTest {
   }
 
   @Test
+  public void testPutIcebergSnapshotsCarriesTableProperties() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("openhouse.watermark", "100");
+    properties.put("openhouse.tableType", "PRIMARY_TABLE");
+    properties.put("user.custom.key", "v");
+    IcebergSnapshotsRequestBody base = RequestConstants.TEST_ICEBERG_SNAPSHOTS_REQUEST_BODY;
+    IcebergSnapshotsRequestBody requestBody =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion(base.getBaseTableVersion())
+            .jsonSnapshots(base.getJsonSnapshots())
+            .snapshotRefs(base.getSnapshotRefs())
+            .createUpdateTableRequestBody(
+                base.getCreateUpdateTableRequestBody()
+                    .toBuilder()
+                    .tableProperties(properties)
+                    .build())
+            .build();
+    mvc.perform(
+        MockMvcRequestBuilders.put(
+                String.format(
+                    CURRENT_MAJOR_VERSION_PREFIX
+                        + "/databases/d200/tables/tb1/iceberg/v2/snapshots"))
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody.toJson()));
+    Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
+    TableAuditEvent actualEvent = argCaptor.getValue();
+    assertEquals(properties, actualEvent.getTableProperties());
+  }
+
+  @Test
   public void testCTASCommitPhase() throws Exception {
     mvc.perform(
         MockMvcRequestBuilders.put(

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
@@ -35,8 +35,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @TestPropertySource(
     properties = {
       "cluster.iceberg.tables.audit.table-properties-allowlist[0]=openhouse.watermark",
-      "cluster.iceberg.tables.audit.table-properties-allowlist[1]=openhouse.tableType",
-      "cluster.iceberg.tables.audit.table-property-value-max-length=20"
+      "cluster.iceberg.tables.audit.table-properties-allowlist[1]=openhouse.tableType"
     })
 @WithMockUser(username = "testUser")
 public class IcebergSnapshotsApiHandlerAuditTest {
@@ -223,40 +222,6 @@ public class IcebergSnapshotsApiHandlerAuditTest {
     expected.put("openhouse.watermark", "100");
     expected.put("openhouse.tableType", "PRIMARY_TABLE");
     assertEquals(expected, actualEvent.getTableProperties());
-  }
-
-  @Test
-  public void testPutIcebergSnapshotsDropsOversizedTableProperty() throws Exception {
-    // Cap is 20 chars (set at class level). "openhouse.watermark"="100" stays;
-    // "openhouse.tableType" with a 30+ char value is dropped.
-    Map<String, String> requestProperties = new HashMap<>();
-    requestProperties.put("openhouse.watermark", "100");
-    requestProperties.put(
-        "openhouse.tableType", "THIS_VALUE_IS_DEFINITELY_LONGER_THAN_TWENTY_CHARS");
-    IcebergSnapshotsRequestBody base = RequestConstants.TEST_ICEBERG_SNAPSHOTS_REQUEST_BODY;
-    IcebergSnapshotsRequestBody requestBody =
-        IcebergSnapshotsRequestBody.builder()
-            .baseTableVersion(base.getBaseTableVersion())
-            .jsonSnapshots(base.getJsonSnapshots())
-            .snapshotRefs(base.getSnapshotRefs())
-            .createUpdateTableRequestBody(
-                base.getCreateUpdateTableRequestBody()
-                    .toBuilder()
-                    .tableProperties(requestProperties)
-                    .build())
-            .build();
-    mvc.perform(
-        MockMvcRequestBuilders.put(
-                String.format(
-                    CURRENT_MAJOR_VERSION_PREFIX
-                        + "/databases/d200/tables/tb1/iceberg/v2/snapshots"))
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(requestBody.toJson()));
-    Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
-    TableAuditEvent actualEvent = argCaptor.getValue();
-    assertEquals(
-        Collections.singletonMap("openhouse.watermark", "100"), actualEvent.getTableProperties());
   }
 
   @Test

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
@@ -25,12 +25,18 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @ContextConfiguration
+@TestPropertySource(
+    properties = {
+      "cluster.iceberg.tables.audit.table-properties-allowlist[0]=openhouse.watermark",
+      "cluster.iceberg.tables.audit.table-properties-allowlist[1]=openhouse.tableType"
+    })
 @WithMockUser(username = "testUser")
 public class IcebergSnapshotsApiHandlerAuditTest {
   @Autowired private MockMvc mvc;
@@ -185,11 +191,11 @@ public class IcebergSnapshotsApiHandlerAuditTest {
   }
 
   @Test
-  public void testPutIcebergSnapshotsCarriesTableProperties() throws Exception {
-    Map<String, String> properties = new HashMap<>();
-    properties.put("openhouse.watermark", "100");
-    properties.put("openhouse.tableType", "PRIMARY_TABLE");
-    properties.put("user.custom.key", "v");
+  public void testPutIcebergSnapshotsFiltersTablePropertiesToAllowlist() throws Exception {
+    Map<String, String> requestProperties = new HashMap<>();
+    requestProperties.put("openhouse.watermark", "100");
+    requestProperties.put("openhouse.tableType", "PRIMARY_TABLE");
+    requestProperties.put("user.custom.key", "v");
     IcebergSnapshotsRequestBody base = RequestConstants.TEST_ICEBERG_SNAPSHOTS_REQUEST_BODY;
     IcebergSnapshotsRequestBody requestBody =
         IcebergSnapshotsRequestBody.builder()
@@ -199,7 +205,7 @@ public class IcebergSnapshotsApiHandlerAuditTest {
             .createUpdateTableRequestBody(
                 base.getCreateUpdateTableRequestBody()
                     .toBuilder()
-                    .tableProperties(properties)
+                    .tableProperties(requestProperties)
                     .build())
             .build();
     mvc.perform(
@@ -212,7 +218,10 @@ public class IcebergSnapshotsApiHandlerAuditTest {
             .content(requestBody.toJson()));
     Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
     TableAuditEvent actualEvent = argCaptor.getValue();
-    assertEquals(properties, actualEvent.getTableProperties());
+    Map<String, String> expected = new HashMap<>();
+    expected.put("openhouse.watermark", "100");
+    expected.put("openhouse.tableType", "PRIMARY_TABLE");
+    assertEquals(expected, actualEvent.getTableProperties());
   }
 
   @Test

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/model/TableAuditModelConstants.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/model/TableAuditModelConstants.java
@@ -225,6 +225,7 @@ public final class TableAuditModelConstants {
           .operationType(OperationType.COMMIT)
           .currentSnapshotId(2151407017102313398L)
           .currentSnapshotTimestampMs(1669126937912L)
+          .branchRefName("main")
           .build();
 
   public static final TableAuditEvent TABLE_AUDIT_EVENT_PUT_ICEBERG_SNAPSHOTS_FAILED =
@@ -237,6 +238,7 @@ public final class TableAuditModelConstants {
           .operationType(OperationType.COMMIT)
           .currentSnapshotId(2151407017102313398L)
           .currentSnapshotTimestampMs(1669126937912L)
+          .branchRefName("main")
           .build();
 
   public static final TableAuditEvent TABLE_AUDIT_EVENT_PUT_ICEBERG_SNAPSHOTS_CTAS =
@@ -249,6 +251,7 @@ public final class TableAuditModelConstants {
           .operationType(OperationType.STAGED_COMMIT)
           .currentSnapshotId(2151407017102313398L)
           .currentSnapshotTimestampMs(1669126937912L)
+          .branchRefName("main")
           .build();
 
   public static final TableAuditEvent TABLE_AUDIT_EVENT_GET_ALL_DATABASES_SUCCESS =


### PR DESCRIPTION
## Problem

The Git for Data feature introduces named Iceberg branch refs, but table operation observability is blind to them. Today `TableAuditEvent` records `currentSnapshotId` and `currentSnapshotTimestampMs` for the main branch, with no signal for *which branch* a write went to. Dali and Grid Observability cannot answer "was this commit to main or a named branch?" without ACL-gated access to current table state.

## Solution

Add `branchRefName` to `TableAuditEvent`, populated at commit time from the existing `snapshotRefs` and `jsonSnapshots` fields already present on `IcebergSnapshotsRequestBody`.

**How the committed branch is identified:** Iceberg appends snapshots chronologically, so the last entry in `jsonSnapshots` is always the newly-committed snapshot. We find the ref in `snapshotRefs` whose snapshot-id matches it — that ref is the branch being written.

This correctly handles:
- Main branch commit → `branchRefName = "main"`
- Named branch commit where main did not advance → `branchRefName = "<branch>"`
- No main ref present → `branchRefName = "<branch>"`, `currentSnapshotId = null`

**Why the last-snapshot assumption is safe:** Every request reaching `putIcebergSnapshots` has a non-empty `jsonSnapshots` — the repository layer (`doUpdateSnapshotsIfNeeded`) gates all `snapshotRefs` processing on `jsonSnapshots` being present. A ref-only update is a silent no-op that never commits, so the last-snapshot invariant holds for all reachable code paths.

## Changes

- `TableAuditEvent.java` — add `String branchRefName`
- `TableAuditAspect.java` — populate in `extractSnapshotInfo()` by matching last snapshot to its ref; no separate pass, no special-casing for main
- `IcebergSnapshotsApiHandlerAuditTest.java` — two new tests: main commit sets `"main"`, named branch commit sets the branch name; existing branch-only test updated to assert `branchRefName`
- `TableAuditModelConstants.java` — add `branchRefName("main")` to the three commit-path expected events

## Depends on

#601 (adds `tableProperties` to `TableAuditEvent`; merge that first)