### PR TITLE
fix(catalog): exclude replica tables from stale-base abort

### DIFF
--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -588,12 +588,6 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
    * stage-create, stage-replace) are authoritative over the snapshot set and are intentionally not
    * defended: there is no stale base to compare against.
    *
-   * <p>Replica tables are likewise exempt: the replication job replays the primary's authoritative
-   * snapshot list wholesale rather than committing incrementally against a loaded base, so its
-   * {@code COMMIT_KEY} does not encode a "base I read" contract that the catalog head can be
-   * compared against. Enforcing the CAS there would spuriously abort legitimate replication
-   * commits.
-   *
    * <p>Must run before failIfRetryUpdate, which strips COMMIT_KEY from the doCommit-local
    * properties copy.
    *
@@ -606,7 +600,10 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
       // metadata before any metadata.json has been written).
       return;
     }
-    if (isReplicatedTable(metadata.properties())) {
+    if (Boolean.parseBoolean(
+        metadata
+            .properties()
+            .getOrDefault(CatalogConstants.OPENHOUSE_IS_TABLE_REPLICATED_KEY, "false"))) {
       // Replica tables are written by the replication job, which replays the primary's
       // authoritative snapshot list wholesale. There is no meaningful writer-vs-catalog base to
       // compare, so the stale-base CAS does not apply.
@@ -832,20 +829,12 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
    * @return
    */
   private boolean isReplicatedTableCreate(Map<String, String> properties) {
-    return isReplicatedTable(properties)
+    return Boolean.parseBoolean(
+            properties.getOrDefault(CatalogConstants.OPENHOUSE_IS_TABLE_REPLICATED_KEY, "false"))
         && properties
             .getOrDefault(
                 CatalogConstants.OPENHOUSE_TABLE_VERSION, CatalogConstants.INITIAL_VERSION)
             .equals(CatalogConstants.INITIAL_VERSION);
-  }
-
-  /**
-   * Whether the properties mark this as a replicated (replica) table, regardless of whether the
-   * commit is a create or an update.
-   */
-  private boolean isReplicatedTable(Map<String, String> properties) {
-    return Boolean.parseBoolean(
-        properties.getOrDefault(CatalogConstants.OPENHOUSE_IS_TABLE_REPLICATED_KEY, "false"));
   }
 
   private List<String> getIntermediateSchemasFromProps(TableMetadata metadata) {

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -588,6 +588,12 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
    * stage-create, stage-replace) are authoritative over the snapshot set and are intentionally not
    * defended: there is no stale base to compare against.
    *
+   * <p>Replica tables are likewise exempt: the replication job replays the primary's authoritative
+   * snapshot list wholesale rather than committing incrementally against a loaded base, so its
+   * {@code COMMIT_KEY} does not encode a "base I read" contract that the catalog head can be
+   * compared against. Enforcing the CAS there would spuriously abort legitimate replication
+   * commits.
+   *
    * <p>Must run before failIfRetryUpdate, which strips COMMIT_KEY from the doCommit-local
    * properties copy.
    *
@@ -598,6 +604,12 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
     if (base == null || base.metadataFileLocation() == null) {
       // No persisted catalog state to defend (initial CREATE, or mid-CREATE constructed
       // metadata before any metadata.json has been written).
+      return;
+    }
+    if (isReplicatedTable(metadata.properties())) {
+      // Replica tables are written by the replication job, which replays the primary's
+      // authoritative snapshot list wholesale. There is no meaningful writer-vs-catalog base to
+      // compare, so the stale-base CAS does not apply.
       return;
     }
     if (!metadata.properties().containsKey(CatalogConstants.SNAPSHOTS_JSON_KEY)) {
@@ -820,12 +832,20 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
    * @return
    */
   private boolean isReplicatedTableCreate(Map<String, String> properties) {
-    return Boolean.parseBoolean(
-            properties.getOrDefault(CatalogConstants.OPENHOUSE_IS_TABLE_REPLICATED_KEY, "false"))
+    return isReplicatedTable(properties)
         && properties
             .getOrDefault(
                 CatalogConstants.OPENHOUSE_TABLE_VERSION, CatalogConstants.INITIAL_VERSION)
             .equals(CatalogConstants.INITIAL_VERSION);
+  }
+
+  /**
+   * Whether the properties mark this as a replicated (replica) table, regardless of whether the
+   * commit is a create or an update.
+   */
+  private boolean isReplicatedTable(Map<String, String> properties) {
+    return Boolean.parseBoolean(
+        properties.getOrDefault(CatalogConstants.OPENHOUSE_IS_TABLE_REPLICATED_KEY, "false"));
   }
 
   private List<String> getIntermediateSchemasFromProps(TableMetadata metadata) {

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -604,9 +604,6 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
         metadata
             .properties()
             .getOrDefault(CatalogConstants.OPENHOUSE_IS_TABLE_REPLICATED_KEY, "false"))) {
-      // Replica tables are written by the replication job, which replays the primary's
-      // authoritative snapshot list wholesale. There is no meaningful writer-vs-catalog base to
-      // compare, so the stale-base CAS does not apply.
       return;
     }
     if (!metadata.properties().containsKey(CatalogConstants.SNAPSHOTS_JSON_KEY)) {

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
@@ -342,7 +342,7 @@ public class OpenHouseInternalTableOperationsTest {
     // Build T_Y (post-refresh base) and round-trip through TableMetadataParser so
     // metadataFileLocation() is non-null, matching a base loaded from disk -- identical to the
     // abort test, so the ONLY behavioral difference is the replica flag.
-    java.nio.file.Path tmpDir = Files.createTempDirectory("oh-incident-12185-replica");
+    java.nio.file.Path tmpDir = Files.createTempDirectory("oh-replica-stale-base");
     String postRefreshBasePath = tmpDir.resolve("00010-post-refresh-base.metadata.json").toString();
     TableMetadata buildable =
         TableMetadata.buildFrom(BASE_TABLE_METADATA)

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
@@ -316,6 +316,80 @@ public class OpenHouseInternalTableOperationsTest {
   }
 
   /**
+   * Companion to {@link #testDoCommitMustAbortStaleBaseRebaseToPreventSnapshotLoss}: the stale-base
+   * CAS must NOT fire for replica tables. The replication job replays the primary's authoritative
+   * snapshot list wholesale, so its {@code COMMIT_KEY} does not encode a "base I read" contract
+   * that the catalog head can be compared against; enforcing the CAS there would spuriously abort
+   * legitimate replication commits.
+   *
+   * <p>Same divergence setup as the abort test (writer {@code COMMIT_KEY = T_X}, catalog base =
+   * T_Y), but with {@code openhouse.isTableReplicated=true} and a non-initial table version -- i.e.
+   * a replica UPDATE, which is the case the create-only {@code isReplicatedTableCreate} guard would
+   * NOT catch. {@code doCommit} must complete normally and persist via {@code
+   * houseTableRepository.save} rather than throwing {@link CommitFailedException}.
+   */
+  @Test
+  void testDoCommitDoesNotAbortStaleBaseForReplicaTable() throws IOException {
+    List<Snapshot> testSnapshots = IcebergTestUtil.getSnapshots();
+    Snapshot writerKnown1 = testSnapshots.get(0);
+    Snapshot writerKnown2 = testSnapshots.get(1);
+    // Lands in the catalog base (T_Y); absent from the replica writer's stale payload.
+    Snapshot racingSnapshot = testSnapshots.get(2);
+
+    String writerClaimedBaseLocation =
+        "/test/openhouse/test_db/test_table/00001-writer-claimed-base.metadata.json";
+
+    // Build T_Y (post-refresh base) and round-trip through TableMetadataParser so
+    // metadataFileLocation() is non-null, matching a base loaded from disk -- identical to the
+    // abort test, so the ONLY behavioral difference is the replica flag.
+    java.nio.file.Path tmpDir = Files.createTempDirectory("oh-incident-12185-replica");
+    String postRefreshBasePath = tmpDir.resolve("00010-post-refresh-base.metadata.json").toString();
+    TableMetadata buildable =
+        TableMetadata.buildFrom(BASE_TABLE_METADATA)
+            .setBranchSnapshot(writerKnown1, SnapshotRef.MAIN_BRANCH)
+            .setBranchSnapshot(writerKnown2, SnapshotRef.MAIN_BRANCH)
+            .setBranchSnapshot(racingSnapshot, SnapshotRef.MAIN_BRANCH)
+            .build();
+    Path postRefreshBaseFsPath = new Path(postRefreshBasePath);
+    FileSystem fs = postRefreshBaseFsPath.getFileSystem(new Configuration());
+    try (FSDataOutputStream out = fs.create(postRefreshBaseFsPath, true)) {
+      out.write(TableMetadataParser.toJson(buildable).getBytes());
+    }
+    TableMetadata postRefreshBase =
+        TableMetadataParser.read(new HadoopFileIO(new Configuration()), postRefreshBasePath);
+    Assertions.assertNotNull(postRefreshBase.metadataFileLocation());
+
+    List<Snapshot> staleWriterPayload = Arrays.asList(writerKnown1, writerKnown2);
+    Map<String, String> properties = new HashMap<>();
+    properties.put(
+        CatalogConstants.SNAPSHOTS_JSON_KEY, SnapshotsUtil.serializedSnapshots(staleWriterPayload));
+    properties.put(
+        CatalogConstants.SNAPSHOTS_REFS_KEY,
+        SnapshotsUtil.serializeMap(IcebergTestUtil.createMainBranchRefPointingTo(writerKnown2)));
+    properties.put(getCanonicalFieldName("tableLocation"), TEST_LOCATION);
+    properties.put(CatalogConstants.COMMIT_KEY, writerClaimedBaseLocation);
+    // Replica UPDATE: replicated flag set, version past INITIAL_VERSION -- the case the create-only
+    // isReplicatedTableCreate guard would miss, so this exercises the broad isReplicatedTable
+    // exemption in abortIfWriterBaseDivergedFromCatalog.
+    properties.put(CatalogConstants.OPENHOUSE_IS_TABLE_REPLICATED_KEY, "true");
+    properties.put(CatalogConstants.OPENHOUSE_TABLE_VERSION, "v1.0.0");
+
+    TableMetadata metadata = postRefreshBase.replaceProperties(properties);
+
+    try (MockedStatic<TableMetadataParser> ignoreWriteMock =
+        Mockito.mockStatic(TableMetadataParser.class)) {
+      Assertions.assertDoesNotThrow(
+          () -> openHouseInternalTableOperations.doCommit(postRefreshBase, metadata),
+          "Replica tables must be exempt from the stale-base CAS: the replication job replays the "
+              + "primary's authoritative snapshot list, so a COMMIT_KEY/base divergence is expected "
+              + "and must not abort the commit.");
+
+      // The replica commit was persisted normally rather than aborted.
+      Mockito.verify(mockHouseTableRepository, Mockito.times(1)).save(Mockito.eq(mockHouseTable));
+    }
+  }
+
+  /**
    * Tests committing changes that both append new snapshots and delete existing ones. Verifies that
    * both appended and deleted snapshots are correctly reflected in table metadata.
    */

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
@@ -41,14 +41,19 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
+ * A stale writer opens an Iceberg transaction at base L1 and stages its L1 snapshot view +
+ * {@code COMMIT_KEY=L1}, held uncommitted. A racing writer commits a new snapshot through the
+ * repository path, advancing the catalog L1 -&gt; L2. Committing the held transaction drives {@code
+ * BaseTransaction.applyUpdates} to silently refresh the in-flight base to L2 (passing the HTS
+ * optimistic-version CAS) while keeping the stale payload + {@code COMMIT_KEY=L1}; {@code doCommit}
+ * then subtracts the racing snapshot. On the buggy catalog the racing commit is silently dropped;
+ * PR #612's stale-base CAS aborts instead. Invariant: the racing data commit always survives.
  *
- * <p>A stale writer opens an Iceberg transaction at base L1 and stages its real L1 snapshot view
- * (the writer's {@code SNAPSHOTS_JSON} payload) plus {@code COMMIT_KEY=L1}, but holds it
- * uncommitted. A racing writer appends a new snapshot via the repository path, advancing the
- * catalog L1 -&gt; L2. When the held transaction is committed, {@code BaseTransaction.applyUpdates}
- * rebases the stale payload + {@code COMMIT_KEY=L1} onto L2, so {@code doCommit} would subtract the
- * racing snapshot. The invariant asserted is that the racing snapshot must survive (PR #612's
- * stale-base CAS aborts the commit; without it the racing snapshot is silently dropped).
+ * <p>Both cases here are <b>subtractive</b> stale commits — the stale payload omits the racing
+ * snapshot and does not add a new snapshot whose sequence number would collide with it. That is the
+ * shape that actually reproduced incident-12185 (an expire/optimizer commit dropping a fresh data
+ * commit). A stale writer that <i>adds</i> its own snapshot on a multi-snapshot base is instead
+ * rejected by Iceberg's snapshot sequence-number validation, so that shape cannot lose data.
  */
 @SpringBootTest
 @ContextConfiguration(initializers = PropertyOverrideContextInitializer.class)
@@ -61,30 +66,12 @@ public class StaleBaseLostUpdateTest {
 
   @Autowired Catalog catalog;
 
-  /** Base table is freshly created with zero committed data snapshots when the race begins. */
-  @Test
-  void testLostUpdateViaStagedTransactionConflictWithNoPriorData() throws Exception {
-    TableDto l1 = createTableWithCommittedDataSnapshots("conflict_staged_no_data", 0);
-    assertRacingSnapshotSurvivesStaleStagedCommit(l1);
-  }
-
   /**
-   * Table already has prior committed data history (two snapshots) before the race begins — the
-   * stale writer's base is a non-trivial, data-bearing table.
-   */
-  @Test
-  void testLostUpdateViaStagedTransactionConflictWithPriorDataSnapshot() throws Exception {
-    TableDto l1 = createTableWithCommittedDataSnapshots("conflict_staged_prior_data", 2);
-    assertRacingSnapshotSurvivesStaleStagedCommit(l1);
-  }
-
-  /**
-   * A snapshot-expiration commit racing a concurrent data insert — the production maintenance
-   * shape. The expire job stages a "keep" subset computed against base L1 (here: keep only the
-   * current head, expiring older snapshots); that subset cannot reference the concurrently-added
-   * data snapshot. When the stale expire rebases onto L2, the subtractive merge would expire the
-   * racing data commit along with the intended old snapshots. Asserts the data commit survives and
-   * the stale expire is rejected wholesale.
+   * Snapshot-expiration commit racing a concurrent data insert — the production maintenance shape,
+   * on a table with prior committed data history. The stale expire keeps only the current head
+   * (expiring older snapshots); its keep-subset cannot reference the concurrently-added data
+   * snapshot, so the subtractive merge would expire the racing data commit. Asserts the data commit
+   * survives and the stale expire is rejected wholesale.
    */
   @Test
   void testExpireSnapshotsDropsConcurrentDataCommit() throws Exception {
@@ -94,131 +81,98 @@ public class StaleBaseLostUpdateTest {
     Table staleHandle = catalog.loadTable(id);
     List<Snapshot> base = Lists.newArrayList(staleHandle.snapshots());
     Snapshot head = staleHandle.currentSnapshot();
-    List<Snapshot> keep = Lists.newArrayList(head); // expire everything older than the head
-    Transaction expireTxn = staleHandle.newTransaction();
-    expireTxn
+    List<Snapshot> keepOnlyHead = Lists.newArrayList(head);
+
+    assertRacingDataCommitSurvivesStaleCommit(l1, base, keepOnlyHead, head);
+  }
+
+  /**
+   * Two writers concurrently perform the first insert into a freshly created table. The racing
+   * writer commits first; the stale writer then commits its own first snapshot still declaring the
+   * create version as its base. The subtractive merge would drop the racing first commit.
+   */
+  @Test
+  void testStaleInsertDropsConcurrentDataCommitOnFreshTable() throws Exception {
+    TableDto l1 = createTableWithCommittedDataSnapshots("insert_race_fresh", 0);
+    TableIdentifier id = idOf(l1);
+
+    Table staleHandle = catalog.loadTable(id);
+    List<Snapshot> base = Lists.newArrayList(staleHandle.snapshots()); // empty
+    Snapshot staleInsert = staleHandle.newAppend().appendFile(dummyDataFile()).apply();
+
+    assertRacingDataCommitSurvivesStaleCommit(l1, base, appended(base, staleInsert), staleInsert);
+  }
+
+  /**
+   * Core reproduction. A stale writer holds a transaction at base {@code l1} staging {@code
+   * stalePayload} (main -&gt; {@code staleHead}); a racing writer commits a fresh data snapshot
+   * first (L1 -&gt; L2); the held transaction then commits, rebasing the stale payload (which omits
+   * the racing snapshot) onto L2. Asserts the racing commit survives and the stale commit is
+   * rejected wholesale (nothing from the stale payload is applied).
+   *
+   * @param base the snapshots present at L1 (the stale writer's view before its own staging)
+   * @param stalePayload the full snapshot set the stale writer commits (omits the racing snapshot)
+   * @param staleHead the snapshot the stale writer points main at
+   */
+  private void assertRacingDataCommitSurvivesStaleCommit(
+      TableDto l1, List<Snapshot> base, List<Snapshot> stalePayload, Snapshot staleHead)
+      throws Exception {
+    TableIdentifier id = idOf(l1);
+    int priorSnapshotCount = base.size();
+
+    // Stale writer: held transaction at L1 staging its payload + COMMIT_KEY=L1, uncommitted.
+    Transaction staleTxn = catalog.loadTable(id).newTransaction();
+    staleTxn
         .updateProperties()
-        .set(CatalogConstants.SNAPSHOTS_JSON_KEY, SnapshotsUtil.serializedSnapshots(keep))
-        .set(CatalogConstants.SNAPSHOTS_REFS_KEY, SnapshotsUtil.serializeMap(refs(head)))
+        .set(CatalogConstants.SNAPSHOTS_JSON_KEY, SnapshotsUtil.serializedSnapshots(stalePayload))
+        .set(CatalogConstants.SNAPSHOTS_REFS_KEY, SnapshotsUtil.serializeMap(refs(staleHead)))
         .set(CatalogConstants.COMMIT_KEY, l1.getTableLocation())
         .commit();
 
-    // Racing data insert -> catalog advances L1 -> L2.
-    Snapshot racingData = catalog.loadTable(id).newAppend().appendFile(dummyDataFile()).apply();
-    List<String> l2Snapshots = new ArrayList<>();
-    for (Snapshot s : base) {
-      l2Snapshots.add(SnapshotParser.toJson(s));
-    }
-    l2Snapshots.add(SnapshotParser.toJson(racingData));
-    openHouseInternalRepository.save(
-        l1.toBuilder()
-            .tableVersion(l1.getTableLocation())
-            .jsonSnapshots(l2Snapshots)
-            .snapshotRefs(refs(racingData))
-            .build());
+    // Racing writer (also based on L1) commits a fresh data snapshot first -> L1 -> L2.
+    Snapshot racing = catalog.loadTable(id).newAppend().appendFile(dummyDataFile()).apply();
+    commitThroughRepository(l1, snapshotJson(base, racing), racing);
 
     clearPerJvmRetryCache();
 
     try {
-      expireTxn.commitTransaction();
+      staleTxn.commitTransaction();
     } catch (Exception expected) {
-      LOG.info("commitTransaction rejected the stale expire: {}", expected.toString());
+      LOG.info("stale commit rejected: {}", expected.toString());
     }
 
     List<Snapshot> remaining = Lists.newArrayList(catalog.loadTable(id).snapshots());
     LOG.info(
-        "expire-race result: remaining snapshots={}",
+        "stale-conflict result: remaining={}",
         remaining.stream().map(Snapshot::snapshotId).collect(Collectors.toList()));
     Assertions.assertTrue(
-        remaining.stream().anyMatch(x -> x.snapshotId() == racingData.snapshotId()),
-        "racing data commit ("
-            + racingData.snapshotId()
-            + ") must not be expired away by a stale concurrent expire");
+        remaining.stream().anyMatch(s -> s.snapshotId() == racing.snapshotId()),
+        "racing data commit (" + racing.snapshotId() + ") must not be silently dropped");
     Assertions.assertEquals(
-        base.size() + 1,
+        priorSnapshotCount + 1,
         remaining.size(),
-        "stale expire must be rejected wholesale; nothing expired and the racing data commit kept");
+        "stale commit must be rejected wholesale; table holds only the prior snapshots + the racing "
+            + "data commit");
 
     cleanup(id);
   }
 
-  /**
-   * Core reproduction. Given a table whose latest committed version is {@code l1}, stages a stale
-   * commit at L1, lands a racing append (L1 -&gt; L2), then commits the stale transaction and
-   * asserts the racing snapshot is not dropped.
-   */
-  private void assertRacingSnapshotSurvivesStaleStagedCommit(TableDto l1) throws Exception {
-    TableIdentifier id = idOf(l1);
-
-    // Stale writer opens a transaction at L1 and performs its own insert: a new data snapshot
-    // appended at base L1. Its staged payload contains the existing snapshots + its own append but
-    // NOT the racing snapshot (which it cannot see), with COMMIT_KEY=L1 — exactly what
-    // OpenHouseInternalRepositoryImpl.save stamps. Held uncommitted so a racing commit lands first.
-    Table staleHandle = catalog.loadTable(id);
-    List<Snapshot> staleView = Lists.newArrayList(staleHandle.snapshots());
-    int priorSnapshotCount = staleView.size();
-    Snapshot staleInsert = staleHandle.newAppend().appendFile(dummyDataFile()).apply();
-    List<Snapshot> stalePayload = new ArrayList<>(staleView);
-    stalePayload.add(staleInsert);
-    Transaction staleTxn = staleHandle.newTransaction();
-    staleTxn
-        .updateProperties()
-        .set(CatalogConstants.SNAPSHOTS_JSON_KEY, SnapshotsUtil.serializedSnapshots(stalePayload))
-        .set(CatalogConstants.SNAPSHOTS_REFS_KEY, SnapshotsUtil.serializeMap(refs(staleInsert)))
-        .set(CatalogConstants.COMMIT_KEY, l1.getTableLocation())
-        .commit();
-
-    // Racing writer appends S2 via the repository path -> catalog advances L1 -> L2.
-    Snapshot s2 = catalog.loadTable(id).newAppend().appendFile(dummyDataFile()).apply();
-    List<String> racingSnapshots = new ArrayList<>();
-    for (Snapshot existing : staleView) {
-      racingSnapshots.add(SnapshotParser.toJson(existing));
-    }
-    racingSnapshots.add(SnapshotParser.toJson(s2));
+  /** Commits {@code jsonSnapshots} (main -&gt; {@code head}) declaring base {@code l1}'s version. */
+  private void commitThroughRepository(TableDto l1, List<String> jsonSnapshots, Snapshot head) {
     openHouseInternalRepository.save(
         l1.toBuilder()
             .tableVersion(l1.getTableLocation())
-            .jsonSnapshots(racingSnapshots)
-            .snapshotRefs(refs(s2))
+            .jsonSnapshots(jsonSnapshots)
+            .snapshotRefs(refs(head))
             .build());
-
-    clearPerJvmRetryCache();
-
-    // Commit the held transaction: applyUpdates sees base L1 != catalog L2, rebases, and re-stamps
-    // the stale view + COMMIT_KEY=L1 onto L2. A clean rejection is acceptable and version-dependent
-    // (CommitFailedException from PR #612's CAS, or BadRequestException from the pre-#406 guard);
-    // the invariant below is the same either way: the racing snapshot must survive.
-    try {
-      staleTxn.commitTransaction();
-    } catch (Exception expected) {
-      LOG.info("commitTransaction rejected the stale commit: {}", expected.toString());
-    }
-
-    List<Snapshot> remaining = Lists.newArrayList(catalog.loadTable(id).snapshots());
-    LOG.info(
-        "staged-conflict result: remaining snapshots={}",
-        remaining.stream().map(Snapshot::snapshotId).collect(Collectors.toList()));
-    Assertions.assertTrue(
-        remaining.stream().anyMatch(x -> x.snapshotId() == s2.snapshotId()),
-        "racing snapshot S2 (" + s2.snapshotId() + ") must not be silently dropped from H2");
-    Assertions.assertTrue(
-        remaining.stream().noneMatch(x -> x.snapshotId() == staleInsert.snapshotId()),
-        "stale writer's conflicting insert ("
-            + staleInsert.snapshotId()
-            + ") must be rejected wholesale, not merged on top of the racing commit");
-    Assertions.assertEquals(
-        priorSnapshotCount + 1,
-        remaining.size(),
-        "table must hold only the prior snapshots + the racing snapshot S2");
-
-    cleanup(id);
   }
 
   /**
    * Creates a table and commits {@code count} data-bearing snapshots through the repository path,
-   * returning the latest committed {@link TableDto} (the base the stale writer will load as L1).
+   * returning the latest committed {@link TableDto} (the base L1 the racers will load).
    */
-  private TableDto createTableWithCommittedDataSnapshots(String tableId, int count) throws Exception {
+  private TableDto createTableWithCommittedDataSnapshots(String tableId, int count)
+      throws Exception {
     Schema schema =
         new Schema(
             required(1, "id", Types.StringType.get()), optional(2, "data", Types.StringType.get()));
@@ -237,17 +191,28 @@ public class StaleBaseLostUpdateTest {
     for (int i = 0; i < count; i++) {
       Snapshot snapshot = catalog.loadTable(id).newAppend().appendFile(dummyDataFile()).apply();
       committed.add(snapshot);
-      List<String> jsonSnapshots =
-          committed.stream().map(SnapshotParser::toJson).collect(Collectors.toList());
       dto =
           openHouseInternalRepository.save(
               dto.toBuilder()
                   .tableVersion(dto.getTableLocation())
-                  .jsonSnapshots(jsonSnapshots)
+                  .jsonSnapshots(
+                      committed.stream().map(SnapshotParser::toJson).collect(Collectors.toList()))
                   .snapshotRefs(refs(snapshot))
                   .build());
     }
     return dto;
+  }
+
+  private static List<Snapshot> appended(List<Snapshot> existing, Snapshot extra) {
+    List<Snapshot> all = new ArrayList<>(existing);
+    all.add(extra);
+    return all;
+  }
+
+  private static List<String> snapshotJson(List<Snapshot> existing, Snapshot extra) {
+    return appended(existing, extra).stream()
+        .map(SnapshotParser::toJson)
+        .collect(Collectors.toList());
   }
 
   private static TableIdentifier idOf(TableDto dto) {
@@ -273,10 +238,10 @@ public class StaleBaseLostUpdateTest {
   }
 
   /**
-   * Invalidates the per-JVM static retry cache used by {@code failIfRetryUpdate} so the test models
-   * a stale commit reaching a replica that never cached the prior {@code COMMIT_KEY}. Without this,
-   * the single-JVM cache hit would short-circuit the second committer before the abort is
-   * exercised.
+   * Invalidates the per-JVM static retry cache used by {@code failIfRetryUpdate} so the stale write
+   * models a request reaching a replica that never cached the racing commit's {@code COMMIT_KEY}.
+   * Without this, the single-JVM cache hit would reject the stale write before the subtractive
+   * merge (or the PR #612 abort) is exercised.
    */
   private static void clearPerJvmRetryCache() throws Exception {
     Field cacheField = OpenHouseInternalTableOperations.class.getDeclaredField("CACHE");

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
@@ -70,16 +70,9 @@ public class StaleBaseLostUpdateTest {
     assertRacingSnapshotSurvivesStaleStagedCommit(l1);
   }
 
-  /** Base table holds a single committed data snapshot when the race begins. */
-  @Test
-  void testLostUpdateViaStagedTransactionConflict() throws Exception {
-    TableDto l1 = createTableWithCommittedDataSnapshots("conflict_staged", 1);
-    assertRacingSnapshotSurvivesStaleStagedCommit(l1);
-  }
-
   /**
-   * Same scenario, but the table already has prior committed data history (two snapshots) before
-   * the race begins — the stale writer's base is a non-trivial, data-bearing table.
+   * Table already has prior committed data history (two snapshots) before the race begins — the
+   * stale writer's base is a non-trivial, data-bearing table.
    */
   @Test
   void testLostUpdateViaStagedTransactionConflictWithPriorDataSnapshot() throws Exception {

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
@@ -15,10 +15,10 @@ import com.linkedin.openhouse.tables.model.TableDtoPrimaryKey;
 import com.linkedin.openhouse.tables.repository.OpenHouseInternalRepository;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -41,11 +41,16 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
- * Deterministic H2 reproduction of the incident-12185 stale-base silent snapshot drop. A stale
- * writer holds an uncommitted transaction opened at base L1; a racing writer advances the catalog
- * L1 -> L2 (adding S2); the stale transaction then commits, and {@code BaseTransaction.applyUpdates}
- * silently rebases the stale {S1} view + COMMIT_KEY=L1 onto L2. Without the PR #612 abort, S2 is
- * silently dropped.
+ * Deterministic H2 reproduction of the incident-12185 stale-base silent snapshot drop. Single-JVM,
+ * no threads, no docker.
+ *
+ * <p>A stale writer opens an Iceberg transaction at base L1 and stages its real L1 snapshot view
+ * (the writer's {@code SNAPSHOTS_JSON} payload) plus {@code COMMIT_KEY=L1}, but holds it
+ * uncommitted. A racing writer appends a new snapshot via the repository path, advancing the
+ * catalog L1 -&gt; L2. When the held transaction is committed, {@code BaseTransaction.applyUpdates}
+ * rebases the stale payload + {@code COMMIT_KEY=L1} onto L2, so {@code doCommit} would subtract the
+ * racing snapshot. The invariant asserted is that the racing snapshot must survive (PR #612's
+ * stale-base CAS aborts the commit; without it the racing snapshot is silently dropped).
  */
 @SpringBootTest
 @ContextConfiguration(initializers = PropertyOverrideContextInitializer.class)
@@ -58,84 +63,97 @@ public class StaleBaseLostUpdateTest {
 
   @Autowired Catalog catalog;
 
+  /** Base table holds a single committed data snapshot when the race begins. */
   @Test
   void testLostUpdateViaStagedTransactionConflict() throws Exception {
-    Setup s = createTableWithOneSnapshot("conflict_staged");
+    TableDto l1 = createTableWithCommittedDataSnapshots("conflict_staged", 1);
+    assertRacingSnapshotSurvivesStaleStagedCommit(l1);
+  }
 
-    // Stale writer opens a transaction at L1 and stages its real L1 view ({S1}) -- exactly what
-    // OpenHouseInternalRepositoryImpl.save does internally, but left uncommitted so a racing commit
-    // can land first.
-    Table staleHandle = catalog.loadTable(s.id);
+  /**
+   * Same scenario, but the table already has prior committed data history (two snapshots) before
+   * the race begins — the stale writer's base is a non-trivial, data-bearing table.
+   */
+  @Test
+  void testLostUpdateViaStagedTransactionConflictWithPriorDataSnapshot() throws Exception {
+    TableDto l1 = createTableWithCommittedDataSnapshots("conflict_staged_prior_data", 2);
+    assertRacingSnapshotSurvivesStaleStagedCommit(l1);
+  }
+
+  /**
+   * Core reproduction. Given a table whose latest committed version is {@code l1}, stages a stale
+   * commit at L1, lands a racing append (L1 -&gt; L2), then commits the stale transaction and
+   * asserts the racing snapshot is not dropped.
+   */
+  private void assertRacingSnapshotSurvivesStaleStagedCommit(TableDto l1) throws Exception {
+    TableIdentifier id = idOf(l1);
+
+    // Stale writer opens a transaction at L1 and stages its real L1 view + COMMIT_KEY=L1 (exactly
+    // what OpenHouseInternalRepositoryImpl.save stamps), held uncommitted so a racing commit lands
+    // first.
+    Table staleHandle = catalog.loadTable(id);
     List<Snapshot> staleView = Lists.newArrayList(staleHandle.snapshots());
-    Assertions.assertEquals(1, staleView.size(), "stale writer's base L1 must hold exactly {S1}");
+    int priorSnapshotCount = staleView.size();
+    Snapshot staleLatest = staleHandle.currentSnapshot();
     Transaction staleTxn = staleHandle.newTransaction();
     staleTxn
         .updateProperties()
         .set(CatalogConstants.SNAPSHOTS_JSON_KEY, SnapshotsUtil.serializedSnapshots(staleView))
-        .set(CatalogConstants.SNAPSHOTS_REFS_KEY, SnapshotsUtil.serializeMap(refs(s.s1)))
-        .set(CatalogConstants.COMMIT_KEY, s.l1.getTableLocation())
+        .set(CatalogConstants.SNAPSHOTS_REFS_KEY, SnapshotsUtil.serializeMap(refs(staleLatest)))
+        .set(CatalogConstants.COMMIT_KEY, l1.getTableLocation())
         .set("foo", "bar")
         .commit();
 
     // Racing writer appends S2 via the repository path -> catalog advances L1 -> L2.
-    Snapshot s2 = catalog.loadTable(s.id).newAppend().appendFile(dummyDataFile()).apply();
+    Snapshot s2 = catalog.loadTable(id).newAppend().appendFile(dummyDataFile()).apply();
+    List<String> racingSnapshots = new ArrayList<>();
+    for (Snapshot existing : staleView) {
+      racingSnapshots.add(SnapshotParser.toJson(existing));
+    }
+    racingSnapshots.add(SnapshotParser.toJson(s2));
     openHouseInternalRepository.save(
-        s.l1
-            .toBuilder()
-            .tableVersion(s.l1.getTableLocation())
-            .jsonSnapshots(Arrays.asList(SnapshotParser.toJson(s.s1), SnapshotParser.toJson(s2)))
+        l1.toBuilder()
+            .tableVersion(l1.getTableLocation())
+            .jsonSnapshots(racingSnapshots)
             .snapshotRefs(refs(s2))
             .build());
 
     clearPerJvmRetryCache();
 
     // Commit the held transaction: applyUpdates sees base L1 != catalog L2, rebases, and re-stamps
-    // the now-stale {S1} list + COMMIT_KEY=L1 onto L2. With #612 this aborts; without it, S2 is
-    // silently dropped.
+    // the stale view + COMMIT_KEY=L1 onto L2. A clean rejection is acceptable and version-dependent
+    // (CommitFailedException from PR #612's CAS, or BadRequestException from the pre-#406 guard);
+    // the invariant below is the same either way: the racing snapshot must survive.
     try {
       staleTxn.commitTransaction();
     } catch (Exception expected) {
-      // A clean rejection is acceptable and version-dependent:
-      //  - D (#612): CommitFailedException from the stale-base CAS.
-      //  - A (pre-#406): BadRequestException from SnapshotInspector.validateSnapshotsUpdate
-      //    ("Cannot delete the latest snapshot").
-      // The invariant asserted below is the same either way: racing S2 must survive.
       LOG.info("commitTransaction rejected the stale commit: {}", expected.toString());
     }
 
-    List<Snapshot> remaining = Lists.newArrayList(catalog.loadTable(s.id).snapshots());
+    List<Snapshot> remaining = Lists.newArrayList(catalog.loadTable(id).snapshots());
     LOG.info(
         "staged-conflict result: remaining snapshots={}",
-        remaining.stream()
-            .map(Snapshot::snapshotId)
-            .collect(java.util.stream.Collectors.toList()));
+        remaining.stream().map(Snapshot::snapshotId).collect(Collectors.toList()));
     Assertions.assertEquals(
-        2, remaining.size(), "S2 (" + s2.snapshotId() + ") must not be silently dropped from H2");
+        priorSnapshotCount + 1,
+        remaining.size(),
+        "racing snapshot S2 (" + s2.snapshotId() + ") must not be silently dropped from H2");
     Assertions.assertTrue(
         remaining.stream().anyMatch(x -> x.snapshotId() == s2.snapshotId()),
         "racing snapshot S2 must still be present after the conflicting stale commit");
 
-    cleanup(s.id);
+    cleanup(id);
   }
 
-  /** Holds the post-setup state of a freshly created table with a single snapshot S1 at L1. */
-  private static final class Setup {
-    final TableIdentifier id;
-    final TableDto l1;
-    final Snapshot s1;
-
-    Setup(TableIdentifier id, TableDto l1, Snapshot s1) {
-      this.id = id;
-      this.l1 = l1;
-      this.s1 = s1;
-    }
-  }
-
-  private Setup createTableWithOneSnapshot(String tableId) throws Exception {
+  /**
+   * Creates a table and commits {@code count} data-bearing snapshots through the repository path,
+   * returning the latest committed {@link TableDto} (the base the stale writer will load as L1).
+   */
+  private TableDto createTableWithCommittedDataSnapshots(String tableId, int count) throws Exception {
     Schema schema =
         new Schema(
             required(1, "id", Types.StringType.get()), optional(2, "data", Types.StringType.get()));
-    TableDto l0 =
+    TableDto dto =
         openHouseInternalRepository.save(
             TABLE_DTO
                 .toBuilder()
@@ -145,16 +163,26 @@ public class StaleBaseLostUpdateTest {
                 .clustering(null)
                 .tableVersion(INITIAL_TABLE_VERSION)
                 .build());
-    TableIdentifier id = TableIdentifier.of(l0.getDatabaseId(), tableId);
-    Snapshot s1 = catalog.loadTable(id).newAppend().appendFile(dummyDataFile()).apply();
-    TableDto l1 =
-        openHouseInternalRepository.save(
-            l0.toBuilder()
-                .tableVersion(l0.getTableLocation())
-                .jsonSnapshots(Collections.singletonList(SnapshotParser.toJson(s1)))
-                .snapshotRefs(refs(s1))
-                .build());
-    return new Setup(id, l1, s1);
+    TableIdentifier id = idOf(dto);
+    List<Snapshot> committed = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      Snapshot snapshot = catalog.loadTable(id).newAppend().appendFile(dummyDataFile()).apply();
+      committed.add(snapshot);
+      List<String> jsonSnapshots =
+          committed.stream().map(SnapshotParser::toJson).collect(Collectors.toList());
+      dto =
+          openHouseInternalRepository.save(
+              dto.toBuilder()
+                  .tableVersion(dto.getTableLocation())
+                  .jsonSnapshots(jsonSnapshots)
+                  .snapshotRefs(refs(snapshot))
+                  .build());
+    }
+    return dto;
+  }
+
+  private static TableIdentifier idOf(TableDto dto) {
+    return TableIdentifier.of(dto.getDatabaseId(), dto.getTableId());
   }
 
   private DataFile dummyDataFile() throws Exception {
@@ -178,7 +206,8 @@ public class StaleBaseLostUpdateTest {
   /**
    * Invalidates the per-JVM static retry cache used by {@code failIfRetryUpdate} so the test models
    * a stale commit reaching a replica that never cached the prior {@code COMMIT_KEY}. Without this,
-   * the single-JVM cache hit would short-circuit the second committer before #612 is exercised.
+   * the single-JVM cache hit would short-circuit the second committer before the abort is
+   * exercised.
    */
   private static void clearPerJvmRetryCache() throws Exception {
     Field cacheField = OpenHouseInternalTableOperations.class.getDeclaredField("CACHE");

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
@@ -41,19 +41,13 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
- * A stale writer opens an Iceberg transaction at base L1 and stages its L1 snapshot view +
- * {@code COMMIT_KEY=L1}, held uncommitted. A racing writer commits a new snapshot through the
- * repository path, advancing the catalog L1 -&gt; L2. Committing the held transaction drives {@code
- * BaseTransaction.applyUpdates} to silently refresh the in-flight base to L2 (passing the HTS
- * optimistic-version CAS) while keeping the stale payload + {@code COMMIT_KEY=L1}; {@code doCommit}
- * then subtracts the racing snapshot. On the buggy catalog the racing commit is silently dropped;
- * PR #612's stale-base CAS aborts instead. Invariant: the racing data commit always survives.
+ * Concurrency tests for committing a snapshot set against a stale base version.
  *
- * <p>Both cases here are <b>subtractive</b> stale commits — the stale payload omits the racing
- * snapshot and does not add a new snapshot whose sequence number would collide with it. That is the
- * shape that actually reproduced incident-12185 (an expire/optimizer commit dropping a fresh data
- * commit). A stale writer that <i>adds</i> its own snapshot on a multi-snapshot base is instead
- * rejected by Iceberg's snapshot sequence-number validation, so that shape cannot lose data.
+ * <p>In each test the table is at version L1, a second writer commits a new snapshot (advancing the
+ * catalog to L2), and then a writer that still declares L1 as its base commits a snapshot set
+ * computed at L1 — which therefore omits the snapshot the second writer just added. The catalog
+ * must not drop that concurrently added snapshot: the stale commit is rejected and the concurrently
+ * added snapshot remains in the table.
  */
 @SpringBootTest
 @ContextConfiguration(initializers = PropertyOverrideContextInitializer.class)
@@ -67,11 +61,10 @@ public class StaleBaseLostUpdateTest {
   @Autowired Catalog catalog;
 
   /**
-   * Snapshot-expiration commit racing a concurrent data insert — the production maintenance shape,
-   * on a table with prior committed data history. The stale expire keeps only the current head
-   * (expiring older snapshots); its keep-subset cannot reference the concurrently-added data
-   * snapshot, so the subtractive merge would expire the racing data commit. Asserts the data commit
-   * survives and the stale expire is rejected wholesale.
+   * An expiration commit declaring a stale base, racing a concurrent insert. The expiring writer
+   * keeps only the current head and drops older snapshots; its kept set, computed at the stale
+   * base, does not include the concurrently inserted snapshot. The concurrent insert must remain
+   * and the expiration must be rejected, leaving the prior snapshots plus the concurrent insert.
    */
   @Test
   void testExpireSnapshotsDropsConcurrentDataCommit() throws Exception {
@@ -87,9 +80,9 @@ public class StaleBaseLostUpdateTest {
   }
 
   /**
-   * Two writers concurrently perform the first insert into a freshly created table. The racing
-   * writer commits first; the stale writer then commits its own first snapshot still declaring the
-   * create version as its base. The subtractive merge would drop the racing first commit.
+   * Two writers each perform the first insert into a freshly created table. One commits first; the
+   * other then commits its own first snapshot still declaring the create version as its base. The
+   * first writer's snapshot must remain.
    */
   @Test
   void testStaleInsertDropsConcurrentDataCommitOnFreshTable() throws Exception {
@@ -104,14 +97,31 @@ public class StaleBaseLostUpdateTest {
   }
 
   /**
-   * Core reproduction. A stale writer holds a transaction at base {@code l1} staging {@code
-   * stalePayload} (main -&gt; {@code staleHead}); a racing writer commits a fresh data snapshot
-   * first (L1 -&gt; L2); the held transaction then commits, rebasing the stale payload (which omits
-   * the racing snapshot) onto L2. Asserts the racing commit survives and the stale commit is
-   * rejected wholesale (nothing from the stale payload is applied).
+   * Two writers insert into a table that already holds data, both based on the same version. The
+   * stale writer's appended snapshot shares a sequence number with the concurrent insert, so the
+   * catalog rejects the stale commit; the concurrent insert remains.
+   */
+  @Test
+  void testConcurrentInsertOnPopulatedTableIsRejected() throws Exception {
+    TableDto l1 = createTableWithCommittedDataSnapshots("insert_race_populated", 2);
+    TableIdentifier id = idOf(l1);
+
+    Table staleHandle = catalog.loadTable(id);
+    List<Snapshot> base = Lists.newArrayList(staleHandle.snapshots());
+    Snapshot staleInsert = staleHandle.newAppend().appendFile(dummyDataFile()).apply();
+
+    assertRacingDataCommitSurvivesStaleCommit(l1, base, appended(base, staleInsert), staleInsert);
+  }
+
+  /**
+   * Loads the table at version {@code l1}, has a second writer commit a fresh data snapshot
+   * (advancing the catalog), then commits a writer that still declares {@code l1} as its base with
+   * {@code stalePayload} (pointing main at {@code staleHead}) — a snapshot set that omits the second
+   * writer's snapshot. Asserts the concurrently committed snapshot remains and the stale commit is
+   * rejected without applying any of its payload.
    *
-   * @param base the snapshots present at L1 (the stale writer's view before its own staging)
-   * @param stalePayload the full snapshot set the stale writer commits (omits the racing snapshot)
+   * @param base the snapshots present at {@code l1}
+   * @param stalePayload the snapshot set the stale writer commits (omits the concurrent snapshot)
    * @param staleHead the snapshot the stale writer points main at
    */
   private void assertRacingDataCommitSurvivesStaleCommit(
@@ -120,7 +130,7 @@ public class StaleBaseLostUpdateTest {
     TableIdentifier id = idOf(l1);
     int priorSnapshotCount = base.size();
 
-    // Stale writer: held transaction at L1 staging its payload + COMMIT_KEY=L1, uncommitted.
+    // Stale writer holds a transaction at L1 staging its payload, left uncommitted.
     Transaction staleTxn = catalog.loadTable(id).newTransaction();
     staleTxn
         .updateProperties()
@@ -129,11 +139,12 @@ public class StaleBaseLostUpdateTest {
         .set(CatalogConstants.COMMIT_KEY, l1.getTableLocation())
         .commit();
 
-    // Racing writer (also based on L1) commits a fresh data snapshot first -> L1 -> L2.
+    // Second writer, also based on L1, commits a fresh data snapshot, advancing the catalog to L2.
     Snapshot racing = catalog.loadTable(id).newAppend().appendFile(dummyDataFile()).apply();
     commitThroughRepository(l1, snapshotJson(base, racing), racing);
 
-    clearPerJvmRetryCache();
+    // Evaluate the stale commit on its base version rather than short-circuit it as a duplicate.
+    clearRetryCache();
 
     try {
       staleTxn.commitTransaction();
@@ -143,16 +154,15 @@ public class StaleBaseLostUpdateTest {
 
     List<Snapshot> remaining = Lists.newArrayList(catalog.loadTable(id).snapshots());
     LOG.info(
-        "stale-conflict result: remaining={}",
+        "remaining snapshots after stale commit={}",
         remaining.stream().map(Snapshot::snapshotId).collect(Collectors.toList()));
     Assertions.assertTrue(
         remaining.stream().anyMatch(s -> s.snapshotId() == racing.snapshotId()),
-        "racing data commit (" + racing.snapshotId() + ") must not be silently dropped");
+        "concurrently committed snapshot (" + racing.snapshotId() + ") must not be dropped");
     Assertions.assertEquals(
         priorSnapshotCount + 1,
         remaining.size(),
-        "stale commit must be rejected wholesale; table holds only the prior snapshots + the racing "
-            + "data commit");
+        "table must hold only the prior snapshots plus the concurrently committed snapshot");
 
     cleanup(id);
   }
@@ -168,8 +178,8 @@ public class StaleBaseLostUpdateTest {
   }
 
   /**
-   * Creates a table and commits {@code count} data-bearing snapshots through the repository path,
-   * returning the latest committed {@link TableDto} (the base L1 the racers will load).
+   * Creates a table and commits {@code count} data-bearing snapshots, returning the latest
+   * committed {@link TableDto} (the version both writers load as their base).
    */
   private TableDto createTableWithCommittedDataSnapshots(String tableId, int count)
       throws Exception {
@@ -221,7 +231,8 @@ public class StaleBaseLostUpdateTest {
 
   private DataFile dummyDataFile() throws Exception {
     return IcebergSnapshotsModelTestUtilities.createDummyDataFile(
-        Files.createTempFile("incident-12185-", ".orc").toString(), PartitionSpec.unpartitioned());
+        Files.createTempFile("stale-base-conflict-", ".orc").toString(),
+        PartitionSpec.unpartitioned());
   }
 
   private static Map<String, String> refs(Snapshot snapshot) {
@@ -238,12 +249,10 @@ public class StaleBaseLostUpdateTest {
   }
 
   /**
-   * Invalidates the per-JVM static retry cache used by {@code failIfRetryUpdate} so the stale write
-   * models a request reaching a replica that never cached the racing commit's {@code COMMIT_KEY}.
-   * Without this, the single-JVM cache hit would reject the stale write before the subtractive
-   * merge (or the PR #612 abort) is exercised.
+   * Invalidates the per-JVM retry cache so the stale commit is evaluated against its base version
+   * rather than short-circuited as a duplicate retry of an already-seen commit.
    */
-  private static void clearPerJvmRetryCache() throws Exception {
+  private static void clearRetryCache() throws Exception {
     Field cacheField = OpenHouseInternalTableOperations.class.getDeclaredField("CACHE");
     cacheField.setAccessible(true);
     ((com.google.common.cache.Cache<?, ?>) cacheField.get(null)).invalidateAll();

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
@@ -1,0 +1,188 @@
+package com.linkedin.openhouse.tables.e2e.h2;
+
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.INITIAL_TABLE_VERSION;
+import static com.linkedin.openhouse.tables.model.TableModelConstants.TABLE_DTO;
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+import com.linkedin.openhouse.common.test.cluster.PropertyOverrideContextInitializer;
+import com.linkedin.openhouse.internal.catalog.CatalogConstants;
+import com.linkedin.openhouse.internal.catalog.OpenHouseInternalTableOperations;
+import com.linkedin.openhouse.internal.catalog.SnapshotsUtil;
+import com.linkedin.openhouse.tables.model.IcebergSnapshotsModelTestUtilities;
+import com.linkedin.openhouse.tables.model.TableDto;
+import com.linkedin.openhouse.tables.model.TableDtoPrimaryKey;
+import com.linkedin.openhouse.tables.repository.OpenHouseInternalRepository;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotParser;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.Transaction;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * Deterministic H2 reproduction of the incident-12185 stale-base silent snapshot drop. A stale
+ * writer holds an uncommitted transaction opened at base L1; a racing writer advances the catalog
+ * L1 -> L2 (adding S2); the stale transaction then commits, and {@code BaseTransaction.applyUpdates}
+ * silently rebases the stale {S1} view + COMMIT_KEY=L1 onto L2. Without the PR #612 abort, S2 is
+ * silently dropped.
+ */
+@SpringBootTest
+@ContextConfiguration(initializers = PropertyOverrideContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+public class StaleBaseLostUpdateTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(StaleBaseLostUpdateTest.class);
+
+  @Autowired OpenHouseInternalRepository openHouseInternalRepository;
+
+  @Autowired Catalog catalog;
+
+  @Test
+  void testLostUpdateViaStagedTransactionConflict() throws Exception {
+    Setup s = createTableWithOneSnapshot("conflict_staged");
+
+    // Stale writer opens a transaction at L1 and stages its real L1 view ({S1}) -- exactly what
+    // OpenHouseInternalRepositoryImpl.save does internally, but left uncommitted so a racing commit
+    // can land first.
+    Table staleHandle = catalog.loadTable(s.id);
+    List<Snapshot> staleView = Lists.newArrayList(staleHandle.snapshots());
+    Assertions.assertEquals(1, staleView.size(), "stale writer's base L1 must hold exactly {S1}");
+    Transaction staleTxn = staleHandle.newTransaction();
+    staleTxn
+        .updateProperties()
+        .set(CatalogConstants.SNAPSHOTS_JSON_KEY, SnapshotsUtil.serializedSnapshots(staleView))
+        .set(CatalogConstants.SNAPSHOTS_REFS_KEY, SnapshotsUtil.serializeMap(refs(s.s1)))
+        .set(CatalogConstants.COMMIT_KEY, s.l1.getTableLocation())
+        .set("foo", "bar")
+        .commit();
+
+    // Racing writer appends S2 via the repository path -> catalog advances L1 -> L2.
+    Snapshot s2 = catalog.loadTable(s.id).newAppend().appendFile(dummyDataFile()).apply();
+    openHouseInternalRepository.save(
+        s.l1
+            .toBuilder()
+            .tableVersion(s.l1.getTableLocation())
+            .jsonSnapshots(Arrays.asList(SnapshotParser.toJson(s.s1), SnapshotParser.toJson(s2)))
+            .snapshotRefs(refs(s2))
+            .build());
+
+    clearPerJvmRetryCache();
+
+    // Commit the held transaction: applyUpdates sees base L1 != catalog L2, rebases, and re-stamps
+    // the now-stale {S1} list + COMMIT_KEY=L1 onto L2. With #612 this aborts; without it, S2 is
+    // silently dropped.
+    try {
+      staleTxn.commitTransaction();
+    } catch (Exception expected) {
+      // A clean rejection is acceptable and version-dependent:
+      //  - D (#612): CommitFailedException from the stale-base CAS.
+      //  - A (pre-#406): BadRequestException from SnapshotInspector.validateSnapshotsUpdate
+      //    ("Cannot delete the latest snapshot").
+      // The invariant asserted below is the same either way: racing S2 must survive.
+      LOG.info("commitTransaction rejected the stale commit: {}", expected.toString());
+    }
+
+    List<Snapshot> remaining = Lists.newArrayList(catalog.loadTable(s.id).snapshots());
+    LOG.info(
+        "staged-conflict result: remaining snapshots={}",
+        remaining.stream()
+            .map(Snapshot::snapshotId)
+            .collect(java.util.stream.Collectors.toList()));
+    Assertions.assertEquals(
+        2, remaining.size(), "S2 (" + s2.snapshotId() + ") must not be silently dropped from H2");
+    Assertions.assertTrue(
+        remaining.stream().anyMatch(x -> x.snapshotId() == s2.snapshotId()),
+        "racing snapshot S2 must still be present after the conflicting stale commit");
+
+    cleanup(s.id);
+  }
+
+  /** Holds the post-setup state of a freshly created table with a single snapshot S1 at L1. */
+  private static final class Setup {
+    final TableIdentifier id;
+    final TableDto l1;
+    final Snapshot s1;
+
+    Setup(TableIdentifier id, TableDto l1, Snapshot s1) {
+      this.id = id;
+      this.l1 = l1;
+      this.s1 = s1;
+    }
+  }
+
+  private Setup createTableWithOneSnapshot(String tableId) throws Exception {
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.StringType.get()), optional(2, "data", Types.StringType.get()));
+    TableDto l0 =
+        openHouseInternalRepository.save(
+            TABLE_DTO
+                .toBuilder()
+                .tableId(tableId)
+                .schema(SchemaParser.toJson(schema, false))
+                .timePartitioning(null)
+                .clustering(null)
+                .tableVersion(INITIAL_TABLE_VERSION)
+                .build());
+    TableIdentifier id = TableIdentifier.of(l0.getDatabaseId(), tableId);
+    Snapshot s1 = catalog.loadTable(id).newAppend().appendFile(dummyDataFile()).apply();
+    TableDto l1 =
+        openHouseInternalRepository.save(
+            l0.toBuilder()
+                .tableVersion(l0.getTableLocation())
+                .jsonSnapshots(Collections.singletonList(SnapshotParser.toJson(s1)))
+                .snapshotRefs(refs(s1))
+                .build());
+    return new Setup(id, l1, s1);
+  }
+
+  private DataFile dummyDataFile() throws Exception {
+    return IcebergSnapshotsModelTestUtilities.createDummyDataFile(
+        Files.createTempFile("incident-12185-", ".orc").toString(), PartitionSpec.unpartitioned());
+  }
+
+  private static Map<String, String> refs(Snapshot snapshot) {
+    return IcebergSnapshotsModelTestUtilities.obtainSnapshotRefsFromSnapshot(
+        SnapshotParser.toJson(snapshot));
+  }
+
+  private void cleanup(TableIdentifier id) {
+    openHouseInternalRepository.deleteById(
+        TableDtoPrimaryKey.builder()
+            .databaseId(id.namespace().toString())
+            .tableId(id.name())
+            .build());
+  }
+
+  /**
+   * Invalidates the per-JVM static retry cache used by {@code failIfRetryUpdate} so the test models
+   * a stale commit reaching a replica that never cached the prior {@code COMMIT_KEY}. Without this,
+   * the single-JVM cache hit would short-circuit the second committer before #612 is exercised.
+   */
+  private static void clearPerJvmRetryCache() throws Exception {
+    Field cacheField = OpenHouseInternalTableOperations.class.getDeclaredField("CACHE");
+    cacheField.setAccessible(true);
+    ((com.google.common.cache.Cache<?, ?>) cacheField.get(null)).invalidateAll();
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
@@ -115,8 +115,8 @@ public class StaleBaseLostUpdateTest {
   }
 
   /**
-   * A stale commit that updates metadata without adding a snapshot, racing a concurrent insert. Its
-   * declared snapshot set is its base view, which omits the concurrent insert, so the diff is a
+   * A stale commit that changes a table property and adds no snapshot, racing a concurrent insert.
+   * Its declared snapshot set is its base view, which omits the concurrent insert, so the diff is a
    * pure deletion of the concurrent snapshot. The concurrent insert must remain and the stale
    * commit must be rejected.
    */
@@ -129,8 +129,55 @@ public class StaleBaseLostUpdateTest {
     List<Snapshot> base = Lists.newArrayList(staleHandle.snapshots());
     Snapshot head = staleHandle.currentSnapshot();
 
-    // The stale writer adds no snapshot; its declared set is its base view and main stays at head.
-    assertRacingDataCommitSurvivesStaleCommit(l1, base, base, head);
+    // Stale writer: set a table property and carry the base snapshot view (no new snapshot), held.
+    Transaction staleTxn = staleHandle.newTransaction();
+    staleTxn
+        .updateProperties()
+        .set("test.stale.property", "changed")
+        .set(CatalogConstants.SNAPSHOTS_JSON_KEY, SnapshotsUtil.serializedSnapshots(base))
+        .set(
+            CatalogConstants.SNAPSHOTS_REFS_KEY,
+            SnapshotsUtil.serializeMap(
+                IcebergSnapshotsModelTestUtilities.obtainSnapshotRefsFromSnapshot(
+                    SnapshotParser.toJson(head))))
+        .set(CatalogConstants.COMMIT_KEY, l1.getTableLocation())
+        .commit();
+
+    // Second writer commits a fresh data snapshot, advancing the catalog.
+    Snapshot racing = catalog.loadTable(id).newAppend().appendFile(dummyDataFile()).apply();
+    List<Snapshot> snapshotsAfterRace = new ArrayList<>(base);
+    snapshotsAfterRace.add(racing);
+    openHouseInternalRepository.save(
+        l1.toBuilder()
+            .tableVersion(l1.getTableLocation())
+            .jsonSnapshots(
+                snapshotsAfterRace.stream()
+                    .map(SnapshotParser::toJson)
+                    .collect(Collectors.toList()))
+            .snapshotRefs(
+                IcebergSnapshotsModelTestUtilities.obtainSnapshotRefsFromSnapshot(
+                    SnapshotParser.toJson(racing)))
+            .build());
+
+    clearRetryCache();
+
+    Set<Long> expected = base.stream().map(Snapshot::snapshotId).collect(Collectors.toSet());
+    expected.add(racing.snapshotId());
+    Assertions.assertThrows(
+        Exception.class,
+        staleTxn::commitTransaction,
+        "the stale property update must be rejected, not applied against the advanced catalog");
+    Set<Long> actual =
+        Lists.newArrayList(catalog.loadTable(id).snapshots()).stream()
+            .map(Snapshot::snapshotId)
+            .collect(Collectors.toSet());
+    Assertions.assertEquals(
+        expected,
+        actual,
+        "table must hold exactly the prior snapshots plus the concurrently committed snapshot "
+            + racing.snapshotId());
+
+    cleanup(id);
   }
 
   /**

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
@@ -41,8 +41,6 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
- * Deterministic H2 reproduction of the incident-12185 stale-base silent snapshot drop. Single-JVM,
- * no threads, no docker.
  *
  * <p>A stale writer opens an Iceberg transaction at base L1 and stages its real L1 snapshot view
  * (the writer's {@code SNAPSHOTS_JSON} payload) plus {@code COMMIT_KEY=L1}, but holds it

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Assertions;
@@ -161,16 +162,14 @@ public class StaleBaseLostUpdateTest {
     // Evaluate the stale commit on its base version rather than short-circuit it as a duplicate.
     clearRetryCache();
 
-    // The stale commit may be rejected outright; it must not succeed by dropping the concurrent
-    // snapshot. The table-state assertion below holds whether or not the commit throws.
-    try {
-      staleTxn.commitTransaction();
-    } catch (Exception rejected) {
-      // Rejection is an acceptable outcome; the table state is asserted below.
-    }
+    // The stale commit declares a base that no longer matches the catalog, so it must be rejected.
+    Assertions.assertThrows(
+        CommitFailedException.class,
+        staleTxn::commitTransaction,
+        "the stale commit must be rejected, not applied against the advanced catalog");
 
-    Set<Long> expected =
-        base.stream().map(Snapshot::snapshotId).collect(Collectors.toSet());
+    // The table must then hold exactly the prior snapshots plus the concurrently committed snapshot.
+    Set<Long> expected = base.stream().map(Snapshot::snapshotId).collect(Collectors.toSet());
     expected.add(racing.snapshotId());
     Set<Long> actual =
         Lists.newArrayList(catalog.loadTable(id).snapshots()).stream()
@@ -180,8 +179,7 @@ public class StaleBaseLostUpdateTest {
         expected,
         actual,
         "table must hold exactly the prior snapshots plus the concurrently committed snapshot "
-            + racing.snapshotId()
-            + "; the stale commit must apply none of its own payload");
+            + racing.snapshotId());
 
     cleanup(id);
   }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.PartitionSpec;
@@ -33,8 +33,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
@@ -46,15 +44,13 @@ import org.springframework.test.context.ContextConfiguration;
  * <p>In each test the table is at version L1, a second writer commits a new snapshot (advancing the
  * catalog to L2), and then a writer that still declares L1 as its base commits a snapshot set
  * computed at L1 — which therefore omits the snapshot the second writer just added. The catalog
- * must not drop that concurrently added snapshot: the stale commit is rejected and the concurrently
- * added snapshot remains in the table.
+ * must not drop that concurrently added snapshot: the stale commit is rejected and the
+ * concurrently added snapshot remains in the table.
  */
 @SpringBootTest
 @ContextConfiguration(initializers = PropertyOverrideContextInitializer.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 public class StaleBaseLostUpdateTest {
-
-  private static final Logger LOG = LoggerFactory.getLogger(StaleBaseLostUpdateTest.class);
 
   @Autowired OpenHouseInternalRepository openHouseInternalRepository;
 
@@ -69,7 +65,7 @@ public class StaleBaseLostUpdateTest {
   @Test
   void testExpireSnapshotsDropsConcurrentDataCommit() throws Exception {
     TableDto l1 = createTableWithCommittedDataSnapshots("expire_race", 2);
-    TableIdentifier id = idOf(l1);
+    TableIdentifier id = TableIdentifier.of(l1.getDatabaseId(), l1.getTableId());
 
     Table staleHandle = catalog.loadTable(id);
     List<Snapshot> base = Lists.newArrayList(staleHandle.snapshots());
@@ -87,7 +83,7 @@ public class StaleBaseLostUpdateTest {
   @Test
   void testStaleInsertDropsConcurrentDataCommitOnFreshTable() throws Exception {
     TableDto l1 = createTableWithCommittedDataSnapshots("insert_race_fresh", 0);
-    TableIdentifier id = idOf(l1);
+    TableIdentifier id = TableIdentifier.of(l1.getDatabaseId(), l1.getTableId());
 
     Table staleHandle = catalog.loadTable(id);
     List<Snapshot> base = Lists.newArrayList(staleHandle.snapshots()); // empty
@@ -104,7 +100,7 @@ public class StaleBaseLostUpdateTest {
   @Test
   void testConcurrentInsertOnPopulatedTableIsRejected() throws Exception {
     TableDto l1 = createTableWithCommittedDataSnapshots("insert_race_populated", 2);
-    TableIdentifier id = idOf(l1);
+    TableIdentifier id = TableIdentifier.of(l1.getDatabaseId(), l1.getTableId());
 
     Table staleHandle = catalog.loadTable(id);
     List<Snapshot> base = Lists.newArrayList(staleHandle.snapshots());
@@ -117,8 +113,8 @@ public class StaleBaseLostUpdateTest {
    * Loads the table at version {@code l1}, has a second writer commit a fresh data snapshot
    * (advancing the catalog), then commits a writer that still declares {@code l1} as its base with
    * {@code stalePayload} (pointing main at {@code staleHead}) — a snapshot set that omits the second
-   * writer's snapshot. Asserts the concurrently committed snapshot remains and the stale commit is
-   * rejected without applying any of its payload.
+   * writer's snapshot. After the stale commit, the table must hold exactly the prior snapshots plus
+   * the second writer's snapshot: the stale commit applies none of its payload.
    *
    * @param base the snapshots present at {@code l1}
    * @param stalePayload the snapshot set the stale writer commits (omits the concurrent snapshot)
@@ -127,54 +123,61 @@ public class StaleBaseLostUpdateTest {
   private void assertRacingDataCommitSurvivesStaleCommit(
       TableDto l1, List<Snapshot> base, List<Snapshot> stalePayload, Snapshot staleHead)
       throws Exception {
-    TableIdentifier id = idOf(l1);
-    int priorSnapshotCount = base.size();
+    TableIdentifier id = TableIdentifier.of(l1.getDatabaseId(), l1.getTableId());
 
     // Stale writer holds a transaction at L1 staging its payload, left uncommitted.
     Transaction staleTxn = catalog.loadTable(id).newTransaction();
     staleTxn
         .updateProperties()
         .set(CatalogConstants.SNAPSHOTS_JSON_KEY, SnapshotsUtil.serializedSnapshots(stalePayload))
-        .set(CatalogConstants.SNAPSHOTS_REFS_KEY, SnapshotsUtil.serializeMap(refs(staleHead)))
+        .set(
+            CatalogConstants.SNAPSHOTS_REFS_KEY,
+            SnapshotsUtil.serializeMap(
+                IcebergSnapshotsModelTestUtilities.obtainSnapshotRefsFromSnapshot(
+                    SnapshotParser.toJson(staleHead))))
         .set(CatalogConstants.COMMIT_KEY, l1.getTableLocation())
         .commit();
 
     // Second writer, also based on L1, commits a fresh data snapshot, advancing the catalog to L2.
     Snapshot racing = catalog.loadTable(id).newAppend().appendFile(dummyDataFile()).apply();
-    commitThroughRepository(l1, snapshotJson(base, racing), racing);
+    openHouseInternalRepository.save(
+        l1.toBuilder()
+            .tableVersion(l1.getTableLocation())
+            .jsonSnapshots(
+                appended(base, racing).stream()
+                    .map(SnapshotParser::toJson)
+                    .collect(Collectors.toList()))
+            .snapshotRefs(
+                IcebergSnapshotsModelTestUtilities.obtainSnapshotRefsFromSnapshot(
+                    SnapshotParser.toJson(racing)))
+            .build());
 
     // Evaluate the stale commit on its base version rather than short-circuit it as a duplicate.
     clearRetryCache();
 
+    // The stale commit may be rejected outright; it must not succeed by dropping the concurrent
+    // snapshot. The table-state assertion below holds whether or not the commit throws.
     try {
       staleTxn.commitTransaction();
-    } catch (Exception expected) {
-      LOG.info("stale commit rejected: {}", expected.toString());
+    } catch (Exception rejected) {
+      // Rejection is an acceptable outcome; the table state is asserted below.
     }
 
-    List<Snapshot> remaining = Lists.newArrayList(catalog.loadTable(id).snapshots());
-    LOG.info(
-        "remaining snapshots after stale commit={}",
-        remaining.stream().map(Snapshot::snapshotId).collect(Collectors.toList()));
-    Assertions.assertTrue(
-        remaining.stream().anyMatch(s -> s.snapshotId() == racing.snapshotId()),
-        "concurrently committed snapshot (" + racing.snapshotId() + ") must not be dropped");
+    Set<Long> expected =
+        base.stream().map(Snapshot::snapshotId).collect(Collectors.toSet());
+    expected.add(racing.snapshotId());
+    Set<Long> actual =
+        Lists.newArrayList(catalog.loadTable(id).snapshots()).stream()
+            .map(Snapshot::snapshotId)
+            .collect(Collectors.toSet());
     Assertions.assertEquals(
-        priorSnapshotCount + 1,
-        remaining.size(),
-        "table must hold only the prior snapshots plus the concurrently committed snapshot");
+        expected,
+        actual,
+        "table must hold exactly the prior snapshots plus the concurrently committed snapshot "
+            + racing.snapshotId()
+            + "; the stale commit must apply none of its own payload");
 
     cleanup(id);
-  }
-
-  /** Commits {@code jsonSnapshots} (main -&gt; {@code head}) declaring base {@code l1}'s version. */
-  private void commitThroughRepository(TableDto l1, List<String> jsonSnapshots, Snapshot head) {
-    openHouseInternalRepository.save(
-        l1.toBuilder()
-            .tableVersion(l1.getTableLocation())
-            .jsonSnapshots(jsonSnapshots)
-            .snapshotRefs(refs(head))
-            .build());
   }
 
   /**
@@ -196,7 +199,7 @@ public class StaleBaseLostUpdateTest {
                 .clustering(null)
                 .tableVersion(INITIAL_TABLE_VERSION)
                 .build());
-    TableIdentifier id = idOf(dto);
+    TableIdentifier id = TableIdentifier.of(dto.getDatabaseId(), dto.getTableId());
     List<Snapshot> committed = new ArrayList<>();
     for (int i = 0; i < count; i++) {
       Snapshot snapshot = catalog.loadTable(id).newAppend().appendFile(dummyDataFile()).apply();
@@ -207,7 +210,9 @@ public class StaleBaseLostUpdateTest {
                   .tableVersion(dto.getTableLocation())
                   .jsonSnapshots(
                       committed.stream().map(SnapshotParser::toJson).collect(Collectors.toList()))
-                  .snapshotRefs(refs(snapshot))
+                  .snapshotRefs(
+                      IcebergSnapshotsModelTestUtilities.obtainSnapshotRefsFromSnapshot(
+                          SnapshotParser.toJson(snapshot)))
                   .build());
     }
     return dto;
@@ -219,25 +224,10 @@ public class StaleBaseLostUpdateTest {
     return all;
   }
 
-  private static List<String> snapshotJson(List<Snapshot> existing, Snapshot extra) {
-    return appended(existing, extra).stream()
-        .map(SnapshotParser::toJson)
-        .collect(Collectors.toList());
-  }
-
-  private static TableIdentifier idOf(TableDto dto) {
-    return TableIdentifier.of(dto.getDatabaseId(), dto.getTableId());
-  }
-
   private DataFile dummyDataFile() throws Exception {
     return IcebergSnapshotsModelTestUtilities.createDummyDataFile(
         Files.createTempFile("stale-base-conflict-", ".orc").toString(),
         PartitionSpec.unpartitioned());
-  }
-
-  private static Map<String, String> refs(Snapshot snapshot) {
-    return IcebergSnapshotsModelTestUtilities.obtainSnapshotRefsFromSnapshot(
-        SnapshotParser.toJson(snapshot));
   }
 
   private void cleanup(TableIdentifier id) {

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
@@ -88,8 +88,10 @@ public class StaleBaseLostUpdateTest {
     Table staleHandle = catalog.loadTable(id);
     List<Snapshot> base = Lists.newArrayList(staleHandle.snapshots()); // empty
     Snapshot staleInsert = staleHandle.newAppend().appendFile(dummyDataFile()).apply();
+    List<Snapshot> stalePayload = new ArrayList<>(base);
+    stalePayload.add(staleInsert);
 
-    assertRacingDataCommitSurvivesStaleCommit(l1, base, appended(base, staleInsert), staleInsert);
+    assertRacingDataCommitSurvivesStaleCommit(l1, base, stalePayload, staleInsert);
   }
 
   /**
@@ -105,8 +107,10 @@ public class StaleBaseLostUpdateTest {
     Table staleHandle = catalog.loadTable(id);
     List<Snapshot> base = Lists.newArrayList(staleHandle.snapshots());
     Snapshot staleInsert = staleHandle.newAppend().appendFile(dummyDataFile()).apply();
+    List<Snapshot> stalePayload = new ArrayList<>(base);
+    stalePayload.add(staleInsert);
 
-    assertRacingDataCommitSurvivesStaleCommit(l1, base, appended(base, staleInsert), staleInsert);
+    assertRacingDataCommitSurvivesStaleCommit(l1, base, stalePayload, staleInsert);
   }
 
   /**
@@ -140,11 +144,13 @@ public class StaleBaseLostUpdateTest {
 
     // Second writer, also based on L1, commits a fresh data snapshot, advancing the catalog to L2.
     Snapshot racing = catalog.loadTable(id).newAppend().appendFile(dummyDataFile()).apply();
+    List<Snapshot> snapshotsAfterRace = new ArrayList<>(base);
+    snapshotsAfterRace.add(racing);
     openHouseInternalRepository.save(
         l1.toBuilder()
             .tableVersion(l1.getTableLocation())
             .jsonSnapshots(
-                appended(base, racing).stream()
+                snapshotsAfterRace.stream()
                     .map(SnapshotParser::toJson)
                     .collect(Collectors.toList()))
             .snapshotRefs(
@@ -216,12 +222,6 @@ public class StaleBaseLostUpdateTest {
                   .build());
     }
     return dto;
-  }
-
-  private static List<Snapshot> appended(List<Snapshot> existing, Snapshot extra) {
-    List<Snapshot> all = new ArrayList<>(existing);
-    all.add(extra);
-    return all;
   }
 
   private DataFile dummyDataFile() throws Exception {

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
@@ -115,6 +115,25 @@ public class StaleBaseLostUpdateTest {
   }
 
   /**
+   * A stale commit that updates metadata without adding a snapshot, racing a concurrent insert. Its
+   * declared snapshot set is its base view, which omits the concurrent insert, so the diff is a
+   * pure deletion of the concurrent snapshot. The concurrent insert must remain and the stale
+   * commit must be rejected.
+   */
+  @Test
+  void testStaleMetadataUpdateDropsConcurrentDataCommit() throws Exception {
+    TableDto l1 = createTableWithCommittedDataSnapshots("metadata_update_race", 2);
+    TableIdentifier id = TableIdentifier.of(l1.getDatabaseId(), l1.getTableId());
+
+    Table staleHandle = catalog.loadTable(id);
+    List<Snapshot> base = Lists.newArrayList(staleHandle.snapshots());
+    Snapshot head = staleHandle.currentSnapshot();
+
+    // The stale writer adds no snapshot; its declared set is its base view and main stays at head.
+    assertRacingDataCommitSurvivesStaleCommit(l1, base, base, head);
+  }
+
+  /**
    * Loads the table at version {@code l1}, has a second writer commit a fresh data snapshot
    * (advancing the catalog), then commits a writer that still declares {@code l1} as its base with
    * {@code stalePayload} (pointing main at {@code staleHead}) — a snapshot set that omits the second
@@ -162,9 +181,10 @@ public class StaleBaseLostUpdateTest {
     // Evaluate the stale commit on its base version rather than short-circuit it as a duplicate.
     clearRetryCache();
 
-    // The stale commit declares a base that no longer matches the catalog, so it must be rejected.
+    // The stale commit declares a base that no longer matches the catalog, so it must be rejected
+    // (the rejection's exception type is not part of the contract).
     Assertions.assertThrows(
-        CommitFailedException.class,
+        Exception.class,
         staleTxn::commitTransaction,
         "the stale commit must be rejected, not applied against the advanced catalog");
 

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
@@ -63,6 +63,13 @@ public class StaleBaseLostUpdateTest {
 
   @Autowired Catalog catalog;
 
+  /** Base table is freshly created with zero committed data snapshots when the race begins. */
+  @Test
+  void testLostUpdateViaStagedTransactionConflictWithNoPriorData() throws Exception {
+    TableDto l1 = createTableWithCommittedDataSnapshots("conflict_staged_no_data", 0);
+    assertRacingSnapshotSurvivesStaleStagedCommit(l1);
+  }
+
   /** Base table holds a single committed data snapshot when the race begins. */
   @Test
   void testLostUpdateViaStagedTransactionConflict() throws Exception {

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
@@ -88,20 +88,22 @@ public class StaleBaseLostUpdateTest {
   private void assertRacingSnapshotSurvivesStaleStagedCommit(TableDto l1) throws Exception {
     TableIdentifier id = idOf(l1);
 
-    // Stale writer opens a transaction at L1 and stages its real L1 view + COMMIT_KEY=L1 (exactly
-    // what OpenHouseInternalRepositoryImpl.save stamps), held uncommitted so a racing commit lands
-    // first.
+    // Stale writer opens a transaction at L1 and performs its own insert: a new data snapshot
+    // appended at base L1. Its staged payload contains the existing snapshots + its own append but
+    // NOT the racing snapshot (which it cannot see), with COMMIT_KEY=L1 — exactly what
+    // OpenHouseInternalRepositoryImpl.save stamps. Held uncommitted so a racing commit lands first.
     Table staleHandle = catalog.loadTable(id);
     List<Snapshot> staleView = Lists.newArrayList(staleHandle.snapshots());
     int priorSnapshotCount = staleView.size();
-    Snapshot staleLatest = staleHandle.currentSnapshot();
+    Snapshot staleInsert = staleHandle.newAppend().appendFile(dummyDataFile()).apply();
+    List<Snapshot> stalePayload = new ArrayList<>(staleView);
+    stalePayload.add(staleInsert);
     Transaction staleTxn = staleHandle.newTransaction();
     staleTxn
         .updateProperties()
-        .set(CatalogConstants.SNAPSHOTS_JSON_KEY, SnapshotsUtil.serializedSnapshots(staleView))
-        .set(CatalogConstants.SNAPSHOTS_REFS_KEY, SnapshotsUtil.serializeMap(refs(staleLatest)))
+        .set(CatalogConstants.SNAPSHOTS_JSON_KEY, SnapshotsUtil.serializedSnapshots(stalePayload))
+        .set(CatalogConstants.SNAPSHOTS_REFS_KEY, SnapshotsUtil.serializeMap(refs(staleInsert)))
         .set(CatalogConstants.COMMIT_KEY, l1.getTableLocation())
-        .set("foo", "bar")
         .commit();
 
     // Racing writer appends S2 via the repository path -> catalog advances L1 -> L2.
@@ -134,13 +136,18 @@ public class StaleBaseLostUpdateTest {
     LOG.info(
         "staged-conflict result: remaining snapshots={}",
         remaining.stream().map(Snapshot::snapshotId).collect(Collectors.toList()));
+    Assertions.assertTrue(
+        remaining.stream().anyMatch(x -> x.snapshotId() == s2.snapshotId()),
+        "racing snapshot S2 (" + s2.snapshotId() + ") must not be silently dropped from H2");
+    Assertions.assertTrue(
+        remaining.stream().noneMatch(x -> x.snapshotId() == staleInsert.snapshotId()),
+        "stale writer's conflicting insert ("
+            + staleInsert.snapshotId()
+            + ") must be rejected wholesale, not merged on top of the racing commit");
     Assertions.assertEquals(
         priorSnapshotCount + 1,
         remaining.size(),
-        "racing snapshot S2 (" + s2.snapshotId() + ") must not be silently dropped from H2");
-    Assertions.assertTrue(
-        remaining.stream().anyMatch(x -> x.snapshotId() == s2.snapshotId()),
-        "racing snapshot S2 must still be present after the conflicting stale commit");
+        "table must hold only the prior snapshots + the racing snapshot S2");
 
     cleanup(id);
   }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/StaleBaseLostUpdateTest.java
@@ -88,6 +88,70 @@ public class StaleBaseLostUpdateTest {
   }
 
   /**
+   * A snapshot-expiration commit racing a concurrent data insert — the production maintenance
+   * shape. The expire job stages a "keep" subset computed against base L1 (here: keep only the
+   * current head, expiring older snapshots); that subset cannot reference the concurrently-added
+   * data snapshot. When the stale expire rebases onto L2, the subtractive merge would expire the
+   * racing data commit along with the intended old snapshots. Asserts the data commit survives and
+   * the stale expire is rejected wholesale.
+   */
+  @Test
+  void testExpireSnapshotsDropsConcurrentDataCommit() throws Exception {
+    TableDto l1 = createTableWithCommittedDataSnapshots("expire_race", 2);
+    TableIdentifier id = idOf(l1);
+
+    Table staleHandle = catalog.loadTable(id);
+    List<Snapshot> base = Lists.newArrayList(staleHandle.snapshots());
+    Snapshot head = staleHandle.currentSnapshot();
+    List<Snapshot> keep = Lists.newArrayList(head); // expire everything older than the head
+    Transaction expireTxn = staleHandle.newTransaction();
+    expireTxn
+        .updateProperties()
+        .set(CatalogConstants.SNAPSHOTS_JSON_KEY, SnapshotsUtil.serializedSnapshots(keep))
+        .set(CatalogConstants.SNAPSHOTS_REFS_KEY, SnapshotsUtil.serializeMap(refs(head)))
+        .set(CatalogConstants.COMMIT_KEY, l1.getTableLocation())
+        .commit();
+
+    // Racing data insert -> catalog advances L1 -> L2.
+    Snapshot racingData = catalog.loadTable(id).newAppend().appendFile(dummyDataFile()).apply();
+    List<String> l2Snapshots = new ArrayList<>();
+    for (Snapshot s : base) {
+      l2Snapshots.add(SnapshotParser.toJson(s));
+    }
+    l2Snapshots.add(SnapshotParser.toJson(racingData));
+    openHouseInternalRepository.save(
+        l1.toBuilder()
+            .tableVersion(l1.getTableLocation())
+            .jsonSnapshots(l2Snapshots)
+            .snapshotRefs(refs(racingData))
+            .build());
+
+    clearPerJvmRetryCache();
+
+    try {
+      expireTxn.commitTransaction();
+    } catch (Exception expected) {
+      LOG.info("commitTransaction rejected the stale expire: {}", expected.toString());
+    }
+
+    List<Snapshot> remaining = Lists.newArrayList(catalog.loadTable(id).snapshots());
+    LOG.info(
+        "expire-race result: remaining snapshots={}",
+        remaining.stream().map(Snapshot::snapshotId).collect(Collectors.toList()));
+    Assertions.assertTrue(
+        remaining.stream().anyMatch(x -> x.snapshotId() == racingData.snapshotId()),
+        "racing data commit ("
+            + racingData.snapshotId()
+            + ") must not be expired away by a stale concurrent expire");
+    Assertions.assertEquals(
+        base.size() + 1,
+        remaining.size(),
+        "stale expire must be rejected wholesale; nothing expired and the racing data commit kept");
+
+    cleanup(id);
+  }
+
+  /**
    * Core reproduction. Given a table whose latest committed version is {@code l1}, stages a stale
    * commit at L1, lands a racing append (L1 -&gt; L2), then commits the stale transaction and
    * asserts the racing snapshot is not dropped.


### PR DESCRIPTION
## Summary

Exempts replica tables from the `doCommit` stale-base CAS
(`abortIfWriterBaseDivergedFromCatalog`) added for incident-12185.

The CAS compares the writer's declared base (`COMMIT_KEY`) against the
catalog's current persisted base and aborts on divergence. That contract
does not hold for replica tables: the replication job replays the
primary's authoritative snapshot list wholesale rather than committing
incrementally against a loaded base, so its `COMMIT_KEY` does not encode
a "base I read" that the catalog head can be compared against. Enforcing
the CAS there would spuriously abort legitimate replication commits.

## Changes

- Early return in `abortIfWriterBaseDivergedFromCatalog` when the table
  is a replica (`openhouse.isTableReplicated=true`).
- Extract a broad `isReplicatedTable(properties)` helper (flag only, no
  version check) and refactor `isReplicatedTableCreate` to reuse it. The
  exemption uses the broad check intentionally so it covers replica
  **updates**, not just creates.

## Testing

`testDoCommitDoesNotAbortStaleBaseForReplicaTable` reuses the abort
test's `COMMIT_KEY`/base divergence setup but sets the replicated flag
and a non-initial table version (the case `isReplicatedTableCreate`
would miss); asserts `doCommit` does not throw and
`houseTableRepository.save` is invoked.

```
./gradlew :iceberg:openhouse:internalcatalog:test --tests "*OpenHouseInternalTableOperationsTest"
```

Both the new test and the original
`testDoCommitMustAbortStaleBaseRebaseToPreventSnapshotLoss` pass.

## Stacking

Stacked on top of #620 (the stale-base abort + regression tests).
Because that branch is not yet on `main`, this PR's diff includes #620's
commits until it merges — review only the replica-exemption commit here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)