### PR TITLE
Re-revert #610: restore HTS fields in table list api (#579)

### DIFF
--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -126,6 +126,15 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
   }
 
   /**
+   * Paginated listing that preserves the underlying {@link HouseTable} rows, so callers can read
+   * HTS-resident columns (e.g. tableLocation) without an extra metadata.json load per table.
+   */
+  public Page<HouseTable> listHouseTables(Namespace namespace, Pageable pageable) {
+    NamespaceUtil.validateOperationNamespace(namespace);
+    return houseTableRepository.findAllByDatabaseId(namespace.toString(), pageable);
+  }
+
+  /**
    * Direct HTS lookup that returns the {@link HouseTable} row without parsing metadata.json. Use
    * this when only HTS-resident columns (e.g. tableUUID, tableLocation) are needed — for example,
    * to authorize a drop without loading the full Iceberg table, which is important when the

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/TablesApiHandler.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/TablesApiHandler.java
@@ -8,6 +8,7 @@ import com.linkedin.openhouse.tables.api.spec.v0.response.GetAclPoliciesResponse
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllSoftDeletedTablesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllTablesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
+import java.util.List;
 
 /**
  * Interface layer between REST and Tables backend. The implementation is injected into the Service
@@ -37,16 +38,25 @@ public interface TablesApiHandler {
 
   /**
    * Function to Get one Page of Table Resources in a given databaseId given the page size and sort
-   * the results by the sortBy field.
+   * the results by the sortBy field. The caller may optionally request that additional fields
+   * (beyond databaseId + tableId) be populated on each returned table. When {@code fields} is
+   * non-empty, {@code actingPrincipal} must hold GET_TABLE_METADATA on the database.
    *
    * @param databaseId
    * @param page
    * @param size
    * @param sortBy
+   * @param fields optional list of GetTableResponseBody field names to populate
+   * @param actingPrincipal authenticated user; required when {@code fields} is non-empty
    * @return A page of tables in the given database.
    */
   ApiResponse<GetAllTablesResponseBody> searchTables(
-      String databaseId, int page, int size, String sortBy);
+      String databaseId,
+      int page,
+      int size,
+      String sortBy,
+      List<String> fields,
+      String actingPrincipal);
 
   /**
    * Function to Create Table Resource in a given databaseId

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/impl/OpenHouseTablesApiHandler.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/impl/OpenHouseTablesApiHandler.java
@@ -14,6 +14,7 @@ import com.linkedin.openhouse.tables.api.validator.TablesApiValidator;
 import com.linkedin.openhouse.tables.dto.mapper.TablesMapper;
 import com.linkedin.openhouse.tables.model.TableDto;
 import com.linkedin.openhouse.tables.services.TablesService;
+import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.util.Pair;
@@ -63,15 +64,20 @@ public class OpenHouseTablesApiHandler implements TablesApiHandler {
 
   @Override
   public ApiResponse<GetAllTablesResponseBody> searchTables(
-      String databaseId, int page, int size, String sortBy) {
-    tablesApiValidator.validateSearchTables(databaseId, page, size, sortBy);
+      String databaseId,
+      int page,
+      int size,
+      String sortBy,
+      List<String> fields,
+      String actingPrincipal) {
+    tablesApiValidator.validateSearchTables(databaseId, page, size, sortBy, fields);
     return ApiResponse.<GetAllTablesResponseBody>builder()
         .httpStatus(HttpStatus.OK)
         .responseBody(
             GetAllTablesResponseBody.builder()
                 .pageResults(
                     tableService
-                        .searchTables(databaseId, page, size, sortBy)
+                        .searchTables(databaseId, page, size, sortBy, fields, actingPrincipal)
                         .map(tableDto -> tablesMapper.toGetTableResponseBody(tableDto)))
                 .build())
         .build();

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/TablesApiValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/TablesApiValidator.java
@@ -3,6 +3,7 @@ package com.linkedin.openhouse.tables.api.validator;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateLockRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.UpdateAclPoliciesRequestBody;
+import java.util.List;
 
 public interface TablesApiValidator {
 
@@ -33,10 +34,12 @@ public interface TablesApiValidator {
    * @param page
    * @param size
    * @param sortBy
+   * @param fields optional list of GetTableResponseBody field names to populate
    * @throws com.linkedin.openhouse.common.exception.RequestValidationFailureException if request is
    *     invalid
    */
-  void validateSearchTables(String databaseId, int page, int size, String sortBy);
+  void validateSearchTables(
+      String databaseId, int page, int size, String sortBy, List<String> fields);
 
   /**
    * Function to validate a request to create a Table Resource.

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/OpenHouseTablesApiValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/OpenHouseTablesApiValidator.java
@@ -43,6 +43,13 @@ import org.springframework.stereotype.Component;
 @Component
 public class OpenHouseTablesApiValidator implements TablesApiValidator {
 
+  /**
+   * Fields selectable via the v2 search {@code ?fields=} query param. Each entry must match a field
+   * name on {@link com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody}.
+   */
+  private static final Set<String> SUPPORTED_SEARCH_FIELDS =
+      Collections.unmodifiableSet(new HashSet<>(Arrays.asList("tableLocation")));
+
   @Autowired private Validator validator;
 
   @Autowired private RetentionPolicySpecValidator retentionPolicySpecValidator;
@@ -73,10 +80,23 @@ public class OpenHouseTablesApiValidator implements TablesApiValidator {
   }
 
   @Override
-  public void validateSearchTables(String databaseId, int page, int size, String sortBy) {
+  public void validateSearchTables(
+      String databaseId, int page, int size, String sortBy, List<String> fields) {
     List<String> validationFailures = new ArrayList<>();
     validateDatabaseId(databaseId, validationFailures);
     ApiValidatorUtil.validatePageable(page, size, sortBy, validationFailures);
+    if (fields != null && !fields.isEmpty()) {
+      List<String> unsupported =
+          fields.stream()
+              .filter(f -> !SUPPORTED_SEARCH_FIELDS.contains(f))
+              .collect(Collectors.toList());
+      if (!unsupported.isEmpty()) {
+        validationFailures.add(
+            String.format(
+                "fields : unsupported field(s) %s. Supported fields: %s",
+                unsupported, SUPPORTED_SEARCH_FIELDS));
+      }
+    }
     if (!validationFailures.isEmpty()) {
       throw new RequestValidationFailureException(validationFailures);
     }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/TablesController.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/TablesController.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
@@ -118,10 +119,19 @@ public class TablesController {
       @Parameter(description = "Database ID", required = true) @PathVariable String databaseId,
       @RequestParam(required = false, defaultValue = "0") int page,
       @RequestParam(required = false, defaultValue = "50") int size,
-      @RequestParam(required = false) String sortBy) {
+      @RequestParam(required = false) String sortBy,
+      @Parameter(
+              description =
+                  "Optional list of GetTableResponseBody field names to populate beyond the "
+                      + "identifiers (databaseId, tableId). Requires GET_TABLE_METADATA on the "
+                      + "database when set. Supported values: \"tableLocation\". Accepts "
+                      + "comma-separated (?fields=a,b) or repeated (?fields=a&fields=b) values.")
+          @RequestParam(name = "fields", required = false)
+          List<String> fields) {
 
     com.linkedin.openhouse.common.api.spec.ApiResponse<GetAllTablesResponseBody> apiResponse =
-        tablesApiHandler.searchTables(databaseId, page, size, sortBy);
+        tablesApiHandler.searchTables(
+            databaseId, page, size, sortBy, fields, extractAuthenticatedUserPrincipal());
 
     return new ResponseEntity<>(
         apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/TablesMapper.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/TablesMapper.java
@@ -1,6 +1,7 @@
 package com.linkedin.openhouse.tables.dto.mapper;
 
 import com.linkedin.openhouse.common.schema.IcebergSchemaHelper;
+import com.linkedin.openhouse.internal.catalog.model.HouseTable;
 import com.linkedin.openhouse.internal.catalog.model.SoftDeletedTableDto;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.IcebergSnapshotsRequestBody;
@@ -14,6 +15,7 @@ import com.linkedin.openhouse.tables.dto.mapper.iceberg.PoliciesSpecMapper;
 import com.linkedin.openhouse.tables.model.TableDto;
 import com.linkedin.openhouse.tables.model.TableDtoPrimaryKey;
 import java.util.HashMap;
+import java.util.Set;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -156,6 +158,20 @@ public interface TablesMapper {
     @Mapping(expression = "java(tableIdentifier.name())", target = "tableId")
   })
   TableDto toTableDto(TableIdentifier tableIdentifier);
+
+  /**
+   * Build a partially-populated TableDto from a HouseTable, populating only the fields the caller
+   * requested. Identifier fields (databaseId, tableId) are always populated. Used by the paginated
+   * search endpoint to avoid loading metadata.json per table.
+   */
+  default TableDto toTableDto(HouseTable houseTable, Set<String> fields) {
+    TableDto.TableDtoBuilder builder =
+        TableDto.builder().databaseId(houseTable.getDatabaseId()).tableId(houseTable.getTableId());
+    if (fields != null && fields.contains("tableLocation")) {
+      builder.tableLocation(houseTable.getTableLocation());
+    }
+    return builder.build();
+  }
 
   /**
    * Transform {@link SoftDeletedTableDto} to {@link GetSoftDeletedTableResponseBody}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/OpenHouseInternalRepository.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/OpenHouseInternalRepository.java
@@ -36,6 +36,13 @@ public interface OpenHouseInternalRepository
 
   Page<TableDto> searchTables(String databaseId, Pageable pageable);
 
+  /**
+   * Paginated search that populates a caller-selected subset of fields on each returned {@link
+   * TableDto}. Passing a null or empty {@code fields} list returns identifier-only results (same as
+   * the two-arg overload).
+   */
+  Page<TableDto> searchTables(String databaseId, Pageable pageable, List<String> fields);
+
   void rename(TableDtoPrimaryKey from, TableDtoPrimaryKey to);
 
   Page<SoftDeletedTableDto> searchSoftDeletedTables(

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -36,9 +36,11 @@ import com.linkedin.openhouse.tables.repository.PreservedKeyChecker;
 import com.linkedin.openhouse.tables.repository.SchemaValidator;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
@@ -731,6 +733,22 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
     return ((OpenHouseInternalCatalog) catalog)
         .listTables(Namespace.of(databaseId), pageable)
         .map(tablesIdentifier -> mapper.toTableDto(tablesIdentifier));
+  }
+
+  @Timed(metricKey = MetricsConstant.REPO_TABLES_SEARCH_BY_DATABASE_PAGINATED_TIME)
+  @Override
+  public Page<TableDto> searchTables(String databaseId, Pageable pageable, List<String> fields) {
+    if (CollectionUtils.isEmpty(fields)) {
+      return searchTables(databaseId, pageable);
+    }
+    if (!(catalog instanceof OpenHouseInternalCatalog)) {
+      throw new UnsupportedOperationException(
+          "Does not support paginated search for getting all tables in a database");
+    }
+    Set<String> fieldSet = new HashSet<>(fields);
+    return ((OpenHouseInternalCatalog) catalog)
+        .listHouseTables(Namespace.of(databaseId), pageable)
+        .map(houseTable -> mapper.toTableDto(houseTable, fieldSet));
   }
 
   @Timed(metricKey = MetricsConstant.REPO_TABLE_IDS_FIND_ALL_TIME)

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesService.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesService.java
@@ -33,15 +33,31 @@ public interface TablesService {
   List<TableDto> searchTables(String databaseId);
 
   /**
-   * Given a databaseId, prepare list of {@link TableDto}s.
+   * Given a databaseId, prepare list of {@link TableDto}s. The returned dtos are populated with
+   * identifier fields plus any HouseTable-resident fields listed in {@code fields}. Passing null or
+   * empty returns identifier-only dtos.
+   *
+   * <p>When {@code fields} is non-empty, {@code actingPrincipal} must hold the {@code
+   * GET_TABLE_METADATA} privilege on the database — per-table sharing ACLs are not consulted by
+   * this call, so this guard prevents callers from bulk-reading field data on tables they would not
+   * be authorized to read individually.
    *
    * @param databaseId
    * @param page
    * @param size
    * @param sortBy
+   * @param fields optional list of {@link TableDto}/{@code GetTableResponseBody} field names to
+   *     populate in addition to identifiers
+   * @param actingPrincipal authenticated user; required when {@code fields} is non-empty
    * @return list of {@link TableDto}
    */
-  Page<TableDto> searchTables(String databaseId, int page, int size, String sortBy);
+  Page<TableDto> searchTables(
+      String databaseId,
+      int page,
+      int size,
+      String sortBy,
+      List<String> fields,
+      String actingPrincipal);
 
   /**
    * Given a {@link CreateUpdateTableRequestBody}, create or update a Openhouse table for it

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
@@ -81,9 +81,19 @@ public class TablesServiceImpl implements TablesService {
   }
 
   @Override
-  public Page<TableDto> searchTables(String databaseId, int page, int size, String sortBy) {
+  public Page<TableDto> searchTables(
+      String databaseId,
+      int page,
+      int size,
+      String sortBy,
+      List<String> fields,
+      String actingPrincipal) {
+    if (fields != null && !fields.isEmpty()) {
+      authorizationUtils.checkDatabasePrivilege(
+          databaseId, actingPrincipal, Privileges.GET_TABLE_METADATA);
+    }
     Pageable pageable = createPageable(page, size, sortBy, null);
-    return openHouseInternalRepository.searchTables(databaseId, pageable);
+    return openHouseInternalRepository.searchTables(databaseId, pageable, fields);
   }
 
   @WithSpan("TablesService.putTable")

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesControllerTest.java
@@ -1027,6 +1027,48 @@ public class TablesControllerTest {
   }
 
   @Test
+  public void testSearchTablesPaginatedWithTableLocationField() throws Exception {
+    List<GetTableResponseBody> tables = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      GetTableResponseBody table = buildGetTableResponseBodyWithDbTbl("d1", "tloc" + i);
+      tables.add(table);
+      RequestAndValidateHelper.createTableAndValidateResponse(table, mvc, storageManager);
+    }
+
+    mvc.perform(
+            MockMvcRequestBuilders.post("/v2/databases/d1/tables/search")
+                .param("page", "0")
+                .param("size", "10")
+                .param("fields", "tableLocation")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.pageResults.content", hasSize(3)))
+        .andExpect(jsonPath("$.pageResults.content[0].tableId", notNullValue()))
+        .andExpect(jsonPath("$.pageResults.content[0].databaseId", is("d1")))
+        .andExpect(jsonPath("$.pageResults.content[0].tableLocation", notNullValue()))
+        .andExpect(
+            jsonPath(
+                "$.pageResults.content[0].tableLocation",
+                org.hamcrest.Matchers.endsWith(".metadata.json")));
+
+    for (GetTableResponseBody t : tables) {
+      RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, t);
+    }
+  }
+
+  @Test
+  public void testSearchTablesPaginatedRejectsUnknownField() throws Exception {
+    mvc.perform(
+            MockMvcRequestBuilders.post("/v2/databases/d1/tables/search")
+                .param("fields", "schema")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message", containsString("schema")))
+        .andExpect(jsonPath("$.message", containsString("tableLocation")));
+  }
+
+  @Test
   public void testUpdateSucceedsForColumnTags() throws Exception {
     MvcResult mvcResult =
         RequestAndValidateHelper.createTableAndValidateResponse(

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
@@ -33,6 +33,8 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.UUID;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Types;
@@ -669,6 +671,58 @@ public class TablesServiceTest {
         () ->
             tablesService.deleteTable(
                 tableDtoCopy.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER));
+  }
+
+  @Test
+  public void testSearchTablesWithFieldsRequiresGetTableMetadata() {
+    TableDto tableDtoCopy = TABLE_DTO.toBuilder().build();
+    verifyPutTableRequest(tableDtoCopy, null, true);
+
+    // No fields requested — identifier-only search must succeed regardless of GET_TABLE_METADATA.
+    Mockito.when(
+            authorizationHandler.checkAccessDecision(
+                Mockito.any(),
+                Mockito.any(DatabaseDto.class),
+                Mockito.eq(Privileges.GET_TABLE_METADATA)))
+        .thenReturn(false);
+    Assertions.assertDoesNotThrow(
+        () ->
+            tablesService.searchTables(
+                tableDtoCopy.getDatabaseId(), 0, 10, null, Collections.emptyList(), TEST_USER));
+    Assertions.assertDoesNotThrow(
+        () ->
+            tablesService.searchTables(tableDtoCopy.getDatabaseId(), 0, 10, null, null, TEST_USER));
+
+    // Fields requested but GET_TABLE_METADATA denied — must throw.
+    Assertions.assertThrows(
+        AccessDeniedException.class,
+        () ->
+            tablesService.searchTables(
+                tableDtoCopy.getDatabaseId(),
+                0,
+                10,
+                null,
+                Arrays.asList("tableLocation"),
+                TEST_USER));
+
+    // Allow GET_TABLE_METADATA — field-projection search now succeeds.
+    Mockito.when(
+            authorizationHandler.checkAccessDecision(
+                Mockito.any(),
+                Mockito.any(DatabaseDto.class),
+                Mockito.eq(Privileges.GET_TABLE_METADATA)))
+        .thenReturn(true);
+    Assertions.assertDoesNotThrow(
+        () ->
+            tablesService.searchTables(
+                tableDtoCopy.getDatabaseId(),
+                0,
+                10,
+                null,
+                Arrays.asList("tableLocation"),
+                TEST_USER));
+
+    tablesService.deleteTable(tableDtoCopy.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER);
   }
 
   /** assert lock is created as policy object on createLock call */

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/MockTablesApiHandler.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/MockTablesApiHandler.java
@@ -20,6 +20,7 @@ import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllTablesResponseBo
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetSoftDeletedTableResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
 import java.util.ArrayList;
+import java.util.List;
 import org.springframework.context.annotation.Primary;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
@@ -64,7 +65,12 @@ public class MockTablesApiHandler implements TablesApiHandler {
 
   @Override
   public ApiResponse<GetAllTablesResponseBody> searchTables(
-      String databaseId, int page, int size, String sortBy) {
+      String databaseId,
+      int page,
+      int size,
+      String sortBy,
+      List<String> fields,
+      String actingPrincipal) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

Re-reverts [#610](https://github.com/linkedin/openhouse/pull/610), which had reverted [#579](https://github.com/linkedin/openhouse/pull/579) ("Support returning HTS fields in table list api"). This restores the #579 additions: the public list-table API support for returning HouseTable (HTS) fields.

This is a clean `git revert` of the #610 squash commit (`8b06479`) with no merge conflicts — the #589 `findHouseTable` drop-path code that originally conflicted is untouched.

## Changes

- [X] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [X] Refactoring
- [X] Tests

Restores the public list-table API additions and supporting tests from #579 across the tables service (handler, validator, controller, mapper, repository, service layers) and the `listHouseTables` catalog method.

## Testing Done

- [X] Added new tests for the changes made.
- [X] Updated existing tests to reflect the changes made.

Restores the original #579 tests (`TablesControllerTest`, `TablesServiceTest`) verbatim. `./gradlew spotlessCheck` passes (JDK 17). Since this is a pure revert-of-revert restoring previously-merged, previously-tested code, no new test logic was introduced.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.
