### PR TITLE
Bump Avro to 1.11.4 — CVE-2024-47561

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,8 @@ ext {
   spark_version = "3.1.1"
   ok_http3_version = "4.11.0"
   junit_version = "5.11.0"
-  iceberg_1_2_version = "1.2.0.17"
-  iceberg_1_5_version = "1.5.2.11"
+  iceberg_1_2_version = "1.2.0.18"
+  iceberg_1_5_version = "1.5.2.14"
   otel_agent_version = "2.12.0" // Bundles OTel SDK 1.47.0
   otel_annotations_version = "2.12.0" // Match agent version
 }
@@ -91,6 +91,7 @@ allprojects {
         force 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
         force 'org.apache.orc:orc-core:1.8.3'
         force 'com.google.guava:guava:33.5.0-jre'
+        force 'org.apache.avro:avro:1.11.4' // CVE-2024-47561; outranks strict transitive pin via iceberg-core
       }
     }
   }


### PR DESCRIPTION
## Summary
Bump Avro to 1.11.4 — CVE-2024-47561 (OpenHouse OSS)

Companion to the merged iceberg-fork PRs (linkedin/iceberg#247 → `1.2.0.18`, linkedin/iceberg#248 → `1.5.2.14`). Propagates Avro 1.11.4 into OpenHouse OSS on both the 1.2 and 1.5 codepaths.

### Why

Apache Avro ≤ 1.11.3 is affected by **[CVE-2024-47561](https://www.cve.org/CVERecord?id=CVE-2024-47561)** — a critical-severity deserialization RCE in the schema parser. Fixed in upstream Avro 1.11.4.

### Why 1.11.4 (not 1.11.5)

1.11.5 is also flagged for **CVE-2025-52999** (a transitive `jackson-core` stack-overflow on deeply nested JSON, fixed in `jackson-core 2.15.0+`). That CVE affects both 1.11.4 and 1.11.5 equally — bumping to 1.11.5 does not fix it. CVE-2025-52999 is tracked separately as a jackson upgrade.

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests
- [x] Upgrade

### Change details

```diff
-  iceberg_1_2_version = "1.2.0.17"
-  iceberg_1_5_version = "1.5.2.11"
+  iceberg_1_2_version = "1.2.0.18"
+  iceberg_1_5_version = "1.5.2.14"

         force 'com.google.guava:guava:33.5.0-jre'
+        force 'org.apache.avro:avro:1.11.4' // CVE-2024-47561; outranks strict transitive pin via iceberg-core
```

The force lifts the server-side Avro resolution to 1.11.4 directly, in addition to picking it up transitively via the new iceberg coordinates. Both paths land at the same result.

What does NOT change

- OSS client uber-JARs (spark-runtime, spark-3.5-runtime, java-runtime, java-1.5-runtime) bundle zero Avro entries — Spark runtimes explicitly exclude org.apache.avro:avro and the Java clients don't pull it. No shadowJar change needed; the fix is purely server-side.
- DALI uniformity is preserved (no API change).

Risk — LOW

1.11.4 is a patch release within the 1.11.x line. No public API changes vs 1.11.1 / 1.11.3, binary-compatible with Iceberg / Parquet / Spark, no wire / file format changes.

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [x] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.
Local docker testing:
```
anath1@anath1-mn4233 openhouse % curl "${curlArgs[@]}" -XPOST http://localhost:8000/v1/databases/d1/tables/ \
--data-raw '{
  "tableId": "t11",
  "databaseId": "d1",
  "baseTableVersion": "INITIAL_VERSION",
  "clusterId": "LocalHadoopCluster",
  "schema": "{\"type\": \"struct\", \"fields\": [{\"id\": 1,\"required\": true,\"name\": \"id\",\"type\": \"string\"},{\"id\": 2,\"required\": true,\"name\": \"name\",\"type\": \"string\"},{\"id\": 3,\"required\": true,\"name\": \"ts\",\"type\": \"timestamp\"}]}",
  "timePartitioning": {
    "columnName": "ts",
    "granularity": "HOUR"
  },
  "clustering": [
    {
      "columnName": "name"
    }
  ],
  "tableProperties": {
    "key": "value"
  }
}' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2305    0  1730  100   575   1674    556  0:00:01  0:00:01 --:--:--  2231
{
  "tableId": "t11",
  "databaseId": "d1",
  "clusterId": "LocalHadoopCluster",
  "tableUri": "LocalHadoopCluster.d1.t11",
  "tableUUID": "f9d434b9-52c4-44a9-bf56-8c8b48e6597d",
  "tableLocation": "hdfs://namenode:9000/data/openhouse/d1/t11-f9d434b9-52c4-44a9-bf56-8c8b48e6597d/00000-9dcfaf86-d7c3-4874-bbcd-6d46d3f52b8f.metadata.json",
  "tableVersion": "INITIAL_VERSION",
  "tableCreator": "DUMMY_ANONYMOUS_USER",
  "schema": "{\"type\":\"struct\",\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"string\"},{\"id\":2,\"name\":\"name\",\"required\":true,\"type\":\"string\"},{\"id\":3,\"name\":\"ts\",\"required\":true,\"type\":\"timestamp\"}]}",
  "lastModifiedTime": 1781640450045,
  "creationTime": 1781640450045,
  "tableProperties": {
    "write.parquet.compression-codec": "zstd",
    "policies": "",
    "write.metadata.delete-after-commit.enabled": "true",
    "openhouse.isTableReplicated": "false",
    "openhouse.clusterId": "LocalHadoopCluster",
    "openhouse.tableId": "t11",
    "openhouse.lastModifiedTime": "1781640450045",
    "openhouse.tableVersion": "INITIAL_VERSION",
    "write.format.default": "orc",
    "openhouse.creationTime": "1781640450045",
    "openhouse.tableUri": "LocalHadoopCluster.d1.t11",
    "write.metadata.previous-versions-max": "28",
    "openhouse.databaseId": "d1",
    "openhouse.tableType": "PRIMARY_TABLE",
    "openhouse.tableLocation": "/data/openhouse/d1/t11-f9d434b9-52c4-44a9-bf56-8c8b48e6597d/00000-9dcfaf86-d7c3-4874-bbcd-6d46d3f52b8f.metadata.json",
    "openhouse.tableUUID": "f9d434b9-52c4-44a9-bf56-8c8b48e6597d",
    "key": "value",
    "openhouse.tableCreator": "DUMMY_ANONYMOUS_USER"
  },
  "timePartitioning": {
    "columnName": "ts",
    "granularity": "HOUR"
  },
  "clustering": [
    {
      "columnName": "name",
      "transform": null
    }
  ],
  "policies": null,
  "tableType": "PRIMARY_TABLE",
  "sortOrder": "{\"order-id\":0,\"fields\":[]}"
}
anath1@anath1-mn4233 openhouse % curl "${curlArgs[@]}" -XGET http://localhost:8000/v1/databases/d1/tables/t11 | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1730    0  1730    0     0   6998      0 --:--:-- --:--:-- --:--:--  7004
{
  "tableId": "t11",
  "databaseId": "d1",
  "clusterId": "LocalHadoopCluster",
  "tableUri": "LocalHadoopCluster.d1.t11",
  "tableUUID": "f9d434b9-52c4-44a9-bf56-8c8b48e6597d",
  "tableLocation": "hdfs://namenode:9000/data/openhouse/d1/t11-f9d434b9-52c4-44a9-bf56-8c8b48e6597d/00000-9dcfaf86-d7c3-4874-bbcd-6d46d3f52b8f.metadata.json",
  "tableVersion": "INITIAL_VERSION",
  "tableCreator": "DUMMY_ANONYMOUS_USER",
  "schema": "{\"type\":\"struct\",\"schema-id\":0,\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"string\"},{\"id\":2,\"name\":\"name\",\"required\":true,\"type\":\"string\"},{\"id\":3,\"name\":\"ts\",\"required\":true,\"type\":\"timestamp\"}]}",
  "lastModifiedTime": 1781640450045,
  "creationTime": 1781640450045,
  "tableProperties": {
    "write.parquet.compression-codec": "zstd",
    "policies": "",
    "write.metadata.delete-after-commit.enabled": "true",
    "openhouse.isTableReplicated": "false",
    "openhouse.clusterId": "LocalHadoopCluster",
    "openhouse.tableId": "t11",
    "openhouse.lastModifiedTime": "1781640450045",
    "openhouse.tableVersion": "INITIAL_VERSION",
    "write.format.default": "orc",
    "openhouse.creationTime": "1781640450045",
    "openhouse.tableUri": "LocalHadoopCluster.d1.t11",
    "write.metadata.previous-versions-max": "28",
    "openhouse.databaseId": "d1",
    "openhouse.tableType": "PRIMARY_TABLE",
    "openhouse.tableLocation": "/data/openhouse/d1/t11-f9d434b9-52c4-44a9-bf56-8c8b48e6597d/00000-9dcfaf86-d7c3-4874-bbcd-6d46d3f52b8f.metadata.json",
    "openhouse.tableUUID": "f9d434b9-52c4-44a9-bf56-8c8b48e6597d",
    "key": "value",
    "openhouse.tableCreator": "DUMMY_ANONYMOUS_USER"
  },
  "timePartitioning": {
    "columnName": "ts",
    "granularity": "HOUR"
  },
  "clustering": [
    {
      "columnName": "name",
      "transform": null
    }
  ],
  "policies": null,
  "tableType": "PRIMARY_TABLE",
  "sortOrder": "{\"order-id\":0,\"fields\":[]}"
}
```

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

Related PRs:
- iceberg fork PR (1.2.0): linkedin/iceberg#247 (merged → 1.2.0.18)
- iceberg fork PR (1.5.2): linkedin/iceberg#248 (merged → 1.5.2.14)

For all the boxes checked, include additional details of the changes made in this pull request.
