### PR TITLE
Gate RTAS with 'replace.enabled' table property

### DIFF
--- a/apps/spark/src/test/java/com/linkedin/openhouse/catalog/e2e/RTASJavaTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/catalog/e2e/RTASJavaTest.java
@@ -65,6 +65,9 @@ public class RTASJavaTest extends OpenHouseSparkITest {
       Table table = catalog.buildTable(TABLE_IDENT, SCHEMA).withPartitionSpec(SPEC).create();
       table.newAppend().appendFile(FILE_A).commit();
 
+      // RTAS is disabled by default; opt the table in before replacing it.
+      table.updateProperties().set("replace.enabled", "true").commit();
+
       String originalLocation = table.location();
       String originalMetadataLocation = getMetadataLocation(table);
       long originalSnapshotId = table.currentSnapshot().snapshotId();
@@ -119,6 +122,9 @@ public class RTASJavaTest extends OpenHouseSparkITest {
 
       // verify that the table was created with one snapshot
       assertEquals(1, Iterables.size(table.snapshots()), "Should have one snapshot after create");
+
+      // RTAS is disabled by default; opt the table in before replacing it.
+      table.updateProperties().set("replace.enabled", "true").commit();
 
       // create or replace on existing table should replace it
       Transaction replaceTxn =

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -752,6 +752,12 @@ public class OperationsTest extends OpenHouseSparkITest {
       prepareTable(ops, tableName);
       populateTable(ops, tableName, numInserts);
 
+      // RTAS is disabled by default; opt the table in before replacing it.
+      ops.spark()
+          .sql(
+              String.format(
+                  "ALTER TABLE %s SET TBLPROPERTIES ('replace.enabled'='true')", tableName));
+
       // replace the table using RTAS
       ops.spark()
           .sql(

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/CatalogConstants.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/CatalogConstants.java
@@ -30,6 +30,10 @@ public final class CatalogConstants {
 
   public static final String EVOLVED_SCHEMA_KEY = "evolved.table.schema";
 
+  public static final String RTAS_ENABLED_TABLE_PROP = "replace.enabled";
+
+  public static final String WAP_ENABLED_TABLE_PROP = "write.wap.enabled";
+
   static final String FEATURE_TOGGLE_STOP_CREATE = "stop_create";
 
   static final String CLIENT_TABLE_SCHEMA = "client.table.schema";

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/RTASTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/RTASTest.java
@@ -10,6 +10,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Row;
@@ -59,6 +60,10 @@ public class RTASTest extends OpenHouseSparkITest {
               tableName, sourceName));
 
       spark.sql(String.format("ALTER TABLE %s SET POLICY (HISTORY MAX_AGE=24H)", tableName));
+
+      // RTAS is disabled by default; opt the table in before replacing it.
+      spark.sql(
+          String.format("ALTER TABLE %s SET TBLPROPERTIES ('replace.enabled'='true')", tableName));
 
       String expectedTableLocation = catalog.loadTable(tableIdent).location();
 
@@ -112,6 +117,29 @@ public class RTASTest extends OpenHouseSparkITest {
   }
 
   @Test
+  public void testRTASFailsWhenReplaceDisabled() throws Exception {
+    try (SparkSession spark = getSparkSession()) {
+      // create the table without opting into RTAS; replace is disabled by default
+      spark.sql(
+          String.format(
+              "CREATE TABLE %s USING iceberg AS SELECT * FROM %s", tableName, sourceName));
+
+      // REPLACE TABLE should be rejected because 'replace.enabled' is not set on the table
+      BadRequestException exception =
+          assertThrows(
+              BadRequestException.class,
+              () ->
+                  spark.sql(
+                      String.format(
+                          "REPLACE TABLE %s USING iceberg AS SELECT * FROM %s",
+                          tableName, sourceName)));
+      assertTrue(
+          exception.getMessage().contains("REPLACE TABLE AS SELECT is not enabled"),
+          "Expected an RTAS-disabled error but got: " + exception.getMessage());
+    }
+  }
+
+  @Test
   public void testCreateRTAS() throws Exception {
     try (SparkSession spark = getSparkSession()) {
       Catalog catalog = getOpenHouseCatalog(spark);
@@ -124,6 +152,10 @@ public class RTASTest extends OpenHouseSparkITest {
               tableName, sourceName));
 
       String expectedTableLocation = catalog.loadTable(tableIdent).location();
+
+      // RTAS is disabled by default; opt the table in before replacing it.
+      spark.sql(
+          String.format("ALTER TABLE %s SET TBLPROPERTIES ('replace.enabled'='true')", tableName));
 
       // create or replace table should replace the table
       spark.sql(
@@ -168,6 +200,10 @@ public class RTASTest extends OpenHouseSparkITest {
       Catalog catalog = getOpenHouseCatalog(spark);
 
       spark.table(sourceName).writeTo(tableName).using("iceberg").create();
+
+      // RTAS is disabled by default; opt the table in before replacing it.
+      spark.sql(
+          String.format("ALTER TABLE %s SET TBLPROPERTIES ('replace.enabled'='true')", tableName));
 
       String expectedTableLocation = catalog.loadTable(tableIdent).location();
 
@@ -225,6 +261,10 @@ public class RTASTest extends OpenHouseSparkITest {
           .partitionedBy(col("part"))
           .using("iceberg")
           .createOrReplace();
+
+      // RTAS is disabled by default; opt the table in before replacing it.
+      spark.sql(
+          String.format("ALTER TABLE %s SET TBLPROPERTIES ('replace.enabled'='true')", tableName));
 
       String expectedTableLocation = catalog.loadTable(tableIdent).location();
 

--- a/services/common/src/main/java/com/linkedin/openhouse/common/exception/UnsupportedClientOperationException.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/exception/UnsupportedClientOperationException.java
@@ -20,6 +20,7 @@ public class UnsupportedClientOperationException extends RuntimeException {
     GRANT_ON_UNSHARED_TABLES,
     ALTER_TABLE_TYPE,
     GRANT_ON_LOCKED_TABLES,
-    LOCKED_TABLE_OPERATION
+    LOCKED_TABLE_OPERATION,
+    RTAS_DISABLED,
   }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -24,6 +24,7 @@ import com.linkedin.openhouse.internal.catalog.SnapshotsUtil;
 import com.linkedin.openhouse.internal.catalog.fileio.FileIOManager;
 import com.linkedin.openhouse.internal.catalog.model.SoftDeletedTableDto;
 import com.linkedin.openhouse.internal.catalog.model.SoftDeletedTablePrimaryKey;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.Policies;
 import com.linkedin.openhouse.tables.common.TableType;
 import com.linkedin.openhouse.tables.dto.mapper.TablesMapper;
 import com.linkedin.openhouse.tables.dto.mapper.iceberg.PartitionSpecMapper;
@@ -151,7 +152,7 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
           tableIdentifier,
           System.currentTimeMillis() - startTime);
     } else if (tableDto.isStageReplace() || tableDto.isReplaceCommit()) {
-      validateReplaceTable(tableDto);
+      validateReplaceTable(tableIdentifier);
       PartitionSpec partitionSpec = partitionSpecMapper.toPartitionSpec(tableDto);
       log.info(
           "Replacing a user table: {} with schema: {} and partitionSpec: {}",
@@ -319,28 +320,30 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
    * RTAS is only permitted when the {@value CatalogConstants#RTAS_ENABLED_TABLE_PROP} table
    * property is set. And it is not allowed on table where WAP or replication is enabled.
    *
-   * @param tableDto the table being persisted
+   * @param tableIdentifier identifier for the table
    */
-  protected void validateReplaceTable(TableDto tableDto) {
-    Map<String, String> tableProperties = tableDto.getTableProperties();
-
+  protected void validateReplaceTable(TableIdentifier tableIdentifier) {
     // A replace is only permitted when RTAS is enabled on the table.
-    if (!Boolean.parseBoolean(tableProperties.get(RTAS_ENABLED_TABLE_PROP))) {
+    Table table = catalog.loadTable(tableIdentifier);
+    Map<String, String> existingProperties = table.properties();
+    if (!Boolean.parseBoolean(existingProperties.get(RTAS_ENABLED_TABLE_PROP))) {
       throw new UnsupportedClientOperationException(
           UnsupportedClientOperationException.Operation.RTAS_DISABLED,
           String.format(
               "REPLACE TABLE AS SELECT is not enabled for table openhouse.%s.%s. You can enable this feature with 'ALTER TABLE openhouse.%s.%s SET TBLPROPERTIES ('%s'='true')'",
-              tableDto.getDatabaseId(),
-              tableDto.getTableId(),
-              tableDto.getDatabaseId(),
-              tableDto.getTableId(),
+              tableIdentifier.namespace(),
+              tableIdentifier.name(),
+              tableIdentifier.namespace(),
+              tableIdentifier.name(),
               RTAS_ENABLED_TABLE_PROP));
     }
 
     // RTAS is incompatible with WAP or replication.
-    boolean wapEnabled = Boolean.parseBoolean(tableProperties.get(WAP_ENABLED_TABLE_PROP));
+    boolean wapEnabled = Boolean.parseBoolean(existingProperties.get(WAP_ENABLED_TABLE_PROP));
+    Policies existingPolicies =
+        policiesMapper.toPoliciesObject(existingProperties.get(POLICIES_KEY));
     boolean replicationEnabled =
-        tableDto.getPolicies() != null && tableDto.getPolicies().getReplication() != null;
+        existingPolicies != null && existingPolicies.getReplication() != null;
     if (wapEnabled || replicationEnabled) {
       List<String> conflictingFeatures = new ArrayList<>();
       if (wapEnabled) {
@@ -353,8 +356,8 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
           UnsupportedClientOperationException.Operation.RTAS_DISABLED,
           String.format(
               "REPLACE TABLE AS SELECT cannot be performed on table %s.%s while %s is enabled.",
-              tableDto.getDatabaseId(),
-              tableDto.getTableId(),
+              tableIdentifier.namespace(),
+              tableIdentifier.name(),
               String.join(" and ", conflictingFeatures)));
     }
   }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -343,7 +343,10 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
     Policies existingPolicies =
         policiesMapper.toPoliciesObject(existingProperties.get(POLICIES_KEY));
     boolean replicationEnabled =
-        existingPolicies != null && existingPolicies.getReplication() != null;
+        existingPolicies != null
+            && existingPolicies.getReplication() != null
+            && existingPolicies.getReplication().getConfig() != null
+            && !existingPolicies.getReplication().getConfig().isEmpty();
     if (wapEnabled || replicationEnabled) {
       List<String> conflictingFeatures = new ArrayList<>();
       if (wapEnabled) {

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -36,6 +36,7 @@ import com.linkedin.openhouse.tables.repository.PreservedKeyChecker;
 import com.linkedin.openhouse.tables.repository.SchemaValidator;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -150,6 +151,7 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
           tableIdentifier,
           System.currentTimeMillis() - startTime);
     } else if (tableDto.isStageReplace() || tableDto.isReplaceCommit()) {
+      validateReplaceTable(tableDto);
       PartitionSpec partitionSpec = partitionSpecMapper.toPartitionSpec(tableDto);
       log.info(
           "Replacing a user table: {} with schema: {} and partitionSpec: {}",
@@ -311,6 +313,50 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
    */
   protected void creationEligibilityCheck(TableDto tableDto) {
     versionCheck(null, tableDto);
+  }
+
+  /**
+   * RTAS is only permitted when the {@value CatalogConstants#RTAS_ENABLED_TABLE_PROP} table
+   * property is set. And it is not allowed on table where WAP or replication is enabled.
+   *
+   * @param tableDto the table being persisted
+   */
+  protected void validateReplaceTable(TableDto tableDto) {
+    Map<String, String> tableProperties = tableDto.getTableProperties();
+
+    // A replace is only permitted when RTAS is enabled on the table.
+    if (!Boolean.parseBoolean(tableProperties.get(RTAS_ENABLED_TABLE_PROP))) {
+      throw new UnsupportedClientOperationException(
+          UnsupportedClientOperationException.Operation.RTAS_DISABLED,
+          String.format(
+              "REPLACE TABLE AS SELECT is not enabled for table openhouse.%s.%s. You can enable this feature with 'ALTER TABLE openhouse.%s.%s SET TBLPROPERTIES ('%s'='true')'",
+              tableDto.getDatabaseId(),
+              tableDto.getTableId(),
+              tableDto.getDatabaseId(),
+              tableDto.getTableId(),
+              RTAS_ENABLED_TABLE_PROP));
+    }
+
+    // RTAS is incompatible with WAP or replication.
+    boolean wapEnabled = Boolean.parseBoolean(tableProperties.get(WAP_ENABLED_TABLE_PROP));
+    boolean replicationEnabled =
+        tableDto.getPolicies() != null && tableDto.getPolicies().getReplication() != null;
+    if (wapEnabled || replicationEnabled) {
+      List<String> conflictingFeatures = new ArrayList<>();
+      if (wapEnabled) {
+        conflictingFeatures.add(String.format("WAP ('%s=true')", WAP_ENABLED_TABLE_PROP));
+      }
+      if (replicationEnabled) {
+        conflictingFeatures.add("replication");
+      }
+      throw new UnsupportedClientOperationException(
+          UnsupportedClientOperationException.Operation.RTAS_DISABLED,
+          String.format(
+              "REPLACE TABLE AS SELECT cannot be performed on table %s.%s while %s is enabled.",
+              tableDto.getDatabaseId(),
+              tableDto.getTableId(),
+              String.join(" and ", conflictingFeatures)));
+    }
   }
 
   /**

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
@@ -104,6 +104,7 @@ public class TablesServiceImpl implements TablesService {
       Boolean failOnExist) {
     String databaseId = createUpdateTableRequestBody.getDatabaseId();
     String tableId = createUpdateTableRequestBody.getTableId();
+
     Optional<TableDto> tableDto =
         openHouseInternalRepository.findById(
             TableDtoPrimaryKey.builder().databaseId(databaseId).tableId(tableId).build());

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/SnapshotsControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/SnapshotsControllerTest.java
@@ -13,6 +13,7 @@ import com.jayway.jsonpath.JsonPath;
 import com.linkedin.openhouse.cluster.storage.StorageManager;
 import com.linkedin.openhouse.cluster.storage.local.LocalStorage;
 import com.linkedin.openhouse.common.test.cluster.PropertyOverrideContextInitializer;
+import com.linkedin.openhouse.internal.catalog.CatalogConstants;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.IcebergSnapshotsRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
@@ -312,6 +313,12 @@ public class SnapshotsControllerTest {
   @MethodSource("responseBodyFeeder")
   public void testPutSnapshotsReplaceCommit(GetTableResponseBody getTableResponseBody)
       throws Exception {
+    // Enable RTAS and remove policy
+    Map<String, String> propsWithRtas = new HashMap<>(getTableResponseBody.getTableProperties());
+    propsWithRtas.put(CatalogConstants.RTAS_ENABLED_TABLE_PROP, "true");
+    getTableResponseBody =
+        getTableResponseBody.toBuilder().tableProperties(propsWithRtas).policies(null).build();
+
     // Step 1: Create a table
     MvcResult createResult =
         RequestAndValidateHelper.createTableAndValidateResponse(

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesControllerTest.java
@@ -51,6 +51,7 @@ import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -829,8 +830,13 @@ public class TablesControllerTest {
   @SneakyThrows
   @Test
   public void testStagedReplace() {
-    GetTableResponseBody stageReplaceTable =
+    // Enable RTAS and remove policy
+    GetTableResponseBody baseTable =
         TableModelConstants.buildGetTableResponseBodyWithDbTbl("d_sr", "t_sr");
+    Map<String, String> propsWithRtas = new HashMap<>(baseTable.getTableProperties());
+    propsWithRtas.put(CatalogConstants.RTAS_ENABLED_TABLE_PROP, "true");
+    GetTableResponseBody stageReplaceTable =
+        baseTable.toBuilder().tableProperties(propsWithRtas).policies(null).build();
 
     // Create a real table first
     MvcResult createResult =
@@ -902,6 +908,130 @@ public class TablesControllerTest {
     Assertions.assertEquals(originalSchema, currentSchema);
 
     RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, stageReplaceTable);
+  }
+
+  @SneakyThrows
+  @Test
+  public void testStagedReplaceFailsWhenRtasDisabled() {
+    // Table created without enabling RTAS; replace is disabled by default.
+    GetTableResponseBody table =
+        TableModelConstants.buildGetTableResponseBodyWithDbTbl("d_sr_dis", "t_sr_dis");
+    MvcResult createResult =
+        RequestAndValidateHelper.createTableAndValidateResponse(table, mvc, storageManager);
+    String originalTableLocation =
+        JsonPath.read(createResult.getResponse().getContentAsString(), "$.tableLocation");
+
+    // A stageReplace against a table without replaceEnabled should be rejected.
+    mvc.perform(
+            MockMvcRequestBuilders.post(
+                    String.format(
+                        ValidationUtilities.CURRENT_MAJOR_VERSION_PREFIX + "/databases/%s/tables/",
+                        table.getDatabaseId()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    buildCreateUpdateTableRequestBody(table)
+                        .toBuilder()
+                        .baseTableVersion(originalTableLocation)
+                        .stageReplace(true)
+                        .build()
+                        .toJson())
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message", containsString("REPLACE TABLE AS SELECT is not enabled")));
+
+    RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, table);
+  }
+
+  @SneakyThrows
+  @Test
+  public void testReplaceWithWapEnabledIsRejected() {
+    // Enable RTAS and remove policy
+    GetTableResponseBody baseTable =
+        TableModelConstants.buildGetTableResponseBodyWithDbTbl("d_sr", "t_sr");
+    Map<String, String> props = new HashMap<>(baseTable.getTableProperties());
+    props.put(CatalogConstants.RTAS_ENABLED_TABLE_PROP, "true");
+    props.put(CatalogConstants.WAP_ENABLED_TABLE_PROP, "true");
+    GetTableResponseBody table =
+        baseTable.toBuilder().tableProperties(props).policies(null).build();
+    MvcResult createResult =
+        RequestAndValidateHelper.createTableAndValidateResponse(table, mvc, storageManager);
+    String originalTableLocation =
+        JsonPath.read(createResult.getResponse().getContentAsString(), "$.tableLocation");
+
+    // A stageReplace whose resulting table enables WAP must be rejected.
+    mvc.perform(
+            MockMvcRequestBuilders.post(
+                    String.format(
+                        ValidationUtilities.CURRENT_MAJOR_VERSION_PREFIX + "/databases/%s/tables/",
+                        table.getDatabaseId()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    buildCreateUpdateTableRequestBody(table)
+                        .toBuilder()
+                        .tableProperties(props)
+                        .baseTableVersion(originalTableLocation)
+                        .stageReplace(true)
+                        .build()
+                        .toJson())
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest())
+        .andExpect(
+            jsonPath("$.message", containsString("REPLACE TABLE AS SELECT cannot be performed")))
+        .andExpect(jsonPath("$.message", containsString("WAP")));
+
+    RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, table);
+  }
+
+  @SneakyThrows
+  @Test
+  public void testReplaceWithReplicationEnabledIsRejected() {
+    // Enable RTAS
+    GetTableResponseBody baseTable =
+        TableModelConstants.buildGetTableResponseBodyWithDbTbl("d_sr", "t_sr");
+    Map<String, String> propsWithRtas = new HashMap<>(baseTable.getTableProperties());
+    propsWithRtas.put(CatalogConstants.RTAS_ENABLED_TABLE_PROP, "true");
+    GetTableResponseBody table = baseTable.toBuilder().tableProperties(propsWithRtas).build();
+    MvcResult createResult =
+        RequestAndValidateHelper.createTableAndValidateResponse(table, mvc, storageManager);
+    String originalTableLocation =
+        JsonPath.read(createResult.getResponse().getContentAsString(), "$.tableLocation");
+
+    // A stageReplace whose resulting table enables replication must be rejected.
+    Policies policiesWithReplication =
+        table
+            .getPolicies()
+            .toBuilder()
+            .replication(
+                Replication.builder()
+                    .config(
+                        Collections.singletonList(
+                            ReplicationConfig.builder()
+                                .destination("CLUSTER1")
+                                .interval("12H")
+                                .build()))
+                    .build())
+            .build();
+    mvc.perform(
+            MockMvcRequestBuilders.post(
+                    String.format(
+                        ValidationUtilities.CURRENT_MAJOR_VERSION_PREFIX + "/databases/%s/tables/",
+                        table.getDatabaseId()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    buildCreateUpdateTableRequestBody(table)
+                        .toBuilder()
+                        .policies(policiesWithReplication)
+                        .baseTableVersion(originalTableLocation)
+                        .stageReplace(true)
+                        .build()
+                        .toJson())
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest())
+        .andExpect(
+            jsonPath("$.message", containsString("REPLACE TABLE AS SELECT cannot be performed")))
+        .andExpect(jsonPath("$.message", containsString("replication")));
+
+    RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, table);
   }
 
   @SneakyThrows

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/model/TableModelConstants.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/model/TableModelConstants.java
@@ -560,8 +560,10 @@ public final class TableModelConstants {
             new ClusteringSpecConverter()
                 .convertToEntityAttribute(JsonPath.read(content, "$.clustering").toString()))
         .policies(
-            new PoliciesSpecConverter()
-                .convertToEntityAttribute(JsonPath.read(content, "$.policies").toString()))
+            JsonPath.read(content, "$.policies") == null
+                ? null
+                : new PoliciesSpecConverter()
+                    .convertToEntityAttribute(JsonPath.read(content, "$.policies").toString()))
         .sortOrder(JsonPath.read(content, "$.sortOrder"))
         .build();
   }


### PR DESCRIPTION
## Summary

Add a per-table flag that gates the RTAS command. RTAS is now **blocked by default** and is only permitted when the table has the regular table property `replace.enabled` set to `true`. The purpose is to disallow it in prod but allow it in testing until the feature is fully-fledged. The gate is set up in repo layer to check the table property when it sees the `stagedReplace` or `replaceCommit` flag. We also disallow RTAS when WAP or replication is enabled.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ]  Tests

## Testing Done

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.
