### PR TITLE
Honor table feature toggles during creation

### DIFF
--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -469,7 +469,10 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
     // Populate non-preserved keys, mainly user defined properties.
     Map<String, String> propertiesMap =
         tableDto.getTableProperties().entrySet().stream()
-            .filter(entry -> preservedKeyChecker.allowKeyInCreation(entry.getKey(), tableDto))
+            .filter(
+                entry ->
+                    !preservedKeyChecker.isKeyPreservedForTable(entry.getKey(), tableDto)
+                        || preservedKeyChecker.allowKeyInCreation(entry.getKey(), tableDto))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     // Only set cluster default for DEFAULT_FILE_FORMAT if user hasn't provided a value

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/CreateTableFeatureToggleTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/CreateTableFeatureToggleTest.java
@@ -1,0 +1,92 @@
+package com.linkedin.openhouse.tables.e2e.h2;
+
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.INITIAL_TABLE_VERSION;
+import static com.linkedin.openhouse.tables.model.TableModelConstants.TABLE_DTO;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.linkedin.openhouse.common.test.cluster.PropertyOverrideContextInitializer;
+import com.linkedin.openhouse.housetables.client.model.ToggleStatus;
+import com.linkedin.openhouse.tables.config.TblPropsToggleRegistry;
+import com.linkedin.openhouse.tables.config.TblPropsToggleRegistryBaseImpl;
+import com.linkedin.openhouse.tables.model.TableDto;
+import com.linkedin.openhouse.tables.model.TableDtoPrimaryKey;
+import com.linkedin.openhouse.tables.repository.OpenHouseInternalRepository;
+import com.linkedin.openhouse.tables.toggle.model.TableToggleStatus;
+import com.linkedin.openhouse.tables.toggle.repository.ToggleStatusesRepository;
+import java.util.Collections;
+import javax.annotation.PostConstruct;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+
+@SpringBootTest
+@ContextConfiguration(initializers = PropertyOverrideContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+@Import(CreateTableFeatureToggleTest.FeatureToggleTestConfig.class)
+public class CreateTableFeatureToggleTest {
+  private static final String TEST_PROPERTY = "openhouse.testFeatureProperty";
+  private static final String TEST_VALUE = "enabled";
+  private static final String TABLE_ID = "create_feature_toggle_test";
+
+  @Autowired private OpenHouseInternalRepository openHouseInternalRepository;
+  @Autowired private ToggleStatusesRepository toggleStatusesRepository;
+
+  @Test
+  void testFeatureToggleAllowsPreservedPropertyDuringCreation() {
+    TableDto tableDto =
+        TABLE_DTO
+            .toBuilder()
+            .tableId(TABLE_ID)
+            .tableVersion(INITIAL_TABLE_VERSION)
+            .tableProperties(Collections.singletonMap(TEST_PROPERTY, TEST_VALUE))
+            .build();
+    TableDtoPrimaryKey primaryKey =
+        TableDtoPrimaryKey.builder()
+            .databaseId(tableDto.getDatabaseId())
+            .tableId(tableDto.getTableId())
+            .build();
+    TableToggleStatus toggleStatus =
+        TableToggleStatus.builder()
+            .featureId(TblPropsToggleRegistryBaseImpl.ENABLE_TBLTYPE)
+            .databaseId(tableDto.getDatabaseId())
+            .tableId(tableDto.getTableId())
+            .toggleStatusEnum(ToggleStatus.StatusEnum.ACTIVE)
+            .build();
+
+    try {
+      toggleStatusesRepository.save(toggleStatus);
+      TableDto createdTable = openHouseInternalRepository.save(tableDto);
+
+      assertEquals(TEST_VALUE, createdTable.getTableProperties().get(TEST_PROPERTY));
+    } finally {
+      if (openHouseInternalRepository.existsById(primaryKey)) {
+        openHouseInternalRepository.deleteById(primaryKey);
+      }
+      toggleStatusesRepository.delete(toggleStatus);
+    }
+  }
+
+  @TestConfiguration
+  static class FeatureToggleTestConfig {
+    @Bean
+    @Primary
+    TblPropsToggleRegistry testTblPropsToggleRegistry() {
+      return new TestTblPropsToggleRegistry();
+    }
+  }
+
+  static class TestTblPropsToggleRegistry extends TblPropsToggleRegistryBaseImpl {
+    @PostConstruct
+    @Override
+    public void initializeKeys() {
+      super.initializeKeys();
+      featureKeys.put(TEST_PROPERTY, ENABLE_TBLTYPE);
+    }
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
@@ -50,6 +50,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.util.AopTestUtils;
 
 @SpringBootTest
 @ContextConfiguration(initializers = PropertyOverrideContextInitializer.class)
@@ -897,9 +898,15 @@ public class RepositoryTest {
             .tableProperties(userPropsWithFormat)
             .build();
 
+    PreservedKeyChecker targetPreservedKeyChecker =
+        AopTestUtils.getUltimateTargetObject(preservedKeyChecker);
+
     // Mock the preservedKeyChecker to simulate toggle disabled (don't allow user override)
+    Mockito.doReturn(true)
+        .when(targetPreservedKeyChecker)
+        .isKeyPreservedForTable(Mockito.eq(TableProperties.DEFAULT_FILE_FORMAT), Mockito.any());
     Mockito.doReturn(false)
-        .when(preservedKeyChecker)
+        .when(targetPreservedKeyChecker)
         .allowKeyInCreation(Mockito.eq(TableProperties.DEFAULT_FILE_FORMAT), Mockito.any());
 
     TableDto createdDto1 = openHouseInternalRepository.save(tableDto1);
@@ -920,9 +927,9 @@ public class RepositoryTest {
             .build();
 
     // Mock the preservedKeyChecker to simulate toggle enabled (allow user override)
-    Mockito.doReturn(true)
-        .when(preservedKeyChecker)
-        .allowKeyInCreation(Mockito.eq(TableProperties.DEFAULT_FILE_FORMAT), Mockito.any());
+    Mockito.doReturn(false)
+        .when(targetPreservedKeyChecker)
+        .isKeyPreservedForTable(Mockito.eq(TableProperties.DEFAULT_FILE_FORMAT), Mockito.any());
 
     TableDto createdDto2 = openHouseInternalRepository.save(tableDto2);
 


### PR DESCRIPTION
## Summary

Issue: table toggles only work for "alter table" ddl while we want them to work on "create table" ddl as well.

Table creation filtered feature-gated preserved properties because `allowKeyInCreation` called the advised `isKeyPreservedForTable` method through Spring self-invocation, bypassing the feature-toggle aspect. Invoke the table-aware check from the repository's Spring proxy before applying the create-only allowlist fallback.

This makes CREATE consistent with ALTER while retaining support for extension-defined properties that are writable only during creation.

## Changes

- [x] Bug Fixes
- [x] Tests

- Evaluate `isKeyPreservedForTable` through the proxied `PreservedKeyChecker` during creation.
- Retain `allowKeyInCreation` as the fallback for create-only preserved properties.
- Add a Spring integration regression test using a real active table feature toggle.
- Update the default-file-format test to model preserved/toggled state on the table-aware method.

## Testing Done

- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [x] Some other form of testing like staging or soak time in production. Please explain.

- Verified the new regression test fails without the production change and passes with it.
- `:services:tables:test` — 463 tests passed.
- `:services:tables:spotlessCheck`
- `:services:tables:checkstyleMain`
- `:services:tables:checkstyleTest`
- Manually reproduced the original behavior against a live OpenHouse namespace: feature-gated properties survived ALTER but were silently filtered during CREATE.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.
