### PR TITLE
Surgical scheduler logs for jobs observability (phase 1.5)

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/JobsScheduler.java
@@ -265,6 +265,19 @@ public class JobsScheduler {
                   }
                   log.info("Shutdown hook completed.");
                 }));
+    log.info(
+        "OH_SCHED_START job_type={} numParallelJobs={} tasksWaitHours={} numJobsSubmitter={} "
+            + "numJobsPoller={} taskPollIntervalMs={} taskQueuedTimeoutMs={} taskTimeoutMs={} "
+            + "multiOperationMode={}",
+        operationType.getValue(),
+        getNumParallelJobs(cmdLine),
+        getTasksWaitHours(cmdLine),
+        getNumJobsSubmitter(cmdLine),
+        getNumJobsPoller(cmdLine),
+        getTaskPollIntervalMs(cmdLine),
+        getTaskQueuedTimeoutMs(cmdLine),
+        getTaskTimeoutMs(cmdLine),
+        isMultiOperationMode(cmdLine));
     app.run(
         operationType,
         operationTaskCls.toString(),

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTask.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTask.java
@@ -170,16 +170,24 @@ public abstract class OperationTask<T extends Metadata> implements Callable<Opti
 
   protected Optional<JobState> pollJobStatus(Attributes typeAttributes) {
     long startTime = System.currentTimeMillis();
+    Optional<JobState> lastObservedState = Optional.empty();
     try {
       Optional<JobState> jobState;
       do {
         jobState = jobsClient.getState(jobId);
+        lastObservedState = jobState;
         long elapsedTime = System.currentTimeMillis() - startTime;
         // Exit status check if a job is queued for more than queuedTimeoutMs.
         if (elapsedTime > queuedTimeoutMs) {
           if (jobState.isPresent() && jobState.get().equals(JobState.QUEUED)) {
+            String executionId =
+                jobsClient.getJob(jobId).map(JobResponseBody::getExecutionId).orElse(null);
             log.info(
-                "Exiting status check for {} for {} due to queued timeout", getType(), metadata);
+                "Exiting status check for {} for {} due to queued timeout lastObservedState={} executionId={}",
+                getType(),
+                metadata,
+                lastObservedState.orElse(null),
+                executionId);
             break;
           }
         }

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/scheduler/tasks/OperationTasksBuilder.java
@@ -442,6 +442,10 @@ public class OperationTasksBuilder {
             () -> {
               operationTaskManager.updateDataGenerationCompletion();
               log.info(
+                  "OH_SCHED_ELIGIBLE job_type={} count={}",
+                  jobType,
+                  operationTaskManager.getTotalDataCount());
+              log.info(
                   "The metadata fetched count: {} for the job type: {}",
                   operationTaskManager.getTotalDataCount(),
                   jobType);
@@ -486,6 +490,10 @@ public class OperationTasksBuilder {
             () -> {
               operationTaskManager.updateDataGenerationCompletion();
               log.info(
+                  "OH_SCHED_ELIGIBLE job_type={} count={}",
+                  jobType,
+                  operationTaskManager.getTotalDataCount());
+              log.info(
                   "The metadata fetched count: {} for the job type: {}",
                   operationTaskManager.getTotalDataCount(),
                   jobType);
@@ -516,6 +524,10 @@ public class OperationTasksBuilder {
         .doAfterTerminate(
             () -> {
               operationTaskManager.updateDataGenerationCompletion();
+              log.info(
+                  "OH_SCHED_ELIGIBLE job_type={} count={}",
+                  jobType,
+                  operationTaskManager.getTotalDataCount());
               log.info(
                   "The metadata fetched count: {} for the job type: {}",
                   operationTaskManager.getTotalDataCount(),


### PR DESCRIPTION
## Summary
Phase 1.5 only from `jobs-observability-plan.md` §10 — localized log lines, no new classes or entry-point changes:

- **`OH_SCHED_START`** in `JobsScheduler.main`: echoes `numParallelJobs`, poller/submitter counts, poll/timeout settings (replaces brittle `values.yaml case()` for cap/deadline KQL).
- **`OH_SCHED_ELIGIBLE`** in `OperationTasksBuilder`: stable eligible-count token alongside existing `metadata fetched count` log.
- **Queued-timeout poll exit** in `OperationTask`: appends `lastObservedState` + `executionId` to distinguish genuine GGW queue timeout vs poll-lag give-up on terminal jobs.

~35 lines across 3 files. Phase 2 (OTEL gauges, heartbeat sampler, DLQ counters) intentionally deferred.

## Test plan
- [x] Compiles; no test signature changes
- [ ] Post OSS→LI bump: grep cron pod logs for `OH_SCHED_START`, `OH_SCHED_ELIGIBLE`, `lastObservedState=` on queued-timeout lines