### PR TITLE
Use regex matching for table property audit event allowlist

### DIFF
--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
@@ -20,9 +20,13 @@ import com.linkedin.openhouse.tables.audit.model.TableAuditEvent;
 import com.linkedin.openhouse.tables.config.InternalCatalogProperties;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotParser;
@@ -48,6 +52,13 @@ public class TableAuditAspect {
   @Autowired private AuditHandler<TableAuditEvent> tableAuditHandler;
 
   @Autowired private InternalCatalogProperties internalCatalogProperties;
+
+  /**
+   * Cached compiled allowlist patterns. Built lazily on first use from {@code
+   * cluster.iceberg.tables.audit.table-properties-allowlist}. The aspect is a singleton and the
+   * config is bound once at startup, so a one-shot lazy init is sufficient.
+   */
+  private volatile List<Pattern> allowlistPatterns;
 
   /**
    * Install the Around advice for getTable() method in OpenHouseTablesApiHandler.
@@ -549,23 +560,35 @@ public class TableAuditAspect {
    * ({@code table-property-value-max-size}) and a combined-total cap ({@code
    * table-properties-total-max-size}). Values exceeding either cap are skipped with a warning log.
    * Returns {@code null} when there is nothing to emit so downstream audit handlers can skip the
-   * field entirely. Iterates the allowlist rather than the source so cost is O(|allowlist|)
-   * regardless of source size.
+   * field entirely.
+   *
+   * <p>Allowlist entries are Java regular expressions matched against the property key (full match,
+   * via {@link Pattern#matches}); a key is emitted if it matches at least one pattern. Invalid
+   * patterns are logged and skipped — they never block audit emission. Source keys are visited in
+   * sorted order so that the total-cap cutoff is deterministic regardless of the source map's
+   * iteration order.
    */
   private Map<String, String> filterTableProperties(Map<String, String> source) {
     if (source == null || source.isEmpty()) {
       return null;
     }
-    InternalCatalogProperties.Audit auditConfig = internalCatalogProperties.getAudit();
-    List<String> allowlist = auditConfig.getTablePropertiesAllowlist();
-    if (allowlist == null || allowlist.isEmpty()) {
+    List<Pattern> patterns = compiledAllowlistPatterns();
+    if (patterns.isEmpty()) {
       return null;
     }
+    InternalCatalogProperties.Audit auditConfig = internalCatalogProperties.getAudit();
     long maxValueBytes = auditConfig.getTablePropertyValueMaxSize().toBytes();
     long maxTotalBytes = auditConfig.getTablePropertiesTotalMaxSize().toBytes();
+    // Sort keys so the greedy total-byte cap below drops the same properties every run; the source
+    // HashMap has no stable order. Irrelevant when the cap isn't hit.
+    List<String> sortedKeys = new ArrayList<>(source.keySet());
+    Collections.sort(sortedKeys);
     Map<String, String> filtered = new HashMap<>();
     long totalBytes = 0;
-    for (String key : allowlist) {
+    for (String key : sortedKeys) {
+      if (!matchesAnyPattern(key, patterns)) {
+        continue;
+      }
       String value = source.get(key);
       if (value == null) {
         continue;
@@ -592,6 +615,42 @@ public class TableAuditAspect {
       totalBytes += valueBytes;
     }
     return filtered.isEmpty() ? null : filtered;
+  }
+
+  /** Returns {@code true} if {@code key} fully matches at least one allowlist pattern. */
+  private boolean matchesAnyPattern(String key, List<Pattern> patterns) {
+    for (Pattern pattern : patterns) {
+      if (pattern.matcher(key).matches()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Compiles the configured allowlist into {@link Pattern}s once and caches the result. Returns
+   * {@link Collections#emptyList()} when the allowlist is unset or every pattern is invalid.
+   */
+  private List<Pattern> compiledAllowlistPatterns() {
+    List<Pattern> cached = allowlistPatterns;
+    if (cached != null) {
+      return cached;
+    }
+    List<String> allowlist = internalCatalogProperties.getAudit().getTablePropertiesAllowlist();
+    if (allowlist == null || allowlist.isEmpty()) {
+      allowlistPatterns = Collections.emptyList();
+      return allowlistPatterns;
+    }
+    List<Pattern> compiled = new ArrayList<>(allowlist.size());
+    for (String regex : allowlist) {
+      try {
+        compiled.add(Pattern.compile(regex));
+      } catch (PatternSyntaxException e) {
+        log.warn("Skipping invalid table-property allowlist regex '{}': {}", regex, e.getMessage());
+      }
+    }
+    allowlistPatterns = Collections.unmodifiableList(compiled);
+    return allowlistPatterns;
   }
 
   private void buildAndSendEvent(

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/config/InternalCatalogProperties.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/config/InternalCatalogProperties.java
@@ -28,6 +28,11 @@ public class InternalCatalogProperties {
   @Getter
   @Setter
   public static class Audit {
+    /**
+     * Allowlist of property-key regular expressions. A committed table property is included on the
+     * TableAuditEvent if its key fully matches at least one pattern (Java regex semantics, {@link
+     * java.util.regex.Pattern#matches}). Default empty = nothing emitted.
+     */
     private List<String> tablePropertiesAllowlist = Collections.emptyList();
 
     /**
@@ -37,8 +42,9 @@ public class InternalCatalogProperties {
     private DataSize tablePropertyValueMaxSize = DataSize.ofKilobytes(256);
 
     /**
-     * Maximum combined UTF-8 byte size of all audited property values. Once including the next
-     * property would exceed this, that property and any remaining ones are skipped.
+     * Maximum combined UTF-8 byte size of all audited property values. Properties are visited in
+     * sorted key order; a property whose value would push the running total past this cap is
+     * skipped, but smaller later values that still fit are kept.
      */
     private DataSize tablePropertiesTotalMaxSize = DataSize.ofKilobytes(512);
   }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
@@ -34,11 +34,16 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 @ContextConfiguration
 @TestPropertySource(
     properties = {
-      "cluster.iceberg.tables.audit.table-properties-allowlist[0]=openhouse.watermark",
-      "cluster.iceberg.tables.audit.table-properties-allowlist[1]=openhouse.tableType",
-      "cluster.iceberg.tables.audit.table-properties-allowlist[2]=openhouse.a",
-      "cluster.iceberg.tables.audit.table-properties-allowlist[3]=openhouse.b",
-      "cluster.iceberg.tables.audit.table-properties-allowlist[4]=openhouse.c",
+      // Java-regex allowlist entries. The four backslashes in the Java source survive javac +
+      // Properties.load() unescaping as a single backslash in the bound value, i.e. a literal dot.
+      //   [0] openhouse\..*    every key beginning with "openhouse."
+      //   [1] replication\..*  a second valid pattern, to exercise OR-across-patterns
+      //   [2] [unclosed(       syntactically invalid: must be logged-and-skipped, never blocking
+      //   [3] exact\.key       an exact (non-.*) pattern, to exercise full-match anchoring
+      "cluster.iceberg.tables.audit.table-properties-allowlist[0]=openhouse\\\\..*",
+      "cluster.iceberg.tables.audit.table-properties-allowlist[1]=replication\\\\..*",
+      "cluster.iceberg.tables.audit.table-properties-allowlist[2]=[unclosed(",
+      "cluster.iceberg.tables.audit.table-properties-allowlist[3]=exact\\\\.key",
       // Small caps (bytes) so the size-limit tests stay readable; production defaults are
       // 256KB/512KB.
       "cluster.iceberg.tables.audit.table-property-value-max-size=256B",
@@ -198,36 +203,19 @@ public class IcebergSnapshotsApiHandlerAuditTest {
   }
 
   @Test
-  public void testPutIcebergSnapshotsFiltersTablePropertiesToAllowlist() throws Exception {
+  public void testPutIcebergSnapshotsFiltersTablePropertiesByRegexAllowlist() throws Exception {
     Map<String, String> requestProperties = new HashMap<>();
     requestProperties.put("openhouse.watermark", "100");
     requestProperties.put("openhouse.tableType", "PRIMARY_TABLE");
+    requestProperties.put("openhouse.replication.config", "{\"target\":\"war\"}");
     requestProperties.put("user.custom.key", "v");
-    IcebergSnapshotsRequestBody base = RequestConstants.TEST_ICEBERG_SNAPSHOTS_REQUEST_BODY;
-    IcebergSnapshotsRequestBody requestBody =
-        IcebergSnapshotsRequestBody.builder()
-            .baseTableVersion(base.getBaseTableVersion())
-            .jsonSnapshots(base.getJsonSnapshots())
-            .snapshotRefs(base.getSnapshotRefs())
-            .createUpdateTableRequestBody(
-                base.getCreateUpdateTableRequestBody()
-                    .toBuilder()
-                    .tableProperties(requestProperties)
-                    .build())
-            .build();
-    mvc.perform(
-        MockMvcRequestBuilders.put(
-                String.format(
-                    CURRENT_MAJOR_VERSION_PREFIX
-                        + "/databases/d200/tables/tb1/iceberg/v2/snapshots"))
-            .accept(MediaType.APPLICATION_JSON)
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(requestBody.toJson()));
-    Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
-    TableAuditEvent actualEvent = argCaptor.getValue();
+    // No dot after "openhouse", so the literal-dot regex (openhouse\..*) rejects it.
+    requestProperties.put("openhousewatermark", "should-not-match");
+    TableAuditEvent actualEvent = putSnapshotsAndCapture(requestProperties);
     Map<String, String> expected = new HashMap<>();
     expected.put("openhouse.watermark", "100");
     expected.put("openhouse.tableType", "PRIMARY_TABLE");
+    expected.put("openhouse.replication.config", "{\"target\":\"war\"}");
     assertEquals(expected, actualEvent.getAuditedTableProperties());
   }
 
@@ -245,9 +233,10 @@ public class IcebergSnapshotsApiHandlerAuditTest {
 
   @Test
   public void testPutIcebergSnapshotsSkipsPropertiesExceedingTotalCap() throws Exception {
-    // Each value passes the 256B per-value cap, but the 512B total cap admits only the first two
-    // (allowlist order: openhouse.a, openhouse.b, openhouse.c). 200 + 200 = 400 <= 512; adding the
-    // third (600) exceeds, so openhouse.c is skipped.
+    // All three keys match the allowlist regex and pass the 256B per-value cap, but the 512B total
+    // cap admits only the first two. Source keys are visited in sorted order (openhouse.a,
+    // openhouse.b, openhouse.c), so 200 + 200 = 400 <= 512; adding the third (600) exceeds, and
+    // openhouse.c is skipped.
     Map<String, String> requestProperties = new HashMap<>();
     requestProperties.put("openhouse.a", "x".repeat(200));
     requestProperties.put("openhouse.b", "y".repeat(200));
@@ -258,6 +247,46 @@ public class IcebergSnapshotsApiHandlerAuditTest {
     assertEquals("x".repeat(200), emitted.get("openhouse.a"));
     assertEquals("y".repeat(200), emitted.get("openhouse.b"));
     assertNull(emitted.get("openhouse.c"));
+  }
+
+  @Test
+  public void testPutIcebergSnapshotsNoMatchingPropertiesEmitsNullNotEmptyMap() throws Exception {
+    // Source is non-empty but nothing matches the allowlist regex, so filterTableProperties must
+    // return null (not an empty map) — downstream handlers skip the field on null.
+    Map<String, String> requestProperties = new HashMap<>();
+    requestProperties.put("user.custom.key", "v");
+    requestProperties.put("foo", "bar");
+    TableAuditEvent actualEvent = putSnapshotsAndCapture(requestProperties);
+    assertNull(actualEvent.getAuditedTableProperties());
+  }
+
+  @Test
+  public void testInvalidRegexIsSkippedAndValidPatternsMatchAcrossOr() throws Exception {
+    // The invalid pattern [2] ([unclosed() must be logged-and-skipped at compile time without
+    // aborting audit emission, and a key matching only the second valid pattern [1] must still be
+    // emitted (OR semantics).
+    Map<String, String> requestProperties = new HashMap<>();
+    requestProperties.put("openhouse.watermark", "100"); // matches pattern [0]
+    requestProperties.put("replication.target", "war"); // matches only pattern [1]
+    requestProperties.put("user.custom.key", "v"); // matches nothing
+    TableAuditEvent actualEvent = putSnapshotsAndCapture(requestProperties);
+    Map<String, String> expected = new HashMap<>();
+    expected.put("openhouse.watermark", "100");
+    expected.put("replication.target", "war");
+    assertEquals(expected, actualEvent.getAuditedTableProperties());
+  }
+
+  @Test
+  public void testExactPatternFullyAnchorsKey() throws Exception {
+    // Pattern [3] (exact\.key) has no .*, so Pattern.matches must anchor the whole key: a longer or
+    // prefixed key must not match.
+    Map<String, String> requestProperties = new HashMap<>();
+    requestProperties.put("exact.key", "1"); // matches pattern [3] exactly
+    requestProperties.put("exact.key.suffix", "2"); // longer -> rejected by the end anchor
+    requestProperties.put("prefix.exact.key", "3"); // prefixed -> rejected by the start anchor
+    TableAuditEvent actualEvent = putSnapshotsAndCapture(requestProperties);
+    assertEquals(
+        Collections.singletonMap("exact.key", "1"), actualEvent.getAuditedTableProperties());
   }
 
   private TableAuditEvent putSnapshotsAndCapture(Map<String, String> tableProperties)
@@ -302,5 +331,59 @@ public class IcebergSnapshotsApiHandlerAuditTest {
     assertTrue(
         new ReflectionEquals(TABLE_AUDIT_EVENT_PUT_ICEBERG_SNAPSHOTS_CTAS, EXCLUDE_FIELDS)
             .matches(actualEvent));
+  }
+}
+
+/**
+ * Verifies the privacy-safe default: with no {@code table-properties-allowlist} configured (the
+ * field defaults to {@link java.util.Collections#emptyList()}), nothing is emitted regardless of
+ * the committed properties. A separate top-level class (not a method on {@link
+ * IcebergSnapshotsApiHandlerAuditTest}) because it must bind an empty allowlist, which requires its
+ * own Spring context — the enclosing class fixes a non-empty allowlist for all of its tests.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ContextConfiguration
+@WithMockUser(username = "testUser")
+class IcebergSnapshotsApiHandlerAuditEmptyAllowlistTest {
+  @Autowired private MockMvc mvc;
+
+  @MockBean private AuditHandler<TableAuditEvent> tableAuditHandler;
+
+  @Captor private ArgumentCaptor<TableAuditEvent> argCaptor;
+
+  @Test
+  public void testEmptyAllowlistEmitsNoTableProperties() throws Exception {
+    Map<String, String> requestProperties = new HashMap<>();
+    requestProperties.put("openhouse.watermark", "100");
+    requestProperties.put("foo", "bar");
+    TableAuditEvent actualEvent = putSnapshotsAndCapture(requestProperties);
+    assertNull(actualEvent.getAuditedTableProperties());
+  }
+
+  private TableAuditEvent putSnapshotsAndCapture(Map<String, String> tableProperties)
+      throws Exception {
+    IcebergSnapshotsRequestBody base = RequestConstants.TEST_ICEBERG_SNAPSHOTS_REQUEST_BODY;
+    IcebergSnapshotsRequestBody requestBody =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion(base.getBaseTableVersion())
+            .jsonSnapshots(base.getJsonSnapshots())
+            .snapshotRefs(base.getSnapshotRefs())
+            .createUpdateTableRequestBody(
+                base.getCreateUpdateTableRequestBody()
+                    .toBuilder()
+                    .tableProperties(tableProperties)
+                    .build())
+            .build();
+    mvc.perform(
+        MockMvcRequestBuilders.put(
+                String.format(
+                    CURRENT_MAJOR_VERSION_PREFIX
+                        + "/databases/d200/tables/tb1/iceberg/v2/snapshots"))
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody.toJson()));
+    Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
+    return argCaptor.getValue();
   }
 }


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

Depends on https://github.com/linkedin/openhouse/pull/601

Allowlist entries are now Java regular expressions matched against the property key.

## Changes

- [x] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

./gradlew :services:tables:test --tests IcebergSnapshotsApiHandlerAuditTest

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
