### PR TITLE
[dataloader] Improve exception handling

### DIFF
--- a/integrations/python/dataloader/src/openhouse/dataloader/__init__.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/__init__.py
@@ -1,7 +1,17 @@
 from importlib.metadata import version
 
-from openhouse.dataloader.catalog import OpenHouseCatalog, OpenHouseCatalogError
+from openhouse.dataloader.catalog import OpenHouseCatalog
 from openhouse.dataloader.data_loader import DataLoaderContext, JvmConfig, OpenHouseDataLoader
+from openhouse.dataloader.exceptions import (
+    OpenHouseAuthenticationError,
+    OpenHouseAuthorizationError,
+    OpenHouseCatalogError,
+    OpenHouseHTTPError,
+    OpenHouseInvalidResponseError,
+    OpenHouseNoSuchTableError,
+    OpenHouseRequestError,
+    OpenHouseTransportError,
+)
 from openhouse.dataloader.filters import SqlTarget, always_true, col, to_sql
 
 __version__ = version("openhouse.dataloader")
@@ -11,6 +21,13 @@ __all__ = [
     "JvmConfig",
     "OpenHouseCatalog",
     "OpenHouseCatalogError",
+    "OpenHouseRequestError",
+    "OpenHouseTransportError",
+    "OpenHouseHTTPError",
+    "OpenHouseAuthenticationError",
+    "OpenHouseAuthorizationError",
+    "OpenHouseNoSuchTableError",
+    "OpenHouseInvalidResponseError",
     "SqlTarget",
     "always_true",
     "col",

--- a/integrations/python/dataloader/src/openhouse/dataloader/catalog.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/catalog.py
@@ -93,11 +93,20 @@ class OpenHouseCatalog(Catalog):
                 f"X-Request-ID: {request_id}. Response: {response.text}"
             )
 
-        table_response = response.json()
+        request_id = response.request.headers[_REQUEST_ID_HEADER]
+        try:
+            table_response = response.json()
+        except requests.JSONDecodeError as exc:
+            raise OpenHouseCatalogError(
+                f"Response for table {database}.{table} is not valid JSON. "
+                f"X-Request-ID: {request_id}. Response: {response.text}"
+            ) from exc
+
         metadata_location = table_response.get(_TABLE_LOCATION)
         if not metadata_location:
             raise OpenHouseCatalogError(
-                f"Response for table {database}.{table} is missing '{_TABLE_LOCATION}'. Response: {table_response}"
+                f"Response for table {database}.{table} is missing '{_TABLE_LOCATION}'. "
+                f"X-Request-ID: {request_id}. Response: {table_response}"
             )
 
         file_io = load_file_io(properties=self.properties, location=metadata_location)

--- a/integrations/python/dataloader/src/openhouse/dataloader/catalog.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/catalog.py
@@ -6,12 +6,17 @@ from uuid import uuid4
 
 import requests
 from pyiceberg.catalog import Catalog
-from pyiceberg.exceptions import NoSuchTableError
 from pyiceberg.io import load_file_io
 from pyiceberg.serializers import FromInputFile
 from pyiceberg.table import Table
 from pyiceberg.typedef import Identifier
 from typing_extensions import Self
+
+from openhouse.dataloader.exceptions import (
+    OpenHouseHTTPError,
+    OpenHouseInvalidResponseError,
+    OpenHouseTransportError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -27,10 +32,6 @@ class _RequestIdSession(requests.Session):
             request.headers = {}
         request.headers.setdefault(_REQUEST_ID_HEADER, str(uuid4()))
         return super().prepare_request(request)
-
-
-class OpenHouseCatalogError(Exception):
-    """Error raised when the OpenHouse catalog fails to load a table."""
 
 
 class OpenHouseCatalog(Catalog):
@@ -83,30 +84,38 @@ class OpenHouseCatalog(Catalog):
         database, table = self.identifier_to_database_and_table(identifier)
         url = f"{self._uri}/v1/databases/{database}/tables/{table}"
 
-        response = self._session.get(url, timeout=self._timeout)
-        if not response.ok:
-            request_id = response.request.headers[_REQUEST_ID_HEADER]
-            if response.status_code == 404:
-                raise NoSuchTableError(f"Table {database}.{table} does not exist. X-Request-ID: {request_id}")
-            raise OSError(
-                f"Failed to load table {database}.{table}: HTTP {response.status_code}. "
-                f"X-Request-ID: {request_id}. Response: {response.text}"
-            )
+        try:
+            response = self._session.get(url, timeout=self._timeout)
+        except requests.RequestException as exc:
+            request_id = exc.request.headers.get(_REQUEST_ID_HEADER) if exc.request is not None else None
+            raise OpenHouseTransportError(
+                f"Failed to load table {database}.{table}: {exc}",
+                request_id=request_id,
+            ) from exc
 
         request_id = response.request.headers[_REQUEST_ID_HEADER]
+        if not response.ok:
+            raise OpenHouseHTTPError.for_response(
+                database,
+                table,
+                status_code=response.status_code,
+                response_body=response.text,
+                request_id=request_id,
+            )
+
         try:
             table_response = response.json()
         except requests.JSONDecodeError as exc:
-            raise OpenHouseCatalogError(
-                f"Response for table {database}.{table} is not valid JSON. "
-                f"X-Request-ID: {request_id}. Response: {response.text}"
+            raise OpenHouseInvalidResponseError(
+                f"Response for table {database}.{table} is not valid JSON. Response: {response.text}",
+                request_id=request_id,
             ) from exc
 
         metadata_location = table_response.get(_TABLE_LOCATION)
         if not metadata_location:
-            raise OpenHouseCatalogError(
-                f"Response for table {database}.{table} is missing '{_TABLE_LOCATION}'. "
-                f"X-Request-ID: {request_id}. Response: {table_response}"
+            raise OpenHouseInvalidResponseError(
+                f"Response for table {database}.{table} is missing '{_TABLE_LOCATION}'. Response: {table_response}",
+                request_id=request_id,
             )
 
         file_io = load_file_io(properties=self.properties, location=metadata_location)

--- a/integrations/python/dataloader/src/openhouse/dataloader/catalog.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/catalog.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+from uuid import uuid4
 
 import requests
 from pyiceberg.catalog import Catalog
@@ -15,6 +16,17 @@ from typing_extensions import Self
 logger = logging.getLogger(__name__)
 
 _TABLE_LOCATION = "tableLocation"
+_REQUEST_ID_HEADER = "X-Request-ID"
+
+
+class _RequestIdSession(requests.Session):
+    """HTTP session that assigns a request ID to every outgoing request."""
+
+    def prepare_request(self, request: requests.Request) -> requests.PreparedRequest:
+        if request.headers is None:
+            request.headers = {}
+        request.headers.setdefault(_REQUEST_ID_HEADER, str(uuid4()))
+        return super().prepare_request(request)
 
 
 class OpenHouseCatalogError(Exception):
@@ -49,7 +61,7 @@ class OpenHouseCatalog(Catalog):
         self._uri = uri.rstrip("/")
         self._timeout = timeout_seconds
         logger.info("Initializing OpenHouseCatalog for service at %s", self._uri)
-        self._session = requests.Session()
+        self._session = _RequestIdSession()
         self._session.headers["Content-Type"] = "application/json"
 
         if auth_token is not None:

--- a/integrations/python/dataloader/src/openhouse/dataloader/catalog.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/catalog.py
@@ -85,10 +85,12 @@ class OpenHouseCatalog(Catalog):
 
         response = self._session.get(url, timeout=self._timeout)
         if not response.ok:
+            request_id = response.request.headers[_REQUEST_ID_HEADER]
             if response.status_code == 404:
-                raise NoSuchTableError(f"Table {database}.{table} does not exist")
+                raise NoSuchTableError(f"Table {database}.{table} does not exist. X-Request-ID: {request_id}")
             raise OSError(
-                f"Failed to load table {database}.{table}: HTTP {response.status_code}. Response: {response.text}"
+                f"Failed to load table {database}.{table}: HTTP {response.status_code}. "
+                f"X-Request-ID: {request_id}. Response: {response.text}"
             )
 
         table_response = response.json()

--- a/integrations/python/dataloader/src/openhouse/dataloader/data_loader.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/data_loader.py
@@ -22,6 +22,7 @@ from openhouse.dataloader._table_scan_context import TableScanContext
 from openhouse.dataloader._timer import log_duration
 from openhouse.dataloader.data_loader_split import DataLoaderSplit
 from openhouse.dataloader.datafusion_sql import DataFusion, to_datafusion_sql
+from openhouse.dataloader.exceptions import OpenHouseCatalogError
 from openhouse.dataloader.filters import (
     AlwaysTrue,
     Filter,
@@ -75,6 +76,8 @@ _plan_files_failure = _meter.create_counter(
 
 def _is_transient(exc: BaseException) -> bool:
     """Return True if the exception is transient and worth retrying."""
+    if isinstance(exc, OpenHouseCatalogError):
+        return exc.retryable
     if isinstance(exc, HTTPError):
         return exc.response is not None and exc.response.status_code >= 500
     return isinstance(exc, OSError)

--- a/integrations/python/dataloader/src/openhouse/dataloader/exceptions.py
+++ b/integrations/python/dataloader/src/openhouse/dataloader/exceptions.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from pyiceberg.exceptions import NoSuchTableError
+
+
+class OpenHouseCatalogError(Exception):
+    """Base error for OpenHouse catalog operations.
+
+    Args:
+        message: Human-readable error detail.
+        request_id: ID assigned to the associated HTTP request, when available.
+    """
+
+    retryable = False
+
+    def __init__(self, message: str, *, request_id: str | None = None) -> None:
+        self.request_id = request_id
+        if request_id is not None:
+            message = f"{message}. X-Request-ID: {request_id}"
+        super().__init__(message)
+
+
+class OpenHouseRequestError(OpenHouseCatalogError):
+    """Base error for failures while making an OpenHouse HTTP request."""
+
+
+class OpenHouseTransportError(OpenHouseRequestError):
+    """Error raised when an OpenHouse HTTP request fails at the transport layer."""
+
+    retryable = True
+
+
+class OpenHouseHTTPError(OpenHouseRequestError):
+    """Error raised when OpenHouse returns a non-success HTTP response."""
+
+    def __init__(
+        self,
+        database: str,
+        table: str,
+        *,
+        status_code: int,
+        response_body: str,
+        request_id: str,
+    ) -> None:
+        self.status_code = status_code
+        self.response_body = response_body
+        self.retryable = status_code in {408, 429} or status_code >= 500
+        super().__init__(
+            f"Failed to load table {database}.{table}: HTTP {status_code}. Response: {response_body}",
+            request_id=request_id,
+        )
+
+    @classmethod
+    def for_response(
+        cls,
+        database: str,
+        table: str,
+        *,
+        status_code: int,
+        response_body: str,
+        request_id: str,
+    ) -> OpenHouseHTTPError:
+        """Build the appropriate typed error for an HTTP response."""
+        error_type: type[OpenHouseHTTPError]
+        if status_code == 401:
+            error_type = OpenHouseAuthenticationError
+        elif status_code == 403:
+            error_type = OpenHouseAuthorizationError
+        elif status_code == 404:
+            error_type = OpenHouseNoSuchTableError
+        else:
+            error_type = cls
+        return error_type(
+            database,
+            table,
+            status_code=status_code,
+            response_body=response_body,
+            request_id=request_id,
+        )
+
+
+class OpenHouseAuthenticationError(OpenHouseHTTPError):
+    """Error raised when OpenHouse rejects request authentication (HTTP 401)."""
+
+
+class OpenHouseAuthorizationError(OpenHouseHTTPError):
+    """Error raised when OpenHouse denies access to a resource (HTTP 403)."""
+
+
+class OpenHouseNoSuchTableError(OpenHouseHTTPError, NoSuchTableError):
+    """Error raised when an OpenHouse table does not exist (HTTP 404)."""
+
+    def __init__(
+        self,
+        database: str,
+        table: str,
+        *,
+        status_code: int,
+        response_body: str,
+        request_id: str,
+    ) -> None:
+        self.status_code = status_code
+        self.response_body = response_body
+        self.retryable = False
+        OpenHouseCatalogError.__init__(
+            self,
+            f"Table {database}.{table} does not exist",
+            request_id=request_id,
+        )
+
+
+class OpenHouseInvalidResponseError(OpenHouseCatalogError):
+    """Error raised when a successful OpenHouse response is malformed."""

--- a/integrations/python/dataloader/tests/test_catalog.py
+++ b/integrations/python/dataloader/tests/test_catalog.py
@@ -1,5 +1,6 @@
 import json
 from unittest.mock import MagicMock, patch
+from uuid import UUID
 
 import pytest
 import responses
@@ -74,6 +75,28 @@ class TestOpenHouseCatalogLoadTable:
             catalog.load_table((DATABASE_NAME, TABLE_NAME))
 
         assert responses.calls[0].request.headers["Content-Type"] == "application/json"
+
+    @responses.activate
+    def test_load_table_sends_request_id(self, mock_iceberg_io):
+        responses.get(TABLE_URL, body=TABLE_RESPONSE_BODY, status=200)
+
+        with OpenHouseCatalog(CATALOG_NAME, uri=BASE_URL) as catalog:
+            catalog.load_table((DATABASE_NAME, TABLE_NAME))
+
+        request_id = responses.calls[0].request.headers["X-Request-ID"]
+        assert str(UUID(request_id)) == request_id
+
+    @responses.activate
+    def test_load_table_uses_unique_request_id_for_each_request(self, mock_iceberg_io):
+        responses.get(TABLE_URL, body=TABLE_RESPONSE_BODY, status=200)
+
+        with OpenHouseCatalog(CATALOG_NAME, uri=BASE_URL) as catalog:
+            catalog.load_table((DATABASE_NAME, TABLE_NAME))
+            catalog.load_table((DATABASE_NAME, TABLE_NAME))
+
+        request_ids = [call.request.headers["X-Request-ID"] for call in responses.calls]
+        assert len(request_ids) == 2
+        assert len(set(request_ids)) == 2
 
     @responses.activate
     def test_load_table_uri_trailing_slash_stripped(self, mock_iceberg_io):

--- a/integrations/python/dataloader/tests/test_catalog.py
+++ b/integrations/python/dataloader/tests/test_catalog.py
@@ -3,10 +3,19 @@ from unittest.mock import MagicMock, patch
 from uuid import UUID
 
 import pytest
+import requests
 import responses
 from pyiceberg.exceptions import NoSuchTableError
 
-from openhouse.dataloader.catalog import OpenHouseCatalog, OpenHouseCatalogError
+from openhouse.dataloader.catalog import OpenHouseCatalog
+from openhouse.dataloader.exceptions import (
+    OpenHouseAuthenticationError,
+    OpenHouseAuthorizationError,
+    OpenHouseHTTPError,
+    OpenHouseInvalidResponseError,
+    OpenHouseNoSuchTableError,
+    OpenHouseTransportError,
+)
 
 CATALOG_NAME = "openhouse"
 BASE_URL = "http://localhost:8080"
@@ -123,18 +132,40 @@ class TestOpenHouseCatalogLoadTable:
             catalog.load_table((DATABASE_NAME, TABLE_NAME))
 
         request_id = responses.calls[0].request.headers["X-Request-ID"]
+        assert isinstance(exc_info.value, OpenHouseNoSuchTableError)
+        assert exc_info.value.request_id == request_id
         assert f"{DATABASE_NAME}.{TABLE_NAME} does not exist" in str(exc_info.value)
         assert f"X-Request-ID: {request_id}" in str(exc_info.value)
 
+    @pytest.mark.parametrize(
+        ("status", "error_type"),
+        [(401, OpenHouseAuthenticationError), (403, OpenHouseAuthorizationError), (500, OpenHouseHTTPError)],
+    )
     @responses.activate
-    def test_load_table_500_raises_os_error(self):
-        responses.get(TABLE_URL, body="Internal Server Error", status=500)
+    def test_load_table_raises_typed_http_error(self, status, error_type):
+        responses.get(TABLE_URL, body="Server response", status=status)
 
-        with OpenHouseCatalog(CATALOG_NAME, uri=BASE_URL) as catalog, pytest.raises(OSError) as exc_info:
+        with OpenHouseCatalog(CATALOG_NAME, uri=BASE_URL) as catalog, pytest.raises(error_type) as exc_info:
             catalog.load_table((DATABASE_NAME, TABLE_NAME))
 
         request_id = responses.calls[0].request.headers["X-Request-ID"]
-        assert "HTTP 500" in str(exc_info.value)
+        assert exc_info.value.status_code == status
+        assert exc_info.value.request_id == request_id
+        assert f"HTTP {status}" in str(exc_info.value)
+        assert f"X-Request-ID: {request_id}" in str(exc_info.value)
+
+    @responses.activate
+    def test_load_table_transport_error_includes_request_id(self):
+        responses.get(TABLE_URL, body=requests.ConnectionError("connection refused"))
+
+        with (
+            OpenHouseCatalog(CATALOG_NAME, uri=BASE_URL) as catalog,
+            pytest.raises(OpenHouseTransportError) as exc_info,
+        ):
+            catalog.load_table((DATABASE_NAME, TABLE_NAME))
+
+        request_id = responses.calls[0].request.headers["X-Request-ID"]
+        assert exc_info.value.request_id == request_id
         assert f"X-Request-ID: {request_id}" in str(exc_info.value)
 
     @responses.activate
@@ -143,11 +174,12 @@ class TestOpenHouseCatalogLoadTable:
 
         with (
             OpenHouseCatalog(CATALOG_NAME, uri=BASE_URL) as catalog,
-            pytest.raises(OpenHouseCatalogError, match="not valid JSON") as exc_info,
+            pytest.raises(OpenHouseInvalidResponseError, match="not valid JSON") as exc_info,
         ):
             catalog.load_table((DATABASE_NAME, TABLE_NAME))
 
         request_id = responses.calls[0].request.headers["X-Request-ID"]
+        assert exc_info.value.request_id == request_id
         assert f"X-Request-ID: {request_id}" in str(exc_info.value)
 
     @responses.activate
@@ -156,11 +188,12 @@ class TestOpenHouseCatalogLoadTable:
 
         with (
             OpenHouseCatalog(CATALOG_NAME, uri=BASE_URL) as catalog,
-            pytest.raises(OpenHouseCatalogError, match="missing 'tableLocation'") as exc_info,
+            pytest.raises(OpenHouseInvalidResponseError, match="missing 'tableLocation'") as exc_info,
         ):
             catalog.load_table((DATABASE_NAME, TABLE_NAME))
 
         request_id = responses.calls[0].request.headers["X-Request-ID"]
+        assert exc_info.value.request_id == request_id
         assert f"X-Request-ID: {request_id}" in str(exc_info.value)
 
     @responses.activate
@@ -173,11 +206,12 @@ class TestOpenHouseCatalogLoadTable:
 
         with (
             OpenHouseCatalog(CATALOG_NAME, uri=BASE_URL) as catalog,
-            pytest.raises(OpenHouseCatalogError, match="missing 'tableLocation'") as exc_info,
+            pytest.raises(OpenHouseInvalidResponseError, match="missing 'tableLocation'") as exc_info,
         ):
             catalog.load_table((DATABASE_NAME, TABLE_NAME))
 
         request_id = responses.calls[0].request.headers["X-Request-ID"]
+        assert exc_info.value.request_id == request_id
         assert f"X-Request-ID: {request_id}" in str(exc_info.value)
 
 

--- a/integrations/python/dataloader/tests/test_catalog.py
+++ b/integrations/python/dataloader/tests/test_catalog.py
@@ -138,14 +138,30 @@ class TestOpenHouseCatalogLoadTable:
         assert f"X-Request-ID: {request_id}" in str(exc_info.value)
 
     @responses.activate
+    def test_load_table_invalid_json_includes_request_id(self):
+        responses.get(TABLE_URL, body="not json", status=200)
+
+        with (
+            OpenHouseCatalog(CATALOG_NAME, uri=BASE_URL) as catalog,
+            pytest.raises(OpenHouseCatalogError, match="not valid JSON") as exc_info,
+        ):
+            catalog.load_table((DATABASE_NAME, TABLE_NAME))
+
+        request_id = responses.calls[0].request.headers["X-Request-ID"]
+        assert f"X-Request-ID: {request_id}" in str(exc_info.value)
+
+    @responses.activate
     def test_load_table_missing_table_location(self):
         responses.get(TABLE_URL, json={"databaseId": DATABASE_NAME, "tableId": TABLE_NAME}, status=200)
 
         with (
             OpenHouseCatalog(CATALOG_NAME, uri=BASE_URL) as catalog,
-            pytest.raises(OpenHouseCatalogError, match="missing 'tableLocation'"),
+            pytest.raises(OpenHouseCatalogError, match="missing 'tableLocation'") as exc_info,
         ):
             catalog.load_table((DATABASE_NAME, TABLE_NAME))
+
+        request_id = responses.calls[0].request.headers["X-Request-ID"]
+        assert f"X-Request-ID: {request_id}" in str(exc_info.value)
 
     @responses.activate
     def test_load_table_empty_table_location(self):
@@ -157,9 +173,12 @@ class TestOpenHouseCatalogLoadTable:
 
         with (
             OpenHouseCatalog(CATALOG_NAME, uri=BASE_URL) as catalog,
-            pytest.raises(OpenHouseCatalogError, match="missing 'tableLocation'"),
+            pytest.raises(OpenHouseCatalogError, match="missing 'tableLocation'") as exc_info,
         ):
             catalog.load_table((DATABASE_NAME, TABLE_NAME))
+
+        request_id = responses.calls[0].request.headers["X-Request-ID"]
+        assert f"X-Request-ID: {request_id}" in str(exc_info.value)
 
 
 class TestOpenHouseCatalogProperties:

--- a/integrations/python/dataloader/tests/test_catalog.py
+++ b/integrations/python/dataloader/tests/test_catalog.py
@@ -119,21 +119,23 @@ class TestOpenHouseCatalogLoadTable:
     def test_load_table_404_raises_no_such_table_error(self):
         responses.get(TABLE_URL, status=404)
 
-        with (
-            OpenHouseCatalog(CATALOG_NAME, uri=BASE_URL) as catalog,
-            pytest.raises(NoSuchTableError, match=f"{DATABASE_NAME}.{TABLE_NAME} does not exist"),
-        ):
+        with OpenHouseCatalog(CATALOG_NAME, uri=BASE_URL) as catalog, pytest.raises(NoSuchTableError) as exc_info:
             catalog.load_table((DATABASE_NAME, TABLE_NAME))
+
+        request_id = responses.calls[0].request.headers["X-Request-ID"]
+        assert f"{DATABASE_NAME}.{TABLE_NAME} does not exist" in str(exc_info.value)
+        assert f"X-Request-ID: {request_id}" in str(exc_info.value)
 
     @responses.activate
     def test_load_table_500_raises_os_error(self):
         responses.get(TABLE_URL, body="Internal Server Error", status=500)
 
-        with (
-            OpenHouseCatalog(CATALOG_NAME, uri=BASE_URL) as catalog,
-            pytest.raises(OSError, match="HTTP 500"),
-        ):
+        with OpenHouseCatalog(CATALOG_NAME, uri=BASE_URL) as catalog, pytest.raises(OSError) as exc_info:
             catalog.load_table((DATABASE_NAME, TABLE_NAME))
+
+        request_id = responses.calls[0].request.headers["X-Request-ID"]
+        assert "HTTP 500" in str(exc_info.value)
+        assert f"X-Request-ID: {request_id}" in str(exc_info.value)
 
     @responses.activate
     def test_load_table_missing_table_location(self):

--- a/integrations/python/dataloader/tests/test_data_loader.py
+++ b/integrations/python/dataloader/tests/test_data_loader.py
@@ -15,7 +15,15 @@ from pyiceberg.types import DoubleType, LongType, NestedField, StringType
 from requests import ConnectionError as RequestsConnectionError
 from requests import HTTPError, Response, Timeout
 
-from openhouse.dataloader import DataLoaderContext, JvmConfig, OpenHouseDataLoader, __version__
+from openhouse.dataloader import (
+    DataLoaderContext,
+    JvmConfig,
+    OpenHouseAuthenticationError,
+    OpenHouseDataLoader,
+    OpenHouseHTTPError,
+    OpenHouseTransportError,
+    __version__,
+)
 from openhouse.dataloader.data_loader_split import DataLoaderSplit, to_sql_identifier
 from openhouse.dataloader.filters import SqlTarget, col
 from openhouse.dataloader.table_transformer import TableTransformer
@@ -210,8 +218,10 @@ def _make_http_error(status_code: int) -> HTTPError:
         RequestsConnectionError("refused"),
         Timeout("timed out"),
         _make_http_error(503),
+        OpenHouseTransportError("connection reset", request_id="request-id"),
+        OpenHouseHTTPError("db", "tbl", status_code=503, response_body="unavailable", request_id="request-id"),
     ],
-    ids=["OSError", "ConnectionError", "Timeout", "5xx"],
+    ids=["OSError", "ConnectionError", "Timeout", "requests-5xx", "OpenHouseTransportError", "OpenHouse-5xx"],
 )
 def test_load_table_retries_on_transient_error(tmp_path, error):
     """load_table retries on transient errors and succeeds on the second attempt."""
@@ -236,6 +246,22 @@ def test_load_table_does_not_retry_on_4xx_http_error():
     with pytest.raises(HTTPError):
         list(loader)
 
+    catalog.load_table.assert_called_once()
+
+
+def test_load_table_does_not_retry_on_authentication_error():
+    """OpenHouse authentication failures are typed and not retried."""
+    catalog = MagicMock()
+    catalog.load_table.side_effect = OpenHouseAuthenticationError(
+        "db", "tbl", status_code=401, response_body="Authentication failed", request_id="request-id"
+    )
+
+    loader = OpenHouseDataLoader(catalog=catalog, database="db", table="tbl")
+
+    with pytest.raises(OpenHouseAuthenticationError) as exc_info:
+        list(loader)
+
+    assert exc_info.value.request_id == "request-id"
     catalog.load_table.assert_called_once()
 
 


### PR DESCRIPTION
## Summary

**Problem:** OpenHouse DataLoader errors could not be reliably correlated with the corresponding Tables Service request. Timestamp-based correlation is noisy, and authentication failures were represented as generic `OSError`s and retried as if they were transient I/O failures.

**Solution:** assign a unique `X-Request-ID` to every outbound catalog HTTP request and expose it through shared, typed catalog exceptions. The exception hierarchy centralizes request-ID formatting and distinguishes authentication, authorization, not-found, transport, HTTP, and malformed-response failures.

## Changes

- [x] Client-facing API Changes
- [x] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [x] Tests

Details:

- Added a central request-aware HTTP session that generates a fresh UUID for every prepared request.
- Added shared exception types:
  - `OpenHouseCatalogError`
  - `OpenHouseRequestError`
  - `OpenHouseTransportError`
  - `OpenHouseHTTPError`
  - `OpenHouseAuthenticationError`
  - `OpenHouseAuthorizationError`
  - `OpenHouseNoSuchTableError`
  - `OpenHouseInvalidResponseError`
- Centralized `X-Request-ID` rendering and exposed it as `exception.request_id`.
- Preserved compatibility with callers catching PyIceberg `NoSuchTableError`.
- Classified 401/403 and other non-transient 4xx failures as non-retryable.
- Kept transport failures, HTTP 408/429, and 5xx responses retryable.

## Testing Done

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [x] Some other form of testing like staging or soak time in production. Please explain.

Validation performed:

- `make verify`
  - Ruff lint passed
  - Ruff formatting passed
  - Mypy passed
  - **272 unit tests passed**
- Added coverage for unique request IDs, typed 401/403/404/500 errors, transport errors, malformed JSON, missing/empty `tableLocation`, retryable failures, and non-retryable authentication failures.
- Used a known request ID against the deployed OpenHouse route and confirmed it appeared in the Nginx access log; follow-up proxy configuration work is tracked separately to preserve the same value through Ambassador.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.
