### PR TITLE
Refactor(spark-3.5): Make OpenHouse SQL extensions standalone 

### DIFF
--- a/integrations/spark/spark-3.5/openhouse-spark-runtime/build.gradle
+++ b/integrations/spark/spark-3.5/openhouse-spark-runtime/build.gradle
@@ -8,6 +8,11 @@ plugins {
 ext {
   icebergVersion = rootProject.ext.iceberg_1_5_version
   sparkVersion = '3.5.2'
+  // Antlr grammar sources are owned by this module (spark-3.5 keeps its own copy of the
+  // grammar so it can evolve independently of spark-3.1).
+  antlrPackageDirPrefix = "com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/"
+  antlrMainDir = "${projectDir}/src/main/antlr/${antlrPackageDirPrefix}"
+  antlrMainGeneratedSrcDir = "${project.buildDir}/generated-src/antlr/main/"
 }
 
 configurations {
@@ -16,18 +21,40 @@ configurations {
     exclude(group: 'org.mapstruct')
   }
   shadow.extendsFrom implementation
+
+  antlr
 }
 
 // Set source for antlr generated directory
 sourceSets {
   main {
     java {
-      srcDirs += "${project(':integrations:spark:spark-3.1:openhouse-spark-runtime_2.12').buildDir}/generated-src/antlr/main"
+      srcDirs antlrMainGeneratedSrcDir
     }
   }
 }
 
+// Task to generate java sources using Antlr tool
+task runAntlr(type: JavaExec) {
+  inputs.dir antlrMainDir
+  outputs.dir antlrMainGeneratedSrcDir
+
+  mainClass = "org.antlr.v4.Tool"
+  args = ["${antlrMainDir}/OpenhouseSqlExtensions.g4",
+          "-visitor",
+          "-o", "${antlrMainGeneratedSrcDir}/${antlrPackageDirPrefix}",
+          "-package", "com.linkedin.openhouse.spark.sql.catalyst.parser.extensions"]
+  maxHeapSize = "64m"
+  classpath = configurations.antlr
+}
+
+compileJava.dependsOn runAntlr
+
 dependencies {
+  // Required because we remove antlr plugin dependencies from the compile configuration
+  runtimeOnly "org.antlr:antlr4-runtime:4.7.1"
+  antlr "org.antlr:antlr4:4.7.1"
+
   compileOnly(project(path: ':integrations:java:iceberg-1.5:openhouse-java-iceberg-1.5-runtime', configuration: 'shadow'))
   compileOnly("org.apache.spark:spark-hive_2.12:${sparkVersion}") {
     exclude group: 'org.apache.avro', module: 'avro'
@@ -51,12 +78,6 @@ dependencies {
 
   fatJarPackagedDependencies(project(path: ':integrations:java:iceberg-1.5:openhouse-java-iceberg-1.5-runtime', configuration: 'shadow')) {
     transitive = false
-  }
-  fatJarPackagedDependencies(project(path: ':integrations:spark:spark-3.1:openhouse-spark-runtime_2.12', configuration: 'shadow')) {
-    transitive = false
-  }
-  implementation(project(path: ':integrations:spark:spark-3.1:openhouse-spark-runtime_2.12', configuration: 'shadow')) {
-    exclude group: "com.linkedin.iceberg", module: "iceberg-spark-runtime-3.1_2.12"
   }
   implementation("com.linkedin.iceberg:iceberg-spark-runtime-3.5_2.12:" + icebergVersion)
 }

--- a/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/antlr/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensions.g4
+++ b/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/antlr/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensions.g4
@@ -1,0 +1,244 @@
+grammar OpenhouseSqlExtensions;
+
+@lexer::members {
+  /**
+   * This method will be called when we see '/*' and try to match it as a bracketed comment.
+   * If the next character is '+', it should be parsed as hint later, and we cannot match
+   * it as a bracketed comment.
+   *
+   * Returns true if the next character is '+'.
+   */
+  public boolean isHint() {
+    int nextChar = _input.LA(1);
+    if (nextChar == '+') {
+      return true;
+    } else {
+      return false;
+    }
+  }
+}
+
+singleStatement
+    : statement EOF
+    ;
+
+statement
+  : ALTER TABLE multipartIdentifier SET POLICY '(' retentionPolicy (columnRetentionPolicy)? ')'        #setRetentionPolicy
+  | ALTER TABLE multipartIdentifier SET POLICY '(' replicationPolicy ')'                               #setReplicationPolicy
+  | ALTER TABLE multipartIdentifier UNSET POLICY '(' replication ')'                                   #unSetReplicationPolicy
+  | ALTER TABLE multipartIdentifier SET POLICY '(' sharingPolicy ')'                                   #setSharingPolicy
+  | ALTER TABLE multipartIdentifier SET POLICY '(' historyPolicy ')'                                   #setHistoryPolicy
+  | ALTER TABLE multipartIdentifier MODIFY columnNameClause SET columnPolicy                           #setColumnPolicyTag
+  | GRANT privilege ON grantableResource TO principal                                                  #grantStatement
+  | REVOKE privilege ON grantableResource FROM principal                                               #revokeStatement
+  | SHOW GRANTS ON grantableResource                                                                   #showGrantsStatement
+  ;
+
+multipartIdentifier
+    : parts+=identifier ('.' parts+=identifier)*
+    ;
+
+privilege
+    : columnLevelPrivilege
+    | SELECT | DESCRIBE | ALTER | GRANT_REVOKE | CREATE_TABLE
+    ;
+
+columnLevelPrivilege
+    : SELECT policyTag
+    ;
+
+grantableResource
+    : TABLE multipartIdentifier
+    | DATABASE multipartIdentifier
+    ;
+
+principal
+    : identifier
+    ;
+
+identifier
+    : IDENTIFIER
+    | quotedIdentifier
+    | nonReserved
+    ;
+
+quotedIdentifier
+    : BACKQUOTED_IDENTIFIER
+    ;
+
+nonReserved
+    : ALTER | TABLE | SET | POLICY | RETENTION | SHARING | REPLICATION | HISTORY
+    | GRANT | REVOKE | ON | TO | SHOW | GRANTS | PATTERN | WHERE | COLUMN
+    ;
+
+sharingPolicy
+    : SHARING '=' BOOLEAN
+    ;
+
+BOOLEAN
+    : 'TRUE' | 'FALSE'
+    ;
+
+retentionPolicy
+    : RETENTION '=' duration
+    ;
+
+columnRetentionPolicy
+    : ON columnNameClause (columnRetentionPolicyPatternClause)?
+    ;
+
+replication
+    : REPLICATION
+    ;
+
+replicationPolicy
+    : replication '=' tableReplicationPolicy
+    ;
+
+tableReplicationPolicy
+    : '(' replicationPolicyClause (',' replicationPolicyClause)* ')'
+    ;
+
+replicationPolicyClause
+    : '{' replicationPolicyClusterClause (',' replicationPolicyIntervalClause)? '}'
+    ;
+
+replicationPolicyClusterClause
+    : DESTINATION ':' STRING
+    ;
+
+replicationPolicyIntervalClause
+    : INTERVAL ':' RETENTION_HOUR
+    | INTERVAL ':' RETENTION_DAY
+    ;
+
+columnRetentionPolicyPatternClause
+    : WHERE retentionColumnPatternClause
+    ;
+
+columnNameClause
+    : COLUMN identifier
+    ;
+
+retentionColumnPatternClause
+    : PATTERN '=' STRING
+    ;
+
+duration
+    : RETENTION_DAY
+    | RETENTION_YEAR
+    | RETENTION_MONTH
+    | RETENTION_HOUR
+    ;
+
+RETENTION_DAY
+    : POSITIVE_INTEGER 'D'
+    ;
+
+RETENTION_YEAR
+    : POSITIVE_INTEGER 'Y'
+    ;
+
+RETENTION_MONTH
+    : POSITIVE_INTEGER 'M'
+    ;
+
+RETENTION_HOUR
+    : POSITIVE_INTEGER 'H'
+    ;
+
+columnPolicy
+    : TAG '=' multiTagIdentifier
+    | TAG '=' '(' NONE ')'
+    ;
+
+multiTagIdentifier
+    : '(' policyTag (',' policyTag)* ')'
+    ;
+
+policyTag
+    : PII | HC
+    ;
+
+historyPolicy
+    : HISTORY maxAge? versions?
+    ;
+
+maxAge
+    : MAX_AGE'='duration
+    ;
+
+versions
+    : VERSIONS'='POSITIVE_INTEGER
+    ;
+
+ALTER: 'ALTER';
+TABLE: 'TABLE';
+SET: 'SET';
+UNSET: 'UNSET';
+POLICY: 'POLICY';
+RETENTION: 'RETENTION';
+REPLICATION: 'REPLICATION';
+HISTORY: 'HISTORY';
+SHARING: 'SHARING';
+GRANT: 'GRANT';
+REVOKE: 'REVOKE';
+ON: 'ON';
+TO: 'TO';
+FROM: 'FROM';
+SELECT: 'SELECT';
+DESCRIBE: 'DESCRIBE';
+GRANT_REVOKE: 'MANAGE GRANTS';
+CREATE_TABLE: 'CREATE TABLE';
+DATABASE: 'DATABASE';
+SHOW: 'SHOW';
+GRANTS: 'GRANTS';
+PATTERN: 'PATTERN';
+DESTINATION: 'DESTINATION';
+INTERVAL: 'INTERVAL';
+WHERE: 'WHERE';
+COLUMN: 'COLUMN';
+PII: 'PII';
+HC: 'HC';
+MODIFY: 'MODIFY';
+TAG: 'TAG';
+NONE: 'NONE';
+VERSIONS: 'VERSIONS';
+MAX_AGE: 'MAX_AGE';
+
+POSITIVE_INTEGER
+    : DIGIT+
+    ;
+
+STRING
+    : '\'' ( ~('\''|'\\') | ('\\' .) )* '\''
+    | '"' ( ~('"'|'\\') | ('\\' .) )* '"'
+    ;
+
+IDENTIFIER
+    : (LETTER | DIGIT | '_')+
+    ;
+
+BACKQUOTED_IDENTIFIER
+    : '`' ( ~'`' | '``' )* '`'
+    ;
+
+fragment DIGIT
+    : [0-9]
+    ;
+
+fragment LETTER
+    : [A-Z]
+    ;
+
+SIMPLE_COMMENT
+    : '--' ('\\\n' | ~[\r\n])* '\r'? '\n'? -> channel(HIDDEN)
+    ;
+
+BRACKETED_COMMENT
+    : '/*' {!isHint()}? (BRACKETED_COMMENT|.)*? '*/' -> channel(HIDDEN)
+    ;
+
+WS
+    : [ \r\n\t]+ -> channel(HIDDEN)
+    ;

--- a/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/java/com/linkedin/openhouse/spark/OpenHouseCatalog.java
+++ b/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/java/com/linkedin/openhouse/spark/OpenHouseCatalog.java
@@ -1,0 +1,18 @@
+package com.linkedin.openhouse.spark;
+
+/**
+ * Catalog implementation to create, read, update and delete tables in OpenHouse. This class
+ * leverages Openhouse tableclient to perform CRUD operations on Tables resource in the Catalog
+ * service. This implementation provides client side catalog implementation for Iceberg tables in
+ * Spark.
+ *
+ * <p>Catalog can be instantiated as a Iceberg catalog, with following configurations:
+ * spark.sql.catalog.openhouse=org.apache.iceberg.spark.SparkCatalog
+ * spark.sql.catalog.openhouse.catalog-impl=com.linkedin.openhouse.spark.OpenHouseCatalog
+ * spark.sql.catalog.openhouse.metrics-reporter-impl=com.linkedin.openhouse.javaclient.OpenHouseMetricsReporter
+ * spark.sql.catalog.openhouse.uri=http://[openhouse service host]:[openhouse service port]
+ * spark.sql.catalog.openhouse.cluster=[openhouse cluster name]
+ *
+ * <p>It can be used in spark shell as follows: spark.sql("USE openhouse")
+ */
+public class OpenHouseCatalog extends com.linkedin.openhouse.javaclient.OpenHouseCatalog {}

--- a/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/extensions/OpenhouseSparkSessionExtensions.scala
+++ b/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/extensions/OpenhouseSparkSessionExtensions.scala
@@ -1,0 +1,12 @@
+package com.linkedin.openhouse.spark.extensions
+
+import com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseSparkSqlExtensionsParser
+import com.linkedin.openhouse.spark.sql.execution.datasources.v2.OpenhouseDataSourceV2Strategy
+import org.apache.spark.sql.SparkSessionExtensions
+
+class OpenhouseSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
+  override def apply(extensions: SparkSessionExtensions): Unit = {
+    extensions.injectParser { case (_, parser) => new OpenhouseSparkSqlExtensionsParser(parser) }
+    extensions.injectPlannerStrategy( spark => OpenhouseDataSourceV2Strategy(spark))
+  }
+}

--- a/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/constants/Principal.scala
+++ b/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/constants/Principal.scala
@@ -1,0 +1,18 @@
+package com.linkedin.openhouse.spark.sql.catalyst.constants
+
+/**
+ * This object is used to represent keyword global user group "PUBLIC" which maps to the acl policy representation "*"
+ */
+object Principal {
+  private val GLOBAL_USER_GROUP = "PUBLIC"
+  private val GLOBAL_USER_GROUP_ACL = "*"
+  def apply(principal: String): String = principal toUpperCase() match {
+    case GLOBAL_USER_GROUP => GLOBAL_USER_GROUP_ACL
+    case _ => principal
+  }
+
+  def unapply(principalAcl: String): Option[String] = principalAcl match {
+    case GLOBAL_USER_GROUP_ACL => Some(GLOBAL_USER_GROUP)
+    case _ => Some(principalAcl)
+  }
+}

--- a/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/enums/GrantableResourceTypes.scala
+++ b/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/enums/GrantableResourceTypes.scala
@@ -1,0 +1,6 @@
+package com.linkedin.openhouse.spark.sql.catalyst.enums
+
+private[sql] object GrantableResourceTypes extends Enumeration {
+  type GrantableResourceType = Value
+  val TABLE, DATABASE = Value
+}

--- a/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensionsAstBuilder.scala
+++ b/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensionsAstBuilder.scala
@@ -1,0 +1,206 @@
+package com.linkedin.openhouse.spark.sql.catalyst.parser.extensions
+
+import com.linkedin.openhouse.spark.sql.catalyst.enums.GrantableResourceTypes
+import com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseSqlExtensionsParser._
+import com.linkedin.openhouse.spark.sql.catalyst.plans.logical.{GrantRevokeStatement, SetColumnPolicyTag, SetHistoryPolicy, SetReplicationPolicy, SetRetentionPolicy, SetSharingPolicy, ShowGrantsStatement, UnSetReplicationPolicy}
+import com.linkedin.openhouse.spark.sql.catalyst.enums.GrantableResourceTypes.GrantableResourceType
+import com.linkedin.openhouse.gen.tables.client.model.TimePartitionSpec
+import org.antlr.v4.runtime.tree.ParseTree
+import org.apache.spark.sql.catalyst.parser.ParserInterface
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+import scala.collection.JavaConversions.iterableAsScalaIterable
+import scala.collection.JavaConverters._
+
+class OpenhouseSqlExtensionsAstBuilder (delegate: ParserInterface) extends OpenhouseSqlExtensionsBaseVisitor[AnyRef] {
+  override def visitSingleStatement(ctx: SingleStatementContext): LogicalPlan = {
+    typedVisit[LogicalPlan](ctx.statement)
+  }
+
+  override def visitSetRetentionPolicy(ctx: SetRetentionPolicyContext): SetRetentionPolicy = {
+    val tableName = typedVisit[Seq[String]](ctx.multipartIdentifier)
+    val (granularity, count) = typedVisit[(String, Int)](ctx.retentionPolicy())
+    val (colName, colPattern) =
+      if (ctx.columnRetentionPolicy() != null)
+        typedVisit[(String, String)](ctx.columnRetentionPolicy())
+      else (null, null)
+    SetRetentionPolicy(tableName, granularity, count, Option(colName), Option(colPattern))
+  }
+
+  override def visitSetReplicationPolicy(ctx: SetReplicationPolicyContext): SetReplicationPolicy = {
+    val tableName = typedVisit[Seq[String]](ctx.multipartIdentifier)
+    val replicationPolicies = typedVisit[Seq[(String, Option[String])]](ctx.replicationPolicy())
+    SetReplicationPolicy(tableName, replicationPolicies)
+  }
+
+  override def visitUnSetReplicationPolicy(ctx: UnSetReplicationPolicyContext): UnSetReplicationPolicy = {
+    val tableName = typedVisit[Seq[String]](ctx.multipartIdentifier)
+    val replicationPolicies = typedVisit[String](ctx.replication())
+    UnSetReplicationPolicy(tableName, replicationPolicies)
+  }
+
+  override def visitSetSharingPolicy(ctx: SetSharingPolicyContext): SetSharingPolicy = {
+    val tableName = typedVisit[Seq[String]](ctx.multipartIdentifier)
+    val sharing = typedVisit[String](ctx.sharingPolicy())
+    SetSharingPolicy(tableName, sharing)
+  }
+
+  override def visitSetColumnPolicyTag(ctx: SetColumnPolicyTagContext): SetColumnPolicyTag = {
+    val tableName = typedVisit[Seq[String]](ctx.multipartIdentifier)
+    val colName = ctx.columnNameClause().identifier().getText
+    val policyTags = typedVisit[Seq[String]](ctx.columnPolicy())
+    SetColumnPolicyTag(tableName, colName, policyTags)
+  }
+
+  override def visitGrantStatement(ctx: GrantStatementContext): GrantRevokeStatement = {
+    val (resourceType, resourceName) = typedVisit[(GrantableResourceType, Seq[String])](ctx.grantableResource())
+    val principal = typedVisit[String](ctx.principal)
+    val privilege = typedVisit[String](ctx.privilege)
+    GrantRevokeStatement(isGrant = true, resourceType, resourceName, privilege, principal)
+  }
+
+  override def visitRevokeStatement(ctx: RevokeStatementContext): GrantRevokeStatement = {
+    val (resourceType, resourceName) = typedVisit[(GrantableResourceType, Seq[String])](ctx.grantableResource())
+    val privilege = typedVisit[String](ctx.privilege)
+    val principal = typedVisit[String](ctx.principal)
+    GrantRevokeStatement(isGrant = false, resourceType, resourceName, privilege, principal)
+  }
+
+  override def visitShowGrantsStatement(ctx: ShowGrantsStatementContext): ShowGrantsStatement = {
+    val (resourceType, resourceName) = typedVisit[(GrantableResourceType, Seq[String])](ctx.grantableResource())
+    ShowGrantsStatement(resourceType, resourceName)
+  }
+
+  override def visitPrincipal(ctx: PrincipalContext): String = {
+    ctx.getText
+  }
+
+  override def visitPrivilege(ctx: PrivilegeContext): String = {
+    ctx.getText.toUpperCase
+  }
+
+  override def visitGrantableResource(ctx: GrantableResourceContext): (GrantableResourceType, Seq[String]) = {
+    val resourceName = typedVisit[Seq[String]](ctx.multipartIdentifier())
+    val resourceType = if (ctx.DATABASE != null) {
+      GrantableResourceTypes.DATABASE
+    } else if (ctx.TABLE != null) {
+      GrantableResourceTypes.TABLE
+    } else {
+      throw new IllegalStateException("Unrecognized grantable resource: " +  ctx.getText)
+    }
+    (resourceType, resourceName)
+  }
+
+  override def visitMultipartIdentifier(ctx: MultipartIdentifierContext): Seq[String] = {
+    toSeq(ctx.parts).map(_.getText)
+  }
+
+  override def visitRetentionPolicy(ctx: RetentionPolicyContext): (String, Int) = {
+    typedVisit[(String, Int)](ctx.duration())
+  }
+
+  override def visitReplicationPolicy(ctx: ReplicationPolicyContext): Seq[(String, Option[String])] = {
+    typedVisit[Seq[(String, Option[String])]](ctx.tableReplicationPolicy())
+  }
+
+  override def visitTableReplicationPolicy(ctx: TableReplicationPolicyContext): Seq[(String, Option[String])] = {
+    toSeq(ctx.replicationPolicyClause()).map(typedVisit[(String, Option[String])])
+  }
+
+  override def visitReplicationPolicyClause(ctx: ReplicationPolicyClauseContext): (String, Option[String]) = {
+    val cluster = typedVisit[String](ctx.replicationPolicyClusterClause())
+    val interval = if (ctx.replicationPolicyIntervalClause() != null)
+      typedVisit[String](ctx.replicationPolicyIntervalClause())
+    else
+      null
+    (cluster, Option(interval))
+  }
+
+  override def visitReplicationPolicyClusterClause(ctx: ReplicationPolicyClusterClauseContext): (String) = {
+    ctx.STRING().getText
+  }
+
+  override def visitReplicationPolicyIntervalClause(ctx: ReplicationPolicyIntervalClauseContext): (String) = {
+    if (ctx.RETENTION_HOUR() != null)
+      ctx.RETENTION_HOUR().getText.toUpperCase()
+    else ctx.RETENTION_DAY().getText.toUpperCase()
+  }
+
+  override def visitColumnRetentionPolicy(ctx: ColumnRetentionPolicyContext): (String, String) = {
+    if (ctx.columnRetentionPolicyPatternClause() != null) {
+      (ctx.columnNameClause().identifier().getText(), ctx.columnRetentionPolicyPatternClause().retentionColumnPatternClause().STRING().getText)
+    } else {
+      (ctx.columnNameClause().identifier().getText(), new String())
+    }
+  }
+
+  override def visitColumnRetentionPolicyPatternClause(ctx: ColumnRetentionPolicyPatternClauseContext): String = {
+    ctx.retentionColumnPatternClause().STRING().getText
+  }
+
+  override def visitReplication(ctx: ReplicationContext): String =
+    {
+      ctx.REPLICATION().getText
+    }
+
+  override def visitSharingPolicy(ctx: SharingPolicyContext): String = {
+    ctx.BOOLEAN().getText
+  }
+
+  override def visitColumnPolicy(ctx: ColumnPolicyContext): Seq[String] = {
+    if (ctx.NONE() == null) {
+      typedVisit[Seq[String]](ctx.multiTagIdentifier());
+    } else {
+      Seq.empty
+    }
+  }
+
+  override def visitMultiTagIdentifier(ctx: MultiTagIdentifierContext): Seq[String] = {
+    toSeq(ctx.policyTag()).map(_.getText)
+  }
+
+  override def visitDuration(ctx: DurationContext): (String, Int) = {
+    val granularity: String = if (ctx.RETENTION_DAY != null) {
+      TimePartitionSpec.GranularityEnum.DAY.getValue()
+    } else if (ctx.RETENTION_YEAR() != null) {
+      TimePartitionSpec.GranularityEnum.YEAR.getValue()
+    } else if (ctx.RETENTION_MONTH() != null) {
+      TimePartitionSpec.GranularityEnum.MONTH.getValue()
+    } else {
+      TimePartitionSpec.GranularityEnum.HOUR.getValue()
+    }
+    val count = ctx.getText.substring(0, ctx.getText.length - 1).toInt
+    (granularity, count)
+  }
+
+  override def visitSetHistoryPolicy(ctx: SetHistoryPolicyContext): SetHistoryPolicy = {
+    val tableName = typedVisit[Seq[String]](ctx.multipartIdentifier)
+    val (granularity, maxAge, versions) = typedVisit[(Option[String], Int, Int)](ctx.historyPolicy())
+    SetHistoryPolicy(tableName, granularity, maxAge, versions)
+  }
+  override def visitHistoryPolicy(ctx: HistoryPolicyContext): (Option[String], Int, Int) = {
+    val maxAgePolicy = if (ctx.maxAge() != null)
+        typedVisit[(String, Int)](ctx.maxAge().duration())
+      else (null, -1)
+    val versionPolicy = if (ctx.versions() != null)
+        typedVisit[Int](ctx.versions())
+      else -1
+    if (maxAgePolicy._2 == -1 && versionPolicy == -1) {
+      throw new OpenhouseParseException("At least one of MAX_AGE or VERSIONS must be specified in HISTORY policy, e.g. " +
+        "ALTER TABLE openhouse.db.table SET POLICY (HISTORY MAX_AGE=2D) or ALTER TABLE openhouse.db.table SET POLICY (HISTORY VERSIONS=3)",
+        ctx.start.getLine, ctx.start.getCharPositionInLine)
+    }
+    (Option(maxAgePolicy._1), maxAgePolicy._2, versionPolicy)
+  }
+
+  override def visitVersions(ctx: VersionsContext): Integer = {
+    ctx.POSITIVE_INTEGER().getText.toInt
+  }
+
+  private def toBuffer[T](list: java.util.List[T]) = list.asScala
+  private def toSeq[T](list: java.util.List[T]) = toBuffer(list).toSeq
+
+  private def typedVisit[T](ctx: ParseTree): T = {
+    ctx.accept(this).asInstanceOf[T]
+  }
+}

--- a/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/OpenhouseDataSourceV2Strategy.scala
+++ b/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/OpenhouseDataSourceV2Strategy.scala
@@ -1,0 +1,51 @@
+package com.linkedin.openhouse.spark.sql.execution.datasources.v2
+
+import com.linkedin.openhouse.spark.sql.catalyst.plans.logical.{GrantRevokeStatement, SetColumnPolicyTag, SetHistoryPolicy, SetReplicationPolicy, SetRetentionPolicy, SetSharingPolicy, ShowGrantsStatement, UnSetReplicationPolicy}
+import org.apache.iceberg.spark.{Spark3Util, SparkCatalog, SparkSessionCatalog}
+import org.apache.spark.sql.{SparkSession, Strategy}
+import org.apache.spark.sql.catalyst.expressions.PredicateHelper
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
+import org.apache.spark.sql.execution.SparkPlan
+
+import scala.collection.JavaConverters._
+
+/* Strategy to convert a logical plan to physical plans */
+case class OpenhouseDataSourceV2Strategy(spark: SparkSession) extends Strategy with PredicateHelper {
+  override def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
+    case SetRetentionPolicy(CatalogAndIdentifierExtractor(catalog, ident), granularity, count, colName, colPattern) =>
+      SetRetentionPolicyExec(catalog, ident, granularity, count, colName, colPattern) :: Nil
+    case SetReplicationPolicy(CatalogAndIdentifierExtractor(catalog, ident), replicationPolicies) =>
+      SetReplicationPolicyExec(catalog, ident, replicationPolicies) :: Nil
+    case UnSetReplicationPolicy(CatalogAndIdentifierExtractor(catalog, ident), replicationPolicies) =>
+      UnSetReplicationPolicyExec(catalog, ident, replicationPolicies) :: Nil
+    case SetHistoryPolicy(CatalogAndIdentifierExtractor(catalog, ident), granularity, maxAge, versions) =>
+      SetHistoryPolicyExec(catalog, ident, granularity, maxAge, versions) :: Nil
+    case SetSharingPolicy(CatalogAndIdentifierExtractor(catalog, ident), sharing) =>
+      SetSharingPolicyExec(catalog, ident, sharing) :: Nil
+    case SetColumnPolicyTag(CatalogAndIdentifierExtractor(catalog, ident), policyTag, cols) =>
+      SetColumnPolicyTagExec(catalog, ident, policyTag, cols) :: Nil
+
+    case GrantRevokeStatement(isGrant, resourceType, CatalogAndIdentifierExtractor(catalog, ident), privilege, principal) =>
+      GrantRevokeStatementExec(isGrant, resourceType, catalog, ident, privilege, principal) :: Nil
+
+    case r @ ShowGrantsStatement(resourceType, CatalogAndIdentifierExtractor(catalog, ident)) =>
+      ShowGrantsStatementExec(r.output, resourceType, catalog, ident) :: Nil
+
+    case _ => Nil
+  }
+
+  private object CatalogAndIdentifierExtractor {
+    def unapply(identifier: Seq[String]): Option[(TableCatalog, Identifier)] = {
+      val catalogAndIdentifier = Spark3Util.catalogAndIdentifier(spark, identifier.asJava)
+      catalogAndIdentifier.catalog match {
+        case icebergCatalog: SparkCatalog =>
+          Some((icebergCatalog, catalogAndIdentifier.identifier))
+        case icebergCatalog: SparkSessionCatalog[_] =>
+          Some((icebergCatalog, catalogAndIdentifier.identifier))
+        case _ =>
+          None
+      }
+    }
+  }
+}

--- a/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/mapper/IcebergCatalogMapper.scala
+++ b/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/mapper/IcebergCatalogMapper.scala
@@ -1,0 +1,38 @@
+package com.linkedin.openhouse.spark.sql.execution.datasources.v2.mapper
+
+import org.apache.iceberg.CachingCatalog
+import org.apache.iceberg.catalog.Catalog
+import org.apache.iceberg.common.DynFields
+import org.apache.iceberg.spark.{SparkCatalog, SparkSessionCatalog}
+import org.apache.spark.sql.connector.catalog.TableCatalog
+
+object IcebergCatalogMapper {
+
+  /**
+   * Convert Spark's {@link TableCatalog} to Iceberg's {@link Catalog}
+   *
+   * {@link Catalog} instance is a private field inside of a chain of wrapping {@link Catalog} classes in {@link TableCatalog}.
+   * To access the instance we need to access following private fields:
+   *    {@link SparkSessionCatalog#icebergCatalog} -> {@link SparkCatalog}
+   *    {@link SparkCatalog#icebergCatalog} -> {@link CachingCatalog}
+   *    {@link CachingCatalog#catalog} -> {@link OpenHouseCatalog}
+   *
+   * @return null :if it is not iceberg based catalog
+   *         catalog :if iceberg catalog
+   */
+  def toIcebergCatalog(catalog: TableCatalog): Catalog = {
+    if (!(catalog.isInstanceOf[SparkCatalog] || catalog.isInstanceOf[SparkSessionCatalog[_]])) {
+      null
+    } else {
+      val sparkCatalog = if (catalog.isInstanceOf[SparkSessionCatalog[_]]) {
+        DynFields.builder.hiddenImpl(classOf[SparkSessionCatalog[_]], "icebergCatalog").build[TableCatalog](catalog).get
+      } else {
+        catalog
+      }
+      var icebergCatalog = DynFields.builder.hiddenImpl(classOf[SparkCatalog], "icebergCatalog").build[Catalog](sparkCatalog).get
+      val cacheEnabled = DynFields.builder.hiddenImpl(classOf[SparkCatalog], "cacheEnabled").build[Boolean](sparkCatalog).get
+      if (cacheEnabled) icebergCatalog = DynFields.builder.hiddenImpl(classOf[CachingCatalog], "catalog").build[Catalog](icebergCatalog).get
+      icebergCatalog
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Gives the spark-3.5 module its own copy of the OpenHouse SQL-extension machinery so the grammar can evolve for spark-3.5. 

Previously spark-3.5 took a dependency on the 3.1 code to avoid duplication. That coupling meant the SQL grammar could not change for spark-3.5 without also changing spark-3.1.

This change will mean that we will explicitly release grammer on each version. 

## Changes
- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation


1. Copy the grammar + 7 borrowed classes into spark-3.5.
2. Add the ANTLR generation task (antlr4 4.7.1, matching spark-3.1) and point `srcDirs`
  at the module's own generated dir.
3. Drop the spark-3.1 module dependency.

## Testing Done
- [x] No behavior change — existing spark-3.5 statement tests pass unmodified against
  the standalone module.

```
./gradlew :integrations:spark:spark-3.5:openhouse-spark-3.5-itest:statementTest
# BUILD SUCCESSFUL — all pre-existing statement tests pass
```

# Additional Information
No breaking changes; no client-facing changes.
