### PR TITLE
[default values] Tables: apply server-supplied per-column defaults at read time

### DIFF
--- a/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/ReadBridgeTest.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/ReadBridgeTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.openhouse.javaclient;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
@@ -35,11 +36,29 @@ class ReadBridgeTest {
   }
 
   @Test
-  void skipsEntriesWithBadFieldIdOrUnparseableValue() {
+  void failsLoudOnKnownEntryWithBadFieldId() {
+    // A non-integer field-id on a key we own can't come from the server encoder (it stamps int
+    // field-ids and JsonNode values), so it's a bug/corruption and throws rather than degrading.
     Map<String, String> config = new HashMap<>();
     config.put(PREFIX + "5", "\"US\"");
-    config.put(PREFIX + "notAnInt", "\"x\""); // non-integer field-id -> skipped
-    config.put(PREFIX + "7", "{bad json"); // unparseable value -> skipped
+    config.put(PREFIX + "notAnInt", "\"x\"");
+    assertThrows(IllegalStateException.class, () -> ReadBridge.columnDefaults(config));
+  }
+
+  @Test
+  void failsLoudOnKnownEntryWithUnparseableValue() {
+    Map<String, String> config = new HashMap<>();
+    config.put(PREFIX + "7", "{bad json");
+    assertThrows(IllegalStateException.class, () -> ReadBridge.columnDefaults(config));
+  }
+
+  @Test
+  void ignoresUnknownKeysWithoutFailing() {
+    // Forward compatibility: a key outside the column-default prefix (e.g. a newer server feature)
+    // is ignored, never enforced — even if its value would not parse as a default.
+    Map<String, String> config = new HashMap<>();
+    config.put(PREFIX + "5", "\"US\"");
+    config.put("openhouse.read-bridge.some-future-feature.3", "{not a default}");
     assertEquals(1, ReadBridge.columnDefaults(config).size());
     assertEquals("US", ReadBridge.columnDefaults(config).get(5).asText());
   }

--- a/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/ReadBridgeTest.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/ReadBridgeTest.java
@@ -1,0 +1,46 @@
+package com.linkedin.openhouse.javaclient;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the client-side read-bridge config decoder ({@link ReadBridge#columnDefaults}),
+ * exercised in isolation. Mirrors the server-side encoder {@code ReadBridgeConfigResolver}.
+ */
+class ReadBridgeTest {
+
+  private static final String PREFIX = ReadBridge.COLUMN_DEFAULT_PREFIX;
+
+  @Test
+  void decodesColumnDefaultsByFieldId() {
+    // Inline calls avoid naming Jackson's JsonNode, which is relocated in the shaded client uber
+    // (and this module compiles at a source level without `var`).
+    Map<String, String> config = new HashMap<>();
+    config.put(PREFIX + "5", "\"US\"");
+    config.put(PREFIX + "7", "0");
+    assertEquals(2, ReadBridge.columnDefaults(config).size());
+    assertEquals("US", ReadBridge.columnDefaults(config).get(5).asText());
+    assertEquals(0, ReadBridge.columnDefaults(config).get(7).asInt());
+  }
+
+  @Test
+  void emptyWhenConfigNullOrNoReadBridgeKeys() {
+    assertTrue(ReadBridge.columnDefaults(null).isEmpty());
+    assertTrue(ReadBridge.columnDefaults(Collections.singletonMap("other.key", "x")).isEmpty());
+  }
+
+  @Test
+  void skipsEntriesWithBadFieldIdOrUnparseableValue() {
+    Map<String, String> config = new HashMap<>();
+    config.put(PREFIX + "5", "\"US\"");
+    config.put(PREFIX + "notAnInt", "\"x\""); // non-integer field-id -> skipped
+    config.put(PREFIX + "7", "{bad json"); // unparseable value -> skipped
+    assertEquals(1, ReadBridge.columnDefaults(config).size());
+    assertEquals("US", ReadBridge.columnDefaults(config).get(5).asText());
+  }
+}

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -128,11 +128,13 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
   }
 
   /**
-   * Loads the table metadata at the given location. Defaults to the stock parser; subclasses may
-   * override to transform the metadata (e.g. attach column defaults) as it loads.
+   * Loads the table metadata from storage, then runs the read-time {@link ReadBridge} over it using
+   * the per-table behavior the server stamped onto {@link #currentConfig()}. Fail-closed:
+   * absent/off/unparseable config leaves the raw metadata untouched.
    */
   protected TableMetadata loadMetadata(String metadataLocation) {
-    return TableMetadataParser.read(io(), metadataLocation);
+    TableMetadata raw = TableMetadataParser.read(io(), metadataLocation);
+    return ReadBridge.apply(raw, currentConfig());
   }
 
   @Override

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -129,8 +129,9 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
 
   /**
    * Loads the table metadata from storage, then runs the read-time {@link ReadBridge} over it using
-   * the per-table behavior the server stamped onto {@link #currentConfig()}. Fail-closed:
-   * absent/off/unparseable config leaves the raw metadata untouched.
+   * the per-table behavior the server stamped onto {@link #currentConfig()}. Absent config, or
+   * config carrying nothing to bridge, leaves the raw metadata untouched; a malformed known entry
+   * fails loud (see {@link ReadBridge}).
    */
   protected TableMetadata loadMetadata(String metadataLocation) {
     TableMetadata raw = TableMetadataParser.read(io(), metadataLocation);

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/ReadBridge.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/ReadBridge.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.iceberg.TableMetadata;
 
 /**
@@ -19,11 +18,19 @@ import org.apache.iceberg.TableMetadata;
  * ReadBridgeConfigResolver} (services/tables). The contract is flat, namespaced config keys (no
  * envelope/POJO): {@code openhouse.read-bridge.column-default.<fieldId> = <single-value-json>}.
  *
- * <p>Kept out of {@link OpenHouseTableOperations} so the read path stays slim. Pure and
- * fail-closed: an entry with a non-integer field-id or an unparseable value is skipped, and nothing
- * to apply returns {@code raw} unchanged.
+ * <p>Kept out of {@link OpenHouseTableOperations} so the read path stays slim. A read-bridge entry
+ * is produced by the server encoder ({@code ReadBridgeConfigResolver}) from typed {@code JsonNode}s
+ * keyed by integer field-id, so its value always round-trips through {@code readTree} and its
+ * suffix always parses as an int. A decode failure on a *known* entry is therefore a bug or
+ * transport corruption, not an expected runtime state, and this fails loud rather than silently
+ * degrading to NULL. An *unknown* key (a newer server feature this client doesn't recognize) is
+ * ignored, preserving forward compatibility. With nothing to apply, {@code raw} is returned
+ * unchanged.
+ *
+ * <p>Note this guarantees only that a stamped value is <em>well-formed</em>, not that it is the
+ * <em>correct</em> default for its column — that semantic (default-to-schema) consistency is a
+ * write-time concern owned by whatever server path sources the defaults.
  */
-@Slf4j
 final class ReadBridge {
 
   /** Mirror of {@code ReadBridgeConfigResolver.COLUMN_DEFAULT_PREFIX}. */
@@ -43,15 +50,19 @@ final class ReadBridge {
       return raw;
     }
     // TODO(read-bridge): overlay columnDefaults onto raw.schemas() via withSchemaOverlay; future V3
-    // features bridged from config are applied here too.
+    // features bridged from config are applied here too. Two failure categories apply there, as
+    // here: a capability gap we don't yet support degrades to NULL, while an invariant violation
+    // (e.g. a default that can't bind to its column) fails loud.
     return raw;
   }
 
   /**
    * Decodes {@code field-id -> initial-default} from the {@code
-   * openhouse.read-bridge.column-default.*} config entries; empty when there are none. Skips any
-   * entry with a non-integer field-id or an unparseable value (fail-closed). Package-visible for
-   * unit testing in isolation.
+   * openhouse.read-bridge.column-default.*} config entries; empty when there are none. On a known
+   * entry, the server encoder guarantees an integer field-id and a value that round-trips through
+   * {@code readTree}, so a non-integer field-id or an unparseable value is an encoder bug or
+   * transport corruption — it throws rather than degrading. Unknown keys are ignored above.
+   * Package-visible for unit testing in isolation.
    */
   static Map<Integer, JsonNode> columnDefaults(Map<String, String> config) {
     if (config == null) {
@@ -66,10 +77,16 @@ final class ReadBridge {
         int fieldId = Integer.parseInt(entry.getKey().substring(COLUMN_DEFAULT_PREFIX.length()));
         byFieldId.put(fieldId, MAPPER.readTree(entry.getValue()));
       } catch (RuntimeException | JsonProcessingException e) {
-        log.warn(
-            "Skipping unparseable read-bridge config entry {}={}",
-            entry.getKey(),
-            entry.getValue(),
+        // The server encoder stamps an int field-id and a JsonNode value that round-trips through
+        // readTree, so reaching here means an encoder bug or transport corruption, not an expected
+        // state. Fail loud so it is caught, rather than silently reading NULL.
+        throw new IllegalStateException(
+            "read-bridge: unusable "
+                + COLUMN_DEFAULT_PREFIX
+                + " entry "
+                + entry.getKey()
+                + "="
+                + entry.getValue(),
             e);
       }
     }

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/ReadBridge.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/ReadBridge.java
@@ -1,0 +1,78 @@
+package com.linkedin.openhouse.javaclient;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.iceberg.TableMetadata;
+
+/**
+ * Read-time bridge: overlays Iceberg V3 read semantics onto loaded metadata for tables/clients that
+ * don't yet carry them natively, using behavior the server delivers in the per-table {@code
+ * config}. Today it applies per-column initial-defaults; further V3 features can be backported
+ * through the same entry point as they are added.
+ *
+ * <p>Client end of the read-bridge wire contract — mirror of the server encoder {@code
+ * ReadBridgeConfigResolver} (services/tables). The contract is flat, namespaced config keys (no
+ * envelope/POJO): {@code openhouse.read-bridge.column-default.<fieldId> = <single-value-json>}.
+ *
+ * <p>Kept out of {@link OpenHouseTableOperations} so the read path stays slim. Pure and
+ * fail-closed: an entry with a non-integer field-id or an unparseable value is skipped, and nothing
+ * to apply returns {@code raw} unchanged.
+ */
+@Slf4j
+final class ReadBridge {
+
+  /** Mirror of {@code ReadBridgeConfigResolver.COLUMN_DEFAULT_PREFIX}. */
+  static final String COLUMN_DEFAULT_PREFIX = "openhouse.read-bridge.column-default.";
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private ReadBridge() {}
+
+  /**
+   * Applies the bridged read-time behavior the server stamped into {@code config} onto {@code raw},
+   * returning the transformed metadata (or {@code raw} when there is nothing to bridge).
+   */
+  static TableMetadata apply(TableMetadata raw, Map<String, String> config) {
+    Map<Integer, JsonNode> columnDefaults = columnDefaults(config);
+    if (columnDefaults.isEmpty()) {
+      return raw;
+    }
+    // TODO(read-bridge): overlay columnDefaults onto raw.schemas() via withSchemaOverlay; future V3
+    // features bridged from config are applied here too.
+    return raw;
+  }
+
+  /**
+   * Decodes {@code field-id -> initial-default} from the {@code
+   * openhouse.read-bridge.column-default.*} config entries; empty when there are none. Skips any
+   * entry with a non-integer field-id or an unparseable value (fail-closed). Package-visible for
+   * unit testing in isolation.
+   */
+  static Map<Integer, JsonNode> columnDefaults(Map<String, String> config) {
+    if (config == null) {
+      return Collections.emptyMap();
+    }
+    Map<Integer, JsonNode> byFieldId = new HashMap<>();
+    for (Map.Entry<String, String> entry : config.entrySet()) {
+      if (!entry.getKey().startsWith(COLUMN_DEFAULT_PREFIX)) {
+        continue;
+      }
+      try {
+        int fieldId = Integer.parseInt(entry.getKey().substring(COLUMN_DEFAULT_PREFIX.length()));
+        byFieldId.put(fieldId, MAPPER.readTree(entry.getValue()));
+      } catch (RuntimeException | JsonProcessingException e) {
+        log.warn(
+            "Skipping unparseable read-bridge config entry {}={}",
+            entry.getKey(),
+            entry.getValue(),
+            e);
+      }
+    }
+    return byFieldId;
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/ApiConfig.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/ApiConfig.java
@@ -2,6 +2,10 @@ package com.linkedin.openhouse.tables.api;
 
 import com.linkedin.openhouse.tables.api.handler.TablesApiHandler;
 import com.linkedin.openhouse.tables.api.handler.impl.OpenHouseTablesApiHandler;
+import com.linkedin.openhouse.tables.readbridge.ColumnDefaultsSource;
+import com.linkedin.openhouse.tables.readbridge.ReadBridgeConfigResolver;
+import java.util.Collections;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,5 +15,25 @@ public class ApiConfig {
   @Bean
   public TablesApiHandler tablesApiHandler() {
     return new OpenHouseTablesApiHandler();
+  }
+
+  /**
+   * Open-source default {@link ColumnDefaultsSource}: supplies none, so read-bridge stays inert.
+   */
+  @Bean
+  @ConditionalOnMissingBean(ColumnDefaultsSource.class)
+  public ColumnDefaultsSource columnDefaultsSource() {
+    return tableDto -> Collections.emptyMap();
+  }
+
+  /**
+   * Server-side encoder that stamps the read-bridge {@code config} from {@link
+   * ColumnDefaultsSource}.
+   */
+  @Bean
+  @ConditionalOnMissingBean(ReadBridgeConfigResolver.class)
+  public ReadBridgeConfigResolver readBridgeConfigResolver(
+      ColumnDefaultsSource columnDefaultsSource) {
+    return new ReadBridgeConfigResolver(columnDefaultsSource);
   }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/impl/OpenHouseTablesApiHandler.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/impl/OpenHouseTablesApiHandler.java
@@ -13,6 +13,7 @@ import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
 import com.linkedin.openhouse.tables.api.validator.TablesApiValidator;
 import com.linkedin.openhouse.tables.dto.mapper.TablesMapper;
 import com.linkedin.openhouse.tables.model.TableDto;
+import com.linkedin.openhouse.tables.readbridge.ReadBridgeConfigResolver;
 import com.linkedin.openhouse.tables.services.TablesService;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -35,15 +36,30 @@ public class OpenHouseTablesApiHandler implements TablesApiHandler {
 
   @Autowired private ClusterProperties clusterProperties;
 
+  @Autowired private ReadBridgeConfigResolver readBridgeConfigResolver;
+
+  /**
+   * Stamp the server-resolved, per-table client {@code config} (Iceberg REST {@code
+   * LoadTableResponse.config} convention) onto a freshly mapped response body. The mapper leaves
+   * {@code config} null; it is a request-time decision resolved here.
+   */
+  private GetTableResponseBody withConfig(
+      GetTableResponseBody body, String databaseId, String tableId, TableDto tableDto) {
+    return body.toBuilder()
+        .config(readBridgeConfigResolver.resolve(databaseId, tableId, tableDto))
+        .build();
+  }
+
   @Override
   public ApiResponse<GetTableResponseBody> getTable(
       String databaseId, String tableId, String actingPrincipal) {
     tablesApiValidator.validateGetTable(databaseId, tableId);
+    TableDto tableDto = tableService.getTable(databaseId, tableId, actingPrincipal);
     return ApiResponse.<GetTableResponseBody>builder()
         .httpStatus(HttpStatus.OK)
         .responseBody(
-            tablesMapper.toGetTableResponseBody(
-                tableService.getTable(databaseId, tableId, actingPrincipal)))
+            withConfig(
+                tablesMapper.toGetTableResponseBody(tableDto), databaseId, tableId, tableDto))
         .build();
   }
 
@@ -92,9 +108,15 @@ public class OpenHouseTablesApiHandler implements TablesApiHandler {
         clusterProperties.getClusterName(), databaseId, createUpdateTableRequestBody);
     Pair<TableDto, Boolean> putResult =
         tableService.putTable(createUpdateTableRequestBody, tableCreator, true);
+    TableDto tableDto = putResult.getFirst();
     return ApiResponse.<GetTableResponseBody>builder()
         .httpStatus(HttpStatus.CREATED)
-        .responseBody(tablesMapper.toGetTableResponseBody(putResult.getFirst()))
+        .responseBody(
+            withConfig(
+                tablesMapper.toGetTableResponseBody(tableDto),
+                databaseId,
+                tableDto.getTableId(),
+                tableDto))
         .build();
   }
 
@@ -109,9 +131,12 @@ public class OpenHouseTablesApiHandler implements TablesApiHandler {
     Pair<TableDto, Boolean> putResult =
         tableService.putTable(createUpdateTableRequestBody, tableCreatorUpdator, false);
     HttpStatus status = putResult.getSecond() ? HttpStatus.CREATED : HttpStatus.OK;
+    TableDto tableDto = putResult.getFirst();
     return ApiResponse.<GetTableResponseBody>builder()
         .httpStatus(status)
-        .responseBody(tablesMapper.toGetTableResponseBody(putResult.getFirst()))
+        .responseBody(
+            withConfig(
+                tablesMapper.toGetTableResponseBody(tableDto), databaseId, tableId, tableDto))
         .build();
   }
 

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/readbridge/ColumnDefaultsSource.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/readbridge/ColumnDefaultsSource.java
@@ -1,0 +1,25 @@
+package com.linkedin.openhouse.tables.readbridge;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.linkedin.openhouse.tables.model.TableDto;
+import java.util.Map;
+
+/**
+ * Pluggable input to the open-source {@code read-bridge} feature: the per-column initial-defaults
+ * to overlay at read time, keyed by Iceberg field-id and valued as Iceberg single-value JSON.
+ *
+ * <p>This is the only part of read-bridge a deployment supplies. The open-source default (see
+ * {@code ApiConfig}) returns nothing, so the feature is wired but inert until a deployment
+ * overrides this bean (e.g. li-openhouse derives the defaults from the {@code avro.schema.literal}
+ * table property).
+ *
+ * <p>Called on every table-load/commit response, so implementations must be cheap and must never
+ * throw — an empty map means "no bridge for this table".
+ */
+public interface ColumnDefaultsSource {
+  /**
+   * @param tableDto the already-loaded table state (no extra fetch needed)
+   * @return field-id -&gt; initial-default as Iceberg single-value JSON; empty/{@code null} = none
+   */
+  Map<Integer, JsonNode> defaults(TableDto tableDto);
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/readbridge/ColumnDefaultsSource.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/readbridge/ColumnDefaultsSource.java
@@ -13,8 +13,12 @@ import java.util.Map;
  * overrides this bean (e.g. li-openhouse derives the defaults from the {@code avro.schema.literal}
  * table property).
  *
- * <p>Called on every table-load/commit response, so implementations must be cheap and must never
- * throw — an empty map means "no bridge for this table".
+ * <p>Called on every table-load/commit response, so implementations must be cheap. An empty map
+ * means "nothing to bridge for this table" — no default is declared, or a declared default is of a
+ * kind this source does not support; either way the column keeps reading {@code NULL} as it does
+ * today. Throw instead when a default <em>is</em> declared but cannot be honored (e.g. it does not
+ * bind to its column's type): degrading there would leave the column reading {@code NULL} while the
+ * table claims to be bridged, hiding a real defect.
  */
 public interface ColumnDefaultsSource {
   /**

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/readbridge/ReadBridgeConfigResolver.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/readbridge/ReadBridgeConfigResolver.java
@@ -1,0 +1,47 @@
+package com.linkedin.openhouse.tables.readbridge;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.linkedin.openhouse.tables.model.TableDto;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Open-source encoder for the {@code read-bridge} feature: it asks the pluggable {@link
+ * ColumnDefaultsSource} for a table's column initial-defaults and stamps each as a namespaced entry
+ * in the per-table {@code config} — {@code openhouse.read-bridge.column-default.<fieldId> =
+ * <single-value-json>}. The client decoder ({@code ReadBridge} in {@code openhouse-java-runtime})
+ * reads these entries and overlays the defaults at metadata-load time.
+ *
+ * <p>No envelope/POJO: the flat config map (Iceberg REST {@code LoadTableResponse.config}
+ * convention) carries the structure directly. Behaviorless by default — the open-source {@link
+ * ColumnDefaultsSource} bean supplies nothing (see {@code ApiConfig}), so no entries are stamped. A
+ * deployment delivers the bridge by overriding only {@link ColumnDefaultsSource}.
+ *
+ * <p><b>Mirror:</b> {@link #COLUMN_DEFAULT_PREFIX} is the shared contract with the client decoder;
+ * keep it in sync. Further V3 features ride the same {@code openhouse.read-bridge.*} namespace as
+ * additional keys.
+ */
+public class ReadBridgeConfigResolver {
+
+  /** Config key prefix for a per-column read-time default; suffixed with the Iceberg field-id. */
+  public static final String COLUMN_DEFAULT_PREFIX = "openhouse.read-bridge.column-default.";
+
+  private final ColumnDefaultsSource columnDefaultsSource;
+
+  public ReadBridgeConfigResolver(ColumnDefaultsSource columnDefaultsSource) {
+    this.columnDefaultsSource = columnDefaultsSource;
+  }
+
+  public Map<String, String> resolve(String databaseId, String tableId, TableDto tableDto) {
+    Map<Integer, JsonNode> columnDefaults = columnDefaultsSource.defaults(tableDto);
+    if (columnDefaults == null || columnDefaults.isEmpty()) {
+      return Collections.emptyMap(); // nothing to bridge -> stamp nothing
+    }
+    Map<String, String> config = new HashMap<>();
+    // JsonNode.toString() is the single-value JSON (e.g. "US" -> "\"US\"", 0 -> "0").
+    columnDefaults.forEach(
+        (fieldId, value) -> config.put(COLUMN_DEFAULT_PREFIX + fieldId, value.toString()));
+    return config;
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/readbridge/ReadBridgeConfigResolverTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/readbridge/ReadBridgeConfigResolverTest.java
@@ -1,0 +1,114 @@
+package com.linkedin.openhouse.tables.readbridge;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.linkedin.openhouse.common.api.spec.ApiResponse;
+import com.linkedin.openhouse.tables.api.handler.impl.OpenHouseTablesApiHandler;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
+import com.linkedin.openhouse.tables.api.validator.TablesApiValidator;
+import com.linkedin.openhouse.tables.dto.mapper.TablesMapper;
+import com.linkedin.openhouse.tables.model.TableDto;
+import com.linkedin.openhouse.tables.services.TablesService;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class ReadBridgeConfigResolverTest {
+
+  /** Open-source default source: supplies nothing, so the feature is inert. */
+  private static final ColumnDefaultsSource NONE = tableDto -> Collections.emptyMap();
+
+  private static final String PREFIX = ReadBridgeConfigResolver.COLUMN_DEFAULT_PREFIX;
+
+  @Test
+  public void testEmptyWhenNoColumnDefaults() {
+    Assertions.assertTrue(
+        new ReadBridgeConfigResolver(NONE).resolve("db", "tbl", mock(TableDto.class)).isEmpty());
+  }
+
+  @Test
+  public void testStampsColumnDefaultEntry() {
+    ColumnDefaultsSource source = tableDto -> Collections.singletonMap(5, TextNode.valueOf("US"));
+    Map<String, String> config =
+        new ReadBridgeConfigResolver(source).resolve("db", "tbl", mock(TableDto.class));
+    // value is the single-value JSON for the default ("US" -> "\"US\"").
+    Assertions.assertEquals("\"US\"", config.get(PREFIX + "5"));
+  }
+
+  @Test
+  public void testStampsAllColumnDefaultsAsSeparateEntries() {
+    ColumnDefaultsSource source =
+        tableDto -> {
+          Map<Integer, JsonNode> defaults = new LinkedHashMap<>();
+          defaults.put(5, TextNode.valueOf("US"));
+          defaults.put(7, IntNode.valueOf(0));
+          return defaults;
+        };
+    Map<String, String> config =
+        new ReadBridgeConfigResolver(source).resolve("db", "tbl", mock(TableDto.class));
+    Assertions.assertEquals(2, config.size());
+    Assertions.assertEquals("\"US\"", config.get(PREFIX + "5"));
+    Assertions.assertEquals("0", config.get(PREFIX + "7"));
+  }
+
+  /** getTable stamps the resolver's config onto the response body. */
+  @Test
+  public void testGetTableStampsResolvedConfig() {
+    TablesService tableService = mock(TablesService.class);
+    TablesMapper tablesMapper = mock(TablesMapper.class);
+    ReadBridgeConfigResolver resolver = mock(ReadBridgeConfigResolver.class);
+
+    TableDto tableDto = mock(TableDto.class);
+    when(tableService.getTable("db", "tbl", "principal")).thenReturn(tableDto);
+    when(tablesMapper.toGetTableResponseBody(tableDto))
+        .thenReturn(GetTableResponseBody.builder().tableId("tbl").databaseId("db").build());
+
+    Map<String, String> resolved = Collections.singletonMap(PREFIX + "5", "\"US\"");
+    when(resolver.resolve(eq("db"), eq("tbl"), eq(tableDto))).thenReturn(resolved);
+
+    OpenHouseTablesApiHandler handler = handlerWith(tableService, tablesMapper, resolver);
+
+    ApiResponse<GetTableResponseBody> response = handler.getTable("db", "tbl", "principal");
+
+    Assertions.assertSame(resolved, response.getResponseBody().getConfig());
+  }
+
+  /** With the behaviorless open-source source wired in, getTable leaves config empty. */
+  @Test
+  public void testGetTableLeavesConfigEmptyWithNoColumnDefaults() {
+    TablesService tableService = mock(TablesService.class);
+    TablesMapper tablesMapper = mock(TablesMapper.class);
+
+    TableDto tableDto = mock(TableDto.class);
+    when(tableService.getTable(anyString(), anyString(), anyString())).thenReturn(tableDto);
+    when(tablesMapper.toGetTableResponseBody(any()))
+        .thenReturn(GetTableResponseBody.builder().tableId("tbl").databaseId("db").build());
+
+    OpenHouseTablesApiHandler handler =
+        handlerWith(tableService, tablesMapper, new ReadBridgeConfigResolver(NONE));
+
+    ApiResponse<GetTableResponseBody> response = handler.getTable("db", "tbl", "principal");
+
+    Assertions.assertTrue(response.getResponseBody().getConfig().isEmpty());
+  }
+
+  private OpenHouseTablesApiHandler handlerWith(
+      TablesService tableService, TablesMapper tablesMapper, ReadBridgeConfigResolver resolver) {
+    OpenHouseTablesApiHandler handler = new OpenHouseTablesApiHandler();
+    ReflectionTestUtils.setField(handler, "tablesApiValidator", mock(TablesApiValidator.class));
+    ReflectionTestUtils.setField(handler, "tableService", tableService);
+    ReflectionTestUtils.setField(handler, "tablesMapper", tablesMapper);
+    ReflectionTestUtils.setField(handler, "readBridgeConfigResolver", resolver);
+    return handler;
+  }
+}


### PR DESCRIPTION
## Summary
Adds the open-source read-bridge feature on top of the per-table `config` channel (#644): the OH server stamps per-column initial-defaults onto `GetTableResponseBody.config`, and the Java client overlays them at metadata-load time so a column added after data exists reads its declared default instead of NULL (a v2→v3 read-time bridge).

The whole feature is open source; it exposes exactly **one** deployment seam:
- **`ColumnDefaultsSource`** (interface) — the single open-source/closed-source line: `field-id -> Iceberg single-value JSON`. The open-source default is a no-op lambda in `ApiConfig`; a deployment overrides this bean (li-openhouse derives values from `avro.schema.literal`).
- **`ReadBridgeConfigResolver`** (server) — stamps each default as a flat, namespaced config entry: `openhouse.read-bridge.column-default.<fieldId> = <single-value-json>`. No envelope/POJO — the REST `config` string map carries the structure directly.
- **`ReadBridge`** (client) — decodes those entries and applies the read-time overlay in `OpenHouseTableOperations.loadMetadata` (the `withInitialDefault`/`withSchemaOverlay` transform is a marked TODO). `loadMetadata` stays one delegating call.

## Scope (engines)
- **Spark 3.1 (iceberg-1.2) and Spark 3.5 (iceberg-1.5): both covered by this PR.** The client code lives under `integrations/java/iceberg-1.2/openhouse-java-runtime`, but it is not 1.2-only: the 1.5 runtime compiles the same source, because its `build.gradle` adds the 1.2 module's source dirs to its own sourceSet (`srcDirs += project(':integrations:java:iceberg-1.2:openhouse-java-runtime').sourceSets.main.java.srcDirs`). So `ReadBridge` and the `loadMetadata` hook are built into both runtimes, and there is no separate 1.5 port. Neither line applies Iceberg v3 `initial-default` natively, so both need the bridge.
- **Flink: separate follow-up PR** (if/when a Flink read path needs the overlay).

## Stack
#644 (config channel, merged) → **#645 (read-bridge mechanism)** → [li-openhouse #2204](https://github.com/linkedin-multiproduct/li-openhouse/pull/2204) (the `ColumnDefaultsSource` seam) → [li-openhouse #2203](https://github.com/linkedin-multiproduct/li-openhouse/pull/2203) (derive the defaults from `avro.schema.literal`)

Rebased onto `main` now that #644 has merged, so the diff is the read-bridge change only.

## Next steps (this PR)
- [ ] **Bump the linkedin/iceberg forks so the overlay APIs exist on both lines.** Verified with `javap` against the pinned jars: `TableMetadata.withSchemaOverlay` is absent from `1.2.0.19`, and `1.5.2.15` has neither `withSchemaOverlay` nor `NestedField.initialDefault` (the backport #642 brought to the 1.2 line). Nothing in this PR uses them — the decode path is only Jackson + `TableMetadata` — but `ReadBridge.apply` cannot be implemented until they land.
- [ ] Implement the overlay in `ReadBridge.apply`. It must cover **every** schema-id in `schemasById` that carries a bridged field-id, not just the current schema: Iceberg resolves a scan's schema from the snapshot's own `schemaId` (`SnapshotUtil.schemaFor`), so time-travel, tag, and non-main-branch reads would otherwise return NULL while latest reads return the default. `withSchemaOverlay` takes a multi-schema map for exactly this.

## Testing Done
- `:services:tables` + iceberg-1.2 runtime compile (JDK 17), and repo-wide `spotlessCheck` green.
- `ReadBridgeConfigResolverTest` (server): each default round-trips as a flat `openhouse.read-bridge.column-default.<fieldId>` entry; empty when the source supplies nothing.
- `ReadBridgeTest` (client): decodes the flat entries by field-id; **fails loud** (`IllegalStateException`, with the offending `key=value`) on a malformed *known* `column-default.*` entry, since the server encoder guarantees an int field-id and a value that round-trips through `readTree` — so a decode failure is an encoder bug or transport corruption, not an expected input. *Unknown* keys are ignored, preserving forward compatibility.
- `OpenHouseTableOperationsTest`: config capture and deserialization.