### PR TITLE
Bump linkedin/iceberg 1.2 to 1.2.0.19 (NestedField column-default APIs)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ ext {
   spark_version = "3.1.1"
   ok_http3_version = "4.11.0"
   junit_version = "5.11.0"
-  iceberg_1_2_version = "1.2.0.18"
+  iceberg_1_2_version = "1.2.0.19"
   iceberg_1_5_version = "1.5.2.15"
   otel_agent_version = "2.12.0" // Bundles OTel SDK 1.47.0
   otel_annotations_version = "2.12.0" // Match agent version


### PR DESCRIPTION
Picks up [linkedin/iceberg#250](https://github.com/linkedin/iceberg/pull/250) (released as `com.linkedin.iceberg` tag `v1.2.0.19`).

## Summary

Bumps the Iceberg 1.2 line from `1.2.0.18` → `1.2.0.19`. The only change in `v1.2.0.19` is linkedin/iceberg#250, which re-baselines upstream's **column default-value API** (`Types.NestedField` initial/write defaults, `Expressions.lit()`, plus `SchemaParser` serialization) onto `openhouse-1.2.0`, bringing the 1.2 line to parity with the 1.5 line on this API.

- Defaults are stored as `Literal<?>` with `withInitialDefault` / `withWriteDefault` builders and matching accessors (`initialDefault()` / `writeDefault()` / `*Literal()`).
- `SchemaParser` serializes the defaults, so they are format-compatible end to end.
- v3-only bits (e.g. `UnknownType`) are dropped since 1.2 lacks them; everything else is a faithful copy from upstream `main` rather than a cherry-pick.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

Dependency version bump only — single line in `build.gradle`. The 1.5 line is already at its latest (`1.5.2.15`); this brings the 1.2 line to its latest within-line release.

## Testing Done

- [ ] Manually Tested on local docker setup.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [X] No tests added or updated. Tests for the new APIs live in linkedin/iceberg#250; this PR is a version bump.
- [ ] Some other form of testing.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
