### PR TITLE
[default values] Add an overridable hook to transform table metadata as it is loaded

### DIFF
--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.SnapshotParser;
 import org.apache.iceberg.SnapshotRefParser;
 import org.apache.iceberg.SortOrderParser;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.CommitFailedException;
@@ -101,8 +102,18 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
       throw new NoSuchTableException(
           "Cannot find table %s after refresh, maybe another process deleted it", tableName());
     }
-    super.refreshFromMetadataLocation(tableLocation.orElse(null));
+    // Read through loadMetadata() so subclasses can transform metadata as it loads. The 4-arg call
+    // with (null, 20) is the stock 1-arg behavior, with the parse step made overridable.
+    super.refreshFromMetadataLocation(tableLocation.orElse(null), null, 20, this::loadMetadata);
     log.debug("Calling doRefresh succeeded");
+  }
+
+  /**
+   * Loads the table metadata at the given location. Defaults to the stock parser; subclasses may
+   * override to transform the metadata (e.g. attach column defaults) as it loads.
+   */
+  protected TableMetadata loadMetadata(String metadataLocation) {
+    return TableMetadataParser.read(io(), metadataLocation);
   }
 
   @Override


### PR DESCRIPTION
## Summary

This adds a small extension point to the OpenHouse client so a subclass can adjust a table's metadata as it is read in, without changing how tables are refreshed or cached. By default nothing changes — the metadata is read exactly as before. This is the open-source, source-agnostic half of a larger effort; the part that derives and attaches LinkedIn-specific column defaults lives in a separate internal client (which overrides this hook) and is intentionally not in this repository.

_Terms:_ `metadata.json` is the file describing a table (its columns, schema history, snapshots). `TableMetadata` is the in-memory object parsed from it. `doRefresh()` is the OpenHouse client method that loads that metadata from storage. `current()` is the standard call a reader makes to get a table's current metadata.

## Changes

- [ ] Client-facing API Changes
- [x] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [ ] Tests

**Internal API Changes + Refactoring — an overridable metadata-load step.**

- **`OpenHouseTableOperations` now reads metadata through one overridable method.** A new `protected TableMetadata loadMetadata(String metadataLocation)` performs the read, and `doRefresh()` calls it instead of parsing inline. The default implementation reads the metadata as-is with the stock parser (`TableMetadataParser.read`).
- **Behavior is unchanged.** `doRefresh()` previously called the one-argument `refreshFromMetadataLocation(location)`. It now calls the four-argument form with `(shouldRetry=null, numRetries=20)` — which is exactly what the one-argument form does internally — with the final parse step routed through `loadMetadata` so it can be overridden.
- **Why route it through a subclass method.** Because the override runs inside the loader, whatever it returns becomes the metadata the table stores and reports, so `current()` stays stock and there is no second, cached copy that could drift out of sync. An override owns the entire read-in, so it can also rewrite the stored bytes before parsing — useful for future format-compatibility shims.

## Testing Done

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [x] No tests added or updated. The change is behavior-preserving: the default `loadMetadata` performs the same stock parse `doRefresh()` already did, and that path is exercised by the existing `OpenHouseTableOperations` / `doRefresh` tests. The override path is tested where it is implemented, in the internal client.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [x] Large PR broken into smaller PRs, and PR plan linked in the description.

This is one half of a larger effort to read column defaults that are declared in a table property rather than in the Iceberg metadata file. This PR contains only the general, source-agnostic extension point. The companion change — which overrides `loadMetadata` to derive those defaults and attach them to the schema — lives in a separate internal client, along with its dependencies, and is intentionally kept out of this repository. No new dependencies; no change to the commit path, caching, or metrics.
