### PR TITLE
[default values] Send client version via User-Agent header

### DIFF
--- a/client/secureclient/build.gradle
+++ b/client/secureclient/build.gradle
@@ -17,6 +17,14 @@ dependencies {
 
 }
 
+// Stamp the project version into the jar manifest so WebClientFactory can advertise the client
+// version in the User-Agent header by reading Implementation-Version at runtime.
+jar {
+    manifest {
+        attributes('Implementation-Version': project.version)
+    }
+}
+
 test {
     useJUnitPlatform()
 }

--- a/client/secureclient/src/main/java/com/linkedin/openhouse/client/ssl/WebClientFactory.java
+++ b/client/secureclient/src/main/java/com/linkedin/openhouse/client/ssl/WebClientFactory.java
@@ -12,6 +12,7 @@ import javax.net.ssl.SSLException;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
@@ -26,6 +27,12 @@ public abstract class WebClientFactory {
   private static final String SESSION_ID = "session-id";
 
   public static final String HTTP_HEADER_CLIENT_NAME = "X-Client-Name";
+  // Product token advertised in the User-Agent header so the server can observe the client version.
+  // The resulting header looks like "openhouse-java-client/1.5.2".
+  public static final String USER_AGENT_CLIENT_PRODUCT = "openhouse-java-client";
+  // Fallback when the client jar manifest carries no Implementation-Version (e.g. running from
+  // classes during local/dev/tests) and no explicit version was set.
+  private static final String CLIENT_VERSION_UNKNOWN = "unknown";
   private static final int IN_MEMORY_BUFFER_SIZE = 20 * 1024 * 1024;
   // The maximum number of connections per connection pool
   private static final int MAX_CONNECTION_POOL_SIZE = 500;
@@ -44,6 +51,10 @@ public abstract class WebClientFactory {
   @Setter private String sessionId = null;
 
   @Setter private String clientName = null;
+
+  // When null, the version is resolved from the client jar manifest's Implementation-Version,
+  // falling back to {@link #CLIENT_VERSION_UNKNOWN}. Callers may set an explicit value to override.
+  @Setter private String clientVersion = null;
 
   protected WebClientFactory() {
     setStrategy();
@@ -159,6 +170,7 @@ public abstract class WebClientFactory {
     WebClient.Builder webClientBuilder = createWebClientBuilder();
     setSessionIdInWebClientHeader(webClientBuilder);
     setClientNameInWebClientHeader(webClientBuilder);
+    setUserAgentInWebClientHeader(webClientBuilder);
     return webClientBuilder
         .baseUrl(baseUrl)
         .clientConnector(new ReactorClientHttpConnector(httpClient))
@@ -207,6 +219,37 @@ public abstract class WebClientFactory {
       webClientBuilder.defaultHeaders(h -> h.add(HTTP_HEADER_CLIENT_NAME, clientName));
     }
     log.info("Client name: {}", clientName);
+  }
+
+  /**
+   * Set the User-Agent header on the webClient so the server can observe the client version on
+   * every request, e.g. "openhouse-java-client/1.5.2". The version is resolved via {@link
+   * #resolveClientVersion()}. Setting our own default User-Agent replaces the transport's default
+   * (e.g. "ReactorNetty/x.y.z").
+   *
+   * @param webClientBuilder
+   */
+  private void setUserAgentInWebClientHeader(WebClient.Builder webClientBuilder) {
+    String userAgent = USER_AGENT_CLIENT_PRODUCT + "/" + resolveClientVersion();
+    webClientBuilder.defaultHeaders(h -> h.set(HttpHeaders.USER_AGENT, userAgent));
+    log.info("Client User-Agent: {}", userAgent);
+  }
+
+  /**
+   * Resolve the client version to advertise: an explicitly set {@link #clientVersion} takes
+   * precedence, otherwise the Implementation-Version stamped into this jar's manifest, otherwise
+   * {@link #CLIENT_VERSION_UNKNOWN}.
+   *
+   * @return the resolved client version, never null
+   */
+  private String resolveClientVersion() {
+    if (!StringUtil.isNullOrEmpty(clientVersion)) {
+      return clientVersion;
+    }
+    String implementationVersion = WebClientFactory.class.getPackage().getImplementationVersion();
+    return StringUtil.isNullOrEmpty(implementationVersion)
+        ? CLIENT_VERSION_UNKNOWN
+        : implementationVersion;
   }
 
   /**

--- a/client/secureclient/src/test/java/com/linkedin/openhouse/client/ssl/TablesApiClientFactoryTest.java
+++ b/client/secureclient/src/test/java/com/linkedin/openhouse/client/ssl/TablesApiClientFactoryTest.java
@@ -99,4 +99,16 @@ public class TablesApiClientFactoryTest {
         .setClientName(clientNameCapture.capture());
     assertEquals("trino", clientNameCapture.getValue());
   }
+
+  @Test
+  public void testSetClientVersionCalled() throws Exception {
+    ArgumentCaptor<String> clientVersionCapture = ArgumentCaptor.forClass(String.class);
+
+    tablesApiClientFactorySpy.setClientVersion("1.2.3");
+    tablesApiClientFactorySpy.createApiClient(
+        "https://test.openhouse.com", "", tmpCert.getAbsolutePath());
+    Mockito.verify(tablesApiClientFactorySpy, Mockito.times(1))
+        .setClientVersion(clientVersionCapture.capture());
+    assertEquals("1.2.3", clientVersionCapture.getValue());
+  }
 }

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
@@ -102,6 +102,8 @@ public class OpenHouseCatalog extends BaseMetastoreCatalog
 
   public static final String CLIENT_NAME = "client-name";
 
+  public static final String CLIENT_VERSION = "client-version";
+
   @Override
   public void initialize(String name, Map<String, String> properties) {
     this.name = name;
@@ -113,10 +115,12 @@ public class OpenHouseCatalog extends BaseMetastoreCatalog
     String token = properties.getOrDefault(AUTH_TOKEN, null);
     String httpConnectionStrategy = properties.getOrDefault(HTTP_CONNECTION_STRATEGY, null);
     String clientName = properties.getOrDefault(CLIENT_NAME, null);
+    String clientVersion = properties.getOrDefault(CLIENT_VERSION, null);
     try {
       TablesApiClientFactory tablesApiClientFactory = TablesApiClientFactory.getInstance();
       tablesApiClientFactory.setStrategy(HttpConnectionStrategy.fromString(httpConnectionStrategy));
       tablesApiClientFactory.setClientName(clientName);
+      tablesApiClientFactory.setClientVersion(clientVersion);
       if (properties.containsKey(CatalogProperties.APP_ID)) {
         tablesApiClientFactory.setSessionId(properties.get(CatalogProperties.APP_ID));
       }


### PR DESCRIPTION
## Problem

We're rolling out **strip protection** for default-value tables: the server blocks commits that would silently drop a column's declared default. The guard decides from the committed schema — **not** from the client version.

To expand it safely from a pilot group to the whole datalake, we need to watch which client versions are committing, to track two signals:
- failures from non-supported clients hitting the guard;
- commits from non-supported clients that slip *through* it.

The version is observability only; it never gates a commit.

## This PR (observability only)

This does **not** prevent stripping and is **not** an input to any guard; it makes the client version reliable to read so those two signals can be measured. The OpenHouse Java client now sets an explicit `User-Agent: openhouse-java-client/<version>` on every outbound request, set once in the shared `WebClientFactory.getWebClient()` so the tables, jobs, and housetables clients are all covered. Version resolves:
1. an explicit `setClientVersion(...)` override,
2. the secureclient jar manifest `Implementation-Version`,
3. `"unknown"`.

`build.gradle` stamps `Implementation-Version` into the jar manifest so the fallback is meaningful in packaged builds.


The `OpenHouseCatalog` now also **reads a `client-version` catalog property and calls `setClientVersion(...)`** (next to its existing `client-name` handling), so consumers set the version via a property rather than touching the relocated/`compileOnly` factory directly. li-openhouse#2147 sets that property from the build-time-baked runtime version.

The `OpenHouseCatalog` also **reads a `client-version` catalog property and calls `setClientVersion(...)`** (next to its existing `client-name` handling), so consumers set the version via a property instead of touching the relocated/`compileOnly` factory directly. li-openhouse#2147 sets that property from the build-time-baked runtime version.


## Why not rely on the transport's default

Previously these requests carried reactor-netty's *default* `User-Agent: ReactorNetty/<version>`, where `<version>` is `getImplementationVersion()` on whatever jar provides reactor-netty's classes. That depends entirely on how the OpenHouse client is packaged, so one token means different things:
- **thin Java runtime** (reactor-netty resolved as a normal dependency, not shaded) → reactor-netty's own *transport* version (e.g. `1.0.x`) — **never** the OpenHouse client's;
- **shaded Spark runtime** (reactor-netty bundled un-relocated into the runtime fat jar) → that fat jar's `Implementation-Version`, i.e. the *runtime's* version — or, if the fat jar carries no version, **nothing** (`ReactorNetty/dev`).

So you can't tell what a `ReactorNetty/<version>` even refers to, and the thin runtime never reports the OpenHouse version at all. Setting our own `openhouse-java-client/<version>` User-Agent makes it explicit and unambiguous across **both** packagings. For shaded runtimes, callers should additionally pass an explicit `setClientVersion(...)`, since jar-manifest introspection is unreliable once shaded.

## Testing

- Added `TablesApiClientFactoryTest.testSetClientVersionCalled`.
- `:client:secureclient:test` and `:client:secureclient:spotlessCheck` pass.

## Follow-ups (separate changes)

- Consume the header server-side (metric tag / per-commit audit dimension).
- Populate `X-Client-Name` (engine/app), which the server already reads for the `client_name` metric.


