### PR TITLE
fix(optimizer): publish optimizer/analyzer/analyzerapp so all-modules POM resolves

### DIFF
--- a/apps/optimizer/analyzerapp/build.gradle
+++ b/apps/optimizer/analyzerapp/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'openhouse.springboot-ext-conventions'
+  id 'openhouse.maven-publish'
   id 'org.springframework.boot' version '2.7.8'
 }
 

--- a/services/optimizer/analyzer/build.gradle
+++ b/services/optimizer/analyzer/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'openhouse.springboot-ext-conventions'
+  id 'openhouse.maven-publish'
   id 'org.springframework.boot' version '2.7.8'
 }
 

--- a/services/optimizer/build.gradle
+++ b/services/optimizer/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'openhouse.springboot-ext-conventions'
+  id 'openhouse.maven-publish'
   id 'org.springframework.boot' version '2.7.8'
 }
 


### PR DESCRIPTION
## Summary

The `:all-modules` aggregate added in #615 globs leaf subprojects:

```groovy
rootProject.subprojects.each { subproject ->
  if (subproject.path != project.path && subproject.subprojects.isEmpty()) {
    implementation project(subproject.path)
  }
}
```

The optimizer split (#533 introduced `:services:optimizer:analyzer` and
`:apps:optimizer:analyzerapp`) turned `:services:optimizer` from a leaf into a
parent, so the glob now picks up `analyzer` / `analyzerapp` instead — but
neither module applied `openhouse.maven-publish`. Consumers resolving
`all-modules:0.5.439` fail on `analyzerapp:0.5.439` / `analyzer:0.5.439`
(and `analyzer`'s POM transitively pulls `optimizer:0.5.439`, also
unpublished). JFrog falls through to the upstream public mirrors which
return 401/403.

Apply `id 'openhouse.maven-publish'` to `:services:optimizer`,
`:services:optimizer:analyzer`, and `:apps:optimizer:analyzerapp` so their
JARs/POMs land in JFrog alongside the aggregate.

## Changes

- [x] Bug Fixes

Apply `id 'openhouse.maven-publish'` to three previously-unpublished optimizer
leaf modules so the `all-modules:0.5.x` aggregate POM resolves cleanly for
downstream consumers.

## Testing Done

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.

```
./gradlew :services:optimizer:publishToMavenLocal \
          :services:optimizer:analyzer:publishToMavenLocal \
          :apps:optimizer:analyzerapp:publishToMavenLocal \
          :all-modules:publishToMavenLocal
```

All four tasks succeed. `~/.m2/repository/com/linkedin/openhouse/{optimizer,analyzer,analyzerapp,all-modules}/unspecified/` now contains main jar, lib jar (where applicable), sources, javadoc, and POM. Cross-module POM refs verified:

- `analyzer.pom` → `com.linkedin.openhouse:optimizer` (compile)
- `analyzerapp.pom` → `com.linkedin.openhouse:analyzer` (runtime)
- `all-modules.pom` → `com.linkedin.openhouse:analyzer` and `com.linkedin.openhouse:analyzerapp` (runtime)

`bootJar SKIPPED` on `:services:optimizer:analyzer` (library; `enabled = false`) does not break the publish — Gradle tolerates the skipped artifact task and `jar` (`archiveClassifier = ''`) is what ships.

- [x] No tests added or updated. Build-system metadata change only; no source/runtime behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)