### PR TITLE
Paginate HTS list-tables queries to avoid WebClient buffer limit

### DIFF
--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -21,10 +21,11 @@ import com.linkedin.openhouse.internal.catalog.repository.exception.HouseTableCo
 import com.linkedin.openhouse.internal.catalog.repository.exception.HouseTableNotFoundException;
 import com.linkedin.openhouse.internal.catalog.repository.exception.HouseTableRepositoryException;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.BaseMetastoreCatalog;
@@ -40,6 +41,7 @@ import org.apache.iceberg.io.SupportsPrefixOperations;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
@@ -98,19 +100,44 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
     throw new UnsupportedOperationException("Location will be provided explicitly");
   }
 
+  // Page size used when internally paginating HTS "list all" queries so that a single HTS
+  // response never grows large enough to exceed the WebClient's in-memory buffer limit
+  // (previously observed as DataBufferLimitException for databases with very many tables).
+  private static final int LIST_TABLES_HTS_PAGE_SIZE = 1000;
+
   @Override
   public List<TableIdentifier> listTables(Namespace namespace) {
     NamespaceUtil.validateOperationNamespace(namespace);
     // TODO: Implement SupportsNamespace interface and listNamespaces() method to remove this
     //  branch. This is anti-pattern and only a temporary solution.
     if (namespace.isEmpty()) {
-      return StreamSupport.stream(houseTableRepository.findAll().spliterator(), false)
+      return fetchAllPages(houseTableRepository::findAll).stream()
           .map(houseTable -> TableIdentifier.of(houseTable.getDatabaseId(), "Unused"))
           .collect(Collectors.toList());
     }
-    return houseTableRepository.findAllByDatabaseId(namespace.toString()).stream()
+    return fetchAllPages(
+            pageable -> houseTableRepository.findAllByDatabaseId(namespace.toString(), pageable))
+        .stream()
         .map(houseTable -> TableIdentifier.of(houseTable.getDatabaseId(), houseTable.getTableId()))
         .collect(Collectors.toList());
+  }
+
+  /**
+   * Repeatedly issues the given paginated HTS query, accumulating every page in memory, until all
+   * results have been retrieved. Used to service the unbounded "list all" catalog APIs on top of
+   * HTS's paginated endpoints, so that no single underlying HTTP response can grow large enough to
+   * exceed the WebClient in-memory buffer limit.
+   */
+  private List<HouseTable> fetchAllPages(Function<Pageable, Page<HouseTable>> pageFetcher) {
+    List<HouseTable> results = new ArrayList<>();
+    Pageable pageable = PageRequest.of(0, LIST_TABLES_HTS_PAGE_SIZE);
+    Page<HouseTable> page;
+    do {
+      page = pageFetcher.apply(pageable);
+      results.addAll(page.getContent());
+      pageable = pageable.next();
+    } while (page.hasNext());
+    return results;
   }
 
   public Page<TableIdentifier> listTables(Namespace namespace, Pageable pageable) {

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalogTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalogTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
@@ -13,13 +14,21 @@ import com.linkedin.openhouse.internal.catalog.model.HouseTable;
 import com.linkedin.openhouse.internal.catalog.model.HouseTablePrimaryKey;
 import com.linkedin.openhouse.internal.catalog.repository.HouseTableRepository;
 import com.linkedin.openhouse.internal.catalog.repository.exception.HouseTableNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.SupportsPrefixOperations;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 public class OpenHouseInternalCatalogTest {
 
@@ -39,6 +48,94 @@ public class OpenHouseInternalCatalogTest {
     Assertions.assertTrue(catalog.isValidBaseIdentifier(TableIdentifier.of("db", "partitions")));
     Assertions.assertFalse(
         catalog.isValidBaseIdentifier(TableIdentifier.of("db", "table", "partitions")));
+  }
+
+  @Test
+  void listTablesForDatabaseAggregatesResultsFromASinglePage() {
+    List<HouseTable> allRows =
+        List.of(houseTableRow(DB, "t0"), houseTableRow(DB, "t1"), houseTableRow(DB, "t2"));
+    HouseTableRepository repo = mock(HouseTableRepository.class);
+    when(repo.findAllByDatabaseId(eq(DB), any(Pageable.class)))
+        .thenAnswer(invocation -> slicedPage(allRows, invocation.getArgument(1)));
+    OpenHouseInternalCatalog catalog = new OpenHouseInternalCatalog();
+    catalog.houseTableRepository = repo;
+
+    List<TableIdentifier> result = catalog.listTables(Namespace.of(DB));
+
+    Assertions.assertEquals(
+        allRows.stream()
+            .map(row -> TableIdentifier.of(row.getDatabaseId(), row.getTableId()))
+            .collect(Collectors.toList()),
+        result);
+    // All 3 rows fit within a single HTS page (page size 1000), so only one call is expected.
+    verify(repo, times(1)).findAllByDatabaseId(eq(DB), any(Pageable.class));
+  }
+
+  @Test
+  void listTablesForDatabasePaginatesAcrossMultipleHtsPages() {
+    // More rows than fit on a single HTS page (page size 1000) so the fix's pagination loop must
+    // issue more than one call and aggregate every page before returning.
+    List<HouseTable> allRows =
+        IntStream.range(0, 1500)
+            .mapToObj(i -> houseTableRow(DB, "t" + i))
+            .collect(Collectors.toList());
+    HouseTableRepository repo = mock(HouseTableRepository.class);
+    when(repo.findAllByDatabaseId(eq(DB), any(Pageable.class)))
+        .thenAnswer(invocation -> slicedPage(allRows, invocation.getArgument(1)));
+    OpenHouseInternalCatalog catalog = new OpenHouseInternalCatalog();
+    catalog.houseTableRepository = repo;
+
+    List<TableIdentifier> result = catalog.listTables(Namespace.of(DB));
+
+    Assertions.assertEquals(
+        allRows.stream()
+            .map(row -> TableIdentifier.of(row.getDatabaseId(), row.getTableId()))
+            .collect(Collectors.toList()),
+        result);
+    verify(repo, times(2)).findAllByDatabaseId(eq(DB), any(Pageable.class));
+  }
+
+  @Test
+  void listTablesForDatabaseReturnsEmptyListWhenDatabaseHasNoTables() {
+    HouseTableRepository repo = mock(HouseTableRepository.class);
+    when(repo.findAllByDatabaseId(eq(DB), any(Pageable.class)))
+        .thenAnswer(invocation -> slicedPage(List.of(), invocation.getArgument(1)));
+    OpenHouseInternalCatalog catalog = new OpenHouseInternalCatalog();
+    catalog.houseTableRepository = repo;
+
+    Assertions.assertTrue(catalog.listTables(Namespace.of(DB)).isEmpty());
+    verify(repo, times(1)).findAllByDatabaseId(eq(DB), any(Pageable.class));
+  }
+
+  @Test
+  void listTablesForEmptyNamespacePaginatesThroughFindAll() {
+    List<HouseTable> allRows = List.of(houseTableRow(DB, "t0"), houseTableRow("other_db", "t1"));
+    HouseTableRepository repo = mock(HouseTableRepository.class);
+    when(repo.findAll(any(Pageable.class)))
+        .thenAnswer(invocation -> slicedPage(allRows, invocation.getArgument(0)));
+    OpenHouseInternalCatalog catalog = new OpenHouseInternalCatalog();
+    catalog.houseTableRepository = repo;
+
+    List<TableIdentifier> result = catalog.listTables(Namespace.empty());
+
+    Assertions.assertEquals(
+        List.of(TableIdentifier.of(DB, "Unused"), TableIdentifier.of("other_db", "Unused")),
+        result);
+  }
+
+  private static HouseTable houseTableRow(String databaseId, String tableId) {
+    return HouseTable.builder().databaseId(databaseId).tableId(tableId).build();
+  }
+
+  /**
+   * Slices {@code allRows} according to {@code pageable}'s offset/page size, mirroring how a real
+   * paginated HTS response would be constructed, so {@link PageImpl#hasNext()} reports correctly
+   * and the catalog's pagination loop can be exercised end-to-end.
+   */
+  private static Page<HouseTable> slicedPage(List<HouseTable> allRows, Pageable pageable) {
+    int start = Math.min((int) pageable.getOffset(), allRows.size());
+    int end = Math.min(start + pageable.getPageSize(), allRows.size());
+    return new PageImpl<>(new ArrayList<>(allRows.subList(start, end)), pageable, allRows.size());
   }
 
   @Test


### PR DESCRIPTION
# Problem & Solution Overview
`OpenHouseInternalCatalog#listTables(Namespace)` issued a single unpaginated HTS query (`findAllByDatabaseId` / `findAll`) to list every table in a database. For databases with a large number of tables, the serialized HTS response can exceed the WebClient in-memory buffer limit configured in `MainApplicationConfig`, causing a `DataBufferLimitException` that surfaces to callers as an HTTP 500 on `GET /tables?databaseId=...`.

This was observed in production for a database that grew past ~30k active tables — the per-table JSON payload (dominated by `metadataLocation` path length) pushed the total response size over the (then 20MB) ceiling.

**Relationship to #649**: #649 bumped the buffer limit 20MB -> 40MB as a stopgap mitigation, explicitly noting in its description that this is temporary and the durable fix is to paginate this call path. This PR is that durable fix: `listTables(Namespace)` now internally pages through HTS using the already-existing paginated repository methods (`findAll(Pageable)` / `findAllByDatabaseId(databaseId, Pageable)`, page size 1000), accumulating all pages before returning. This bounds every individual HTTP response regardless of how many tables a database has -- independent of whatever the buffer ceiling is set to -- while preserving the existing `List<TableIdentifier>` return type and behavior of the unpaginated API.

# Testing Done
- `./gradlew :iceberg:openhouse:internalcatalog:compileJava :services:tables:compileJava` — compiles cleanly.
- `./gradlew :iceberg:openhouse:internalcatalog:test` — all tests pass (11/11 in `OpenHouseInternalCatalogTest`, including 4 new tests covering single-page, multi-page, empty-database, and empty-namespace pagination paths), no regressions.
- **End-to-end local repro against the real code path**, run via Docker Compose (`infra/recipes/docker-compose/oh-only`, Tables Service + HouseTables Service, H2 in-memory DB):
  1. Built `services:tables`/`services:housetables` jars from this branch and rebuilt the Docker images (Dockerfiles copy prebuilt jars, so this step is required to pick up code changes).
  2. Seeded 55,000 synthetic `UserTable` rows into a single database directly via the HTS `PUT /hts/tables` API (bypassing full Iceberg table creation), with realistic `metadataLocation` path lengths.
  3. Called `POST /v1/databases/{databaseId}/tables/search` (`TablesController.searchTables` -> `OpenHouseInternalCatalog.listTables`) against the **pre-fix** jars first: reproduced the exact production failure, `DataBufferLimitException: Exceeded limit on max bytes to buffer : 20971520`.
  4. Re-ran the identical request against the **post-fix** jars: `HTTP 200`, all 55,000 results returned (18.3MB response, aggregated internally over 55 paginated HTS calls of 1000 rows each) -- confirming the fix resolves the failure regardless of buffer size.
- Risk: low — change is isolated to internal list-tables aggregation logic; public method signature and semantics are unchanged.