### PR TITLE
Bump linkedin/iceberg 1.5 to 1.5.2.15 (default partitioned write distribution NONE)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ ext {
   ok_http3_version = "4.11.0"
   junit_version = "5.11.0"
   iceberg_1_2_version = "1.2.0.18"
-  iceberg_1_5_version = "1.5.2.14"
+  iceberg_1_5_version = "1.5.2.15"
   otel_agent_version = "2.12.0" // Bundles OTel SDK 1.47.0
   otel_annotations_version = "2.12.0" // Match agent version
 }


### PR DESCRIPTION
Picks up [linkedin/iceberg#249](https://github.com/linkedin/iceberg/pull/249) (released as `com.linkedin.iceberg` tag `v1.5.2.15`).

## Summary

Bumps the Iceberg 1.5 line from `1.5.2.14` → `1.5.2.15`. The only change in `v1.5.2.15` is linkedin/iceberg#249, which flips the **default write distribution mode for partitioned, unsorted Spark 3.5 writes from `HASH` to `NONE`**.

Background: Iceberg 1.5 implements `RequiresDistributionAndOrdering`, so every Spark 3.5 write to a partitioned table requests a HASH distribution by default, which Spark plans as a REBALANCE shuffle. REBALANCE is poorly handled by Celeborn 0.4 and has caused production incidents. #249 restores the Spark 3.1 status quo:

- Scope is narrow — only normal (batch/append) writes change. `DELETE`/`UPDATE`/`MERGE` keep their existing `HASH` defaults.
- Local ordering is unchanged (sort is kept), so users don't need to add `.sortWithinPartitions()`.
- Explicit distribution requests (write option / session conf / table property) still work.
- Any resulting small files are handled by OpenHouse post-write compaction.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [X] Performance Improvements — avoids the default REBALANCE shuffle on partitioned Spark 3.5 writes.
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

Dependency version bump only — single line in `build.gradle`.

## Testing Done

- [ ] Manually Tested on local docker setup.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [X] No tests added or updated. Tests for the behavior change live in linkedin/iceberg#249 (`TestSparkWriteConf`, `TestSparkDistributionAndOrderingUtil`); this PR is a version bump.
- [ ] Some other form of testing.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
