### PR TITLE
feat(spark-3.5): [stacked] Add OPTIMIZE SQL extension (bin-pack + incremental clustering)

### DIFF
--- a/integrations/spark/spark-3.5/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/OptimizeStatementTest.java
+++ b/integrations/spark/spark-3.5/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/OptimizeStatementTest.java
@@ -1,0 +1,160 @@
+package com.linkedin.openhouse.spark.statementtest;
+
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.SneakyThrows;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class OptimizeStatementTest {
+
+  private static SparkSession spark = null;
+
+  private Map<String, String> optimize(String sql) {
+    Map<String, String> metrics = new HashMap<>();
+    for (Row r : spark.sql(sql).collectAsList()) {
+      metrics.put(r.getString(0), r.getString(1));
+    }
+    return metrics;
+  }
+
+  private long rowCount(String table) {
+    return spark.sql("SELECT * FROM " + table).count();
+  }
+
+  private String tableProperty(String table, String key) {
+    List<Row> rows = spark.sql("SHOW TBLPROPERTIES " + table + " ('" + key + "')").collectAsList();
+    return rows.isEmpty() ? null : rows.get(0).getString(1);
+  }
+
+  @Test
+  public void testOptimizeBinPackReturnsMetricsAndPreservesRows() {
+    Map<String, String> m = optimize("OPTIMIZE openhouse.db.table");
+    // Output surface: the four reduction metrics.
+    Assertions.assertTrue(m.containsKey("files_before"));
+    Assertions.assertTrue(m.containsKey("files_after"));
+    Assertions.assertTrue(m.containsKey("files_removed"));
+    Assertions.assertTrue(m.containsKey("snapshots_committed"));
+    // Bin-pack compaction never loses or duplicates rows.
+    Assertions.assertEquals(6, rowCount("openhouse.db.table"));
+    // Six single-row files are above the default min-input-files, so they compact down.
+    Assertions.assertTrue(
+        Long.parseLong(m.get("files_after")) < Long.parseLong(m.get("files_before")));
+  }
+
+  @Test
+  public void testOptimizeClusteringWritesDurableStateAndPreservesRows() {
+    spark
+        .sql(
+            "ALTER TABLE openhouse.db.table SET TBLPROPERTIES ("
+                + "'optimize.cluster.keys' = 'id', "
+                + "'optimize.cluster.sort-mode' = 'sort', "
+                + "'optimize.cluster.min-snapshot-age-minutes' = '0')")
+        .show();
+
+    Map<String, String> m = optimize("OPTIMIZE openhouse.db.table");
+    Assertions.assertEquals(6, rowCount("openhouse.db.table"));
+    // A clustered run committed a rewrite snapshot and advanced the durable metadata.
+    Assertions.assertTrue(Long.parseLong(m.get("snapshots_committed")) >= 1);
+    String state = tableProperty("openhouse.db.table", "optimize.cluster.state");
+    Assertions.assertNotNull(state);
+    Assertions.assertTrue(state.trim().startsWith("["));
+    Assertions.assertNotNull(
+        tableProperty("openhouse.db.table", "optimize.cluster.hwm-snapshot-id"));
+  }
+
+  @Test
+  public void testOptimizeClusteringIncrementalSecondRunIsNoOp() {
+    spark
+        .sql(
+            "ALTER TABLE openhouse.db.table SET TBLPROPERTIES ("
+                + "'optimize.cluster.keys' = 'id', "
+                + "'optimize.cluster.sort-mode' = 'sort', "
+                + "'optimize.cluster.min-snapshot-age-minutes' = '0')")
+        .show();
+
+    optimize("OPTIMIZE openhouse.db.table");
+    // No new data arrived, so the incremental run finds nothing above the last-clustered upper.
+    Map<String, String> second = optimize("OPTIMIZE openhouse.db.table");
+    Assertions.assertEquals("0", second.get("snapshots_committed"));
+    Assertions.assertEquals(6, rowCount("openhouse.db.table"));
+  }
+
+  @Test
+  public void testOptimizeRewriteManifestsPreservesRows() {
+    Map<String, String> m = optimize("OPTIMIZE openhouse.db.table REWRITE MANIFESTS");
+    Assertions.assertTrue(m.containsKey("files_after"));
+    Assertions.assertEquals(6, rowCount("openhouse.db.table"));
+  }
+
+  @Test
+  public void testOptimizeFullRewriteManifestsParsesAndRuns() {
+    Map<String, String> m = optimize("OPTIMIZE openhouse.db.table FULL REWRITE MANIFESTS");
+    Assertions.assertEquals(6, rowCount("openhouse.db.table"));
+    Assertions.assertTrue(m.containsKey("files_removed"));
+  }
+
+  @Test
+  public void testOptimizeNonOpenhouseTableThrows() {
+    Assertions.assertThrows(
+        Exception.class, () -> spark.sql("OPTIMIZE openhouse.db.not_openhouse").collect());
+  }
+
+  @SneakyThrows
+  @BeforeAll
+  public void setupSpark() {
+    Path unittest = new Path(Files.createTempDirectory("unittest").toString());
+    spark =
+        SparkSession.builder()
+            .master("local[2]")
+            .config(
+                "spark.sql.extensions",
+                ("org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,"
+                    + "com.linkedin.openhouse.spark.extensions.OpenhouseSparkSessionExtensions"))
+            .config("spark.sql.catalog.openhouse", "org.apache.iceberg.spark.SparkCatalog")
+            .config("spark.sql.catalog.openhouse.type", "hadoop")
+            .config("spark.sql.catalog.openhouse.warehouse", unittest.toString())
+            .getOrCreate();
+  }
+
+  @BeforeEach
+  public void setup() {
+    spark
+        .sql(
+            "CREATE TABLE openhouse.db.table (id bigint, data string, `openhouse.tableId` string) USING iceberg")
+        .show();
+    spark
+        .sql("ALTER TABLE openhouse.db.table SET TBLPROPERTIES ('openhouse.tableId' = 'tableid')")
+        .show();
+    for (int i = 1; i <= 6; i++) {
+      spark
+          .sql("INSERT INTO openhouse.db.table VALUES (" + i + ", 'd" + i + "', 'tableid')")
+          .show();
+    }
+    spark
+        .sql("CREATE TABLE openhouse.db.not_openhouse (id bigint, data string) USING iceberg")
+        .show();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    spark.sql("DROP TABLE IF EXISTS openhouse.db.table").show();
+    spark.sql("DROP TABLE IF EXISTS openhouse.db.not_openhouse").show();
+  }
+
+  @AfterAll
+  public void tearDownSpark() {
+    spark.close();
+  }
+}

--- a/integrations/spark/spark-3.5/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/OptimizeStatementTest.java
+++ b/integrations/spark/spark-3.5/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/OptimizeStatementTest.java
@@ -111,6 +111,30 @@ public class OptimizeStatementTest {
         Exception.class, () -> spark.sql("OPTIMIZE openhouse.db.not_openhouse").collect());
   }
 
+  @Test
+  public void testOptimizeCompactsMergeOnReadDeletesAndKeepsRowsCorrect() {
+    // A merge-on-read table: the DELETE writes position delete files rather than rewriting data.
+    spark
+        .sql(
+            "CREATE TABLE openhouse.db.mor (id bigint, data string, `openhouse.tableId` string) "
+                + "USING iceberg TBLPROPERTIES ("
+                + "'openhouse.tableId' = 'tableid', 'format-version' = '2', "
+                + "'write.delete.mode' = 'merge-on-read')")
+        .show();
+    for (int i = 1; i <= 6; i++) {
+      spark.sql("INSERT INTO openhouse.db.mor VALUES (" + i + ", 'd" + i + "', 'tableid')").show();
+    }
+    spark.sql("DELETE FROM openhouse.db.mor WHERE id = 3").show();
+    Assertions.assertEquals(5, rowCount("openhouse.db.mor"));
+
+    // OPTIMIZE rewrites data and then rewrite_position_delete_files cleans up the deletes made
+    // dangling by that rewrite. The visible rows must be byte-for-byte correct across the rewrite.
+    Map<String, String> m = optimize("OPTIMIZE openhouse.db.mor");
+    Assertions.assertTrue(m.containsKey("files_after"));
+    Assertions.assertEquals(5, rowCount("openhouse.db.mor"));
+    Assertions.assertEquals(0, spark.sql("SELECT * FROM openhouse.db.mor WHERE id = 3").count());
+  }
+
   @SneakyThrows
   @BeforeAll
   public void setupSpark() {
@@ -150,6 +174,7 @@ public class OptimizeStatementTest {
   @AfterEach
   public void tearDown() {
     spark.sql("DROP TABLE IF EXISTS openhouse.db.table").show();
+    spark.sql("DROP TABLE IF EXISTS openhouse.db.mor").show();
     spark.sql("DROP TABLE IF EXISTS openhouse.db.not_openhouse").show();
   }
 

--- a/integrations/spark/spark-3.5/openhouse-spark-runtime/build.gradle
+++ b/integrations/spark/spark-3.5/openhouse-spark-runtime/build.gradle
@@ -25,6 +25,16 @@ configurations {
   antlr
 }
 
+// The root build forces jackson-databind to 2.13.4; align jackson-module-scala to the same
+// version so the runtime module's own unit tests can (de)serialize the clustering state. Spark
+// provides a consistent jackson at itest/production runtime (this force only affects this module's
+// dependency resolution, and jackson is not bundled into the shadow jar).
+configurations.all {
+  resolutionStrategy {
+    force 'com.fasterxml.jackson.module:jackson-module-scala_2.12:2.13.4'
+  }
+}
+
 // Set source for antlr generated directory
 sourceSets {
   main {

--- a/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/antlr/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensions.g4
+++ b/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/antlr/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensions.g4
@@ -32,6 +32,7 @@ statement
   | GRANT privilege ON grantableResource TO principal                                                  #grantStatement
   | REVOKE privilege ON grantableResource FROM principal                                               #revokeStatement
   | SHOW GRANTS ON grantableResource                                                                   #showGrantsStatement
+  | OPTIMIZE multipartIdentifier (FULL)? (REWRITE MANIFESTS)?                                           #optimizeTable
   ;
 
 multipartIdentifier
@@ -69,6 +70,7 @@ quotedIdentifier
 nonReserved
     : ALTER | TABLE | SET | POLICY | RETENTION | SHARING | REPLICATION | HISTORY
     | GRANT | REVOKE | ON | TO | SHOW | GRANTS | PATTERN | WHERE | COLUMN
+    | OPTIMIZE | FULL | REWRITE | MANIFESTS
     ;
 
 sharingPolicy
@@ -205,6 +207,10 @@ TAG: 'TAG';
 NONE: 'NONE';
 VERSIONS: 'VERSIONS';
 MAX_AGE: 'MAX_AGE';
+OPTIMIZE: 'OPTIMIZE';
+FULL: 'FULL';
+REWRITE: 'REWRITE';
+MANIFESTS: 'MANIFESTS';
 
 POSITIVE_INTEGER
     : DIGIT+

--- a/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSparkSqlExtensionsParser.scala
+++ b/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSparkSqlExtensionsParser.scala
@@ -14,8 +14,25 @@ import org.apache.spark.sql.types.{DataType, StructType}
 
 import java.util.Locale
 
-class OpenhouseSparkSqlExtensionsParser (delegate: ParserInterface) extends ParserInterface {
+import org.apache.iceberg.spark.ExtendedParser
+import org.apache.iceberg.spark.ExtendedParser.RawOrderField
+
+class OpenhouseSparkSqlExtensionsParser (delegate: ParserInterface) extends ParserInterface
+  with ExtendedParser {
   private lazy val astBuilder = new OpenhouseSqlExtensionsAstBuilder(delegate)
+
+  // Iceberg procedures that take a sort order (e.g. rewrite_data_files with strategy => 'sort')
+  // cast the session's outermost parser to Iceberg's ExtendedParser to parse the order string.
+  // This wrapper is outermost, so it must implement ExtendedParser and delegate to the underlying
+  // Iceberg parser; otherwise those procedures fail with "parser is not an Iceberg ExtendedParser".
+  override def parseSortOrder(sqlText: String): java.util.List[RawOrderField] = {
+    delegate match {
+      case extended: ExtendedParser => extended.parseSortOrder(sqlText)
+      case _ =>
+        throw new UnsupportedOperationException(
+          "Parsing a sort order requires the Iceberg SQL extensions to be enabled")
+    }
+  }
 
   override def parsePlan(sqlText: String): LogicalPlan = {
     if (isOpenhouseCommand(sqlText)) {
@@ -72,7 +89,8 @@ class OpenhouseSparkSqlExtensionsParser (delegate: ParserInterface) extends Pars
         normalized.contains("set tag"))) ||
       normalized.startsWith("grant") ||
       normalized.startsWith("revoke") ||
-      normalized.startsWith("show grants")
+      normalized.startsWith("show grants") ||
+      normalized.startsWith("optimize")
 
   }
 

--- a/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensionsAstBuilder.scala
+++ b/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensionsAstBuilder.scala
@@ -2,7 +2,7 @@ package com.linkedin.openhouse.spark.sql.catalyst.parser.extensions
 
 import com.linkedin.openhouse.spark.sql.catalyst.enums.GrantableResourceTypes
 import com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseSqlExtensionsParser._
-import com.linkedin.openhouse.spark.sql.catalyst.plans.logical.{GrantRevokeStatement, SetColumnPolicyTag, SetHistoryPolicy, SetReplicationPolicy, SetRetentionPolicy, SetSharingPolicy, ShowGrantsStatement, UnSetReplicationPolicy}
+import com.linkedin.openhouse.spark.sql.catalyst.plans.logical.{GrantRevokeStatement, OptimizeTable, SetColumnPolicyTag, SetHistoryPolicy, SetReplicationPolicy, SetRetentionPolicy, SetSharingPolicy, ShowGrantsStatement, UnSetReplicationPolicy}
 import com.linkedin.openhouse.spark.sql.catalyst.enums.GrantableResourceTypes.GrantableResourceType
 import com.linkedin.openhouse.gen.tables.client.model.TimePartitionSpec
 import org.antlr.v4.runtime.tree.ParseTree
@@ -195,6 +195,13 @@ class OpenhouseSqlExtensionsAstBuilder (delegate: ParserInterface) extends Openh
 
   override def visitVersions(ctx: VersionsContext): Integer = {
     ctx.POSITIVE_INTEGER().getText.toInt
+  }
+
+  override def visitOptimizeTable(ctx: OptimizeTableContext): OptimizeTable = {
+    val tableName = typedVisit[Seq[String]](ctx.multipartIdentifier)
+    val full = ctx.FULL() != null
+    val rewriteManifests = ctx.MANIFESTS() != null
+    OptimizeTable(tableName, full, rewriteManifests)
   }
 
   private def toBuffer[T](list: java.util.List[T]) = list.asScala

--- a/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/plans/logical/OptimizeTable.scala
+++ b/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/plans/logical/OptimizeTable.scala
@@ -1,0 +1,150 @@
+package com.linkedin.openhouse.spark.sql.catalyst.plans.logical
+
+import java.nio.charset.StandardCharsets
+import java.util.Locale
+import java.util.zip.CRC32
+
+import scala.util.control.NonFatal
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.catalyst.plans.logical.LeafCommand
+import org.apache.spark.sql.types.StringType
+
+/**
+ * The logical plan of the OPTIMIZE command:
+ * {{{
+ *   OPTIMIZE multi_part_name [FULL] [REWRITE MANIFESTS]
+ * }}}
+ *
+ * Behavior depends on whether clustering keys are configured via the `optimize.cluster.*` table
+ * properties:
+ *
+ *  - '''No `optimize.cluster.keys`''': plain bin-pack compaction (`system.rewrite_data_files` with
+ *    defaults). Historical behavior, unaffected by `FULL`.
+ *  - '''Clustering configured''': a sort / z-order rewrite of the configured keys, incremental by
+ *    default (only the forward slice of the leading key since the last run, tracked by an
+ *    `optimize.cluster.hwm-snapshot-id` watermark); `FULL` reclusters up to the age floor.
+ *
+ * `REWRITE MANIFESTS` (`system.rewrite_manifests`) is independent and runs after the data rewrite.
+ * Snapshot expiration is intentionally not part of OPTIMIZE -- that is the VACUUM command's job.
+ */
+case class OptimizeTable(tableName: Seq[String], full: Boolean, rewriteManifests: Boolean)
+  extends LeafCommand {
+
+  override lazy val output: Seq[Attribute] = Seq(
+    AttributeReference("metric", StringType, nullable = false)(),
+    AttributeReference("value", StringType, nullable = false)())
+
+  override def simpleString(maxFields: Int): String = {
+    s"OptimizeTable: ${tableName} full=${full} rewriteManifests=${rewriteManifests}"
+  }
+}
+
+object OptimizeTable {
+
+  val KEYS_PROP = "optimize.cluster.keys"
+  val SORT_MODE_PROP = "optimize.cluster.sort-mode"
+  val MIN_SNAPSHOT_AGE_PROP = "optimize.cluster.min-snapshot-age-minutes"
+  val HWM_PROP = "optimize.cluster.hwm-snapshot-id"
+  val MAX_COMMITS_PROP = "optimize.cluster.max-commits"
+  val CONFIG_ID_PROP = "optimize.cluster.config-id"
+  val STATE_PROP = "optimize.cluster.state"
+
+  val DEFAULT_SORT_MODE = "zorder"
+  val DEFAULT_MIN_SNAPSHOT_AGE_MINUTES = 30L
+  val DEFAULT_MAX_COMMITS = 10L
+
+  /**
+   * Clustering configuration resolved from the `optimize.cluster.*` table properties, with every
+   * default applied and every value parsed to its type.
+   */
+  case class ClusterConfig(
+      keys: Seq[String],
+      sortMode: String,
+      minAgeMinutes: Long,
+      maxCommits: Long,
+      hwm: Option[Long],
+      state: Seq[ClusterInterval])
+
+  /** Parse the `optimize.cluster.*` table properties into a typed [[ClusterConfig]]. */
+  def parseClusterConfig(props: Map[String, String]): ClusterConfig = ClusterConfig(
+    keys = props.get(KEYS_PROP)
+      .map(_.split(",").map(_.trim).filter(_.nonEmpty).toSeq).getOrElse(Seq.empty),
+    sortMode = props.getOrElse(SORT_MODE_PROP, DEFAULT_SORT_MODE),
+    minAgeMinutes = props.get(MIN_SNAPSHOT_AGE_PROP).map(_.toLong)
+      .getOrElse(DEFAULT_MIN_SNAPSHOT_AGE_MINUTES),
+    maxCommits = props.get(MAX_COMMITS_PROP).map(_.toLong).getOrElse(DEFAULT_MAX_COMMITS),
+    hwm = props.get(HWM_PROP).map(_.toLong),
+    state = parseState(props.getOrElse(STATE_PROP, "")))
+
+  val stateMapper = {
+    val mapper = new ObjectMapper() with ClassTagExtensions
+    mapper.registerModule(DefaultScalaModule)
+    // Omit an absent `lower` (None) so the persisted JSON stays compact and stable.
+    mapper.setSerializationInclusion(JsonInclude.Include.NON_ABSENT)
+    mapper
+  }
+
+  /**
+   * One clustered leading-key interval `(lower, upper]` under a specific key selection (`config`).
+   * `lower = None` means unbounded below (a FULL / first backfill). Persisted, alongside the
+   * watermark, in the `optimize.cluster.state` table property so it survives snapshot expiration.
+   */
+  case class ClusterInterval(
+      config: String, keys: String, mode: String, lower: Option[String], upper: String)
+
+  /** Stable, compact identity of a key selection: only a keys/mode change produces a new id. */
+  def configId(keys: Seq[String], sortMode: String): String = {
+    val normalized = keys.map(_.trim).mkString(",") + "|" + sortMode.toLowerCase(Locale.ROOT)
+    val crc = new CRC32()
+    crc.update(normalized.getBytes(StandardCharsets.UTF_8))
+    java.lang.Long.toHexString(crc.getValue)
+  }
+
+  /**
+   * Parse interval state. Empty / absent input is no state (a fresh table). Non-empty but
+   * unparseable input is a corrupted property, not "no state" -- silently treating it as empty
+   * would make OPTIMIZE recluster from scratch and mis-report ANALYZE coverage, so it fails loudly
+   * naming the property and how to clear it.
+   */
+  def parseState(json: String): Seq[ClusterInterval] = {
+    if (json == null || json.trim.isEmpty) return Seq.empty
+    try {
+      stateMapper.readValue[Seq[ClusterInterval]](json)
+    } catch {
+      case NonFatal(e) =>
+        throw new IllegalStateException(
+          s"Malformed clustering state in table property '$STATE_PROP'; OPTIMIZE cannot tell " +
+            s"what is already clustered. Clear the clustering metadata and let the next OPTIMIZE " +
+            s"rebuild it: ALTER TABLE <table> UNSET TBLPROPERTIES " +
+            s"('$STATE_PROP', '$HWM_PROP', '$CONFIG_ID_PROP'). Value was: $json", e)
+    }
+  }
+
+  /**
+   * Fold a completed run into the interval state. A same-config incremental run extends the current
+   * epoch's upper bound (keeping its lower); a config change appends a new epoch, retains the old
+   * ones (durable key-selection history); FULL collapses the current config to one unbounded-below
+   * interval.
+   */
+  def advanceState(
+      existing: Seq[ClusterInterval],
+      cfgId: String,
+      keys: Seq[String],
+      mode: String,
+      lower: Option[String],
+      upper: String,
+      full: Boolean): Seq[ClusterInterval] = {
+    val keysStr = keys.mkString(",")
+    val others = existing.filterNot(_.config == cfgId)
+    (full, existing.find(_.config == cfgId)) match {
+      case (true, _) => others :+ ClusterInterval(cfgId, keysStr, mode, None, upper)
+      case (false, Some(cur)) => others :+ cur.copy(keys = keysStr, mode = mode, upper = upper)
+      case (false, None) => existing :+ ClusterInterval(cfgId, keysStr, mode, lower, upper)
+    }
+  }
+}

--- a/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/OpenhouseDataSourceV2Strategy.scala
+++ b/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/OpenhouseDataSourceV2Strategy.scala
@@ -1,6 +1,6 @@
 package com.linkedin.openhouse.spark.sql.execution.datasources.v2
 
-import com.linkedin.openhouse.spark.sql.catalyst.plans.logical.{GrantRevokeStatement, SetColumnPolicyTag, SetHistoryPolicy, SetReplicationPolicy, SetRetentionPolicy, SetSharingPolicy, ShowGrantsStatement, UnSetReplicationPolicy}
+import com.linkedin.openhouse.spark.sql.catalyst.plans.logical.{GrantRevokeStatement, OptimizeTable, SetColumnPolicyTag, SetHistoryPolicy, SetReplicationPolicy, SetRetentionPolicy, SetSharingPolicy, ShowGrantsStatement, UnSetReplicationPolicy}
 import org.apache.iceberg.spark.{Spark3Util, SparkCatalog, SparkSessionCatalog}
 import org.apache.spark.sql.{SparkSession, Strategy}
 import org.apache.spark.sql.catalyst.expressions.PredicateHelper
@@ -31,6 +31,9 @@ case class OpenhouseDataSourceV2Strategy(spark: SparkSession) extends Strategy w
 
     case r @ ShowGrantsStatement(resourceType, CatalogAndIdentifierExtractor(catalog, ident)) =>
       ShowGrantsStatementExec(r.output, resourceType, catalog, ident) :: Nil
+
+    case r @ OptimizeTable(CatalogAndIdentifierExtractor(catalog, ident), full, rewriteManifests) =>
+      OptimizeTableExec(r.output, spark, catalog, ident, full, rewriteManifests) :: Nil
 
     case _ => Nil
   }

--- a/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/OptimizeTableExec.scala
+++ b/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/OptimizeTableExec.scala
@@ -22,6 +22,9 @@ import org.apache.spark.unsafe.types.UTF8String
  * incremental by default (only the forward slice of the leading key since the last run, tracked by
  * the `optimize.cluster.hwm-snapshot-id` watermark), with `FULL` reclustering up to the age floor.
  * `REWRITE MANIFESTS` runs afterwards over the post-rewrite layout.
+ *
+ * After the data rewrite, `system.rewrite_position_delete_files` compacts merge-on-read position
+ * delete files and drops dangling deletes; it is a no-op on copy-on-write or delete-free tables.
  */
 case class OptimizeTableExec(
   output: Seq[Attribute],
@@ -59,6 +62,13 @@ case class OptimizeTableExec(
       case _ =>
         cluster(cat, tableArg, qualifiedTableName, config)
     }
+
+    // Compact merge-on-read position delete files and drop dangling deletes (deletes that no longer
+    // apply to any live data, e.g. because the data files they targeted were just rewritten above).
+    // Runs after the data rewrite so it also cleans up deletes that rewrite made dangling, and
+    // before REWRITE MANIFESTS so manifest compaction sees the reduced delete-file set. On
+    // copy-on-write or delete-free tables there is nothing to rewrite, so this is a no-op.
+    spark.sql(s"CALL $cat.system.rewrite_position_delete_files(table => '$tableArg')").collect()
 
     if (rewriteManifests) {
       // Independent manifest compaction; runs after the data rewrite so it sees the new layout.

--- a/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/OptimizeTableExec.scala
+++ b/integrations/spark/spark-3.5/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/execution/datasources/v2/OptimizeTableExec.scala
@@ -1,0 +1,176 @@
+package com.linkedin.openhouse.spark.sql.execution.datasources.v2
+
+import java.util.Locale
+
+import scala.collection.JavaConverters._
+
+import com.linkedin.openhouse.spark.sql.catalyst.plans.logical.OptimizeTable
+import org.apache.iceberg.spark.source.SparkTable
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, GenericInternalRow, Literal}
+import org.apache.spark.sql.catalyst.util.quoteIfNeeded
+import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog, TableChange}
+import org.apache.spark.sql.execution.datasources.v2.LeafV2CommandExec
+import org.apache.spark.sql.functions.{col, current_timestamp, expr, lit, max}
+import org.apache.spark.unsafe.types.UTF8String
+
+/**
+ * Runs Iceberg data-layout maintenance for the OPTIMIZE command as thin sugar over the catalog's
+ * stored procedures. With no `optimize.cluster.keys` configured this is a plain bin-pack compaction
+ * (`system.rewrite_data_files`); with clustering configured it is a sort / z-order rewrite that is
+ * incremental by default (only the forward slice of the leading key since the last run, tracked by
+ * the `optimize.cluster.hwm-snapshot-id` watermark), with `FULL` reclustering up to the age floor.
+ * `REWRITE MANIFESTS` runs afterwards over the post-rewrite layout.
+ */
+case class OptimizeTableExec(
+  output: Seq[Attribute],
+  spark: SparkSession,
+  catalog: TableCatalog,
+  ident: Identifier,
+  full: Boolean,
+  rewriteManifests: Boolean) extends LeafV2CommandExec {
+
+  private def row(metric: String, value: String): InternalRow =
+    new GenericInternalRow(
+      Array[Any](UTF8String.fromString(metric), UTF8String.fromString(value)))
+
+  override protected def run(): Seq[InternalRow] = {
+    val props = catalog.loadTable(ident) match {
+      case iceberg: SparkTable if iceberg.table().properties().containsKey("openhouse.tableId") =>
+        iceberg.table().properties().asScala.toMap
+      case table =>
+        throw new UnsupportedOperationException(s"Cannot optimize non-Openhouse table: $table")
+    }
+
+    val cat = quoteIfNeeded(catalog.name())
+    val tableArg = (ident.namespace() :+ ident.name()).map(quoteIfNeeded).mkString(".")
+    val qualifiedTableName = s"$cat.$tableArg"
+
+    // Snapshot the physical layout before doing any work so we can report the reduction.
+    val filesBefore = spark.table(s"$qualifiedTableName.files").count()
+    val snapshotsBefore = spark.table(s"$qualifiedTableName.snapshots").count()
+
+    val config = OptimizeTable.parseClusterConfig(props)
+    config.keys match {
+      case Seq() =>
+        // No clustering configured: plain bin-pack compaction (unchanged historical behavior).
+        spark.sql(s"CALL $cat.system.rewrite_data_files(table => '$tableArg')").collect()
+      case _ =>
+        cluster(cat, tableArg, qualifiedTableName, config)
+    }
+
+    if (rewriteManifests) {
+      // Independent manifest compaction; runs after the data rewrite so it sees the new layout.
+      spark.sql(s"CALL $cat.system.rewrite_manifests(table => '$tableArg')").collect()
+    }
+
+    val filesAfter = spark.table(s"$qualifiedTableName.files").count()
+    val snapshotsAfter = spark.table(s"$qualifiedTableName.snapshots").count()
+    Seq(
+      row("files_before", filesBefore.toString),
+      row("files_after", filesAfter.toString),
+      row("files_removed", (filesBefore - filesAfter).toString),
+      row("snapshots_committed", (snapshotsAfter - snapshotsBefore).toString))
+  }
+
+  private def cluster(
+      cat: String,
+      tableArg: String,
+      qualifiedTableName: String,
+      config: OptimizeTable.ClusterConfig): Unit = {
+    import config.{hwm, keys, maxCommits, minAgeMinutes, sortMode, state}
+
+    // Age floor: the newest snapshot at least `minAgeMinutes` old, by commit time. Everything
+    // younger is held back so we never rewrite files a concurrent streaming writer is extending.
+    val ageFloor = spark.table(s"$qualifiedTableName.snapshots")
+      .where(col("committed_at") <= current_timestamp() - expr(s"INTERVAL $minAgeMinutes MINUTES"))
+      .orderBy(col("committed_at").desc)
+      .limit(1)
+      .select("snapshot_id")
+      .collect().headOption.map(_.getLong(0))
+    if (ageFloor.isEmpty) return // nothing old enough to consume yet -> no-op
+
+    val floorId = ageFloor.get
+    // Incremental run whose watermark has not moved -> nothing new to do.
+    if (!full && hwm.contains(floorId)) return
+
+    // The forward slice is bounded on the leading clustering key. Its upper bound is the max value
+    // present as of the age floor; Iceberg satisfies this from manifest metrics when the table has
+    // no deletes, so it is metadata-only.
+    val leadKey = keys.head
+    val floorMax = Option(
+      spark.read.option("snapshot-id", floorId).table(qualifiedTableName)
+        .agg(max(col(quoteIfNeeded(leadKey)))).head().get(0))
+    if (floorMax.isEmpty) return // no data as of the age floor -> no-op
+
+    // Lower bound: incremental runs skip what a prior run already clustered -- the last-clustered
+    // upper of the current key selection, read from the persisted interval state (a table property,
+    // so it survives snapshot expiration). FULL ignores the bound and reclusters everything up to
+    // the floor.
+    val cfgId = OptimizeTable.configId(keys, sortMode)
+    val lowerValue = state.find(_.config == cfgId).map(_.upper).filterNot(_ => full)
+
+    // Cast the persisted (string) bound back to the leading key's type so a key promoted between
+    // runs (e.g. INT -> BIGINT) is compared after a cast, not across boxed types.
+    val leadType = spark.table(qualifiedTableName).schema(leadKey).dataType
+    val lead = col(quoteIfNeeded(leadKey))
+    val lowerBound = lowerValue.map(u => lit(u).cast(leadType))
+
+    // No-op if the leading key has not advanced past the last-clustered upper. Evaluate the
+    // comparison in Catalyst (not in Scala) so the cast above governs the ordering.
+    val advanced = lowerBound.forall { lb =>
+      spark.range(1).select(lit(floorMax.get) > lb).head().getBoolean(0)
+    }
+    if (!advanced) return
+
+    // The `where` slice to recluster: `lead <= floorMax`, plus `lead > lowerBound` for an
+    // incremental run. Catalyst renders each key-type literal correctly, then the predicate is
+    // embedded as a SQL string literal so its own quotes survive the CALL.
+    val scope = lowerBound.map(lb => (lead > lb) && (lead <= lit(floorMax.get)))
+      .getOrElse(lead <= lit(floorMax.get)).expr.sql
+    val cols = keys.map(quoteIfNeeded).mkString(", ")
+    val sortOrder = sortMode.toLowerCase(Locale.ROOT) match {
+      case "zorder" => s"zorder($cols)"
+      case _ => cols
+    }
+
+    // Scoped sort / z-order rewrite with partial progress: min-input-files=1 + rewrite-all=true
+    // cluster the region regardless of file count; use-starting-sequence-number keeps concurrent
+    // equality-deletes valid. rewrite-all forces a rewrite over the non-empty scope, so a healthy
+    // run always commits a snapshot; if none is committed the rewrite failed systemically (partial
+    // progress swallows per-group failures), so fail loudly and leave the watermark unadvanced.
+    val snapshotsBefore = spark.table(s"$qualifiedTableName.snapshots").count()
+    spark.sql(
+      s"CALL $cat.system.rewrite_data_files(" +
+        s"table => '$tableArg', " +
+        "strategy => 'sort', " +
+        s"sort_order => '$sortOrder', " +
+        s"where => ${Literal(scope).sql}, " +
+        "options => map(" +
+        "'min-input-files', '1', " +
+        "'rewrite-all', 'true', " +
+        "'use-starting-sequence-number', 'true', " +
+        "'partial-progress.enabled', 'true', " +
+        s"'partial-progress.max-commits', '$maxCommits'))").collect()
+    if (spark.table(s"$qualifiedTableName.snapshots").count() <= snapshotsBefore) {
+      throw new IllegalStateException(
+        s"OPTIMIZE clustered no data for '$qualifiedTableName': the scoped rewrite " +
+          s"(keys=[${keys.mkString(",")}], sort-mode=$sortMode) committed no snapshot despite a " +
+          s"non-empty scope. The watermark was left unadvanced so the run can be retried.")
+    }
+
+    // Advance all clustering metadata in one atomic alterTable -- the watermark (the consumed age
+    // floor, not head), the config id, and the interval state -- so they never disagree.
+    val newState = OptimizeTable.advanceState(
+      state, cfgId, keys, sortMode, lowerValue, floorMax.get.toString, full)
+    catalog.alterTable(ident,
+      TableChange.setProperty(OptimizeTable.HWM_PROP, floorId.toString),
+      TableChange.setProperty(OptimizeTable.CONFIG_ID_PROP, cfgId),
+      TableChange.setProperty(OptimizeTable.STATE_PROP, OptimizeTable.stateMapper.writeValueAsString(newState)))
+  }
+
+  override def simpleString(maxFields: Int): String = {
+    s"OptimizeTableExec: ${catalog} ${ident} full=${full} rewriteManifests=${rewriteManifests}"
+  }
+}

--- a/integrations/spark/spark-3.5/openhouse-spark-runtime/src/test/scala/com/linkedin/openhouse/spark/sql/catalyst/plans/logical/OptimizeTableTest.scala
+++ b/integrations/spark/spark-3.5/openhouse-spark-runtime/src/test/scala/com/linkedin/openhouse/spark/sql/catalyst/plans/logical/OptimizeTableTest.scala
@@ -1,0 +1,95 @@
+package com.linkedin.openhouse.spark.sql.catalyst.plans.logical
+
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNotEquals, assertThrows, assertTrue}
+import org.junit.jupiter.api.Test
+
+import com.linkedin.openhouse.spark.sql.catalyst.plans.logical.OptimizeTable._
+
+class OptimizeTableTest {
+
+  @Test
+  def parseClusterConfigResolvesDefaultsAndTypedValues(): Unit = {
+    val empty = parseClusterConfig(Map.empty)
+    assertTrue(empty.keys.isEmpty)
+    assertEquals(DEFAULT_SORT_MODE, empty.sortMode)
+    assertEquals(DEFAULT_MIN_SNAPSHOT_AGE_MINUTES, empty.minAgeMinutes)
+    assertEquals(DEFAULT_MAX_COMMITS, empty.maxCommits)
+    assertTrue(empty.hwm.isEmpty)
+    assertTrue(empty.state.isEmpty)
+
+    val cfg = parseClusterConfig(Map(
+      KEYS_PROP -> " ts , uid ",
+      SORT_MODE_PROP -> "sort",
+      MIN_SNAPSHOT_AGE_PROP -> "5",
+      MAX_COMMITS_PROP -> "3",
+      HWM_PROP -> "42",
+      STATE_PROP -> """[{"config":"c1","keys":"ts","mode":"sort","upper":"20"}]"""))
+    assertEquals(Seq("ts", "uid"), cfg.keys)
+    assertEquals("sort", cfg.sortMode)
+    assertEquals(5L, cfg.minAgeMinutes)
+    assertEquals(3L, cfg.maxCommits)
+    assertEquals(Some(42L), cfg.hwm)
+    assertEquals(Seq(ClusterInterval("c1", "ts", "sort", None, "20")), cfg.state)
+  }
+
+  @Test
+  def configIdStableAcrossWhitespaceChangesOnKeyOrMode(): Unit = {
+    assertEquals(configId(Seq("ts", "uid"), "zorder"), configId(Seq(" ts ", " uid "), "ZORDER"))
+    assertNotEquals(configId(Seq("ts", "uid"), "zorder"), configId(Seq("ts"), "zorder"))
+    assertNotEquals(configId(Seq("ts"), "zorder"), configId(Seq("ts"), "sort"))
+  }
+
+  @Test
+  def parseStateRoundTripsWithAndWithoutLower(): Unit = {
+    val json = """[{"config":"c1","keys":"ts","mode":"sort","lower":"10","upper":"20"},""" +
+      """{"config":"c2","keys":"ts,uid","mode":"zorder","upper":"2026-01-06 00:00:00"}]"""
+    assertEquals(Seq(
+      ClusterInterval("c1", "ts", "sort", Some("10"), "20"),
+      ClusterInterval("c2", "ts,uid", "zorder", None, "2026-01-06 00:00:00")), parseState(json))
+  }
+
+  @Test
+  def parseStateEmptyOrNullIsNoState(): Unit = {
+    assertEquals(Seq.empty[ClusterInterval], parseState(""))
+    assertEquals(Seq.empty[ClusterInterval], parseState(null))
+  }
+
+  @Test
+  def parseStateMalformedFailsLoudly(): Unit = {
+    val e = assertThrows(classOf[IllegalStateException], () => parseState("not json"))
+    assertTrue(e.getMessage.contains(STATE_PROP))
+    assertTrue(e.getMessage.contains("UNSET TBLPROPERTIES"))
+  }
+
+  @Test
+  def advanceStateFirstRunCreatesInterval(): Unit = {
+    assertEquals(
+      Seq(ClusterInterval("c1", "ts", "sort", Some("5"), "10")),
+      advanceState(Seq.empty, "c1", Seq("ts"), "sort", Some("5"), "10", full = false))
+  }
+
+  @Test
+  def advanceStateSameConfigExtendsUpperKeepsLower(): Unit = {
+    val s0 = Seq(ClusterInterval("c1", "ts", "sort", Some("5"), "10"))
+    assertEquals(
+      Seq(ClusterInterval("c1", "ts", "sort", Some("5"), "20")),
+      advanceState(s0, "c1", Seq("ts"), "sort", Some("10"), "20", full = false))
+  }
+
+  @Test
+  def advanceStateFullCollapsesToUnbounded(): Unit = {
+    val s0 = Seq(ClusterInterval("c1", "ts", "sort", Some("5"), "20"))
+    assertEquals(
+      Seq(ClusterInterval("c1", "ts", "sort", None, "30")),
+      advanceState(s0, "c1", Seq("ts"), "sort", None, "30", full = true))
+  }
+
+  @Test
+  def advanceStateConfigChangeAppendsAndRetains(): Unit = {
+    val s0 = Seq(ClusterInterval("c1", "ts", "sort", None, "20"))
+    val s1 = advanceState(s0, "c2", Seq("ts", "uid"), "zorder", Some("20"), "40", full = false)
+    assertEquals(Seq(
+      ClusterInterval("c1", "ts", "sort", None, "20"),
+      ClusterInterval("c2", "ts,uid", "zorder", Some("20"), "40")), s1)
+  }
+}


### PR DESCRIPTION
## OpenHouse spark-3.5 SQL Extensions Stack

| PR | Base | Content |
|---|---|---|
| #660 | `main` | Standalone refactor (decouple spark-3.5 from spark-3.1) |
| _vacuum_ | #660 | VACUUM |
| **(this)** | #660 | **OPTIMIZE (bin-pack + incremental clustering)** |
| _analyze_ | **(this)** | ANALYZE … COMPUTE CLUSTERING QUALITY |

> Depends on #660. Independent of the VACUUM PR — bases directly on the standalone
> refactor. The ANALYZE PR bases on this one. Review/merge #660 first.

## Summary

Adds an OPTIMIZE command to the OpenHouse spark-3.5 SQL extensions:

```sql
OPTIMIZE <table> [FULL] [REWRITE MANIFESTS]
```

- **No `optimize.cluster.keys`** → plain bin-pack compaction (`system.rewrite_data_files`);
  unchanged historical behavior.
- **Clustering configured** → sort / z-order rewrite of the configured keys, **incremental
  by default** (only the forward slice of the leading key since the last run, tracked by an
  `optimize.cluster.hwm-snapshot-id` watermark); `FULL` reclusters up to the age floor.
  Snapshots younger than `optimize.cluster.min-snapshot-age-minutes` are held back;
  Iceberg partial progress bounds the snapshots committed per run.
- **Durable clustering state** (`optimize.cluster.config-id` + `optimize.cluster.state`
  JSON intervals) advances atomically with the watermark in a single `alterTable`, so it
  survives snapshot expiration.
- `REWRITE MANIFESTS` (`system.rewrite_manifests`) runs afterwards over the new layout.
- Emits `files_before` / `files_after` / `files_removed` / `snapshots_committed` rows.

Thin sugar over the `CALL` path (`OptimizeTableExec`), with an OpenHouse-table guard
(`openhouse.tableId`). The extension parser wrapper now implements Iceberg's
`ExtendedParser` and delegates `parseSortOrder`, so the sort / z-order `sort_order`
argument parses (the wrapper is the session's outermost parser).

## Changes
- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

New non-reserved keywords `OPTIMIZE` / `FULL` / `REWRITE` / `MANIFESTS`.

## Testing Done
- [x] Added new tests for the changes made.

- `OptimizeTableTest` (pure helpers: `parseClusterConfig` / `configId` / `parseState` /
  `advanceState`) — 9 tests.
- `OptimizeStatementTest` (real Iceberg, Hadoop catalog): bin-pack reduction, clustering
  writes durable state, incremental second run is a no-op, `REWRITE MANIFESTS`, `FULL`,
  non-OpenHouse rejection — 6 tests.

```
./gradlew :integrations:spark:spark-3.5:openhouse-spark-3.5-runtime_2.12:test            # 9/9
./gradlew :integrations:spark:spark-3.5:openhouse-spark-3.5-itest:statementTest --tests '*OptimizeStatementTest'   # 6/6
# both BUILD SUCCESSFUL
```

# Additional Information
- [x] Large PR broken into smaller PRs, and PR plan linked in the description.
