### PR TITLE
Fix RENAME COLUMN silent no-op

### DIFF
--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/BaseIcebergSchemaValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/BaseIcebergSchemaValidator.java
@@ -58,7 +58,15 @@ public class BaseIcebergSchemaValidator implements SchemaValidator {
                 for (int i = 0; i < originals.size(); i++) {
                   Types.NestedField original = originals.get(i);
                   Types.NestedField tableField = tableById.get(original.fieldId());
-                  String name = (tableField != null) ? tableField.name() : original.name();
+                  // Only normalize *casing*: adopt the table's spelling when the write name differs
+                  // from it by case alone. A genuinely different name (a real column rename) is
+                  // left
+                  // intact so schema validation rejects it loudly, instead of it being silently
+                  // reverted to the old name and dropped as a no-op.
+                  String name =
+                      (tableField != null && tableField.name().equalsIgnoreCase(original.name()))
+                          ? tableField.name()
+                          : original.name();
                   Type type = fieldTypes.get(i);
                   // Reuse the original if nothing changed (cheap reference-equality short-circuit).
                   if (name.equals(original.name()) && type == original.type()) {

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
@@ -599,8 +599,15 @@ public class RepositoryTest {
             .tableVersion(createdDto.getTableLocation())
             .build();
 
-    Assertions.assertThrows(
-        InvalidSchemaEvolutionException.class, () -> openHouseInternalRepository.save(renameDto));
+    InvalidSchemaEvolutionException thrown =
+        Assertions.assertThrows(
+            InvalidSchemaEvolutionException.class,
+            () -> openHouseInternalRepository.save(renameDto));
+    // Validate the *specific* failure: the rename is detected because the old column "id" is no
+    // longer present in the new schema (it was renamed to "user_id"), not some generic error.
+    Assertions.assertTrue(
+        thrown.getMessage().contains("Column[id] not found in newSchema"),
+        "expected the missing-renamed-column error, got: " + thrown.getMessage());
 
     TableDtoPrimaryKey primaryKey = getPrimaryKey(TABLE_DTO);
     openHouseInternalRepository.deleteById(primaryKey);

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
@@ -569,6 +569,45 @@ public class RepositoryTest {
   }
 
   @Test
+  void testColumnRenameIsRejectedNotSilentlyDropped() {
+    // Regression guard: renaming a column (same field id, genuinely different name) must be
+    // rejected loudly through save(), not silently reverted to the old name and dropped as a no-op.
+    // The casing normalizer previously rewrote the new name back to the old one, so the schemas
+    // compared equal and validation was skipped.
+    Schema oldSchema =
+        new Schema(
+            required(1, "id", Types.StringType.get()), required(2, "count", Types.LongType.get()));
+    Schema renamedSchema =
+        new Schema(
+            required(1, "user_id", Types.StringType.get()), // id=1 renamed: id -> user_id
+            required(2, "count", Types.LongType.get()));
+
+    TableDto createDto =
+        TABLE_DTO
+            .toBuilder()
+            .schema(SchemaParser.toJson(oldSchema, false))
+            .timePartitioning(null)
+            .clustering(null)
+            .tableVersion(INITIAL_TABLE_VERSION)
+            .build();
+    TableDto createdDto = openHouseInternalRepository.save(createDto);
+
+    TableDto renameDto =
+        createdDto
+            .toBuilder()
+            .schema(SchemaParser.toJson(renamedSchema, false))
+            .tableVersion(createdDto.getTableLocation())
+            .build();
+
+    Assertions.assertThrows(
+        InvalidSchemaEvolutionException.class, () -> openHouseInternalRepository.save(renameDto));
+
+    TableDtoPrimaryKey primaryKey = getPrimaryKey(TABLE_DTO);
+    openHouseInternalRepository.deleteById(primaryKey);
+    Assertions.assertFalse(openHouseInternalRepository.existsById(primaryKey));
+  }
+
+  @Test
   void testSchemaEvolutionWithMismatchedFieldId() {
     Schema oldSchema =
         new Schema(

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/repository/impl/BaseIcebergSchemaValidatorTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/repository/impl/BaseIcebergSchemaValidatorTest.java
@@ -44,6 +44,21 @@ public class BaseIcebergSchemaValidatorTest {
   }
 
   @Test
+  void normalizeSchemaCasingToTable_preservesGenuineRename_notRevertedToOldName() {
+    // Table has field id=1 named "id"; the writer submits id=1 named "user_id" — a genuine rename,
+    // not merely a case change. The normalizer must NOT rewrite it back to "id" (which would make
+    // the rename a silent no-op); leaving "user_id" lets validateWriteSchema reject it loudly.
+    Schema tableSchema = new Schema(Types.NestedField.required(1, "id", Types.StringType.get()));
+    Schema writeSchema =
+        new Schema(Types.NestedField.required(1, "user_id", Types.StringType.get()));
+
+    Schema normalized =
+        BaseIcebergSchemaValidator.normalizeSchemaCasingToTable(writeSchema, tableSchema);
+
+    assertEquals("user_id", normalized.findField(1).name());
+  }
+
+  @Test
   void normalizeSchemaCasingToTable_preservesNewColumns_unchanged() {
     // Table has id=1, writer adds a new column id=2 with different-cased name
     Schema tableSchema = new Schema(Types.NestedField.required(1, "ID", Types.StringType.get()));


### PR DESCRIPTION
## Summary

`ALTER TABLE ... RENAME COLUMN` is a silent no-op: it returns success but the column keeps its old
name. `BaseIcebergSchemaValidator.normalizeSchemaCasingToTable` rewrites every write-schema field
name back to the table's spelling by Iceberg field id — including for a genuine rename — so the
write schema compares equal to the table schema, `sameSchema` short-circuits, and schema validation
is skipped. The rename is dropped without any error. This is a regression from #558, which added the
casing normalizer to support case-insensitive writes.

## Fix

Only normalize when the write name differs from the table name by case alone (`equalsIgnoreCase`). A
genuine rename is left intact, so it flows to `validateWriteSchema` and is rejected loudly
(`InvalidSchemaEvolutionException`) instead of being silently reverted. Case-insensitive writes are
preserved.

## Testing Done
- **Manual:** - Darwin was used to manually spot check the issue exists in prod.
- **Unit:** `BaseIcebergSchemaValidatorTest.normalizeSchemaCasingToTable_preservesGenuineRename_notRevertedToOldName`
- **Integration (e2e):** `RepositoryTest.testColumnRenameIsRejectedNotSilentlyDropped` — a rename
  through `save()` now throws `InvalidSchemaEvolutionException`

Future:
- li-openhouse Integration tests
