### PR TITLE
Filter all-modules aggregate to only published modules

### DIFF
--- a/all-modules/build.gradle
+++ b/all-modules/build.gradle
@@ -3,12 +3,30 @@ plugins {
   id 'openhouse.maven-publish'
 }
 
-// This module depends on all other OpenHouse modules. Its primary purpose is to allow downstream
-// consumers to track a single artifact in ELR instead of enumerating every module individually.
-dependencies {
-  rootProject.subprojects.each { subproject ->
-    if (subproject.path != project.path && subproject.subprojects.isEmpty()) {
-      implementation project(subproject.path)
+// `all-modules` aggregates every PUBLISHED OpenHouse module as a real (compile/runtime) dependency, so
+// its published POM lists every OpenHouse coordinate under <dependencies>. Downstream ELR tooling reads
+// this single coordinate's POM, walks those dependencies transitively, and mirrors the full artifact
+// set into the internal artifactory — instead of enumerating every module by hand.
+//
+// This MUST stay a real-dependency aggregate, NOT a BOM. A BOM publishes only lazy
+// <dependencyManagement> constraints, which ELR has nothing to walk, so the mirror would come up empty.
+//
+// Only leaf modules that actually apply maven-publish are included. Referencing an unpublished module
+// (e.g. the codegen-only client:common, which is consumed at build time via `apply from:` and never
+// published) would point the aggregate POM at a coordinate ELR cannot resolve and break the mirror.
+// Each candidate leaf is evaluated first so its plugin state is known before we decide to depend on it.
+def publishedMembers = []
+rootProject.subprojects.each { subproject ->
+  if (subproject.path != project.path && subproject.subprojects.isEmpty()) {
+    evaluationDependsOn(subproject.path)
+    if (subproject.pluginManager.hasPlugin('maven-publish')) {
+      publishedMembers << subproject
     }
+  }
+}
+
+dependencies {
+  publishedMembers.each { member ->
+    implementation project(member.path)
   }
 }


### PR DESCRIPTION
## Summary

The `all-modules` aggregate referenced **every** leaf module, including `client/common` — a codegen-only helper consumed at build time via `apply from:` that is never published to Maven. ELR reads the `all-modules` POM and walks its `<dependencies>` transitively to mirror artifacts into the internal artifactory, so referencing an unpublished coordinate breaks the mirror (and collides on artifactId `common` with the published `services/common`).

This restricts the aggregate to leaf modules that apply `maven-publish`, so the published POM lists only resolvable coordinates. The member list now tracks publish status automatically — a module that stops publishing drops out of the POM with no manual upkeep.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.

`all-modules/build.gradle` now evaluates each leaf module and includes it only if it applies `maven-publish`:

```diff
-  rootProject.subprojects.each { subproject ->
-    if (subproject.path != project.path && subproject.subprojects.isEmpty()) {
-      implementation project(subproject.path)
+def publishedMembers = []
+rootProject.subprojects.each { subproject ->
+  if (subproject.path != project.path && subproject.subprojects.isEmpty()) {
+    evaluationDependsOn(subproject.path)
+    if (subproject.pluginManager.hasPlugin('maven-publish')) {
+      publishedMembers << subproject
     }
   }
 }
+
+dependencies {
+  publishedMembers.each { member ->
+    implementation project(member.path)
+  }
+}
```

Kept as a **real-dependency aggregate, not a BOM**: ELR walks `<dependencies>`, and a BOM publishes only lazy `<dependencyManagement>` constraints, which would leave nothing to mirror.

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [x] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

Build-config change, verified by generating and inspecting the published POM locally:

```
./gradlew :all-modules:generatePomFileForMavenJavaPublication
```

- Generated POM lists **35** published OpenHouse modules as real `implementation` dependencies; the single unpublished leaf (`client/common`) is absent.
- Regression check: temporarily removed `maven-publish` from `apps/optimizer/analyzerapp`, regenerated the POM → `analyzerapp` dropped out (35 → 34) while the still-published `analyzer` library it wraps stayed in. Reverted.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.

No breaking changes — downstream ELR consumers continue to depend on the single `all-modules` coordinate.
