### PR TITLE
Revert "Paginate HTS list-tables queries to avoid WebClient buffer limit (#648)"

### DIFF
--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -21,11 +21,10 @@ import com.linkedin.openhouse.internal.catalog.repository.exception.HouseTableCo
 import com.linkedin.openhouse.internal.catalog.repository.exception.HouseTableNotFoundException;
 import com.linkedin.openhouse.internal.catalog.repository.exception.HouseTableRepositoryException;
 import io.micrometer.core.instrument.MeterRegistry;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.BaseMetastoreCatalog;
@@ -41,7 +40,6 @@ import org.apache.iceberg.io.SupportsPrefixOperations;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
@@ -100,44 +98,19 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
     throw new UnsupportedOperationException("Location will be provided explicitly");
   }
 
-  // Page size used when internally paginating HTS "list all" queries so that a single HTS
-  // response never grows large enough to exceed the WebClient's in-memory buffer limit
-  // (previously observed as DataBufferLimitException for databases with very many tables).
-  private static final int LIST_TABLES_HTS_PAGE_SIZE = 1000;
-
   @Override
   public List<TableIdentifier> listTables(Namespace namespace) {
     NamespaceUtil.validateOperationNamespace(namespace);
     // TODO: Implement SupportsNamespace interface and listNamespaces() method to remove this
     //  branch. This is anti-pattern and only a temporary solution.
     if (namespace.isEmpty()) {
-      return fetchAllPages(houseTableRepository::findAll).stream()
+      return StreamSupport.stream(houseTableRepository.findAll().spliterator(), false)
           .map(houseTable -> TableIdentifier.of(houseTable.getDatabaseId(), "Unused"))
           .collect(Collectors.toList());
     }
-    return fetchAllPages(
-            pageable -> houseTableRepository.findAllByDatabaseId(namespace.toString(), pageable))
-        .stream()
+    return houseTableRepository.findAllByDatabaseId(namespace.toString()).stream()
         .map(houseTable -> TableIdentifier.of(houseTable.getDatabaseId(), houseTable.getTableId()))
         .collect(Collectors.toList());
-  }
-
-  /**
-   * Repeatedly issues the given paginated HTS query, accumulating every page in memory, until all
-   * results have been retrieved. Used to service the unbounded "list all" catalog APIs on top of
-   * HTS's paginated endpoints, so that no single underlying HTTP response can grow large enough to
-   * exceed the WebClient in-memory buffer limit.
-   */
-  private List<HouseTable> fetchAllPages(Function<Pageable, Page<HouseTable>> pageFetcher) {
-    List<HouseTable> results = new ArrayList<>();
-    Pageable pageable = PageRequest.of(0, LIST_TABLES_HTS_PAGE_SIZE);
-    Page<HouseTable> page;
-    do {
-      page = pageFetcher.apply(pageable);
-      results.addAll(page.getContent());
-      pageable = pageable.next();
-    } while (page.hasNext());
-    return results;
   }
 
   public Page<TableIdentifier> listTables(Namespace namespace, Pageable pageable) {

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalogTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalogTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
@@ -14,21 +13,13 @@ import com.linkedin.openhouse.internal.catalog.model.HouseTable;
 import com.linkedin.openhouse.internal.catalog.model.HouseTablePrimaryKey;
 import com.linkedin.openhouse.internal.catalog.repository.HouseTableRepository;
 import com.linkedin.openhouse.internal.catalog.repository.exception.HouseTableNotFoundException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.SupportsPrefixOperations;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 
 public class OpenHouseInternalCatalogTest {
 
@@ -48,94 +39,6 @@ public class OpenHouseInternalCatalogTest {
     Assertions.assertTrue(catalog.isValidBaseIdentifier(TableIdentifier.of("db", "partitions")));
     Assertions.assertFalse(
         catalog.isValidBaseIdentifier(TableIdentifier.of("db", "table", "partitions")));
-  }
-
-  @Test
-  void listTablesForDatabaseAggregatesResultsFromASinglePage() {
-    List<HouseTable> allRows =
-        List.of(houseTableRow(DB, "t0"), houseTableRow(DB, "t1"), houseTableRow(DB, "t2"));
-    HouseTableRepository repo = mock(HouseTableRepository.class);
-    when(repo.findAllByDatabaseId(eq(DB), any(Pageable.class)))
-        .thenAnswer(invocation -> slicedPage(allRows, invocation.getArgument(1)));
-    OpenHouseInternalCatalog catalog = new OpenHouseInternalCatalog();
-    catalog.houseTableRepository = repo;
-
-    List<TableIdentifier> result = catalog.listTables(Namespace.of(DB));
-
-    Assertions.assertEquals(
-        allRows.stream()
-            .map(row -> TableIdentifier.of(row.getDatabaseId(), row.getTableId()))
-            .collect(Collectors.toList()),
-        result);
-    // All 3 rows fit within a single HTS page (page size 1000), so only one call is expected.
-    verify(repo, times(1)).findAllByDatabaseId(eq(DB), any(Pageable.class));
-  }
-
-  @Test
-  void listTablesForDatabasePaginatesAcrossMultipleHtsPages() {
-    // More rows than fit on a single HTS page (page size 1000) so the fix's pagination loop must
-    // issue more than one call and aggregate every page before returning.
-    List<HouseTable> allRows =
-        IntStream.range(0, 1500)
-            .mapToObj(i -> houseTableRow(DB, "t" + i))
-            .collect(Collectors.toList());
-    HouseTableRepository repo = mock(HouseTableRepository.class);
-    when(repo.findAllByDatabaseId(eq(DB), any(Pageable.class)))
-        .thenAnswer(invocation -> slicedPage(allRows, invocation.getArgument(1)));
-    OpenHouseInternalCatalog catalog = new OpenHouseInternalCatalog();
-    catalog.houseTableRepository = repo;
-
-    List<TableIdentifier> result = catalog.listTables(Namespace.of(DB));
-
-    Assertions.assertEquals(
-        allRows.stream()
-            .map(row -> TableIdentifier.of(row.getDatabaseId(), row.getTableId()))
-            .collect(Collectors.toList()),
-        result);
-    verify(repo, times(2)).findAllByDatabaseId(eq(DB), any(Pageable.class));
-  }
-
-  @Test
-  void listTablesForDatabaseReturnsEmptyListWhenDatabaseHasNoTables() {
-    HouseTableRepository repo = mock(HouseTableRepository.class);
-    when(repo.findAllByDatabaseId(eq(DB), any(Pageable.class)))
-        .thenAnswer(invocation -> slicedPage(List.of(), invocation.getArgument(1)));
-    OpenHouseInternalCatalog catalog = new OpenHouseInternalCatalog();
-    catalog.houseTableRepository = repo;
-
-    Assertions.assertTrue(catalog.listTables(Namespace.of(DB)).isEmpty());
-    verify(repo, times(1)).findAllByDatabaseId(eq(DB), any(Pageable.class));
-  }
-
-  @Test
-  void listTablesForEmptyNamespacePaginatesThroughFindAll() {
-    List<HouseTable> allRows = List.of(houseTableRow(DB, "t0"), houseTableRow("other_db", "t1"));
-    HouseTableRepository repo = mock(HouseTableRepository.class);
-    when(repo.findAll(any(Pageable.class)))
-        .thenAnswer(invocation -> slicedPage(allRows, invocation.getArgument(0)));
-    OpenHouseInternalCatalog catalog = new OpenHouseInternalCatalog();
-    catalog.houseTableRepository = repo;
-
-    List<TableIdentifier> result = catalog.listTables(Namespace.empty());
-
-    Assertions.assertEquals(
-        List.of(TableIdentifier.of(DB, "Unused"), TableIdentifier.of("other_db", "Unused")),
-        result);
-  }
-
-  private static HouseTable houseTableRow(String databaseId, String tableId) {
-    return HouseTable.builder().databaseId(databaseId).tableId(tableId).build();
-  }
-
-  /**
-   * Slices {@code allRows} according to {@code pageable}'s offset/page size, mirroring how a real
-   * paginated HTS response would be constructed, so {@link PageImpl#hasNext()} reports correctly
-   * and the catalog's pagination loop can be exercised end-to-end.
-   */
-  private static Page<HouseTable> slicedPage(List<HouseTable> allRows, Pageable pageable) {
-    int start = Math.min((int) pageable.getOffset(), allRows.size());
-    int end = Math.min(start + pageable.getPageSize(), allRows.size());
-    return new PageImpl<>(new ArrayList<>(allRows.subList(start, end)), pageable, allRows.size());
   }
 
   @Test


### PR DESCRIPTION
# Problem & Solution Overview
This reverts commit e80d45d1e1d5460403358d4241f4270af662037f (#648).

#648 changed `OpenHouseInternalCatalog#listTables(Namespace)` to internally paginate HTS "list all" queries (page size 1000) instead of issuing a single unpaginated request, in order to avoid `DataBufferLimitException` on very large databases.

In production, this caused `GET /v1/databases` (empty-namespace list-tables path) to fan out into many sequential HTS calls per request instead of one. For a deployment with a large number of databases/tables, this significantly increased request volume against HTS, saturating its JDBC connection pool (Hikari) and causing collateral failures on unrelated HTS calls (e.g. `HikariPool-1 - Connection is not available, request timed out after 30000ms`, `java.io.EOFException: connection was unexpectedly lost`, `PrematureCloseException: Connection prematurely closed BEFORE response`).

This PR reverts the pagination change to restore the prior unpaginated `listTables` behavior while a safer fix (e.g. bounded concurrency, smarter page sizing, or pushing pagination to the client-facing paginated APIs only) is designed.

# Testing Done
- `git revert e80d45d1e1d5460403358d4241f4270af662037f` applied cleanly with no conflicts against current `main` (two unrelated commits, #650 and #651, merged on top since #648; neither touches this file).
- `./gradlew :iceberg:openhouse:internalcatalog:compileJava` compiles cleanly after the revert.
- Risk: low — this is a straight revert of a recent, isolated change back to previously-running production behavior (pre-#648). Follow-up work is needed to re-address the original `DataBufferLimitException` motivating #648, without triggering HTS connection-pool exhaustion.
