### PR TITLE
Reject CREATE OR REPLACE (RTAS) on a locked table

### DIFF
--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/IcebergSnapshotsServiceImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/IcebergSnapshotsServiceImpl.java
@@ -65,19 +65,23 @@ public class IcebergSnapshotsServiceImpl implements IcebergSnapshotsService {
                         .build()),
             icebergSnapshotRequestBody);
 
-    if (tableDto.isPresent()
-        && icebergSnapshotRequestBody.getCreateUpdateTableRequestBody().isReplaceCommit()) {
-      // Check if table creator has the privilege to replace the table.
-      authorizationUtils.checkReplaceTablePrivilege(tableDto.get(), tableCreatorUpdater);
-    } else if (tableDto.isPresent()) {
+    if (tableDto.isPresent()) {
+      // A locked table must reject every write, including CREATE OR REPLACE (RTAS). The lock is
+      // checked here — before the replace-vs-update split — so the replace path can no longer
+      // bypass it and silently overwrite a locked table.
       if (isTableLocked(tableDto.get())) {
         throw new UnsupportedClientOperationException(
             UnsupportedClientOperationException.Operation.LOCKED_TABLE_OPERATION,
             String.format(
                 "Table %s.%s is in locked state and cannot be written to", databaseId, tableId));
       }
-      authorizationUtils.checkTableWritePathPrivileges(
-          tableDto.get(), tableCreatorUpdater, Privileges.UPDATE_TABLE_METADATA);
+      if (icebergSnapshotRequestBody.getCreateUpdateTableRequestBody().isReplaceCommit()) {
+        // Check if table creator has the privilege to replace the table.
+        authorizationUtils.checkReplaceTablePrivilege(tableDto.get(), tableCreatorUpdater);
+      } else {
+        authorizationUtils.checkTableWritePathPrivileges(
+            tableDto.get(), tableCreatorUpdater, Privileges.UPDATE_TABLE_METADATA);
+      }
     } else {
       authorizationUtils.checkDatabasePrivilege(
           databaseId, tableCreatorUpdater, Privileges.CREATE_TABLE);

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/SnapshotsControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/SnapshotsControllerTest.java
@@ -14,6 +14,7 @@ import com.linkedin.openhouse.cluster.storage.StorageManager;
 import com.linkedin.openhouse.cluster.storage.local.LocalStorage;
 import com.linkedin.openhouse.common.test.cluster.PropertyOverrideContextInitializer;
 import com.linkedin.openhouse.internal.catalog.CatalogConstants;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateLockRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.IcebergSnapshotsRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
@@ -50,10 +51,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 /** A dedicated test classes of e2e controller tests for Snapshot API. */
 @SpringBootTest
@@ -386,6 +389,87 @@ public class SnapshotsControllerTest {
     // Step 3: Verify the table is overwritten with new schema, partition spec, properties, and
     // snapshots
     putSnapshotsAndValidateResponse(catalog, mvc, replaceCommitRequest, false);
+  }
+
+  @ParameterizedTest
+  @MethodSource("responseBodyFeeder")
+  public void testReplaceCommitRejectedOnLockedTable(GetTableResponseBody getTableResponseBody)
+      throws Exception {
+    // Regression guard (integration): a CREATE OR REPLACE (RTAS) against a locked table must be
+    // rejected with 400, just like a normal write. Previously the replace path bypassed the lock.
+
+    // Enable RTAS
+    Map<String, String> propsWithRtas = new HashMap<>(getTableResponseBody.getTableProperties());
+    propsWithRtas.put(CatalogConstants.RTAS_ENABLED_TABLE_PROP, "true");
+    getTableResponseBody =
+        getTableResponseBody.toBuilder().tableProperties(propsWithRtas).policies(null).build();
+
+    // Step 1: create the table
+    MvcResult createResult =
+        RequestAndValidateHelper.createTableAndValidateResponse(
+            getTableResponseBody, mvc, storageManager);
+    GetTableResponseBody getResponseBody = buildGetTableResponseBody(createResult);
+
+    // Step 2: lock the table via REST
+    mvc.perform(
+            MockMvcRequestBuilders.post(
+                    String.format(
+                        CURRENT_MAJOR_VERSION_PREFIX + "/databases/%s/tables/%s/lock",
+                        getResponseBody.getDatabaseId(),
+                        getResponseBody.getTableId()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    CreateUpdateLockRequestBody.builder()
+                        .locked(true)
+                        .message("setting lock")
+                        .build()
+                        .toJson())
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isCreated());
+
+    // Step 3: build a replace commit (RTAS) with a new snapshot
+    String currentTableLocation =
+        RequestAndValidateHelper.getCurrentTableLocation(
+            mvc, getResponseBody.getDatabaseId(), getResponseBody.getTableId());
+    Table table =
+        catalog.loadTable(
+            TableIdentifier.of(getResponseBody.getDatabaseId(), getResponseBody.getTableId()));
+    String dataFilePath =
+        storageManager.getDefaultStorage().getClient().getRootPrefix() + "/data_locked_replace.orc";
+    DataFile newDataFile =
+        createDummyDataFile(dataFilePath, getPartitionSpec(getTableResponseBody));
+    Snapshot newSnapshot = table.newAppend().appendFile(newDataFile).apply();
+    List<String> jsonSnapshots = Collections.singletonList(SnapshotParser.toJson(newSnapshot));
+    Map<String, String> snapshotRefs =
+        obtainSnapshotRefsFromSnapshot(SnapshotParser.toJson(newSnapshot));
+
+    CreateUpdateTableRequestBody replaceRequestBody =
+        buildCreateUpdateTableRequestBody(getResponseBody)
+            .toBuilder()
+            .baseTableVersion(currentTableLocation)
+            .replaceCommit(true)
+            .build();
+    IcebergSnapshotsRequestBody replaceCommitRequest =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion(currentTableLocation)
+            .createUpdateTableRequestBody(replaceRequestBody)
+            .jsonSnapshots(jsonSnapshots)
+            .snapshotRefs(snapshotRefs)
+            .build();
+
+    // Step 4: the RTAS must be rejected because the table is locked.
+    mvc.perform(
+            MockMvcRequestBuilders.put(
+                    String.format(
+                        CURRENT_MAJOR_VERSION_PREFIX
+                            + "/databases/%s/tables/%s/iceberg/v2/snapshots",
+                        getResponseBody.getDatabaseId(),
+                        getResponseBody.getTableId()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(replaceCommitRequest.toJson())
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message", containsString("locked state")));
   }
 
   @AfterEach

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/service/IcebergSnapshotsServiceTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/service/IcebergSnapshotsServiceTest.java
@@ -197,6 +197,46 @@ public class IcebergSnapshotsServiceTest {
         () -> service.putIcebergSnapshots(dbId, tableId, requestBody, null));
   }
 
+  @Test
+  public void testReplaceCommitOnLockedTableThrowsException() {
+    // A CREATE OR REPLACE (RTAS) against a locked table must be rejected just like a normal write.
+    // Regression guard for the gap where the replace-commit path bypassed the table lock and could
+    // silently overwrite a locked table.
+    final IcebergSnapshotsRequestBody base = TEST_ICEBERG_SNAPSHOTS_REQUEST_BODY_FOR_LOCKED;
+    final IcebergSnapshotsRequestBody requestBody =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion(base.getBaseTableVersion())
+            .jsonSnapshots(base.getJsonSnapshots())
+            .snapshotRefs(base.getSnapshotRefs())
+            .createUpdateTableRequestBody(
+                base.getCreateUpdateTableRequestBody().toBuilder().replaceCommit(true).build())
+            .build();
+    final String dbId = requestBody.getCreateUpdateTableRequestBody().getDatabaseId();
+    final String tableId = requestBody.getCreateUpdateTableRequestBody().getTableId();
+    final TableDtoPrimaryKey key =
+        TableDtoPrimaryKey.builder().databaseId(dbId).tableId(tableId).build();
+    final TableDto tableDto =
+        tablesMapper.toTableDto(
+            TableDto.builder()
+                .clusterId(requestBody.getCreateUpdateTableRequestBody().getClusterId())
+                .databaseId(dbId)
+                .tableId(tableId)
+                .tableLocation(requestBody.getBaseTableVersion())
+                .policies(
+                    Policies.builder().lockState(LockState.builder().locked(true).build()).build())
+                .tableCreator(TEST_TABLE_CREATOR)
+                .build(),
+            requestBody);
+    Mockito.when(tableUUIDGenerator.generateUUID(Mockito.any(IcebergSnapshotsRequestBody.class)))
+        .thenReturn(UUID.randomUUID());
+    Mockito.when(mockRepository.findById(key)).thenReturn(Optional.of(tableDto));
+    Mockito.when(mockRepository.save(tableDtoArgumentCaptor.capture())).thenReturn(tableDto);
+
+    Assertions.assertThrows(
+        UnsupportedClientOperationException.class,
+        () -> service.putIcebergSnapshots(dbId, tableId, requestBody, null));
+  }
+
   private void verifyCalls(
       TableDtoPrimaryKey expectedKey,
       String expectedTableCreator,


### PR DESCRIPTION
## Summary

`CREATE OR REPLACE ... AS SELECT` (RTAS) is not blocked on a locked table. 

The table lock is enforced only on the normal write/update path: in `IcebergSnapshotsServiceImpl.putIcebergSnapshots` and the new condition added for RTAS never checks a locked table. 

SOP should be to unlock the table before RTAS.

## Fix

Check `isTableLocked` before the replace-vs-update split so it applies to both paths. A locked table
now rejects RTAS with `LOCKED_TABLE_OPERATION` (HTTP 400), consistent with a normal write.

## Testing Done

- **Unit:** `IcebergSnapshotsServiceTest.testReplaceCommitOnLockedTableThrowsException` — a replace
  commit on a locked table throws `UnsupportedClientOperationException`. Full class passes.
- **Integration (e2e):** `SnapshotsControllerTest.testReplaceCommitRejectedOnLockedTable` — creates a
  table, locks it via REST, attempts RTAS, and asserts HTTP 400 with a "locked state" message.
- `./gradlew :services:tables:test` (JDK 17) targeted runs pass; Spotless clean on the module.

Integration tests will be added in li-openhouse to follow.
