### PR TITLE
Add clientUserAgent and snapshotSummary to the table audit event

### DIFF
--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotParser;
@@ -36,7 +37,11 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 /**
  * Aspect class to support table operation auditing for all controllers. It enhances the ability of
@@ -59,6 +64,12 @@ public class TableAuditAspect {
    * config is bound once at startup, so a one-shot lazy init is sufficient.
    */
   private volatile List<Pattern> allowlistPatterns;
+
+  // Iceberg serializes a snapshot's operation as a separate top-level field rather than inside the
+  // summary map (SnapshotParser parses it out into Snapshot#operation), so there is no public
+  // constant for this key. We merge it back into the emitted summary under this name to mirror the
+  // on-disk JSON.
+  private static final String SNAPSHOT_OPERATION_KEY = "operation";
 
   /**
    * Install the Around advice for getTable() method in OpenHouseTablesApiHandler.
@@ -455,6 +466,7 @@ public class TableAuditAspect {
         Snapshot snapshot = SnapshotParser.fromJson(snapshotJson);
         if (snapshot.snapshotId() == mainSnapshotId) {
           eventBuilder.currentSnapshotTimestampMs(snapshot.timestampMillis());
+          eventBuilder.snapshotSummary(buildSnapshotSummary(snapshot));
           return;
         }
       }
@@ -462,6 +474,21 @@ public class TableAuditAspect {
       // Snapshot extraction is best-effort; don't fail the audit event
       log.warn("Failed to extract snapshot info for audit event", e);
     }
+  }
+
+  /**
+   * Builds the emitted snapshot summary: the snapshot's own summary map plus its operation (which
+   * Iceberg parses out of the summary into a separate field), mirroring the on-disk JSON.
+   */
+  private static Map<String, String> buildSnapshotSummary(Snapshot snapshot) {
+    Map<String, String> summary = new HashMap<>();
+    if (snapshot.summary() != null) {
+      summary.putAll(snapshot.summary());
+    }
+    if (snapshot.operation() != null) {
+      summary.put(SNAPSHOT_OPERATION_KEY, snapshot.operation());
+    }
+    return summary;
   }
 
   /** Install the Around advice for getAllDatabases() method in OpenHouseDatabasesApiHandler */
@@ -662,7 +689,28 @@ public class TableAuditAspect {
             .user(extractAuthenticatedUserPrincipal())
             .operationStatus(status)
             .currentTableRoot(currentTableRoot)
+            .clientUserAgent(extractUserAgent())
             .build();
     tableAuditHandler.audit(completeEvent);
+  }
+
+  /**
+   * Reads the raw {@code User-Agent} request header verbatim, or null when no servlet request is
+   * bound to the current thread (e.g. async or test contexts). The value is stored unparsed so the
+   * client runtime version can be extracted at query time. Best-effort: a failure here must never
+   * disrupt the audited operation. Mirrors the request access in {@link
+   * com.linkedin.openhouse.common.audit.ServiceAuditAspect}.
+   */
+  private String extractUserAgent() {
+    try {
+      RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+      if (requestAttributes instanceof ServletRequestAttributes) {
+        HttpServletRequest request = ((ServletRequestAttributes) requestAttributes).getRequest();
+        return request.getHeader(HttpHeaders.USER_AGENT);
+      }
+    } catch (Exception e) {
+      log.warn("Failed to read User-Agent header for audit event", e);
+    }
+    return null;
   }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/model/TableAuditEvent.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/model/TableAuditEvent.java
@@ -44,4 +44,27 @@ public class TableAuditEvent extends BaseAuditEvent {
 
   /** Allowlisted subset of table properties at commit time, not the full property map. */
   private Map<String, String> auditedTableProperties;
+
+  /**
+   * Full Iceberg summary map of the snapshot the table's {@code main} ref points to after the
+   * commit (the same snapshot as {@link #currentSnapshotId}), emitted verbatim. It carries {@code
+   * operation} (append/overwrite/replace/delete), the engine/app identity ({@code spark.app.id} /
+   * {@code trino_query_id}), {@code engine-version}/{@code iceberg-version}, and the core-computed
+   * file-delta counts ({@code added-delete-files}, {@code added-data-files}, ...). Emitted
+   * unaggregated so downstream queries derive operation, engine/app identity, and write-mode
+   * signals without a lossy server-side classification: there is no per-commit field that cleanly
+   * declares copy-on-write vs merge-on-read across engines (the table's {@code write.*.mode}
+   * properties are intent that Trino/Flink ignore, and delete-file presence marks MOR but its
+   * absence is not COW). {@code Snapshot.summary()} omits the operation (Iceberg parses it out into
+   * a separate field), so it is merged back to mirror the on-disk summary. Null when the request
+   * carries no {@code main} ref (e.g. branch-only commits), matching {@link #currentSnapshotId}.
+   */
+  private Map<String, String> snapshotSummary;
+
+  /**
+   * Raw {@code User-Agent} request header, verbatim (e.g. {@code openhouse-java-client/4.1.328},
+   * {@code ReactorNetty/4.1.297}, {@code dev}). Stored unparsed so the client/runtime version can
+   * be extracted at query time. Observability only; never gates a request.
+   */
+  private String clientUserAgent;
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
@@ -92,6 +93,23 @@ public class IcebergSnapshotsApiHandlerAuditTest {
   }
 
   @Test
+  public void testPutIcebergSnapshotsCapturesClientUserAgent() throws Exception {
+    // The raw User-Agent is captured verbatim on the audit event so the client/runtime version can
+    // be derived at query time.
+    mvc.perform(
+        MockMvcRequestBuilders.put(
+                String.format(
+                    CURRENT_MAJOR_VERSION_PREFIX
+                        + "/databases/d200/tables/tb1/iceberg/v2/snapshots"))
+            .header(HttpHeaders.USER_AGENT, "openhouse-java-client/1.2.3")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(RequestConstants.TEST_ICEBERG_SNAPSHOTS_REQUEST_BODY.toJson()));
+    Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
+    assertEquals("openhouse-java-client/1.2.3", argCaptor.getValue().getClientUserAgent());
+  }
+
+  @Test
   public void testPutIcebergSnapshotsContainsSnapshotInfo() throws Exception {
     mvc.perform(
         MockMvcRequestBuilders.put(
@@ -105,6 +123,13 @@ public class IcebergSnapshotsApiHandlerAuditTest {
     TableAuditEvent actualEvent = argCaptor.getValue();
     assertEquals(2151407017102313398L, actualEvent.getCurrentSnapshotId().longValue());
     assertEquals(1669126937912L, actualEvent.getCurrentSnapshotTimestampMs().longValue());
+    // The full snapshot summary (of the snapshot main points to) is emitted verbatim so queries can
+    // derive operation, app-id, and write-mode signals downstream. The fixture is a pure append.
+    Map<String, String> summary = actualEvent.getSnapshotSummary();
+    assertEquals("append", summary.get("operation"));
+    assertEquals("local-1669126906634", summary.get("spark.app.id"));
+    assertEquals("1", summary.get("added-data-files"));
+    assertEquals("0", summary.get("total-delete-files"));
   }
 
   @Test
@@ -123,6 +148,10 @@ public class IcebergSnapshotsApiHandlerAuditTest {
     // failure
     assertEquals(2151407017102313398L, actualEvent.getCurrentSnapshotId().longValue());
     assertEquals(1669126937912L, actualEvent.getCurrentSnapshotTimestampMs().longValue());
+    // The summary is likewise captured on failure.
+    Map<String, String> summary = actualEvent.getSnapshotSummary();
+    assertEquals("append", summary.get("operation"));
+    assertEquals("local-1669126906634", summary.get("spark.app.id"));
   }
 
   @Test
@@ -152,6 +181,92 @@ public class IcebergSnapshotsApiHandlerAuditTest {
     TableAuditEvent actualEvent = argCaptor.getValue();
     assertNull(actualEvent.getCurrentSnapshotId());
     assertNull(actualEvent.getCurrentSnapshotTimestampMs());
+    // No main ref, so no snapshot summary either — consistent with currentSnapshotId.
+    assertNull(actualEvent.getSnapshotSummary());
+  }
+
+  @Test
+  public void testPutIcebergSnapshotsEmitsRewriteSummaryVerbatim() throws Exception {
+    // A copy-on-write overwrite removes existing data files (deleted-data-files > 0) and writes no
+    // delete files. The audit emits those raw counters in the summary verbatim; the query
+    // classifies write mode downstream.
+    String cowSnapshotJson =
+        "{\n"
+            + "  \"snapshot-id\" : 777,\n"
+            + "  \"timestamp-ms\" : 7000,\n"
+            + "  \"summary\" : {\n"
+            + "    \"operation\" : \"overwrite\",\n"
+            + "    \"added-data-files\" : \"2\",\n"
+            + "    \"deleted-data-files\" : \"2\"\n"
+            + "  },\n"
+            + "  \"manifest-list\" : \"/tmp/cow.avro\",\n"
+            + "  \"schema-id\" : 0\n"
+            + "}";
+    IcebergSnapshotsRequestBody requestBody =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion("v1")
+            .jsonSnapshots(Collections.singletonList(cowSnapshotJson))
+            .snapshotRefs(
+                Collections.singletonMap("main", "{\"snapshot-id\":777,\"type\":\"branch\"}"))
+            .createUpdateTableRequestBody(RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY)
+            .build();
+
+    mvc.perform(
+        MockMvcRequestBuilders.put(
+                String.format(
+                    CURRENT_MAJOR_VERSION_PREFIX
+                        + "/databases/d200/tables/tb1/iceberg/v2/snapshots"))
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody.toJson()));
+    Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
+    TableAuditEvent actualEvent = argCaptor.getValue();
+    Map<String, String> summary = actualEvent.getSnapshotSummary();
+    assertEquals("overwrite", summary.get("operation"));
+    assertEquals("2", summary.get("added-data-files"));
+    assertEquals("2", summary.get("deleted-data-files"));
+  }
+
+  @Test
+  public void testPutIcebergSnapshotsEmitsDeleteFileSummaryVerbatim() throws Exception {
+    // A merge-on-read delete writes position delete files (added-delete-files > 0) and removes no
+    // data files. The audit emits those raw counters in the summary verbatim; the query classifies
+    // write mode downstream.
+    String morSnapshotJson =
+        "{\n"
+            + "  \"snapshot-id\" : 888,\n"
+            + "  \"timestamp-ms\" : 8000,\n"
+            + "  \"summary\" : {\n"
+            + "    \"operation\" : \"delete\",\n"
+            + "    \"added-delete-files\" : \"1\",\n"
+            + "    \"added-position-delete-files\" : \"1\"\n"
+            + "  },\n"
+            + "  \"manifest-list\" : \"/tmp/mor.avro\",\n"
+            + "  \"schema-id\" : 0\n"
+            + "}";
+    IcebergSnapshotsRequestBody requestBody =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion("v1")
+            .jsonSnapshots(Collections.singletonList(morSnapshotJson))
+            .snapshotRefs(
+                Collections.singletonMap("main", "{\"snapshot-id\":888,\"type\":\"branch\"}"))
+            .createUpdateTableRequestBody(RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY)
+            .build();
+
+    mvc.perform(
+        MockMvcRequestBuilders.put(
+                String.format(
+                    CURRENT_MAJOR_VERSION_PREFIX
+                        + "/databases/d200/tables/tb1/iceberg/v2/snapshots"))
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody.toJson()));
+    Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
+    TableAuditEvent actualEvent = argCaptor.getValue();
+    Map<String, String> summary = actualEvent.getSnapshotSummary();
+    assertEquals("delete", summary.get("operation"));
+    assertEquals("1", summary.get("added-delete-files"));
+    assertEquals("1", summary.get("added-position-delete-files"));
   }
 
   @Test

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/model/TableAuditModelConstants.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/model/TableAuditModelConstants.java
@@ -9,7 +9,11 @@ public final class TableAuditModelConstants {
   private static final String USER = "testUser";
   private static final String MOCK_USER = "DUMMY_ANONYMOUS_USER";
 
-  public static final String[] EXCLUDE_FIELDS = new String[] {"eventTimestamp", "currentTableRoot"};
+  // snapshotSummary (the full verbatim Iceberg summary map) is excluded from reflection-based
+  // comparisons; it is asserted explicitly where it matters rather than baked into every expected
+  // constant.
+  public static final String[] EXCLUDE_FIELDS =
+      new String[] {"eventTimestamp", "currentTableRoot", "snapshotSummary"};
 
   public static final TableAuditEvent TABLE_AUDIT_EVENT_CREATE_TABLE_SUCCESS_E2E =
       TableAuditEvent.builder()


### PR DESCRIPTION
## Summary

Adds two purely-additive fields to `TableAuditEvent` for client/commit observability, populated server-side in `TableAuditAspect` (both are **observability only** — neither gates a request):

- **`clientUserAgent`** — the raw `User-Agent` request header, stored verbatim, so the client/runtime version can be derived at query time (e.g. `openhouse-java-client/<version>`). Set in the shared `buildAndSendEvent`, read from the bound servlet request via `RequestContextHolder` (mirroring `ServiceAuditAspect`); best-effort and never disrupts the audited operation.
- **`snapshotSummary`** — the full Iceberg summary map of the snapshot the `main` ref points to (the same snapshot as `currentSnapshotId`), emitted verbatim (`operation`, `spark.app.id`/`trino_query_id`, engine/iceberg versions, and the core-computed file-delta counts). Emitted unaggregated so queries derive operation and write-mode signals downstream without a lossy server-side classification — there is no per-commit field that cleanly declares copy-on-write vs merge-on-read across engines. `Snapshot.summary()` omits the `operation` key (Iceberg parses it out into a separate field), so it is merged back to mirror the on-disk summary. It is hooked onto the snapshot `extractSnapshotInfo` already resolves for `currentSnapshotTimestampMs`; null when the request carries no `main` ref (branch-only commits), consistent with `currentSnapshotId`.

## Changes

- [x] Internal API Changes
- [x] New Features
- [x] Tests

`TableAuditEvent` gains `clientUserAgent` (`String`) and `snapshotSummary` (`Map<String,String>`). `snapshotSummary` is emitted unbounded by design (unlike the allowlist-filtered `auditedTableProperties`) — a snapshot summary is naturally a small, fixed set of keys; `clientUserAgent` is captured on every audited event, not just commits.

## Testing Done

- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.

`IcebergSnapshotsApiHandlerAuditTest`:
- `testPutIcebergSnapshotsCapturesClientUserAgent` — sets a `User-Agent` header and asserts verbatim capture.
- `testPutIcebergSnapshotsEmitsRewriteSummaryVerbatim` / `testPutIcebergSnapshotsEmitsDeleteFileSummaryVerbatim` — assert the raw summary counters are emitted for a copy-on-write overwrite and a merge-on-read delete.
- Extended `testPutIcebergSnapshotsContainsSnapshotInfo` and the failed-path test to assert the summary is captured (including on failure), and the branch-only test to assert it is null when there is no `main` ref.

`snapshotSummary` is excluded from the `ReflectionEquals` expected constants and asserted explicitly. Full audit test suite passes (`IcebergSnapshotsApiHandlerAuditTest` 16, plus `TablesApiHandlerAuditTest` / `DatabasesApiHandlerAuditTest`).

# Additional Information

- [x] Large PR broken into smaller PRs, and PR plan linked in the description.

Part of a sliced rollout of server-side commit-audit observability. A follow-up will add `failureType` (the exception class on failed commits) plus isolation of the audit emission so it can never mask the operation being audited.
