### PR TITLE
Add lightweight tableExists endpoint to tables service

### DIFF
--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/TablesApiHandler.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/TablesApiHandler.java
@@ -27,6 +27,16 @@ public interface TablesApiHandler {
       String databaseId, String tableId, String actingPrincipal);
 
   /**
+   * Function to check whether a table exists for the given databaseId and tableId. Uses a
+   * lightweight HouseTable reference lookup (no metadata.json/HDFS read).
+   *
+   * @param databaseId
+   * @param tableId
+   * @return an empty-bodied response with HTTP 200 if the table exists, HTTP 404 otherwise.
+   */
+  ApiResponse<Void> tableExists(String databaseId, String tableId);
+
+  /**
    * Function to Get all Table Resources in a given databaseId by filters and return requested
    * columns. If no columns are specified only identifier columns are returned.
    *

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/impl/OpenHouseTablesApiHandler.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/impl/OpenHouseTablesApiHandler.java
@@ -47,6 +47,15 @@ public class OpenHouseTablesApiHandler implements TablesApiHandler {
   }
 
   @Override
+  public ApiResponse<Void> tableExists(String databaseId, String tableId) {
+    tablesApiValidator.validateGetTable(databaseId, tableId);
+    return ApiResponse.<Void>builder()
+        .httpStatus(
+            tableService.tableExists(databaseId, tableId) ? HttpStatus.OK : HttpStatus.NOT_FOUND)
+        .build();
+  }
+
+  @Override
   public ApiResponse<GetAllTablesResponseBody> searchTables(String databaseId) {
     tablesApiValidator.validateSearchTables(databaseId);
     return ApiResponse.<GetAllTablesResponseBody>builder()

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/TablesController.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/TablesController.java
@@ -70,6 +70,38 @@ public class TablesController {
   }
 
   @Operation(
+      summary = "Check if a Table exists in a Database",
+      description =
+          "Returns HTTP 200 if the Table identified by tableId exists in the database identified by "
+              + "databaseId, and HTTP 404 otherwise. Uses a lightweight HouseTable lookup that does "
+              + "not read metadata from storage, making it cheaper than GET Table.",
+      tags = {"Table"})
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "Table EXISTS: OK"),
+        @ApiResponse(responseCode = "401", description = "Table EXISTS: UNAUTHORIZED"),
+        @ApiResponse(responseCode = "403", description = "Table EXISTS: FORBIDDEN"),
+        @ApiResponse(responseCode = "404", description = "Table EXISTS: NOT_FOUND")
+      })
+  @GetMapping(
+      value = {
+        "/v0/databases/{databaseId}/tables/{tableId}/exists",
+        "/v1/databases/{databaseId}/tables/{tableId}/exists"
+      },
+      produces = {"application/json"})
+  @Secured(value = Privileges.Privilege.GET_TABLE_METADATA)
+  public ResponseEntity<Void> tableExists(
+      @Parameter(description = "Database ID", required = true) @PathVariable String databaseId,
+      @Parameter(description = "Table ID", required = true) @PathVariable String tableId) {
+
+    com.linkedin.openhouse.common.api.spec.ApiResponse<Void> apiResponse =
+        tablesApiHandler.tableExists(databaseId, tableId);
+
+    return new ResponseEntity<>(
+        apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
+  }
+
+  @Operation(
       summary = "Search Tables in a Database",
       description =
           "Returns a list of Table resources present in a database. Only filter supported is 'database_id'.",

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesService.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesService.java
@@ -25,6 +25,16 @@ public interface TablesService {
   TableDto getTable(String databaseId, String tableId, String actingPrincipal);
 
   /**
+   * Check whether a table identified by databaseId and tableId exists, using a lightweight
+   * HouseTable reference lookup that does not parse metadata.json (i.e. no HDFS read).
+   *
+   * @param databaseId
+   * @param tableId
+   * @return true iff the table exists in the catalog.
+   */
+  boolean tableExists(String databaseId, String tableId);
+
+  /**
    * Given a databaseId, prepare list of {@link TableDto}s.
    *
    * @param databaseId

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
@@ -76,6 +76,16 @@ public class TablesServiceImpl implements TablesService {
   }
 
   @Override
+  public boolean tableExists(String databaseId, String tableId) {
+    // Lightweight HouseTable reference lookup (no metadata.json parse / HDFS read) is enough to
+    // determine existence. Authorization is enforced at the controller via @Secured.
+    return openHouseInternalRepository
+        .findTableRefById(
+            TableDtoPrimaryKey.builder().databaseId(databaseId).tableId(tableId).build())
+        .isPresent();
+  }
+
+  @Override
   public List<TableDto> searchTables(String databaseId) {
     return openHouseInternalRepository.searchTables(databaseId);
   }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
@@ -306,6 +306,42 @@ public class TablesServiceTest {
   }
 
   @Test
+  public void testTableExists() {
+    Assertions.assertFalse(
+        tablesService.tableExists(TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId()),
+        "tableExists should be false before the table is created");
+
+    verifyPutTableRequest(TABLE_DTO, null, true);
+    Assertions.assertTrue(
+        tablesService.tableExists(TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId()),
+        "tableExists should be true after the table is created");
+
+    tablesService.deleteTable(TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER);
+    Assertions.assertFalse(
+        tablesService.tableExists(TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId()),
+        "tableExists should be false after the table is deleted");
+  }
+
+  /**
+   * tableExists relies on the HTS-only findTableRefById lookup, so it must report existence without
+   * parsing metadata.json — even when metadata.json is corrupted and loadTable would throw.
+   */
+  @Test
+  public void testTableExistsWhenMetadataJsonIsCorrupted() throws IOException {
+    TableDto created = verifyPutTableRequest(TABLE_DTO, null, true);
+
+    Path metadataPath = Paths.get(URI.create(created.getTableLocation()));
+    Files.write(metadataPath, "{\"not\":\"valid iceberg metadata\"}".getBytes());
+
+    // getTable parses metadata.json and fails, but tableExists only consults HTS and succeeds.
+    Assertions.assertThrows(
+        Exception.class,
+        () -> tablesService.getTable(TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER));
+    Assertions.assertTrue(
+        tablesService.tableExists(TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId()));
+  }
+
+  @Test
   public void testTimePartitioning() {
     Schema schema =
         new Schema(

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/MockTablesApiHandler.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/MockTablesApiHandler.java
@@ -48,6 +48,20 @@ public class MockTablesApiHandler implements TablesApiHandler {
   }
 
   @Override
+  public ApiResponse<Void> tableExists(String databaseId, String tableId) {
+    switch (databaseId) {
+      case "d200":
+        return ApiResponse.<Void>builder().httpStatus(HttpStatus.OK).build();
+      case "d404":
+        return ApiResponse.<Void>builder().httpStatus(HttpStatus.NOT_FOUND).build();
+      case "dnullpointer":
+        throw new NullPointerException(); // test for exception handler
+      default:
+        return null;
+    }
+  }
+
+  @Override
   public ApiResponse<GetAllTablesResponseBody> searchTables(String databaseId) {
     switch (databaseId) {
       case "d200":

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/controller/TablesControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/controller/TablesControllerTest.java
@@ -138,6 +138,37 @@ public class TablesControllerTest {
   }
 
   @Test
+  public void tableExists200() throws Exception {
+    mvc.perform(
+            MockMvcRequestBuilders.get(
+                    CURRENT_MAJOR_VERSION_PREFIX + "/databases/d200/tables/t1/exists")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwtAccessToken))
+        .andExpect(status().isOk())
+        .andExpect(content().string(""));
+  }
+
+  @Test
+  public void tableExists404() throws Exception {
+    mvc.perform(
+            MockMvcRequestBuilders.get(
+                    CURRENT_MAJOR_VERSION_PREFIX + "/databases/d404/tables/t1/exists")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwtAccessToken))
+        .andExpect(status().isNotFound())
+        .andExpect(content().string(""));
+  }
+
+  @Test
+  public void tableExists401() throws Exception {
+    mvc.perform(
+            MockMvcRequestBuilders.get(
+                    CURRENT_MAJOR_VERSION_PREFIX + "/databases/d200/tables/t1/exists")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
   @MockUnauthenticatedUser
   public void findTableById403() throws Exception {
     mvcUnauthenticated


### PR DESCRIPTION
## Summary
Add a new lightweight `tableExists` endpoint which bypass HDFS and only query HTS. This is useful to Metacat and ODD which only need to know if table exists without knowing its metadata.

## Changes

- [x] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
