### PR TITLE
Carry Iceberg REST updates[] on the snapshots commit, and use them for audit branchRefName

### DIFF
--- a/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsMetadataUpdatesTest.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsMetadataUpdatesTest.java
@@ -143,17 +143,26 @@ public class OpenHouseTableOperationsMetadataUpdatesTest {
    */
   @Test
   public void testAppendToBranchEmitsAddSnapshotAndSetSnapshotRef() {
-    TableMetadata base = tableWithOneSnapshot();
+    // Iceberg 1.5 requires (1) the branch already exists and (2) the new snapshot's
+    // sequence-number > last (v1 tables pin every snapshot at 0 and reject the add).
+    // discardChanges so the commit under test is the append, not CREATE BRANCH + upgrade.
+    TableMetadata withBranch =
+        TableMetadata.buildFrom(tableWithOneSnapshot())
+            .upgradeFormatVersion(2)
+            .setRef("feature_a", SnapshotRef.branchBuilder(42L).build())
+            .discardChanges()
+            .build();
     Snapshot newSnapshot =
         SnapshotParser.fromJson(
             "{\"snapshot-id\":43,"
                 + "\"parent-snapshot-id\":42,"
+                + "\"sequence-number\":1,"
                 + "\"timestamp-ms\":1669126937999,"
                 + "\"summary\":{\"operation\":\"append\"},"
                 + "\"manifest-list\":\"/tmp/snap-43.avro\","
                 + "\"schema-id\":0}");
     TableMetadata afterAppend =
-        TableMetadata.buildFrom(base).setBranchSnapshot(newSnapshot, "feature_a").build();
+        TableMetadata.buildFrom(withBranch).setBranchSnapshot(newSnapshot, "feature_a").build();
 
     List<Map<String, Object>> updates =
         OpenHouseTableOperations.serializeMetadataUpdates(afterAppend);

--- a/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsMetadataUpdatesTest.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsMetadataUpdatesTest.java
@@ -4,6 +4,7 @@ import com.linkedin.openhouse.relocated.com.fasterxml.jackson.databind.JsonNode;
 import com.linkedin.openhouse.relocated.com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
@@ -17,11 +18,12 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Verifies that {@link OpenHouseTableOperations#serializeMetadataUpdates} emits Iceberg REST spec
- * {@code TableUpdate} actions for the operations OpenHouse commits, and in particular that a
+ * {@code TableUpdate} objects for the operations OpenHouse commits, and in particular that a
  * ref-only operation is distinguishable from a data write.
  *
  * <p>These assertions are the load-bearing premise of the audit path: the server can only report
- * which branch a commit wrote because the client states it here.
+ * which branch a commit wrote because the client states it here. Items are objects, not JSON
+ * strings, so the request field is {@code CommitTableRequest.updates[]}.
  */
 public class OpenHouseTableOperationsMetadataUpdatesTest {
 
@@ -62,8 +64,8 @@ public class OpenHouseTableOperationsMetadataUpdatesTest {
         .build();
   }
 
-  private static JsonNode parse(String json) throws Exception {
-    return MAPPER.readTree(json);
+  private static JsonNode asNode(Map<String, Object> update) {
+    return MAPPER.valueToTree(update);
   }
 
   /**
@@ -72,38 +74,43 @@ public class OpenHouseTableOperationsMetadataUpdatesTest {
    * names the branch explicitly and contains no {@code add-snapshot}.
    */
   @Test
-  public void testCreateBranchEmitsOnlySetSnapshotRefNamingTheNewBranch() throws Exception {
+  public void testCreateBranchEmitsOnlySetSnapshotRefNamingTheNewBranch() {
     TableMetadata base = tableWithOneSnapshot();
     TableMetadata afterCreateBranch =
         TableMetadata.buildFrom(base)
             .setRef("feature_a", SnapshotRef.branchBuilder(42L).build())
             .build();
 
-    List<String> updates = OpenHouseTableOperations.serializeMetadataUpdates(afterCreateBranch);
+    List<Map<String, Object>> updates =
+        OpenHouseTableOperations.serializeMetadataUpdates(afterCreateBranch);
 
     Assertions.assertNotNull(updates);
     Assertions.assertEquals(1, updates.size(), "CREATE BRANCH must not report a snapshot write");
-    JsonNode update = parse(updates.get(0));
+    JsonNode update = asNode(updates.get(0));
     Assertions.assertEquals("set-snapshot-ref", update.get("action").asText());
     Assertions.assertEquals("feature_a", update.get("ref-name").asText());
     Assertions.assertEquals("branch", update.get("type").asText());
     Assertions.assertEquals(42L, update.get("snapshot-id").asLong());
+    Assertions.assertTrue(
+        updates.get(0).get("snapshot-id") instanceof Long,
+        "integral snapshot-id must stay Long so the wire is 42, not 42.0");
   }
 
   /** A tag carries {@code type: tag}, so consumers can tell it apart from a branch. */
   @Test
-  public void testCreateTagEmitsTagTypedSetSnapshotRef() throws Exception {
+  public void testCreateTagEmitsTagTypedSetSnapshotRef() {
     TableMetadata base = tableWithOneSnapshot();
     TableMetadata afterCreateTag =
         TableMetadata.buildFrom(base)
             .setRef("v1_release", SnapshotRef.tagBuilder(42L).build())
             .build();
 
-    List<String> updates = OpenHouseTableOperations.serializeMetadataUpdates(afterCreateTag);
+    List<Map<String, Object>> updates =
+        OpenHouseTableOperations.serializeMetadataUpdates(afterCreateTag);
 
     Assertions.assertNotNull(updates);
     Assertions.assertEquals(1, updates.size());
-    JsonNode update = parse(updates.get(0));
+    JsonNode update = asNode(updates.get(0));
     Assertions.assertEquals("set-snapshot-ref", update.get("action").asText());
     Assertions.assertEquals("v1_release", update.get("ref-name").asText());
     Assertions.assertEquals("tag", update.get("type").asText());
@@ -111,7 +118,7 @@ public class OpenHouseTableOperationsMetadataUpdatesTest {
 
   /** DROP BRANCH is a removal, never a write. */
   @Test
-  public void testDropBranchEmitsRemoveSnapshotRef() throws Exception {
+  public void testDropBranchEmitsRemoveSnapshotRef() {
     TableMetadata withBranch =
         TableMetadata.buildFrom(tableWithOneSnapshot())
             .setRef("feature_a", SnapshotRef.branchBuilder(42L).build())
@@ -120,11 +127,12 @@ public class OpenHouseTableOperationsMetadataUpdatesTest {
     TableMetadata afterDropBranch =
         TableMetadata.buildFrom(withBranch).removeRef("feature_a").build();
 
-    List<String> updates = OpenHouseTableOperations.serializeMetadataUpdates(afterDropBranch);
+    List<Map<String, Object>> updates =
+        OpenHouseTableOperations.serializeMetadataUpdates(afterDropBranch);
 
     Assertions.assertNotNull(updates);
     Assertions.assertEquals(1, updates.size());
-    JsonNode update = parse(updates.get(0));
+    JsonNode update = asNode(updates.get(0));
     Assertions.assertEquals("remove-snapshot-ref", update.get("action").asText());
     Assertions.assertEquals("feature_a", update.get("ref-name").asText());
   }
@@ -134,7 +142,7 @@ public class OpenHouseTableOperationsMetadataUpdatesTest {
    * write remains distinguishable from the ref-only case above.
    */
   @Test
-  public void testAppendToBranchEmitsAddSnapshotAndSetSnapshotRef() throws Exception {
+  public void testAppendToBranchEmitsAddSnapshotAndSetSnapshotRef() {
     TableMetadata base = tableWithOneSnapshot();
     Snapshot newSnapshot =
         SnapshotParser.fromJson(
@@ -147,15 +155,16 @@ public class OpenHouseTableOperationsMetadataUpdatesTest {
     TableMetadata afterAppend =
         TableMetadata.buildFrom(base).setBranchSnapshot(newSnapshot, "feature_a").build();
 
-    List<String> updates = OpenHouseTableOperations.serializeMetadataUpdates(afterAppend);
+    List<Map<String, Object>> updates =
+        OpenHouseTableOperations.serializeMetadataUpdates(afterAppend);
 
     Assertions.assertNotNull(updates);
     Assertions.assertEquals(
         2, updates.size(), "append reports exactly the new snapshot and the ref that moved");
     boolean sawAddSnapshot = false;
     boolean sawBranchRef = false;
-    for (String json : updates) {
-      JsonNode update = parse(json);
+    for (Map<String, Object> item : updates) {
+      JsonNode update = asNode(item);
       String action = update.get("action").asText();
       if ("add-snapshot".equals(action)) {
         sawAddSnapshot = true;
@@ -179,5 +188,22 @@ public class OpenHouseTableOperationsMetadataUpdatesTest {
     TableMetadata noChanges =
         TableMetadata.buildFrom(tableWithOneSnapshot()).discardChanges().build();
     Assertions.assertNull(OpenHouseTableOperations.serializeMetadataUpdates(noChanges));
+  }
+
+  /**
+   * A snapshot id that does not fit in a double mantissa must survive {@code MetadataUpdateParser}
+   * → Map so Jackson writes the same integer the spec parser emitted.
+   */
+  @Test
+  public void testTableUpdateObjectPreservesLargeSnapshotId() {
+    long snapshotId = 2151407017102313398L;
+    Map<String, Object> update =
+        OpenHouseTableOperations.tableUpdateObject(
+            "{\"action\":\"set-snapshot-ref\",\"ref-name\":\"main\","
+                + "\"snapshot-id\":"
+                + snapshotId
+                + ",\"type\":\"branch\"}");
+    Assertions.assertEquals(snapshotId, update.get("snapshot-id"));
+    Assertions.assertTrue(update.get("snapshot-id") instanceof Long);
   }
 }

--- a/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsMetadataUpdatesTest.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsMetadataUpdatesTest.java
@@ -1,0 +1,183 @@
+package com.linkedin.openhouse.javaclient;
+
+import com.linkedin.openhouse.relocated.com.fasterxml.jackson.databind.JsonNode;
+import com.linkedin.openhouse.relocated.com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import java.util.List;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotParser;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@link OpenHouseTableOperations#serializeMetadataUpdates} emits Iceberg REST spec
+ * {@code TableUpdate} actions for the operations OpenHouse commits, and in particular that a
+ * ref-only operation is distinguishable from a data write.
+ *
+ * <p>These assertions are the load-bearing premise of the audit path: the server can only report
+ * which branch a commit wrote because the client states it here.
+ */
+public class OpenHouseTableOperationsMetadataUpdatesTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private static final Schema SCHEMA =
+      new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()));
+
+  private static final String SNAPSHOT_JSON =
+      "{\"snapshot-id\":42,"
+          + "\"timestamp-ms\":1669126937912,"
+          + "\"summary\":{\"operation\":\"append\"},"
+          + "\"manifest-list\":\"/tmp/snap-42.avro\","
+          + "\"schema-id\":0}";
+
+  /**
+   * A table with one snapshot on main, with the construction history discarded.
+   *
+   * <p>{@code discardChanges()} matters: {@link TableMetadata#changes()} accumulates across builds
+   * within a session, so metadata assembled in-test would otherwise still carry its {@code
+   * assign-uuid} / {@code add-schema} / {@code add-spec} creation updates. In production the base
+   * comes from {@code doRefresh}, i.e. parsed off disk with no changes attached, so each commit's
+   * {@code changes()} is exactly that commit's delta. This reproduces that starting condition.
+   */
+  private static TableMetadata tableWithOneSnapshot() {
+    TableMetadata empty =
+        TableMetadata.newTableMetadata(
+            SCHEMA,
+            PartitionSpec.unpartitioned(),
+            SortOrder.unsorted(),
+            "/tmp/tbl",
+            Collections.emptyMap());
+    Snapshot snapshot = SnapshotParser.fromJson(SNAPSHOT_JSON);
+    // setBranchSnapshot adds the snapshot and points the ref at it in one step.
+    return TableMetadata.buildFrom(empty)
+        .setBranchSnapshot(snapshot, SnapshotRef.MAIN_BRANCH)
+        .discardChanges()
+        .build();
+  }
+
+  private static JsonNode parse(String json) throws Exception {
+    return MAPPER.readTree(json);
+  }
+
+  /**
+   * CREATE BRANCH adds a ref at the existing head and commits no snapshot. The resulting table
+   * state is ambiguous — main and the new branch point at the same snapshot — but the update list
+   * names the branch explicitly and contains no {@code add-snapshot}.
+   */
+  @Test
+  public void testCreateBranchEmitsOnlySetSnapshotRefNamingTheNewBranch() throws Exception {
+    TableMetadata base = tableWithOneSnapshot();
+    TableMetadata afterCreateBranch =
+        TableMetadata.buildFrom(base)
+            .setRef("feature_a", SnapshotRef.branchBuilder(42L).build())
+            .build();
+
+    List<String> updates = OpenHouseTableOperations.serializeMetadataUpdates(afterCreateBranch);
+
+    Assertions.assertNotNull(updates);
+    Assertions.assertEquals(1, updates.size(), "CREATE BRANCH must not report a snapshot write");
+    JsonNode update = parse(updates.get(0));
+    Assertions.assertEquals("set-snapshot-ref", update.get("action").asText());
+    Assertions.assertEquals("feature_a", update.get("ref-name").asText());
+    Assertions.assertEquals("branch", update.get("type").asText());
+    Assertions.assertEquals(42L, update.get("snapshot-id").asLong());
+  }
+
+  /** A tag carries {@code type: tag}, so consumers can tell it apart from a branch. */
+  @Test
+  public void testCreateTagEmitsTagTypedSetSnapshotRef() throws Exception {
+    TableMetadata base = tableWithOneSnapshot();
+    TableMetadata afterCreateTag =
+        TableMetadata.buildFrom(base)
+            .setRef("v1_release", SnapshotRef.tagBuilder(42L).build())
+            .build();
+
+    List<String> updates = OpenHouseTableOperations.serializeMetadataUpdates(afterCreateTag);
+
+    Assertions.assertNotNull(updates);
+    Assertions.assertEquals(1, updates.size());
+    JsonNode update = parse(updates.get(0));
+    Assertions.assertEquals("set-snapshot-ref", update.get("action").asText());
+    Assertions.assertEquals("v1_release", update.get("ref-name").asText());
+    Assertions.assertEquals("tag", update.get("type").asText());
+  }
+
+  /** DROP BRANCH is a removal, never a write. */
+  @Test
+  public void testDropBranchEmitsRemoveSnapshotRef() throws Exception {
+    TableMetadata withBranch =
+        TableMetadata.buildFrom(tableWithOneSnapshot())
+            .setRef("feature_a", SnapshotRef.branchBuilder(42L).build())
+            .discardChanges()
+            .build();
+    TableMetadata afterDropBranch =
+        TableMetadata.buildFrom(withBranch).removeRef("feature_a").build();
+
+    List<String> updates = OpenHouseTableOperations.serializeMetadataUpdates(afterDropBranch);
+
+    Assertions.assertNotNull(updates);
+    Assertions.assertEquals(1, updates.size());
+    JsonNode update = parse(updates.get(0));
+    Assertions.assertEquals("remove-snapshot-ref", update.get("action").asText());
+    Assertions.assertEquals("feature_a", update.get("ref-name").asText());
+  }
+
+  /**
+   * An append to a named branch reports both the new snapshot and the ref that moved, so a data
+   * write remains distinguishable from the ref-only case above.
+   */
+  @Test
+  public void testAppendToBranchEmitsAddSnapshotAndSetSnapshotRef() throws Exception {
+    TableMetadata base = tableWithOneSnapshot();
+    Snapshot newSnapshot =
+        SnapshotParser.fromJson(
+            "{\"snapshot-id\":43,"
+                + "\"parent-snapshot-id\":42,"
+                + "\"timestamp-ms\":1669126937999,"
+                + "\"summary\":{\"operation\":\"append\"},"
+                + "\"manifest-list\":\"/tmp/snap-43.avro\","
+                + "\"schema-id\":0}");
+    TableMetadata afterAppend =
+        TableMetadata.buildFrom(base).setBranchSnapshot(newSnapshot, "feature_a").build();
+
+    List<String> updates = OpenHouseTableOperations.serializeMetadataUpdates(afterAppend);
+
+    Assertions.assertNotNull(updates);
+    Assertions.assertEquals(
+        2, updates.size(), "append reports exactly the new snapshot and the ref that moved");
+    boolean sawAddSnapshot = false;
+    boolean sawBranchRef = false;
+    for (String json : updates) {
+      JsonNode update = parse(json);
+      String action = update.get("action").asText();
+      if ("add-snapshot".equals(action)) {
+        sawAddSnapshot = true;
+      } else if ("set-snapshot-ref".equals(action)
+          && "feature_a".equals(update.get("ref-name").asText())) {
+        sawBranchRef = true;
+        Assertions.assertEquals("branch", update.get("type").asText());
+        Assertions.assertEquals(43L, update.get("snapshot-id").asLong());
+      }
+    }
+    Assertions.assertTrue(sawAddSnapshot, "append must report add-snapshot");
+    Assertions.assertTrue(sawBranchRef, "append must report the branch it moved");
+  }
+
+  /**
+   * Metadata read straight off disk carries no changes. The field is omitted entirely rather than
+   * reported as an empty list, so consumers see "not stated" rather than "nothing happened".
+   */
+  @Test
+  public void testMetadataWithNoChangesYieldsNull() {
+    TableMetadata noChanges =
+        TableMetadata.buildFrom(tableWithOneSnapshot()).discardChanges().build();
+    Assertions.assertNull(OpenHouseTableOperations.serializeMetadataUpdates(noChanges));
+  }
+}

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -3,7 +3,12 @@ package com.linkedin.openhouse.javaclient;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
 import com.linkedin.openhouse.javaclient.builder.ClusteringSpecBuilder;
 import com.linkedin.openhouse.javaclient.builder.TimePartitionSpecBuilder;
 import com.linkedin.openhouse.javaclient.exception.WebClientRequestWithMessageException;
@@ -15,6 +20,7 @@ import com.linkedin.openhouse.tables.client.model.GetTableResponseBody;
 import com.linkedin.openhouse.tables.client.model.IcebergSnapshotsRequestBody;
 import com.linkedin.openhouse.tables.client.model.Policies;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -374,7 +380,7 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
             .collect(
                 Collectors.toMap(Map.Entry::getKey, e -> SnapshotRefParser.toJson(e.getValue()))));
     icebergSnapshotsRequestBody.createUpdateTableRequestBody(createUpdateTableRequestBody);
-    icebergSnapshotsRequestBody.jsonMetadataUpdates(serializeMetadataUpdates(newMetadata));
+    icebergSnapshotsRequestBody.updates(serializeMetadataUpdates(newMetadata));
 
     snapshotApi
         .putSnapshotsV1(
@@ -391,33 +397,36 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
   }
 
   /**
-   * Serializes the deltas this commit applies into Iceberg REST spec {@code TableUpdate} JSON.
+   * The deltas this commit applies, as Iceberg REST {@code CommitTableRequest.updates[]} items.
    *
-   * <p>{@link TableMetadata#changes()} is the same delta list every Iceberg REST catalog sends as
-   * {@code CommitTableRequest.updates[]}, and {@code MetadataUpdateParser} emits the spec wire
-   * format verbatim. It states what the commit did rather than what the table now looks like, so a
-   * ref-only operation such as {@code CREATE BRANCH b} is visible as a lone {@code
-   * set-snapshot-ref} naming {@code b} — something no amount of inspecting the resulting snapshot
-   * list can recover.
+   * <p>{@link TableMetadata#changes()} is the same list every Iceberg REST catalog sends, and
+   * {@code MetadataUpdateParser} emits the spec {@code TableUpdate} object. Reifying that JSON as a
+   * {@link Map} (not a string) is what makes the request field an object array — the REST envelope
+   * — rather than {@code string[]} of serialized JSON.
    *
-   * <p>Advisory only today: the server builds metadata from the full-state fields, so this method
-   * returns null rather than propagating any failure. It must never be able to fail a commit.
+   * <p>A ref-only operation such as {@code CREATE BRANCH b} is visible as a lone {@code
+   * set-snapshot-ref} naming {@code b}, which no amount of inspecting the resulting snapshot list
+   * can recover.
    *
-   * @return spec-shaped update actions, or null when there is nothing trustworthy to report
+   * <p>Advisory only today: the server still builds metadata from the full-state fields, so this
+   * method returns null rather than failing the commit. When {@code updates} becomes authoritative,
+   * unknown actions MUST 400 per the REST spec — do not keep this skip.
+   *
+   * @return spec-shaped update objects, or null when there is nothing trustworthy to report
    */
   @VisibleForTesting
-  static List<String> serializeMetadataUpdates(TableMetadata newMetadata) {
+  static List<Map<String, Object>> serializeMetadataUpdates(TableMetadata newMetadata) {
     try {
       List<MetadataUpdate> changes = newMetadata.changes();
       if (changes == null || changes.isEmpty()) {
         return null;
       }
-      List<String> serialized = new ArrayList<>(changes.size());
+      List<Map<String, Object>> serialized = new ArrayList<>(changes.size());
       for (MetadataUpdate change : changes) {
         // MetadataUpdateParser rejects update types it does not recognize. Skip those rather than
         // dropping the whole list, so one unknown action cannot blind the rest.
         try {
-          serialized.add(MetadataUpdateParser.toJson(change));
+          serialized.add(tableUpdateObject(MetadataUpdateParser.toJson(change)));
         } catch (RuntimeException e) {
           log.debug("Skipping unserializable metadata update {}", change.getClass().getName(), e);
         }
@@ -427,6 +436,53 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
       log.warn("Failed to serialize metadata updates; omitting from commit request", e);
       return null;
     }
+  }
+
+  /**
+   * Turns {@link MetadataUpdateParser} JSON into a plain object graph so Jackson writes a JSON
+   * object. Gson {@code fromJson(..., Map.class)} would coerce every number to {@code Double} and
+   * emit {@code 42.0} / lose large snapshot ids; integral values stay {@link Long} here.
+   */
+  @VisibleForTesting
+  static Map<String, Object> tableUpdateObject(String json) {
+    return jsonObjectToPlain(new JsonParser().parse(json).getAsJsonObject());
+  }
+
+  private static Map<String, Object> jsonObjectToPlain(JsonObject object) {
+    Map<String, Object> map = new LinkedHashMap<>();
+    for (Map.Entry<String, JsonElement> entry : object.entrySet()) {
+      map.put(entry.getKey(), jsonValueToPlain(entry.getValue()));
+    }
+    return map;
+  }
+
+  private static Object jsonValueToPlain(JsonElement element) {
+    if (element == null || element.isJsonNull()) {
+      return null;
+    }
+    if (element.isJsonObject()) {
+      return jsonObjectToPlain(element.getAsJsonObject());
+    }
+    if (element.isJsonArray()) {
+      JsonArray array = element.getAsJsonArray();
+      List<Object> values = new ArrayList<>(array.size());
+      for (JsonElement item : array) {
+        values.add(jsonValueToPlain(item));
+      }
+      return values;
+    }
+    JsonPrimitive primitive = element.getAsJsonPrimitive();
+    if (primitive.isBoolean()) {
+      return primitive.getAsBoolean();
+    }
+    if (primitive.isNumber()) {
+      try {
+        return primitive.getAsBigDecimal().toBigIntegerExact().longValue();
+      } catch (ArithmeticException notIntegral) {
+        return primitive.getAsDouble();
+      }
+    }
+    return primitive.getAsString();
   }
 
   /**

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -26,6 +26,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.iceberg.BaseMetastoreTableOperations;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.MetadataUpdateParser;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.SnapshotParser;
 import org.apache.iceberg.SnapshotRefParser;
@@ -372,6 +374,7 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
             .collect(
                 Collectors.toMap(Map.Entry::getKey, e -> SnapshotRefParser.toJson(e.getValue()))));
     icebergSnapshotsRequestBody.createUpdateTableRequestBody(createUpdateTableRequestBody);
+    icebergSnapshotsRequestBody.jsonMetadataUpdates(serializeMetadataUpdates(newMetadata));
 
     snapshotApi
         .putSnapshotsV1(
@@ -385,6 +388,45 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
                     createUpdateTableRequestBody.getDatabaseId(),
                     createUpdateTableRequestBody.getTableId()))
         .block();
+  }
+
+  /**
+   * Serializes the deltas this commit applies into Iceberg REST spec {@code TableUpdate} JSON.
+   *
+   * <p>{@link TableMetadata#changes()} is the same delta list every Iceberg REST catalog sends as
+   * {@code CommitTableRequest.updates[]}, and {@code MetadataUpdateParser} emits the spec wire
+   * format verbatim. It states what the commit did rather than what the table now looks like, so a
+   * ref-only operation such as {@code CREATE BRANCH b} is visible as a lone {@code
+   * set-snapshot-ref} naming {@code b} — something no amount of inspecting the resulting snapshot
+   * list can recover.
+   *
+   * <p>Advisory only today: the server builds metadata from the full-state fields, so this method
+   * returns null rather than propagating any failure. It must never be able to fail a commit.
+   *
+   * @return spec-shaped update actions, or null when there is nothing trustworthy to report
+   */
+  @VisibleForTesting
+  static List<String> serializeMetadataUpdates(TableMetadata newMetadata) {
+    try {
+      List<MetadataUpdate> changes = newMetadata.changes();
+      if (changes == null || changes.isEmpty()) {
+        return null;
+      }
+      List<String> serialized = new ArrayList<>(changes.size());
+      for (MetadataUpdate change : changes) {
+        // MetadataUpdateParser rejects update types it does not recognize. Skip those rather than
+        // dropping the whole list, so one unknown action cannot blind the rest.
+        try {
+          serialized.add(MetadataUpdateParser.toJson(change));
+        } catch (RuntimeException e) {
+          log.debug("Skipping unserializable metadata update {}", change.getClass().getName(), e);
+        }
+      }
+      return serialized.isEmpty() ? null : serialized;
+    } catch (RuntimeException e) {
+      log.warn("Failed to serialize metadata updates; omitting from commit request", e);
+      return null;
+    }
   }
 
   /**

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/IcebergSnapshotsRequestBody.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/IcebergSnapshotsRequestBody.java
@@ -32,6 +32,33 @@ public class IcebergSnapshotsRequestBody {
               + "Key is the branch name, and value is the SnapshotRef.")
   private Map<String, String> snapshotRefs;
 
+  /**
+   * The deltas this commit applies, in Iceberg REST spec form.
+   *
+   * <p>Each element is one {@code TableUpdate} from the Iceberg REST catalog spec (an object with
+   * an {@code action} discriminator, e.g. {@code add-snapshot}, {@code set-snapshot-ref}, {@code
+   * remove-snapshot-ref}), serialized by {@code MetadataUpdateParser} so the wire format is
+   * byte-identical to {@code CommitTableRequest.updates[]}.
+   *
+   * <p>Unlike {@link #jsonSnapshots} and {@link #snapshotRefs} — which carry complete replacement
+   * state and therefore force the server to rediscover what changed by diffing — this field states
+   * the change directly. A {@code CREATE BRANCH b} that commits no new snapshot appears here as a
+   * single {@code set-snapshot-ref} naming {@code b}, which is otherwise unknowable server-side.
+   *
+   * <p>Optional and advisory in this release: the server still builds table metadata from {@code
+   * jsonSnapshots}/{@code snapshotRefs}, and clients predating this field simply omit it. Consumers
+   * must tolerate null/empty. This is the forward-compatible shape — when OpenHouse adopts the REST
+   * {@code CommitTableRequest} endpoint, this field is promoted to {@code updates} and the
+   * full-state fields retire.
+   */
+  @Schema(
+      description =
+          "Optional. Iceberg REST spec TableUpdate actions describing the deltas this commit "
+              + "applies, each serialized by MetadataUpdateParser and wire-compatible with "
+              + "CommitTableRequest.updates[]. Advisory only: table metadata is still built from "
+              + "jsonSnapshots/snapshotRefs. Older clients omit this field.")
+  private List<String> jsonMetadataUpdates;
+
   @Schema(description = "The request body that contains complete metadata")
   private CreateUpdateTableRequestBody createUpdateTableRequestBody;
 

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/IcebergSnapshotsRequestBody.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/IcebergSnapshotsRequestBody.java
@@ -1,6 +1,7 @@
 package com.linkedin.openhouse.tables.api.spec.v0.request;
 
 import com.google.gson.Gson;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.Map;
@@ -33,31 +34,39 @@ public class IcebergSnapshotsRequestBody {
   private Map<String, String> snapshotRefs;
 
   /**
-   * The deltas this commit applies, in Iceberg REST spec form.
+   * The deltas this commit applies, as Iceberg REST {@code CommitTableRequest.updates[]}.
    *
-   * <p>Each element is one {@code TableUpdate} from the Iceberg REST catalog spec (an object with
-   * an {@code action} discriminator, e.g. {@code add-snapshot}, {@code set-snapshot-ref}, {@code
-   * remove-snapshot-ref}), serialized by {@code MetadataUpdateParser} so the wire format is
-   * byte-identical to {@code CommitTableRequest.updates[]}.
+   * <p>Each element is one {@code TableUpdate} object (discriminated by {@code action}: {@code
+   * add-snapshot}, {@code set-snapshot-ref}, {@code remove-snapshot-ref}, …). The wire type is an
+   * array of objects, not an array of JSON strings, so this field <em>is</em> {@code updates[]} —
+   * same name, same item shape. Convergence is then dropping {@link #jsonSnapshots}/{@link
+   * #snapshotRefs}/{@link #baseTableVersion} and adding {@code requirements[]}, not a rename or a
+   * type change.
    *
-   * <p>Unlike {@link #jsonSnapshots} and {@link #snapshotRefs} — which carry complete replacement
-   * state and therefore force the server to rediscover what changed by diffing — this field states
-   * the change directly. A {@code CREATE BRANCH b} that commits no new snapshot appears here as a
-   * single {@code set-snapshot-ref} naming {@code b}, which is otherwise unknowable server-side.
+   * <p>Unlike the full-state fields — which force the server to rediscover what changed by diffing
+   * — this field states the change. A {@code CREATE BRANCH b} that commits no snapshot appears as a
+   * single {@code set-snapshot-ref} naming {@code b}.
    *
-   * <p>Optional and advisory in this release: the server still builds table metadata from {@code
-   * jsonSnapshots}/{@code snapshotRefs}, and clients predating this field simply omit it. Consumers
-   * must tolerate null/empty. This is the forward-compatible shape — when OpenHouse adopts the REST
-   * {@code CommitTableRequest} endpoint, this field is promoted to {@code updates} and the
-   * full-state fields retire.
+   * <p>Optional and advisory in this release: table metadata is still built from {@code
+   * jsonSnapshots}/{@code snapshotRefs}, and clients predating this field omit it. Consumers must
+   * tolerate null/empty and must not fail the commit on an unknown or unparseable action. When this
+   * field becomes authoritative, the REST rule applies: unknown updates MUST 400.
    */
-  @Schema(
-      description =
-          "Optional. Iceberg REST spec TableUpdate actions describing the deltas this commit "
-              + "applies, each serialized by MetadataUpdateParser and wire-compatible with "
-              + "CommitTableRequest.updates[]. Advisory only: table metadata is still built from "
-              + "jsonSnapshots/snapshotRefs. Older clients omit this field.")
-  private List<String> jsonMetadataUpdates;
+  @ArraySchema(
+      arraySchema =
+          @Schema(
+              description =
+                  "Optional. Iceberg REST CommitTableRequest.updates[]: TableUpdate objects "
+                      + "for the deltas this commit applies. Advisory only: table metadata is "
+                      + "still built from jsonSnapshots/snapshotRefs. Older clients omit this "
+                      + "field. When this field becomes authoritative, unknown updates MUST 400."),
+      schema =
+          @Schema(
+              type = "object",
+              description =
+                  "One Iceberg REST TableUpdate, discriminated by action (e.g. add-snapshot, "
+                      + "set-snapshot-ref)."))
+  private List<Map<String, Object>> updates;
 
   @Schema(description = "The request body that contains complete metadata")
   private CreateUpdateTableRequestBody createUpdateTableRequestBody;

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
@@ -3,6 +3,7 @@ package com.linkedin.openhouse.tables.audit;
 import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.INITIAL_TABLE_VERSION;
 import static com.linkedin.openhouse.common.security.AuthenticationUtils.extractAuthenticatedUserPrincipal;
 
+import com.google.gson.Gson;
 import com.linkedin.openhouse.cluster.configs.ClusterProperties;
 import com.linkedin.openhouse.common.api.spec.ApiResponse;
 import com.linkedin.openhouse.common.audit.AuditHandler;
@@ -55,6 +56,11 @@ public class TableAuditAspect {
    * enum is package-private, so the spec's wire value is matched directly.
    */
   private static final String BRANCH_REF_TYPE = "branch";
+
+  /**
+   * Re-serializes a bound {@code TableUpdate} object so {@code MetadataUpdateParser} can read it.
+   */
+  private static final Gson TABLE_UPDATE_GSON = new Gson();
 
   @Autowired private ClusterProperties clusterProperties;
 
@@ -481,22 +487,25 @@ public class TableAuditAspect {
    * correctly ignored. When several branches move in one commit the first is reported, matching the
    * order the client applied them.
    *
-   * <p>Clients predating {@code jsonMetadataUpdates} omit it, in which case branchRefName is left
-   * unset. The previous behavior guessed by matching refs against the last snapshot in the list,
-   * which returned an arbitrary branch whenever two refs shared a snapshot — exactly what {@code
-   * CREATE BRANCH} produces. An absent field is preferable to a coin-flip one in an audit log.
+   * <p>Clients predating {@code updates} omit it, in which case branchRefName is left unset. The
+   * previous behavior guessed by matching refs against the last snapshot in the list, which
+   * returned an arbitrary branch whenever two refs shared a snapshot — exactly what {@code CREATE
+   * BRANCH} produces. An absent field is preferable to a coin-flip one in an audit log.
+   *
+   * <p>Unknown or unparseable actions are skipped today because the field is advisory. When {@code
+   * updates} becomes the commit, those MUST 400 per the REST spec.
    */
   private void extractBranchRefName(
       IcebergSnapshotsRequestBody requestBody,
       TableAuditEvent.TableAuditEventBuilder eventBuilder) {
-    List<String> jsonMetadataUpdates = requestBody.getJsonMetadataUpdates();
-    if (jsonMetadataUpdates == null || jsonMetadataUpdates.isEmpty()) {
+    List<Map<String, Object>> updates = requestBody.getUpdates();
+    if (updates == null || updates.isEmpty()) {
       return;
     }
-    for (String jsonMetadataUpdate : jsonMetadataUpdates) {
+    for (Map<String, Object> updateObject : updates) {
       MetadataUpdate update;
       try {
-        update = MetadataUpdateParser.fromJson(jsonMetadataUpdate);
+        update = MetadataUpdateParser.fromJson(TABLE_UPDATE_GSON.toJson(updateObject));
       } catch (Exception e) {
         // A single unparseable action must not hide the rest of the commit's updates.
         log.debug("Skipping unparseable metadata update in audit extraction", e);

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/TableAuditAspect.java
@@ -28,6 +28,8 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.MetadataUpdateParser;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotParser;
 import org.apache.iceberg.SnapshotRef;
@@ -46,6 +48,13 @@ import org.springframework.stereotype.Component;
 @Aspect
 @Component
 public class TableAuditAspect {
+
+  /**
+   * The {@code type} discriminator the Iceberg REST spec assigns to branch refs in a {@code
+   * set-snapshot-ref} action (the alternative being {@code tag}). Iceberg's {@code SnapshotRefType}
+   * enum is package-private, so the spec's wire value is matched directly.
+   */
+  private static final String BRANCH_REF_TYPE = "branch";
 
   @Autowired private ClusterProperties clusterProperties;
 
@@ -415,22 +424,26 @@ public class TableAuditAspect {
   }
 
   /**
-   * Extracts snapshot ID and timestamp of the main branch from the request body. The snapshotRefs
-   * map contains branch name to JSON-serialized SnapshotRef. We read the main branch's snapshot-id
-   * (this is what Iceberg treats as current-snapshot-id — see TableMetadata.Builder.setRef()) and
-   * then find the matching snapshot in jsonSnapshots to get its timestamp-ms.
+   * Extracts snapshot ID, timestamp, and branch ref name from the request body.
    *
-   * <p>Leaves both fields null if the main branch ref is absent (e.g. branch-only commits where
-   * main didn't advance, or non-commit operations) or if the matching snapshot can't be found.
+   * <p>currentSnapshotId and currentSnapshotTimestampMs track the main branch ref for backwards
+   * compatibility. They are null when main is absent from snapshotRefs.
    */
   private void extractSnapshotInfo(
       IcebergSnapshotsRequestBody requestBody,
       TableAuditEvent.TableAuditEventBuilder eventBuilder) {
     try {
       Map<String, String> snapshotRefs = requestBody.getSnapshotRefs();
-      if (snapshotRefs == null) {
+      List<String> jsonSnapshots = requestBody.getJsonSnapshots();
+
+      extractBranchRefName(requestBody, eventBuilder);
+
+      if (snapshotRefs == null || jsonSnapshots == null || jsonSnapshots.isEmpty()) {
         return;
       }
+
+      // Extract snapshot ID and timestamp for main branch (backwards-compatible).
+      // Iterate jsonSnapshots in reverse: main's snapshot is typically the most recent.
       String mainRefJson = snapshotRefs.get(SnapshotRef.MAIN_BRANCH);
       if (mainRefJson == null) {
         return;
@@ -438,14 +451,6 @@ public class TableAuditAspect {
       long mainSnapshotId = SnapshotRefParser.fromJson(mainRefJson).snapshotId();
       eventBuilder.currentSnapshotId(mainSnapshotId);
 
-      // Find the matching snapshot in jsonSnapshots to get its timestamp-ms. Iterate in reverse
-      // because Iceberg appends snapshots chronologically and main's snapshot is typically the
-      // most recent. Skip snapshots whose JSON doesn't contain the target id as a cheap
-      // pre-filter before invoking the JSON parser.
-      List<String> jsonSnapshots = requestBody.getJsonSnapshots();
-      if (jsonSnapshots == null) {
-        return;
-      }
       String mainSnapshotIdStr = Long.toString(mainSnapshotId);
       for (int i = jsonSnapshots.size() - 1; i >= 0; i--) {
         String snapshotJson = jsonSnapshots.get(i);
@@ -461,6 +466,49 @@ public class TableAuditAspect {
     } catch (Exception e) {
       // Snapshot extraction is best-effort; don't fail the audit event
       log.warn("Failed to extract snapshot info for audit event", e);
+    }
+  }
+
+  /**
+   * Sets branchRefName from the commit's Iceberg REST spec {@code TableUpdate} actions.
+   *
+   * <p>The client sends the deltas it applied, so the branch that was written is stated outright by
+   * a {@code set-snapshot-ref} action rather than inferred. This matters most for operations that
+   * commit no snapshot at all: {@code CREATE BRANCH b} produces a lone {@code set-snapshot-ref}
+   * naming {@code b}, where the resulting table state is indistinguishable from a no-op on main.
+   *
+   * <p>Only branch-typed refs qualify; a {@code CREATE TAG} carries {@code type: tag} and is
+   * correctly ignored. When several branches move in one commit the first is reported, matching the
+   * order the client applied them.
+   *
+   * <p>Clients predating {@code jsonMetadataUpdates} omit it, in which case branchRefName is left
+   * unset. The previous behavior guessed by matching refs against the last snapshot in the list,
+   * which returned an arbitrary branch whenever two refs shared a snapshot — exactly what {@code
+   * CREATE BRANCH} produces. An absent field is preferable to a coin-flip one in an audit log.
+   */
+  private void extractBranchRefName(
+      IcebergSnapshotsRequestBody requestBody,
+      TableAuditEvent.TableAuditEventBuilder eventBuilder) {
+    List<String> jsonMetadataUpdates = requestBody.getJsonMetadataUpdates();
+    if (jsonMetadataUpdates == null || jsonMetadataUpdates.isEmpty()) {
+      return;
+    }
+    for (String jsonMetadataUpdate : jsonMetadataUpdates) {
+      MetadataUpdate update;
+      try {
+        update = MetadataUpdateParser.fromJson(jsonMetadataUpdate);
+      } catch (Exception e) {
+        // A single unparseable action must not hide the rest of the commit's updates.
+        log.debug("Skipping unparseable metadata update in audit extraction", e);
+        continue;
+      }
+      if (update instanceof MetadataUpdate.SetSnapshotRef) {
+        MetadataUpdate.SetSnapshotRef setSnapshotRef = (MetadataUpdate.SetSnapshotRef) update;
+        if (BRANCH_REF_TYPE.equalsIgnoreCase(setSnapshotRef.type())) {
+          eventBuilder.branchRefName(setSnapshotRef.name());
+          return;
+        }
+      }
     }
   }
 

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/model/TableAuditEvent.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/model/TableAuditEvent.java
@@ -42,6 +42,8 @@ public class TableAuditEvent extends BaseAuditEvent {
 
   private Long currentSnapshotTimestampMs;
 
+  private String branchRefName;
+
   /** Allowlisted subset of table properties at commit time, not the full property map. */
   private Map<String, String> auditedTableProperties;
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/RequestConstants.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/RequestConstants.java
@@ -12,7 +12,9 @@ import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllTablesResponseBo
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetDatabaseResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.components.AclPolicy;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 
@@ -94,11 +96,23 @@ public final class RequestConstants {
   public static final String TEST_MAIN_SNAPSHOT_REF_JSON =
       "{\"snapshot-id\":2151407017102313398,\"type\":\"branch\"}";
 
+  /**
+   * The Iceberg REST spec {@code TableUpdate} actions a plain append to main produces: the snapshot
+   * is added, then main is moved onto it. Shaped exactly as {@code MetadataUpdateParser} emits them
+   * client-side, so these fixtures exercise the same bytes a real commit sends.
+   */
+  public static final List<String> TEST_MAIN_APPEND_METADATA_UPDATES =
+      Arrays.asList(
+          "{\"action\":\"add-snapshot\",\"snapshot\":" + TEST_ICEBERG_SNAPSHOT_JSON + "}",
+          "{\"action\":\"set-snapshot-ref\",\"ref-name\":\"main\","
+              + "\"snapshot-id\":2151407017102313398,\"type\":\"branch\"}");
+
   public static final IcebergSnapshotsRequestBody TEST_ICEBERG_SNAPSHOTS_REQUEST_BODY =
       IcebergSnapshotsRequestBody.builder()
           .baseTableVersion("v1")
           .jsonSnapshots(Collections.singletonList(TEST_ICEBERG_SNAPSHOT_JSON))
           .snapshotRefs(Collections.singletonMap("main", TEST_MAIN_SNAPSHOT_REF_JSON))
+          .jsonMetadataUpdates(TEST_MAIN_APPEND_METADATA_UPDATES)
           .createUpdateTableRequestBody(TEST_CREATE_TABLE_REQUEST_BODY)
           .build();
 
@@ -123,6 +137,7 @@ public final class RequestConstants {
               .baseTableVersion("INITIAL_VERSION")
               .jsonSnapshots(Collections.singletonList(TEST_ICEBERG_SNAPSHOT_JSON))
               .snapshotRefs(Collections.singletonMap("main", TEST_MAIN_SNAPSHOT_REF_JSON))
+              .jsonMetadataUpdates(TEST_MAIN_APPEND_METADATA_UPDATES)
               .createUpdateTableRequestBody(TEST_CREATE_TABLE_REQUEST_BODY)
               .build();
 

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/RequestConstants.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/RequestConstants.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.tables.mock;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateLockRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.IcebergSnapshotsRequestBody;
@@ -12,9 +13,11 @@ import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllTablesResponseBo
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetDatabaseResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.components.AclPolicy;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 
@@ -96,23 +99,27 @@ public final class RequestConstants {
   public static final String TEST_MAIN_SNAPSHOT_REF_JSON =
       "{\"snapshot-id\":2151407017102313398,\"type\":\"branch\"}";
 
+  private static final ObjectMapper TABLE_UPDATE_MAPPER = new ObjectMapper();
+
   /**
    * The Iceberg REST spec {@code TableUpdate} actions a plain append to main produces: the snapshot
-   * is added, then main is moved onto it. Shaped exactly as {@code MetadataUpdateParser} emits them
-   * client-side, so these fixtures exercise the same bytes a real commit sends.
+   * is added, then main is moved onto it. Objects, not JSON strings — the {@code
+   * CommitTableRequest.updates[]} envelope.
    */
-  public static final List<String> TEST_MAIN_APPEND_METADATA_UPDATES =
+  public static final List<Map<String, Object>> TEST_MAIN_APPEND_METADATA_UPDATES =
       Arrays.asList(
-          "{\"action\":\"add-snapshot\",\"snapshot\":" + TEST_ICEBERG_SNAPSHOT_JSON + "}",
-          "{\"action\":\"set-snapshot-ref\",\"ref-name\":\"main\","
-              + "\"snapshot-id\":2151407017102313398,\"type\":\"branch\"}");
+          tableUpdate(
+              "{\"action\":\"add-snapshot\",\"snapshot\":" + TEST_ICEBERG_SNAPSHOT_JSON + "}"),
+          tableUpdate(
+              "{\"action\":\"set-snapshot-ref\",\"ref-name\":\"main\","
+                  + "\"snapshot-id\":2151407017102313398,\"type\":\"branch\"}"));
 
   public static final IcebergSnapshotsRequestBody TEST_ICEBERG_SNAPSHOTS_REQUEST_BODY =
       IcebergSnapshotsRequestBody.builder()
           .baseTableVersion("v1")
           .jsonSnapshots(Collections.singletonList(TEST_ICEBERG_SNAPSHOT_JSON))
           .snapshotRefs(Collections.singletonMap("main", TEST_MAIN_SNAPSHOT_REF_JSON))
-          .jsonMetadataUpdates(TEST_MAIN_APPEND_METADATA_UPDATES)
+          .updates(TEST_MAIN_APPEND_METADATA_UPDATES)
           .createUpdateTableRequestBody(TEST_CREATE_TABLE_REQUEST_BODY)
           .build();
 
@@ -137,7 +144,7 @@ public final class RequestConstants {
               .baseTableVersion("INITIAL_VERSION")
               .jsonSnapshots(Collections.singletonList(TEST_ICEBERG_SNAPSHOT_JSON))
               .snapshotRefs(Collections.singletonMap("main", TEST_MAIN_SNAPSHOT_REF_JSON))
-              .jsonMetadataUpdates(TEST_MAIN_APPEND_METADATA_UPDATES)
+              .updates(TEST_MAIN_APPEND_METADATA_UPDATES)
               .createUpdateTableRequestBody(TEST_CREATE_TABLE_REQUEST_BODY)
               .build();
 
@@ -155,4 +162,16 @@ public final class RequestConstants {
 
   public static final CreateUpdateLockRequestBody TEST_UPDATE_LOCK_POLICIES_REQUEST_BODY =
       CreateUpdateLockRequestBody.builder().locked(true).message("").build();
+
+  /**
+   * Parses one REST {@code TableUpdate} object. Jackson keeps large snapshot ids as {@code Long}.
+   */
+  @SuppressWarnings("unchecked")
+  public static Map<String, Object> tableUpdate(String json) {
+    try {
+      return TABLE_UPDATE_MAPPER.readValue(json, Map.class);
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
 }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
@@ -5,6 +5,8 @@ import static com.linkedin.openhouse.tables.model.TableAuditModelConstants.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.openhouse.common.audit.AuditHandler;
 import com.linkedin.openhouse.tables.api.spec.v0.request.IcebergSnapshotsRequestBody;
 import com.linkedin.openhouse.tables.audit.model.TableAuditEvent;
@@ -161,8 +163,7 @@ public class IcebergSnapshotsApiHandlerAuditTest {
             .baseTableVersion("v1")
             .jsonSnapshots(Collections.singletonList(newSnapshotJson))
             .snapshotRefs(refs)
-            .jsonMetadataUpdates(
-                Collections.singletonList(setSnapshotRef("feature", 999L, "branch")))
+            .updates(Collections.singletonList(setSnapshotRef("feature", 999L, "branch")))
             .createUpdateTableRequestBody(RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY)
             .build();
 
@@ -200,8 +201,7 @@ public class IcebergSnapshotsApiHandlerAuditTest {
             .baseTableVersion("v1")
             .jsonSnapshots(Collections.singletonList(RequestConstants.TEST_ICEBERG_SNAPSHOT_JSON))
             .snapshotRefs(refs)
-            .jsonMetadataUpdates(
-                Collections.singletonList(setSnapshotRef("b", HEAD_SNAPSHOT_ID, "branch")))
+            .updates(Collections.singletonList(setSnapshotRef("b", HEAD_SNAPSHOT_ID, "branch")))
             .createUpdateTableRequestBody(RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY)
             .build();
 
@@ -226,7 +226,7 @@ public class IcebergSnapshotsApiHandlerAuditTest {
             .baseTableVersion("v1")
             .jsonSnapshots(Collections.singletonList(RequestConstants.TEST_ICEBERG_SNAPSHOT_JSON))
             .snapshotRefs(refs)
-            .jsonMetadataUpdates(
+            .updates(
                 Collections.singletonList(
                     setSnapshotRef("zzz_sorts_last", HEAD_SNAPSHOT_ID, "branch")))
             .createUpdateTableRequestBody(RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY)
@@ -250,7 +250,7 @@ public class IcebergSnapshotsApiHandlerAuditTest {
             .baseTableVersion("v1")
             .jsonSnapshots(Collections.singletonList(RequestConstants.TEST_ICEBERG_SNAPSHOT_JSON))
             .snapshotRefs(refs)
-            .jsonMetadataUpdates(
+            .updates(
                 Collections.singletonList(setSnapshotRef("v1_release", HEAD_SNAPSHOT_ID, "tag")))
             .createUpdateTableRequestBody(RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY)
             .build();
@@ -272,9 +272,7 @@ public class IcebergSnapshotsApiHandlerAuditTest {
             .baseTableVersion("v1")
             .jsonSnapshots(Collections.singletonList(RequestConstants.TEST_ICEBERG_SNAPSHOT_JSON))
             .snapshotRefs(Collections.singletonMap("main", TEST_HEAD_SNAPSHOT_REF_JSON))
-            .jsonMetadataUpdates(
-                Collections.singletonList(
-                    "{\"action\":\"remove-snapshot-ref\",\"ref-name\":\"b\"}"))
+            .updates(Collections.singletonList(removeSnapshotRef("b")))
             .createUpdateTableRequestBody(RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY)
             .build();
 
@@ -282,8 +280,8 @@ public class IcebergSnapshotsApiHandlerAuditTest {
   }
 
   /**
-   * Clients predating {@code jsonMetadataUpdates} omit it. branchRefName is then left unset rather
-   * than guessed — an absent audit field beats one that is wrong on ties.
+   * Clients predating {@code updates} omit it. branchRefName is then left unset rather than guessed
+   * — an absent audit field beats one that is wrong on ties.
    */
   @Test
   public void testPutIcebergSnapshotsWithoutMetadataUpdatesLeavesBranchRefNameNull()
@@ -303,7 +301,38 @@ public class IcebergSnapshotsApiHandlerAuditTest {
     assertEquals(1669126937912L, actualEvent.getCurrentSnapshotTimestampMs().longValue());
   }
 
-  /** A malformed action must not hide the well-formed ones around it. */
+  /**
+   * {@code updates} is REST {@code CommitTableRequest.updates[]}: an array of objects, not
+   * stringified JSON. A later rename is unnecessary; dropping the full-state fields is the
+   * remaining convergence step.
+   */
+  @Test
+  public void testUpdatesFieldIsRestObjectArray() throws Exception {
+    IcebergSnapshotsRequestBody requestBody =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion("v1")
+            .jsonSnapshots(Collections.singletonList(RequestConstants.TEST_ICEBERG_SNAPSHOT_JSON))
+            .snapshotRefs(Collections.singletonMap("main", TEST_HEAD_SNAPSHOT_REF_JSON))
+            .updates(
+                Collections.singletonList(setSnapshotRef("feature", HEAD_SNAPSHOT_ID, "branch")))
+            .createUpdateTableRequestBody(RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY)
+            .build();
+
+    JsonNode root = new ObjectMapper().readTree(requestBody.toJson());
+    JsonNode updates = root.get("updates");
+    assertTrue(updates.isArray());
+    assertTrue(updates.get(0).isObject(), "updates[] items must be objects, not strings");
+    assertEquals("set-snapshot-ref", updates.get(0).get("action").asText());
+    assertEquals("feature", updates.get(0).get("ref-name").asText());
+    assertEquals(HEAD_SNAPSHOT_ID, updates.get(0).get("snapshot-id").asLong());
+    assertFalse(updates.get(0).get("snapshot-id").isTextual());
+  }
+
+  /**
+   * An unknown {@code action} must not hide the well-formed ones around it. Invalid JSON is a
+   * request-binding 400 (the field is an object array, not stringified JSON) and is not skipped
+   * here.
+   */
   @Test
   public void testPutIcebergSnapshotsSkipsUnparseableMetadataUpdate() throws Exception {
     IcebergSnapshotsRequestBody requestBody =
@@ -311,10 +340,9 @@ public class IcebergSnapshotsApiHandlerAuditTest {
             .baseTableVersion("v1")
             .jsonSnapshots(Collections.singletonList(RequestConstants.TEST_ICEBERG_SNAPSHOT_JSON))
             .snapshotRefs(Collections.singletonMap("main", TEST_HEAD_SNAPSHOT_REF_JSON))
-            .jsonMetadataUpdates(
+            .updates(
                 Arrays.asList(
-                    "{\"action\":\"not-a-real-action\"}",
-                    "}{ malformed json",
+                    unknownAction("not-a-real-action"),
                     setSnapshotRef("feature", HEAD_SNAPSHOT_ID, "branch")))
             .createUpdateTableRequestBody(RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY)
             .build();
@@ -334,7 +362,7 @@ public class IcebergSnapshotsApiHandlerAuditTest {
             .snapshotRefs(
                 Collections.singletonMap(
                     "my_branch", "{\"snapshot-id\":2151407017102313398,\"type\":\"branch\"}"))
-            .jsonMetadataUpdates(
+            .updates(
                 Collections.singletonList(setSnapshotRef("my_branch", HEAD_SNAPSHOT_ID, "branch")))
             .createUpdateTableRequestBody(RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY)
             .build();
@@ -385,8 +413,7 @@ public class IcebergSnapshotsApiHandlerAuditTest {
             .baseTableVersion("v1")
             .jsonSnapshots(Arrays.asList(olderSnapshotJson, newerSnapshotJson))
             .snapshotRefs(refs)
-            .jsonMetadataUpdates(
-                Collections.singletonList(setSnapshotRef("feature", 200L, "branch")))
+            .updates(Collections.singletonList(setSnapshotRef("feature", 200L, "branch")))
             .createUpdateTableRequestBody(RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY)
             .build();
 
@@ -412,11 +439,27 @@ public class IcebergSnapshotsApiHandlerAuditTest {
   private static final String TEST_HEAD_SNAPSHOT_REF_JSON =
       "{\"snapshot-id\":" + HEAD_SNAPSHOT_ID + ",\"type\":\"branch\"}";
 
-  /** Builds one Iceberg REST spec {@code set-snapshot-ref} action. */
-  private static String setSnapshotRef(String refName, long snapshotId, String type) {
-    return String.format(
-        "{\"action\":\"set-snapshot-ref\",\"ref-name\":\"%s\",\"snapshot-id\":%d,\"type\":\"%s\"}",
-        refName, snapshotId, type);
+  /** One Iceberg REST spec {@code set-snapshot-ref} object. */
+  private static Map<String, Object> setSnapshotRef(String refName, long snapshotId, String type) {
+    Map<String, Object> update = new LinkedHashMap<>();
+    update.put("action", "set-snapshot-ref");
+    update.put("ref-name", refName);
+    update.put("snapshot-id", snapshotId);
+    update.put("type", type);
+    return update;
+  }
+
+  private static Map<String, Object> removeSnapshotRef(String refName) {
+    Map<String, Object> update = new LinkedHashMap<>();
+    update.put("action", "remove-snapshot-ref");
+    update.put("ref-name", refName);
+    return update;
+  }
+
+  private static Map<String, Object> unknownAction(String action) {
+    Map<String, Object> update = new LinkedHashMap<>();
+    update.put("action", action);
+    return update;
   }
 
   private TableAuditEvent putSnapshots(IcebergSnapshotsRequestBody requestBody) throws Exception {

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/IcebergSnapshotsApiHandlerAuditTest.java
@@ -12,6 +12,7 @@ import com.linkedin.openhouse.tables.mock.RequestConstants;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -126,10 +127,206 @@ public class IcebergSnapshotsApiHandlerAuditTest {
   }
 
   @Test
+  public void testPutIcebergSnapshotsMainCommitSetsBranchRefNameToMain() throws Exception {
+    mvc.perform(
+        MockMvcRequestBuilders.put(
+                String.format(
+                    CURRENT_MAJOR_VERSION_PREFIX
+                        + "/databases/d200/tables/tb1/iceberg/v2/snapshots"))
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(RequestConstants.TEST_ICEBERG_SNAPSHOTS_REQUEST_BODY.toJson()));
+    Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
+    assertEquals("main", argCaptor.getValue().getBranchRefName());
+  }
+
+  @Test
+  public void testPutIcebergSnapshotsNamedBranchCommitSetsBranchRefName() throws Exception {
+    // Realistic named-branch commit: main ref exists but its snapshot is NOT in jsonSnapshots
+    // (main didn't advance). Only the feature branch got a new snapshot.
+    String newSnapshotJson =
+        "{\n"
+            + "  \"snapshot-id\" : 999,\n"
+            + "  \"timestamp-ms\" : 5000,\n"
+            + "  \"summary\" : {\"operation\": \"append\"},\n"
+            + "  \"manifest-list\" : \"/tmp/feature.avro\",\n"
+            + "  \"schema-id\" : 0\n"
+            + "}";
+    Map<String, String> refs = new HashMap<>();
+    refs.put("main", "{\"snapshot-id\":100,\"type\":\"branch\"}"); // main stayed at old snapshot
+    refs.put("feature", "{\"snapshot-id\":999,\"type\":\"branch\"}"); // feature got new snapshot
+
+    IcebergSnapshotsRequestBody requestBody =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion("v1")
+            .jsonSnapshots(Collections.singletonList(newSnapshotJson))
+            .snapshotRefs(refs)
+            .jsonMetadataUpdates(
+                Collections.singletonList(setSnapshotRef("feature", 999L, "branch")))
+            .createUpdateTableRequestBody(RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY)
+            .build();
+
+    mvc.perform(
+        MockMvcRequestBuilders.put(
+                String.format(
+                    CURRENT_MAJOR_VERSION_PREFIX
+                        + "/databases/d200/tables/tb1/iceberg/v2/snapshots"))
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody.toJson()));
+    Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
+    TableAuditEvent actualEvent = argCaptor.getValue();
+    assertEquals("feature", actualEvent.getBranchRefName());
+    // main didn't advance, so currentSnapshotId is main's old snapshot and timestamp is null
+    assertEquals(100L, actualEvent.getCurrentSnapshotId().longValue());
+    assertNull(actualEvent.getCurrentSnapshotTimestampMs());
+  }
+
+  /**
+   * {@code ALTER TABLE t CREATE BRANCH b} on a table that already has snapshots. This is the case
+   * the resulting table state cannot express: the ref is created at the current head and no
+   * snapshot is committed, so main and b are indistinguishable in {@code snapshotRefs} — both point
+   * at the same, already-existing snapshot. The commit's {@code set-snapshot-ref} action names b
+   * outright.
+   */
+  @Test
+  public void testPutIcebergSnapshotsCreateBranchAtHeadReportsNewBranchNotMain() throws Exception {
+    Map<String, String> refs = new HashMap<>();
+    refs.put("main", TEST_HEAD_SNAPSHOT_REF_JSON);
+    refs.put("b", TEST_HEAD_SNAPSHOT_REF_JSON); // same snapshot as main
+
+    IcebergSnapshotsRequestBody requestBody =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion("v1")
+            .jsonSnapshots(Collections.singletonList(RequestConstants.TEST_ICEBERG_SNAPSHOT_JSON))
+            .snapshotRefs(refs)
+            .jsonMetadataUpdates(
+                Collections.singletonList(setSnapshotRef("b", HEAD_SNAPSHOT_ID, "branch")))
+            .createUpdateTableRequestBody(RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY)
+            .build();
+
+    assertEquals("b", putSnapshots(requestBody).getBranchRefName());
+  }
+
+  /**
+   * The same tie, with the ref map ordered so "main" is encountered first. Under the previous
+   * snapshot-matching heuristic the answer depended on {@link HashMap} iteration order and could
+   * flip between runs; keyed off the commit's declared updates it is fixed.
+   */
+  @Test
+  public void testPutIcebergSnapshotsCreateBranchIsDeterministicRegardlessOfRefOrder()
+      throws Exception {
+    Map<String, String> refs = new LinkedHashMap<>();
+    refs.put("main", TEST_HEAD_SNAPSHOT_REF_JSON);
+    refs.put("aaa_sorts_first", TEST_HEAD_SNAPSHOT_REF_JSON);
+    refs.put("zzz_sorts_last", TEST_HEAD_SNAPSHOT_REF_JSON);
+
+    IcebergSnapshotsRequestBody requestBody =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion("v1")
+            .jsonSnapshots(Collections.singletonList(RequestConstants.TEST_ICEBERG_SNAPSHOT_JSON))
+            .snapshotRefs(refs)
+            .jsonMetadataUpdates(
+                Collections.singletonList(
+                    setSnapshotRef("zzz_sorts_last", HEAD_SNAPSHOT_ID, "branch")))
+            .createUpdateTableRequestBody(RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY)
+            .build();
+
+    assertEquals("zzz_sorts_last", putSnapshots(requestBody).getBranchRefName());
+  }
+
+  /**
+   * {@code CREATE TAG} carries {@code "type": "tag"}. A tag is not a branch, so branchRefName stays
+   * null rather than reporting a tag name in a field documented as a branch.
+   */
+  @Test
+  public void testPutIcebergSnapshotsTagCommitLeavesBranchRefNameNull() throws Exception {
+    Map<String, String> refs = new HashMap<>();
+    refs.put("main", TEST_HEAD_SNAPSHOT_REF_JSON);
+    refs.put("v1_release", "{\"snapshot-id\":" + HEAD_SNAPSHOT_ID + ",\"type\":\"tag\"}");
+
+    IcebergSnapshotsRequestBody requestBody =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion("v1")
+            .jsonSnapshots(Collections.singletonList(RequestConstants.TEST_ICEBERG_SNAPSHOT_JSON))
+            .snapshotRefs(refs)
+            .jsonMetadataUpdates(
+                Collections.singletonList(setSnapshotRef("v1_release", HEAD_SNAPSHOT_ID, "tag")))
+            .createUpdateTableRequestBody(RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY)
+            .build();
+
+    TableAuditEvent actualEvent = putSnapshots(requestBody);
+    assertNull(actualEvent.getBranchRefName());
+    // The tag commit does not move main, but main's snapshot info is still reported.
+    assertEquals(HEAD_SNAPSHOT_ID, actualEvent.getCurrentSnapshotId().longValue());
+  }
+
+  /**
+   * {@code DROP BRANCH b} removes a ref and commits nothing. No branch was written, so
+   * branchRefName stays null; {@code remove-snapshot-ref} is deliberately not treated as a write.
+   */
+  @Test
+  public void testPutIcebergSnapshotsDropBranchLeavesBranchRefNameNull() throws Exception {
+    IcebergSnapshotsRequestBody requestBody =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion("v1")
+            .jsonSnapshots(Collections.singletonList(RequestConstants.TEST_ICEBERG_SNAPSHOT_JSON))
+            .snapshotRefs(Collections.singletonMap("main", TEST_HEAD_SNAPSHOT_REF_JSON))
+            .jsonMetadataUpdates(
+                Collections.singletonList(
+                    "{\"action\":\"remove-snapshot-ref\",\"ref-name\":\"b\"}"))
+            .createUpdateTableRequestBody(RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY)
+            .build();
+
+    assertNull(putSnapshots(requestBody).getBranchRefName());
+  }
+
+  /**
+   * Clients predating {@code jsonMetadataUpdates} omit it. branchRefName is then left unset rather
+   * than guessed — an absent audit field beats one that is wrong on ties.
+   */
+  @Test
+  public void testPutIcebergSnapshotsWithoutMetadataUpdatesLeavesBranchRefNameNull()
+      throws Exception {
+    IcebergSnapshotsRequestBody legacyRequestBody =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion("v1")
+            .jsonSnapshots(Collections.singletonList(RequestConstants.TEST_ICEBERG_SNAPSHOT_JSON))
+            .snapshotRefs(Collections.singletonMap("main", TEST_HEAD_SNAPSHOT_REF_JSON))
+            .createUpdateTableRequestBody(RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY)
+            .build();
+
+    TableAuditEvent actualEvent = putSnapshots(legacyRequestBody);
+    assertNull(actualEvent.getBranchRefName());
+    // Everything else on the legacy path is unaffected.
+    assertEquals(HEAD_SNAPSHOT_ID, actualEvent.getCurrentSnapshotId().longValue());
+    assertEquals(1669126937912L, actualEvent.getCurrentSnapshotTimestampMs().longValue());
+  }
+
+  /** A malformed action must not hide the well-formed ones around it. */
+  @Test
+  public void testPutIcebergSnapshotsSkipsUnparseableMetadataUpdate() throws Exception {
+    IcebergSnapshotsRequestBody requestBody =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion("v1")
+            .jsonSnapshots(Collections.singletonList(RequestConstants.TEST_ICEBERG_SNAPSHOT_JSON))
+            .snapshotRefs(Collections.singletonMap("main", TEST_HEAD_SNAPSHOT_REF_JSON))
+            .jsonMetadataUpdates(
+                Arrays.asList(
+                    "{\"action\":\"not-a-real-action\"}",
+                    "}{ malformed json",
+                    setSnapshotRef("feature", HEAD_SNAPSHOT_ID, "branch")))
+            .createUpdateTableRequestBody(RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY)
+            .build();
+
+    assertEquals("feature", putSnapshots(requestBody).getBranchRefName());
+  }
+
+  @Test
   public void testPutIcebergSnapshotsBranchOnlyCommitLeavesSnapshotInfoNull() throws Exception {
-    // Simulate a branch-only commit where main is absent from snapshotRefs.
-    // In this case the main branch ref doesn't exist, so currentSnapshotId /
-    // currentSnapshotTimestampMs should be null.
+    // Simulate a branch-only commit where main is absent from snapshotRefs entirely.
+    // currentSnapshotId / currentSnapshotTimestampMs are null (no main), but branchRefName
+    // is still populated from the ref that received the new snapshot.
     IcebergSnapshotsRequestBody branchOnlyRequestBody =
         IcebergSnapshotsRequestBody.builder()
             .baseTableVersion("v1")
@@ -137,6 +334,8 @@ public class IcebergSnapshotsApiHandlerAuditTest {
             .snapshotRefs(
                 Collections.singletonMap(
                     "my_branch", "{\"snapshot-id\":2151407017102313398,\"type\":\"branch\"}"))
+            .jsonMetadataUpdates(
+                Collections.singletonList(setSnapshotRef("my_branch", HEAD_SNAPSHOT_ID, "branch")))
             .createUpdateTableRequestBody(RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY)
             .build();
 
@@ -150,6 +349,7 @@ public class IcebergSnapshotsApiHandlerAuditTest {
             .content(branchOnlyRequestBody.toJson()));
     Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
     TableAuditEvent actualEvent = argCaptor.getValue();
+    assertEquals("my_branch", actualEvent.getBranchRefName());
     assertNull(actualEvent.getCurrentSnapshotId());
     assertNull(actualEvent.getCurrentSnapshotTimestampMs());
   }
@@ -185,6 +385,8 @@ public class IcebergSnapshotsApiHandlerAuditTest {
             .baseTableVersion("v1")
             .jsonSnapshots(Arrays.asList(olderSnapshotJson, newerSnapshotJson))
             .snapshotRefs(refs)
+            .jsonMetadataUpdates(
+                Collections.singletonList(setSnapshotRef("feature", 200L, "branch")))
             .createUpdateTableRequestBody(RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY)
             .build();
 
@@ -200,6 +402,34 @@ public class IcebergSnapshotsApiHandlerAuditTest {
     TableAuditEvent actualEvent = argCaptor.getValue();
     assertEquals(100L, actualEvent.getCurrentSnapshotId().longValue());
     assertEquals(1000L, actualEvent.getCurrentSnapshotTimestampMs().longValue());
+    // The commit declared it moved feature; main is untouched despite sharing the ref map.
+    assertEquals("feature", actualEvent.getBranchRefName());
+  }
+
+  /** The snapshot id carried by {@link RequestConstants#TEST_ICEBERG_SNAPSHOT_JSON}. */
+  private static final long HEAD_SNAPSHOT_ID = 2151407017102313398L;
+
+  private static final String TEST_HEAD_SNAPSHOT_REF_JSON =
+      "{\"snapshot-id\":" + HEAD_SNAPSHOT_ID + ",\"type\":\"branch\"}";
+
+  /** Builds one Iceberg REST spec {@code set-snapshot-ref} action. */
+  private static String setSnapshotRef(String refName, long snapshotId, String type) {
+    return String.format(
+        "{\"action\":\"set-snapshot-ref\",\"ref-name\":\"%s\",\"snapshot-id\":%d,\"type\":\"%s\"}",
+        refName, snapshotId, type);
+  }
+
+  private TableAuditEvent putSnapshots(IcebergSnapshotsRequestBody requestBody) throws Exception {
+    mvc.perform(
+        MockMvcRequestBuilders.put(
+                String.format(
+                    CURRENT_MAJOR_VERSION_PREFIX
+                        + "/databases/d200/tables/tb1/iceberg/v2/snapshots"))
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody.toJson()));
+    Mockito.verify(tableAuditHandler, atLeastOnce()).audit(argCaptor.capture());
+    return argCaptor.getValue();
   }
 
   @Test

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/model/TableAuditModelConstants.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/model/TableAuditModelConstants.java
@@ -225,6 +225,7 @@ public final class TableAuditModelConstants {
           .operationType(OperationType.COMMIT)
           .currentSnapshotId(2151407017102313398L)
           .currentSnapshotTimestampMs(1669126937912L)
+          .branchRefName("main")
           .build();
 
   public static final TableAuditEvent TABLE_AUDIT_EVENT_PUT_ICEBERG_SNAPSHOTS_FAILED =
@@ -237,6 +238,7 @@ public final class TableAuditModelConstants {
           .operationType(OperationType.COMMIT)
           .currentSnapshotId(2151407017102313398L)
           .currentSnapshotTimestampMs(1669126937912L)
+          .branchRefName("main")
           .build();
 
   public static final TableAuditEvent TABLE_AUDIT_EVENT_PUT_ICEBERG_SNAPSHOTS_CTAS =
@@ -249,6 +251,7 @@ public final class TableAuditModelConstants {
           .operationType(OperationType.STAGED_COMMIT)
           .currentSnapshotId(2151407017102313398L)
           .currentSnapshotTimestampMs(1669126937912L)
+          .branchRefName("main")
           .build();
 
   public static final TableAuditEvent TABLE_AUDIT_EVENT_GET_ALL_DATABASES_SUCCESS =


### PR DESCRIPTION
## Summary

Adds an optional `updates` field to `IcebergSnapshotsRequestBody` — Iceberg REST `CommitTableRequest.updates[]` by name and by item shape — and uses it to populate `branchRefName` on `TableAuditEvent` so operations against named Iceberg branches become observable.

Today the commit request carries only replacement state (`jsonSnapshots` + `snapshotRefs`) — what the table now looks like, never what the commit changed. That makes "which branch was written" unanswerable for `ALTER TABLE t CREATE BRANCH b`: it adds a ref at the current head and commits no snapshot, so `main` and `b` point at the same snapshot.

> **Relationship to #616:** this supersedes #616, which added the same `branchRefName` using a snapshot-ordering heuristic. Only one should merge. See "Why not infer it" below.

## Changes

- [x] **Client-facing API Changes** — new optional `updates` on `IcebergSnapshotsRequestBody`. Array of `TableUpdate` objects (discriminated by `action`), not stringified JSON. Additive: the server still builds table metadata from `jsonSnapshots`/`snapshotRefs`, older clients omit the field, consumers must tolerate null/empty.
- [x] **New Features** — `TableAuditEvent.branchRefName`, populated from the commit's `set-snapshot-ref` action.
- [x] **Tests** — see below.

### Why this is the REST field, not a lookalike

[`CommitTableRequest`](https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml) is `{requirements[], updates[]}`, where `updates[]` is a discriminated union on `action`. `CREATE BRANCH b` is a single `set-snapshot-ref` with `ref-name: b`, `type: branch`, and no `add-snapshot`.

The client already has this list — `TableMetadata.changes()`, the same one every Iceberg REST catalog sends — and `MetadataUpdateParser` emits the spec object. Shipping that as an object array (not `string[]`) means this field *is* `updates[]`. Convergence is dropping the full-state fields and adding `requirements[]`, not a rename or a type change.

`updates` does not 1:1-replace the old parameters. It is this commit's deltas. `jsonSnapshots`/`snapshotRefs` remain the full current set; `baseTableVersion` has no counterpart until `requirements[]`; `createUpdateTableRequestBody` still carries the OpenHouse envelope (policies, tableType, clustering, …) and always-current schema/properties.

This is phase 1 of 3. Phase 2: server prefers these deltas over the snapshot-set diff in `OpenHouseInternalTableOperations`. Phase 3: `requirements[]` instead of `baseTableVersion`. Each is separately reviewable; this PR changes no commit behavior.

### Why not infer it from the resulting state

Matching the last snapshot in `jsonSnapshots` to the ref pointing at it is wrong in four ways, all of which `CREATE BRANCH` triggers:

1. **Nondeterministic on ties.** After `CREATE BRANCH b`, `main` and `b` both point at the last snapshot. `snapshotRefs` is a `HashMap`.
2. **The invariant does not hold.** "The last snapshot is the newly-committed one" is false for any commit that writes no snapshot.
3. **Tags counted as branches.** `SnapshotRefParser` parses both and ref type was absent from the comparison.
4. **Order dependence.** Correctness rested on client serialization order of `TableMetadata.snapshots()`.

Reading the commit's declared `set-snapshot-ref` removes all four.

### Safety

- Client-side serialization failures are swallowed and individual unserializable actions skipped — the field can never fail a commit.
- Server-side, unknown/unparseable actions are skipped individually. When `updates` becomes authoritative, those MUST 400 per the REST spec.
- Clients predating the field omit it, and `branchRefName` is then left **unset rather than guessed**.
- Invalid JSON in `updates` is a request-binding 400 (object array, not stringified JSON).
- One source file serves both the iceberg-1.2 and iceberg-1.5 runtimes.

## Testing Done

- [x] **Added new tests for the changes made.**

Server-side (`IcebergSnapshotsApiHandlerAuditTest`):
- `CreateBranchAtHeadReportsNewBranchNotMain` — the tie; reports `b`, not `main`
- `CreateBranchIsDeterministicRegardlessOfRefOrder`
- `TagCommitLeavesBranchRefNameNull`
- `DropBranchLeavesBranchRefNameNull`
- `WithoutMetadataUpdatesLeavesBranchRefNameNull` — clients omitting the field
- `SkipsUnparseableMetadataUpdate` — unknown `action` does not hide valid ones
- `UpdatesFieldIsRestObjectArray` — wire items are objects, snapshot-id is numeric

Client-side (`OpenHouseTableOperationsMetadataUpdatesTest`): CREATE BRANCH emits only a branch-typed `set-snapshot-ref` with no `add-snapshot`; CREATE TAG is tag-typed; DROP BRANCH is `remove-snapshot-ref`; an append reports both `add-snapshot` and the ref that moved; large snapshot ids stay `Long` (not `Double`).

- [x] **Updated existing tests to reflect the changes made.**

Note for reviewers: `TableMetadata.changes()` accumulates across builds within a session, so the client fixture discards construction history to match production, where the base always comes from a refresh parsed off disk.

# Additional Information

- [x] **Large PR broken into smaller PRs.** Three commits: the original contract, the audit consumer, then the envelope fix so the field is REST `updates[]` rather than `jsonMetadataUpdates: string[]`. Phases 2-3 are separate PRs.

Not covered, and worth flagging before phase 2 relies on this field for commit behavior: no end-to-end assertion through `BranchTestSpark3_5.java`, and `putSnapshotsForReplace` (CTAS/RTAS) is not covered by the `changes()` tests. Multiple `set-snapshot-ref` actions report the first branch.