### PR TITLE
Add table- and column-level SQL lineage to the Spark runtime

### DIFF
--- a/integrations/spark/README.md
+++ b/integrations/spark/README.md
@@ -1,0 +1,122 @@
+# OpenHouse Spark integration
+
+Two runtime artifacts are published from this directory:
+
+| Module | Artifact | Spark |
+| --- | --- | --- |
+| `spark-3.1/openhouse-spark-runtime` | `openhouse-spark-runtime_2.12` | 3.1 |
+| `spark-3.5/openhouse-spark-runtime` | `openhouse-spark-3.5-runtime_2.12` | 3.5 |
+
+Both add the OpenHouse SQL extensions (`GRANT`/`REVOKE`/`SHOW GRANTS` and the `ALTER TABLE ... SET
+POLICY` retention, replication, sharing, history and column-tag statements) to a Spark session. The
+3.5 artifact repackages the 3.1 shadow jar, so **everything under `com.linkedin.openhouse.spark` is
+compiled once against Spark 3.1 and executed on both releases.**
+
+## SQL lineage
+
+`com.linkedin.openhouse.spark.lineage` extracts table- and column-level lineage from the analyzed
+logical plan of every statement, and answers four questions per statement:
+
+* **which tables were read** — `inputTables`, including tables reached only through subqueries, CTEs
+  and the target of a `MERGE`/`UPDATE`;
+* **which table was written** — `outputTable`;
+* **how each output column is calculated** — `columnLineage`, giving the upstream columns, the SQL
+  formula and a coarse `transformationType` (`IDENTITY`, `LITERAL`, `EXPRESSION`, `AGGREGATION`,
+  `WINDOW`, `GENERATOR`);
+* **which columns decided the rows** — `conditions`, the indirect ("influence") lineage carried by
+  `WHERE`, `JOIN ... ON`, `GROUP BY` and `MERGE ... ON`.
+
+### Enabling it
+
+Declaratively, as a query execution listener:
+
+```
+--conf spark.sql.queryExecutionListeners=com.linkedin.openhouse.spark.lineage.OpenhouseLineageListener
+```
+
+Every executed statement then produces one INFO line on the driver:
+
+```
+openhouse-lineage {"operation":"INSERT_INTO","sql":"INSERT INTO ...","outputTable":"openhouse.db.order_facts", ...}
+```
+
+Set the `com.linkedin.openhouse.spark.lineage` logger to `DEBUG` to additionally get a readable
+block:
+
+```
+OpenHouse lineage
+  operation   : INSERT_INTO
+  outputTable : openhouse.db.order_facts
+  inputTables : openhouse.db.orders, openhouse.db.customers
+  columns     :
+      openhouse.db.order_facts.revenue <- openhouse.db.orders.quantity, openhouse.db.orders.unit_price  [EXPRESSION] (quantity * unit_price)
+      openhouse.db.order_facts.region <- openhouse.db.orders.region  [IDENTITY] region
+  conditions  :
+      FILTER: (tier = 'GOLD') -> openhouse.db.customers.tier
+      JOIN: (customer_id = customer_id) -> openhouse.db.orders.customer_id, openhouse.db.customers.customer_id
+```
+
+Programmatically, which is what a shell session or a test wants:
+
+```scala
+val sink = new InMemoryLineageSink
+OpenhouseLineageListener.register(spark, sink)
+spark.sql("INSERT INTO openhouse.db.order_facts SELECT ... ").collect()
+sink.last.foreach(l => println(l.toPrettyString))
+```
+
+Or without executing anything at all:
+
+```scala
+SqlLineageExtractor.extractFromSql(spark, "INSERT INTO db.t2 SELECT a * b AS c FROM db.t1")
+```
+
+### Emitting lineage somewhere other than the log
+
+`LineageSink` is the only transport seam:
+
+```scala
+trait LineageSink { def emit(lineage: SqlLineage): Unit }
+```
+
+`LogLineageSink` (the default) writes to the driver log and `InMemoryLineageSink` collects in
+memory. A Kafka publisher is a third implementation — `SqlLineage.toJson` already produces a compact
+single-line payload — and is wired in by registering the listener programmatically with that sink.
+Failures inside a sink are caught and logged: lineage capture never breaks the query that produced
+it.
+
+### What the tests demonstrate
+
+`SqlLineageExtractorTest` in the 3.1 module is the catalogue of supported SQL shapes; each test names
+the shape and the lineage it yields (projections, computed columns, `CASE`, aggregates, window
+functions, joins, self joins, unions, CTEs, subqueries, `CTAS`, `INSERT`/`INSERT OVERWRITE`,
+`MERGE`, `UPDATE`, `DELETE`, and the statements that intentionally produce no lineage).
+`SqlLineageExtractorTestSpark3_5` in the 3.5 module reruns a representative subset on Spark 3.5.
+
+Run them with a JDK 11 toolchain:
+
+```bash
+./gradlew :integrations:spark:spark-3.1:openhouse-spark-runtime_2.12:test --tests '*lineage*'
+./gradlew :integrations:spark:spark-3.5:openhouse-spark-3.5-runtime_2.12:test
+```
+
+### Cross-version constraints
+
+Because the code is compiled against Spark 3.1 and also runs on Spark 3.5, plan nodes are **never**
+matched with case-class patterns — a fixed-arity `unapply` would throw `NoSuchMethodError` on the
+release where the node gained a field (`CreateTableAsSelect`, `MergeIntoTable` and
+`InsertIntoStatement` all did). `PlanAccessors` reads nodes through their accessor methods, whose
+names and return types are stable, and node types are recognised by simple name. The same mechanism
+transparently covers engine-specific nodes such as Iceberg's rewritten row-level plans, which are not
+on the compile classpath at all.
+
+Two Spark 3.4+ analysis changes are handled explicitly and are visible in the extracted lineage:
+
+* CTEs are no longer inlined; `CTERelationRef` placeholders are linked back to their
+  `CTERelationDef` so lineage still reaches the base tables.
+* `UPDATE`, `DELETE` and `MERGE INTO` are rewritten into a generic `ReplaceData`/`WriteDelta` before
+  the listener sees them. The original statement is recovered from the connector's
+  `RowLevelOperation.command`, the internal row-tracking columns (`_file`, `_pos`) the rewrite adds
+  are dropped, and the per-branch `MERGE` assignments are folded back into one entry per target
+  column. Note that under copy-on-write an `UPDATE` genuinely rewrites every column of the matching
+  files, so all of them are reported with the predicate column as a source.

--- a/integrations/spark/spark-3.1/openhouse-spark-runtime/build.gradle
+++ b/integrations/spark/spark-3.1/openhouse-spark-runtime/build.gradle
@@ -87,6 +87,19 @@ task runAntlr(type:JavaExec) {
 
 compileJava.dependsOn runAntlr
 
+test {
+  // Spark 3.1 needs these to run on JDK 9+.
+  if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
+    jvmArgs \
+        '--add-opens=java.base/java.nio=ALL-UNNAMED',
+        '--add-opens=java.base/java.util=ALL-UNNAMED',
+        '--add-opens=java.base/java.lang=ALL-UNNAMED',
+        '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED',
+        '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
+        '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED'
+  }
+}
+
 shadowJar {
   dependencies {
     exclude("javax/**")

--- a/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/lineage/ColumnOriginResolver.scala
+++ b/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/lineage/ColumnOriginResolver.scala
@@ -1,0 +1,316 @@
+package com.linkedin.openhouse.spark.lineage
+
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, ExprId, Expression, Generator, LeafExpression, Literal, NamedExpression, SubqueryExpression, Unevaluable, WindowExpression}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Generate, LogicalPlan, Project, Union, Window}
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, Identifier}
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.types.{DataType, StringType}
+
+import scala.util.Try
+
+/**
+ * Walks a logical plan bottom-up and answers "which upstream table columns does this expression id
+ * come from?".
+ *
+ * The resolver builds a map from every [[ExprId]] visible in the plan to the set of base-table
+ * [[ColumnRef]]s that feed it. Leaf relations seed the map with their own columns; every operator
+ * that introduces new expression ids ([[Project]], [[Aggregate]], [[Window]], [[Generate]],
+ * [[Union]], `Expand`, CTE references, ...) extends it by resolving its expressions against the map
+ * produced by its children. Because the map is keyed by expression id rather than by name, aliasing,
+ * self joins and repeated column names all resolve correctly.
+ */
+private[lineage] class ColumnOriginResolver(
+    val rootCteDefinitions: Map[Long, LogicalPlan] = Map.empty) {
+
+  type OriginMap = Map[ExprId, Seq[ColumnRef]]
+
+  private val EmptyOrigins: OriginMap = Map.empty
+
+  /**
+   * Builds the expression-id to source-column map for the whole plan.
+   *
+   * `rootCteDefinitions` carries the `WITH` clauses of the enclosing statement: a command's query
+   * subtree references them but does not contain them, so they have to be supplied from the root.
+   */
+  def resolve(plan: LogicalPlan): OriginMap =
+    build(plan, rootCteDefinitions ++ ColumnOriginResolver.cteDefinitions(plan))
+
+  /** Source columns feeding an arbitrary expression, deduplicated and stably ordered. */
+  def sourcesOf(expression: Expression, origins: OriginMap): Seq[ColumnRef] =
+    expression
+      .collect { case a: Attribute => a }
+      .flatMap(a => origins.getOrElse(a.exprId, Nil))
+      .distinct
+
+  /** Source columns feeding any of the given expressions. */
+  def sourcesOfAll(expressions: Seq[Expression], origins: OriginMap): Seq[ColumnRef] =
+    expressions.flatMap(sourcesOf(_, origins)).distinct
+
+  // scalastyle:off cyclomatic.complexity
+  private def build(plan: LogicalPlan, cteDefs: Map[Long, LogicalPlan]): OriginMap = {
+    // Correlated and scalar subqueries hang off expressions rather than off `children`, so they have
+    // to be folded in explicitly or lineage through `IN (SELECT ...)` would be lost.
+    val subqueryOrigins = plan.subqueries.map(build(_, cteDefs)).foldLeft(EmptyOrigins)(_ ++ _)
+
+    val ownOrigins = plan match {
+      case relation if relationRef(relation).isDefined =>
+        val table = relationRef(relation).get
+        relation.output.map(attr => attr.exprId -> Seq(ColumnRef(table, attr.name))).toMap
+
+      case project: Project =>
+        val childOrigins = build(project.child, cteDefs)
+        childOrigins ++ aliasOrigins(project.projectList, childOrigins)
+
+      case aggregate: Aggregate =>
+        val childOrigins = build(aggregate.child, cteDefs)
+        childOrigins ++ aliasOrigins(aggregate.aggregateExpressions, childOrigins)
+
+      case window: Window =>
+        val childOrigins = build(window.child, cteDefs)
+        childOrigins ++ aliasOrigins(window.windowExpressions, childOrigins)
+
+      case generate: Generate =>
+        val childOrigins = build(generate.child, cteDefs)
+        val generatorSources = sourcesOf(generate.generator, childOrigins)
+        childOrigins ++ generate.generatorOutput.map(_.exprId -> generatorSources).toMap
+
+      case union: Union =>
+        val childOrigins = union.children.map(build(_, cteDefs))
+        val merged = childOrigins.foldLeft(EmptyOrigins)(_ ++ _)
+        merged ++ positionalOrigins(union.output, union.children.map(_.output), childOrigins)
+
+      case mergeRows if mergeRows.getClass.getSimpleName == "MergeRows" =>
+        val childOrigins = build(mergeRows.children.head, cteDefs)
+        val branches = ColumnOriginResolver.mergeBranches(mergeRows)
+        childOrigins ++ mergeRows.output.zipWithIndex.map { case (attr, idx) =>
+          attr.exprId -> branches.flatMap {
+            case (_, outputs) => outputs.lift(idx).toSeq.flatMap(sourcesOf(_, childOrigins))
+          }.distinct
+        }.toMap
+
+      case other =>
+        val childOrigins = other.children.map(build(_, cteDefs))
+        val merged = childOrigins.foldLeft(EmptyOrigins)(_ ++ _)
+        merged ++ expandOrigins(other, merged) ++ cteRefOrigins(other, cteDefs) ++
+          passthroughOrigins(other, merged)
+    }
+
+    subqueryOrigins ++ ownOrigins
+  }
+  // scalastyle:on cyclomatic.complexity
+
+  private def aliasOrigins(expressions: Seq[NamedExpression], childOrigins: OriginMap): OriginMap =
+    expressions.map(expr => expr.exprId -> sourcesOf(expr, childOrigins)).toMap
+
+  /**
+   * Maps each output attribute to the union of the sources of the i-th output attribute of every
+   * branch. Used for `UNION`, where the output attributes are new expression ids covering all
+   * branches.
+   */
+  private def positionalOrigins(
+      output: Seq[Attribute],
+      branchOutputs: Seq[Seq[Attribute]],
+      branchOrigins: Seq[OriginMap]): OriginMap =
+    output.zipWithIndex.map { case (attr, idx) =>
+      val sources = branchOutputs
+        .zip(branchOrigins)
+        .flatMap { case (branch, origins) =>
+          branch.lift(idx).toSeq.flatMap(a => origins.getOrElse(a.exprId, Nil))
+        }
+        .distinct
+      attr.exprId -> sources
+    }.toMap
+
+  /** `Expand` (GROUPING SETS / CUBE / ROLLUP) rewrites output attributes over several projections. */
+  private def expandOrigins(plan: LogicalPlan, childOrigins: OriginMap): OriginMap = {
+    if (plan.getClass.getSimpleName != "Expand") {
+      return EmptyOrigins
+    }
+    val projections = PlanAccessors
+      .seq[scala.collection.Seq[Expression]](plan, "projections")
+      .map(_.toList)
+    if (projections.isEmpty) EmptyOrigins
+    else {
+      plan.output.zipWithIndex.map { case (attr, idx) =>
+        attr.exprId -> projections.flatMap(p => p.lift(idx).toSeq.flatMap(sourcesOf(_, childOrigins))).distinct
+      }.toMap
+    }
+  }
+
+  /**
+   * Spark 3.4+ keeps CTEs as `CTERelationDef` / `CTERelationRef` pairs in the analyzed plan instead
+   * of inlining them, so a reference has to be linked back to its definition to keep lineage intact.
+   */
+  private def cteRefOrigins(plan: LogicalPlan, cteDefs: Map[Long, LogicalPlan]): OriginMap =
+    ColumnOriginResolver.cteReference(plan, cteDefs) match {
+      case Some((_, defPlan)) =>
+        val defOrigins = build(defPlan, cteDefs)
+        defOrigins ++ positionalOrigins(plan.output, Seq(defPlan.output), Seq(defOrigins))
+      case None => EmptyOrigins
+    }
+
+  /**
+   * Generic safety net for single-child nodes that re-project their child's output under fresh
+   * expression ids (Spark 3.1's `View`, Iceberg's rewritten row-level nodes, ...). Only attributes
+   * that could not be resolved otherwise are filled in, so this never overrides a precise mapping.
+   */
+  private def passthroughOrigins(plan: LogicalPlan, origins: OriginMap): OriginMap = {
+    val children = plan.children
+    if (children.size != 1 || children.head.output.size != plan.output.size) {
+      return EmptyOrigins
+    }
+    plan.output
+      .zip(children.head.output)
+      .collect {
+        case (out, in) if out.exprId != in.exprId && !origins.contains(out.exprId) &&
+          origins.contains(in.exprId) =>
+          out.exprId -> origins(in.exprId)
+      }
+      .toMap
+  }
+
+  /** Recognises the leaf nodes that read from a persisted table. */
+  def relationRef(plan: LogicalPlan): Option[TableRef] = plan match {    case relation: LogicalRelation => relation.catalogTable.map(catalogTableRef)
+    case _ if plan.getClass.getSimpleName == "DataSourceV2Relation" => v2RelationRef(plan)
+    case _ if plan.getClass.getSimpleName == "DataSourceV2ScanRelation" =>
+      PlanAccessors.invoke[LogicalPlan](plan, "relation").flatMap(v2RelationRef)
+    case _ if plan.getClass.getSimpleName == "HiveTableRelation" =>
+      PlanAccessors.invoke[CatalogTable](plan, "tableMeta").map(catalogTableRef)
+    case _ if plan.getClass.getSimpleName == "UnresolvedRelation" =>
+      Some(TableRef.fromMultipart(PlanAccessors.seq[String](plan, "multipartIdentifier")))
+    case _ => None
+  }
+
+  private def v2RelationRef(plan: AnyRef): Option[TableRef] = {    val catalogName = PlanAccessors
+      .option[CatalogPlugin](plan, "catalog")
+      .flatMap(c => Try(c.name()).toOption)
+    val fromIdentifier = PlanAccessors.option[Identifier](plan, "identifier").map { id =>
+      TableRef(catalogName, id.namespace().toSeq, id.name())
+    }
+    fromIdentifier.orElse {
+      // Fall back to the connector-reported name, which for Iceberg is already fully qualified.
+      PlanAccessors
+        .invoke[AnyRef](plan, "table")
+        .flatMap(t => Try(t.getClass.getMethod("name").invoke(t).asInstanceOf[String]).toOption)
+        .map(name => TableRef.fromMultipart(name.split('.').toSeq, catalogName))
+    }
+  }
+
+  private def catalogTableRef(table: CatalogTable): TableRef =
+    TableRef(None, table.identifier.database.toSeq, table.identifier.table)
+
+  /**
+   * Resolves the table a write command targets. The target is rarely the top node itself: an alias
+   * (`MERGE INTO db.t AS t`) or an engine-specific wrapper usually sits in between, so the subtree
+   * is searched for the first readable relation.
+   */
+  def targetRelationRef(plan: LogicalPlan): Option[TableRef] =
+    relationRef(plan).orElse(plan.children.iterator.flatMap(targetRelationRef).toStream.headOption)
+
+  /** Classifies how an output column is computed. */
+  def classify(expression: Expression): String = {
+    val unwrapped = expression match {
+      case alias: Alias => alias.child
+      case other => other
+    }
+    if (unwrapped.find(_.isInstanceOf[WindowExpression]).isDefined) {
+      TransformationType.Window
+    } else if (unwrapped.find(_.isInstanceOf[AggregateExpression]).isDefined) {
+      TransformationType.Aggregation
+    } else if (unwrapped.find(_.isInstanceOf[Generator]).isDefined) {
+      TransformationType.Generator
+    } else {
+      unwrapped match {
+        case _: AttributeReference => TransformationType.Identity
+        case _: Literal => TransformationType.Literal
+        case other if other.find(_.isInstanceOf[Attribute]).isEmpty => TransformationType.Literal
+        case _ => TransformationType.Expression
+      }
+    }
+  }
+
+  /**
+   * Best-effort SQL rendering of an expression.
+   *
+   * Attribute references are rewritten to their bare column name first: Spark renders them as
+   * fully-qualified backquoted identifiers, which makes the formula unreadable. The fully-qualified
+   * provenance is already carried by [[ColumnLineage.sources]].
+   */
+  def render(expression: Expression): String = {
+    val unwrapped = expression match {
+      case alias: Alias => alias.child
+      case other => other
+    }
+    val readable = Try(unwrapped.transformUp { case attr: Attribute => PlainColumnName(attr.name) })
+      .getOrElse(unwrapped)
+    Try(readable.sql).getOrElse(readable.toString)
+  }
+
+  /** Source plans referenced by subquery expressions in the given expression. */
+  def subqueryPlans(expression: Expression): Seq[LogicalPlan] =
+    expression.collect { case sub: SubqueryExpression => sub.plan }
+}
+
+private[lineage] object ColumnOriginResolver {
+
+  /**
+   * Maps every `CTERelationDef` id in the plan to the subtree it defines.
+   *
+   * Spark 3.4+ stops inlining `WITH` clauses during analysis and instead leaves a `WithCTE` node
+   * holding the definitions plus `CTERelationRef` placeholders where they are used, so the two have
+   * to be reconnected for lineage to reach through a CTE.
+   */
+  def cteDefinitions(plan: LogicalPlan): Map[Long, LogicalPlan] = {
+    val defs = plan.collect {
+      case p if p.getClass.getSimpleName == "CTERelationDef" => p
+    } ++ plan.subqueries.flatMap(sub => sub.collect {
+      case p if p.getClass.getSimpleName == "CTERelationDef" => p
+    })
+    defs.flatMap { d =>
+      for {
+        id <- PlanAccessors.invoke[java.lang.Long](d, "id").map(_.longValue())
+        child <- PlanAccessors.plan(d, "child")
+      } yield id -> child
+    }.toMap
+  }
+
+  /** The definition a `CTERelationRef` points at, if it is known. */
+  def cteReference(plan: LogicalPlan, cteDefs: Map[Long, LogicalPlan]): Option[(Long, LogicalPlan)] =
+    if (plan.getClass.getSimpleName != "CTERelationRef") {
+      None
+    } else {
+      PlanAccessors
+        .invoke[java.lang.Long](plan, "cteId")
+        .map(_.longValue())
+        .flatMap(id => cteDefs.get(id).map(id -> _))
+    }
+
+  /**
+   * The `(condition, output expressions)` pairs of a `MergeRows` node.
+   *
+   * Spark 3.4+ rewrites `MERGE INTO` during analysis into a `ReplaceData`/`WriteDelta` over a
+   * `MergeRows` node, which replaces the original per-branch assignment lists with one output
+   * expression row per branch, positionally aligned with the node's output attributes.
+   */
+  def mergeBranches(plan: LogicalPlan): Seq[(Option[Expression], Seq[Expression])] = {
+    val instructions = PlanAccessors.seq[AnyRef](plan, "matchedInstructions") ++
+      PlanAccessors.seq[AnyRef](plan, "notMatchedInstructions") ++
+      PlanAccessors.seq[AnyRef](plan, "notMatchedBySourceInstructions")
+    instructions.flatMap { instruction =>
+      val condition = PlanAccessors.expression(instruction, "condition")
+      PlanAccessors
+        .seq[scala.collection.Seq[Expression]](instruction, "outputs")
+        .map(row => condition -> row.toList)
+    }
+  }
+}
+
+/** Renders as a bare column name; used only to pretty-print expressions, never evaluated. */
+private[lineage] case class PlainColumnName(name: String) extends LeafExpression with Unevaluable {
+  override def dataType: DataType = StringType
+  override def nullable: Boolean = true
+  override def sql: String = name
+  override def toString: String = name
+}

--- a/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/lineage/LineageModel.scala
+++ b/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/lineage/LineageModel.scala
@@ -1,0 +1,224 @@
+package com.linkedin.openhouse.spark.lineage
+
+/**
+ * Data model describing table- and column-level lineage extracted from a Spark logical plan.
+ *
+ * The model is intentionally free of any transport concern: [[LineageSink]] implementations decide
+ * whether a [[SqlLineage]] is logged, emitted onto Kafka, or shipped elsewhere.
+ */
+
+/** Fully qualified reference to a table, e.g. `openhouse.db.tbl`. */
+case class TableRef(catalog: Option[String], namespace: Seq[String], name: String) {
+
+  def qualifiedName: String = (catalog.toSeq ++ namespace :+ name).mkString(".")
+
+  /** Name without the catalog prefix, e.g. `db.tbl`. */
+  def namespacedName: String = (namespace :+ name).mkString(".")
+
+  override def toString: String = qualifiedName
+}
+
+object TableRef {
+
+  /** Builds a [[TableRef]] from a multipart identifier such as `Seq("openhouse", "db", "tbl")`. */
+  def fromMultipart(parts: Seq[String], catalog: Option[String] = None): TableRef = {
+    val cleaned = parts.filter(_ != null).filter(_.nonEmpty)
+    cleaned match {
+      case Seq() => TableRef(catalog, Nil, LineageConstants.UnknownTable)
+      case _ => TableRef(catalog, cleaned.dropRight(1), cleaned.last)
+    }
+  }
+
+  def unknown: TableRef = TableRef(None, Nil, LineageConstants.UnknownTable)
+}
+
+/** Fully qualified reference to a single column of a table. */
+case class ColumnRef(table: TableRef, column: String) {
+
+  def qualifiedName: String = s"${table.qualifiedName}.$column"
+
+  override def toString: String = qualifiedName
+}
+
+/**
+ * Lineage of a single output column.
+ *
+ * @param column             name of the produced column
+ * @param sources            upstream columns this column is derived from; empty for literals
+ * @param transformation     SQL rendering of the expression producing the column
+ * @param transformationType coarse classification, see [[TransformationType]]
+ */
+case class ColumnLineage(
+    column: String,
+    sources: Seq[ColumnRef],
+    transformation: String,
+    transformationType: String) {
+
+  def isIdentity: Boolean = transformationType == TransformationType.Identity
+}
+
+/**
+ * Columns that influence which rows are produced without being projected themselves, e.g. the
+ * columns of a `WHERE`, `JOIN ... ON`, `GROUP BY` or `MERGE ... ON` clause. This is commonly
+ * referred to as indirect (or "influence") lineage.
+ *
+ * @param kind       see [[ConditionKind]]
+ * @param expression SQL rendering of the condition
+ * @param columns    upstream columns referenced by the condition
+ */
+case class ConditionLineage(kind: String, expression: String, columns: Seq[ColumnRef])
+
+/** Complete lineage of one SQL statement. */
+case class SqlLineage(
+    operation: String,
+    sql: Option[String],
+    outputTable: Option[TableRef],
+    inputTables: Seq[TableRef],
+    columnLineage: Seq[ColumnLineage],
+    conditions: Seq[ConditionLineage]) {
+
+  /** All upstream columns referenced anywhere in the statement, projected or not. */
+  def allSourceColumns: Seq[ColumnRef] =
+    (columnLineage.flatMap(_.sources) ++ conditions.flatMap(_.columns)).distinct
+
+  def columnLineageFor(column: String): Option[ColumnLineage] =
+    columnLineage.find(_.column.equalsIgnoreCase(column))
+
+  def sourcesOf(column: String): Seq[ColumnRef] =
+    columnLineageFor(column).map(_.sources).getOrElse(Nil)
+
+  /** Compact single-line JSON, suitable for structured logging or a Kafka payload. */
+  def toJson: String = {
+    val sb = new StringBuilder
+    sb.append('{')
+    sb.append(LineageJson.field("operation", operation)).append(',')
+    sql.foreach(s => sb.append(LineageJson.field("sql", LineageJson.singleLine(s))).append(','))
+    outputTable.foreach(t =>
+      sb.append(LineageJson.field("outputTable", t.qualifiedName)).append(','))
+    sb.append(LineageJson.arrayField("inputTables", inputTables.map(_.qualifiedName))).append(',')
+    sb.append("\"columnLineage\":[")
+    sb.append(
+      columnLineage
+        .map { cl =>
+          "{" + LineageJson.field("column", cl.column) + "," +
+            LineageJson.field("transformationType", cl.transformationType) + "," +
+            LineageJson.field("transformation", cl.transformation) + "," +
+            LineageJson.arrayField("sources", cl.sources.map(_.qualifiedName)) + "}"
+        }
+        .mkString(","))
+    sb.append("],")
+    sb.append("\"conditions\":[")
+    sb.append(
+      conditions
+        .map { c =>
+          "{" + LineageJson.field("kind", c.kind) + "," +
+            LineageJson.field("expression", LineageJson.singleLine(c.expression)) + "," +
+            LineageJson.arrayField("columns", c.columns.map(_.qualifiedName)) + "}"
+        }
+        .mkString(","))
+    sb.append("]}")
+    sb.toString
+  }
+
+  /** Multi-line human readable rendering, used by [[LogLineageSink]]. */
+  def toPrettyString: String = {
+    val sb = new StringBuilder
+    sb.append("OpenHouse lineage\n")
+    sb.append(s"  operation   : $operation\n")
+    sql.foreach(s => sb.append(s"  sql         : ${LineageJson.singleLine(s)}\n"))
+    sb.append(s"  outputTable : ${outputTable.map(_.qualifiedName).getOrElse("-")}\n")
+    sb.append(
+      s"  inputTables : ${if (inputTables.isEmpty) "-" else inputTables.map(_.qualifiedName).mkString(", ")}\n")
+    sb.append("  columns     :\n")
+    if (columnLineage.isEmpty) {
+      sb.append("      -\n")
+    } else {
+      columnLineage.foreach { cl =>
+        val target = outputTable.map(t => s"${t.qualifiedName}.${cl.column}").getOrElse(cl.column)
+        val sources = if (cl.sources.isEmpty) "<none>" else cl.sources.map(_.qualifiedName).mkString(", ")
+        sb.append(s"      $target <- $sources  [${cl.transformationType}] ${cl.transformation}\n")
+      }
+    }
+    if (conditions.nonEmpty) {
+      sb.append("  conditions  :\n")
+      conditions.foreach { c =>
+        val cols = if (c.columns.isEmpty) "<none>" else c.columns.map(_.qualifiedName).mkString(", ")
+        sb.append(s"      ${c.kind}: ${LineageJson.singleLine(c.expression)} -> $cols\n")
+      }
+    }
+    sb.toString
+  }
+}
+
+/** Coarse classification of how an output column is computed. */
+object TransformationType {
+
+  /** Column is a straight copy (possibly renamed) of a single upstream column. */
+  val Identity = "IDENTITY"
+
+  /** Column is a constant; it has no upstream columns. */
+  val Literal = "LITERAL"
+
+  /** Column is produced by an aggregate function such as `SUM` or `COUNT`. */
+  val Aggregation = "AGGREGATION"
+
+  /** Column is produced by a window function. */
+  val Window = "WINDOW"
+
+  /** Column is produced by a generator such as `EXPLODE`. */
+  val Generator = "GENERATOR"
+
+  /** Any other scalar expression, e.g. `a * b`, `CASE WHEN ...`, `UPPER(x)`. */
+  val Expression = "EXPRESSION"
+}
+
+/** Kind of an indirect-lineage condition. */
+object ConditionKind {
+  val Filter = "FILTER"
+  val Join = "JOIN"
+  val GroupBy = "GROUP_BY"
+  val MergeOn = "MERGE_ON"
+  val Sort = "SORT"
+}
+
+/** Operation names reported on [[SqlLineage.operation]]. */
+object LineageOperation {
+  val Select = "SELECT"
+  val CreateTableAsSelect = "CREATE_TABLE_AS_SELECT"
+  val ReplaceTableAsSelect = "REPLACE_TABLE_AS_SELECT"
+  val CreateViewAsSelect = "CREATE_VIEW_AS_SELECT"
+  val InsertInto = "INSERT_INTO"
+  val InsertOverwrite = "INSERT_OVERWRITE"
+  val InsertOverwritePartitions = "INSERT_OVERWRITE_PARTITIONS"
+  val Merge = "MERGE_INTO"
+  val Update = "UPDATE"
+  val Delete = "DELETE"
+}
+
+private[lineage] object LineageConstants {
+  val UnknownTable = "<unknown>"
+}
+
+private[lineage] object LineageJson {
+
+  def field(name: String, value: String): String = s""""$name":"${escape(value)}""""
+
+  def arrayField(name: String, values: Seq[String]): String =
+    s""""$name":[${values.map(v => "\"" + escape(v) + "\"").mkString(",")}]"""
+
+  def singleLine(s: String): String = s.replaceAll("\\s+", " ").trim
+
+  def escape(s: String): String = {
+    val sb = new StringBuilder
+    s.foreach {
+      case '"' => sb.append("\\\"")
+      case '\\' => sb.append("\\\\")
+      case '\n' => sb.append("\\n")
+      case '\r' => sb.append("\\r")
+      case '\t' => sb.append("\\t")
+      case c if c < 0x20 => sb.append("\\u%04x".format(c.toInt))
+      case c => sb.append(c)
+    }
+    sb.toString
+  }
+}

--- a/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/lineage/LineageSink.scala
+++ b/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/lineage/LineageSink.scala
@@ -1,0 +1,47 @@
+package com.linkedin.openhouse.spark.lineage
+
+import org.slf4j.LoggerFactory
+
+/**
+ * Destination for extracted lineage.
+ *
+ * Production deployments emit lineage as Kafka events; this interface is the seam where such a
+ * publisher plugs in. [[LogLineageSink]] is the default and simply writes to the driver log.
+ */
+trait LineageSink {
+  def emit(lineage: SqlLineage): Unit
+}
+
+/** Writes lineage to the driver log: one JSON line, plus a readable block at DEBUG level. */
+class LogLineageSink extends LineageSink {
+
+  private val log = LoggerFactory.getLogger(classOf[LogLineageSink])
+
+  override def emit(lineage: SqlLineage): Unit = {
+    log.info("openhouse-lineage {}", lineage.toJson)
+    if (log.isDebugEnabled) {
+      log.debug("\n{}", lineage.toPrettyString)
+    }
+  }
+}
+
+/** Keeps lineage in memory. Intended for tests and for interactive exploration in a shell. */
+class InMemoryLineageSink extends LineageSink {
+
+  private val collected = new java.util.concurrent.ConcurrentLinkedQueue[SqlLineage]()
+
+  override def emit(lineage: SqlLineage): Unit = collected.add(lineage)
+
+  def events: Seq[SqlLineage] = {
+    val iterator = collected.iterator()
+    val builder = Seq.newBuilder[SqlLineage]
+    while (iterator.hasNext) {
+      builder += iterator.next()
+    }
+    builder.result()
+  }
+
+  def last: Option[SqlLineage] = events.lastOption
+
+  def clear(): Unit = collected.clear()
+}

--- a/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/lineage/OpenhouseLineageListener.scala
+++ b/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/lineage/OpenhouseLineageListener.scala
@@ -1,0 +1,86 @@
+package com.linkedin.openhouse.spark.lineage
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.execution.QueryExecution
+import org.apache.spark.sql.util.QueryExecutionListener
+import org.slf4j.LoggerFactory
+
+import scala.util.Try
+
+/**
+ * Captures table- and column-level lineage for every statement executed in a Spark session and
+ * hands it to a [[LineageSink]].
+ *
+ * Enable it declaratively, which is the mechanism Spark uses to instantiate listeners at session
+ * start:
+ * {{{
+ *   spark.sql.queryExecutionListeners=com.linkedin.openhouse.spark.lineage.OpenhouseLineageListener
+ * }}}
+ *
+ * or programmatically, which is convenient in a shell or a test:
+ * {{{
+ *   val sink = new InMemoryLineageSink
+ *   OpenhouseLineageListener.register(spark, sink)
+ * }}}
+ *
+ * The listener fires only for statements that actually run, so `spark.sql("SELECT ...")` alone
+ * produces nothing until an action is invoked. Use [[SqlLineageExtractor.extractFromSql]] to analyse
+ * SQL text without executing it.
+ */
+class OpenhouseLineageListener(sink: LineageSink) extends QueryExecutionListener {
+
+  private val log = LoggerFactory.getLogger(classOf[OpenhouseLineageListener])
+
+  def this() = this(new LogLineageSink)
+
+  def this(conf: SparkConf) = this(new LogLineageSink)
+
+  override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit =
+    capture(qe)
+
+  override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit =
+    capture(qe)
+
+  private def capture(qe: QueryExecution): Unit = {
+    try {
+      SqlLineageExtractor.extract(qe.analyzed, sqlTextOf(qe)).foreach(sink.emit)
+    } catch {
+      // Lineage capture must never break the query that produced it.
+      case e: Throwable => log.warn("Failed to extract OpenHouse lineage", e)
+    }
+  }
+
+  /**
+   * Recovers the original statement text.
+   *
+   * Spark 3.4 onwards keeps it on the plan's `Origin`; on older releases the only generally
+   * available source is the job description, which JDBC/Thrift clients and
+   * `SparkContext.setJobDescription` populate.
+   */
+  private def sqlTextOf(qe: QueryExecution): Option[String] = {
+    val fromOrigin = Try {
+      val origin = qe.analyzed.origin
+      val method = origin.getClass.getMethod("sqlText")
+      method.invoke(origin).asInstanceOf[Option[String]]
+    }.toOption.flatten
+    fromOrigin.orElse {
+      Option(qe.sparkSession)
+        .flatMap(session => Option(session.sparkContext.getLocalProperty("spark.job.description")))
+    }
+  }
+}
+
+object OpenhouseLineageListener {
+
+  /** Registers a listener on an existing session and returns it so it can be unregistered later. */
+  def register(spark: SparkSession, sink: LineageSink = new LogLineageSink)
+      : OpenhouseLineageListener = {
+    val listener = new OpenhouseLineageListener(sink)
+    spark.listenerManager.register(listener)
+    listener
+  }
+
+  def unregister(spark: SparkSession, listener: OpenhouseLineageListener): Unit =
+    spark.listenerManager.unregister(listener)
+}

--- a/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/lineage/PlanAccessors.scala
+++ b/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/lineage/PlanAccessors.scala
@@ -1,0 +1,64 @@
+package com.linkedin.openhouse.spark.lineage
+
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+import scala.util.Try
+
+/**
+ * Reflection helpers used to read fields off Spark/Iceberg logical plan nodes.
+ *
+ * The OpenHouse Spark runtime is compiled once against Spark 3.1 and shipped on both Spark 3.1 and
+ * Spark 3.5 (`openhouse-spark-3.5-runtime` repackages the 3.1 jar). Between those releases several
+ * command nodes changed their constructor signature - `CreateTableAsSelect`, for example, went from
+ * `(catalog, tableName, partitioning, query, ...)` to `(name, partitioning, query, tableSpec, ...)`,
+ * and `MergeIntoTable` gained a `notMatchedBySourceActions` field. Scala pattern matching on those
+ * case classes compiles down to a call to a fixed-arity `unapply`, so a destructuring match would
+ * link against 3.1 and blow up at runtime on 3.5.
+ *
+ * Field *accessor* methods, on the other hand, kept both their name and their return type across
+ * those versions. Reading through accessors therefore keeps a single compiled artifact working on
+ * every supported Spark line, and additionally lets us read Iceberg's own rewritten plan nodes
+ * (`MergeIntoIcebergTable`, `UpdateIcebergTable`, ...) which are not on the compile classpath at
+ * all but expose the same accessor names.
+ */
+private[lineage] object PlanAccessors {
+
+  def invoke[T](target: AnyRef, method: String)(implicit tag: reflect.ClassTag[T]): Option[T] =
+    Try {
+      val m = target.getClass.getMethod(method)
+      m.setAccessible(true)
+      m.invoke(target)
+    }.toOption.flatMap {
+      case null => None
+      case v if tag.runtimeClass.isInstance(v) => Some(v.asInstanceOf[T])
+      case _ => None
+    }
+
+  def hasMethod(target: AnyRef, method: String): Boolean =
+    Try(target.getClass.getMethod(method)).isSuccess
+
+  def plan(target: AnyRef, method: String): Option[LogicalPlan] = invoke[LogicalPlan](target, method)
+
+  def expression(target: AnyRef, method: String): Option[Expression] =
+    invoke[Expression](target, method)
+
+  def boolean(target: AnyRef, method: String): Option[Boolean] =
+    invoke[java.lang.Boolean](target, method).map(_.booleanValue())
+
+  /** Reads a `Seq[T]` accessor and converts it to a Scala [[Seq]] the JVM can hand back to us. */
+  def seq[T](target: AnyRef, method: String): Seq[T] =
+    Try {
+      val m = target.getClass.getMethod(method)
+      m.setAccessible(true)
+      m.invoke(target).asInstanceOf[scala.collection.Seq[T]]
+    }.toOption.map(_.toList).getOrElse(Nil)
+
+  /** Reads an `Option[T]` accessor. */
+  def option[T](target: AnyRef, method: String): Option[T] =
+    Try {
+      val m = target.getClass.getMethod(method)
+      m.setAccessible(true)
+      m.invoke(target).asInstanceOf[Option[T]]
+    }.toOption.flatten
+}

--- a/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/lineage/SqlLineageExtractor.scala
+++ b/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/lineage/SqlLineageExtractor.scala
@@ -1,0 +1,542 @@
+package com.linkedin.openhouse.spark.lineage
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Cast, ExprId, Expression, NamedExpression}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, Join, LogicalPlan, Project, Window}
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, Identifier}
+
+import scala.util.Try
+
+/**
+ * Turns a Spark logical plan into a [[SqlLineage]] describing which tables were read, which table
+ * was written and, for every produced column, which upstream columns it came from and through which
+ * expression.
+ *
+ * Usage:
+ * {{{
+ *   // from an executed query (see OpenhouseLineageListener)
+ *   val lineage = SqlLineageExtractor.extract(queryExecution.analyzed, Some(sqlText))
+ *
+ *   // or statically, without running the statement
+ *   val lineage = SqlLineageExtractor.extractFromSql(spark, "INSERT INTO db.t2 SELECT a, b FROM db.t1")
+ * }}}
+ *
+ * Implementation note: command nodes are inspected through accessor methods rather than case-class
+ * pattern matching, see [[PlanAccessors]] for why.
+ */
+object SqlLineageExtractor {
+
+  private val MaxInlineDepth = 32
+
+  /**
+   * Parses and analyses `sqlText` without executing it, then extracts lineage. Safe to call for
+   * DML/DDL: only the analyzer runs, so no table is created or written.
+   */
+  def extractFromSql(spark: SparkSession, sqlText: String): Option[SqlLineage] =
+    extract(analyze(spark, sqlText), Some(sqlText))
+
+  /** Analyses `sqlText` against the session catalog without executing it. */
+  def analyze(spark: SparkSession, sqlText: String): LogicalPlan = {
+    val parsed = spark.sessionState.sqlParser.parsePlan(sqlText)
+    spark.sessionState.analyzer.execute(parsed)
+  }
+
+  /** Extracts lineage from an analyzed logical plan. Returns [[None]] for plans without lineage. */
+  def extract(plan: LogicalPlan, sql: Option[String] = None): Option[SqlLineage] = {
+    // `WITH` definitions live on the root `WithCTE` node while the references live in the command's
+    // query subtree, so they are collected before the root is unwrapped and handed to the resolver.
+    val resolver = new ColumnOriginResolver(ColumnOriginResolver.cteDefinitions(plan))
+    val lineage = Try(extractInternal(unwrapWithCte(plan), sql, resolver)).toOption.flatten
+    lineage.filter(l => l.outputTable.isDefined || l.inputTables.nonEmpty)
+  }
+
+  // scalastyle:off cyclomatic.complexity method.length
+  private def extractInternal(
+      plan: LogicalPlan,
+      sql: Option[String],
+      resolver: ColumnOriginResolver): Option[SqlLineage] = {
+    val simpleName = plan.getClass.getSimpleName
+
+    if (isV2Write(plan)) {
+      val query = PlanAccessors.plan(plan, "query").getOrElse(plan.children.head)
+      val target = PlanAccessors.plan(plan, "table").flatMap(resolver.targetRelationRef)
+      val targetColumns = PlanAccessors.plan(plan, "table").map(_.output.map(_.name)).getOrElse(Nil)
+      val operation = v2WriteOperation(plan, simpleName)
+      allNodes(query, resolver).find(_.getClass.getSimpleName == "MergeRows") match {
+        case Some(mergeRows) =>
+          Some(
+            rewrittenMergeLineage(operation, sql, target, targetColumns, query, mergeRows, resolver))
+        case None =>
+          Some(queryLineage(operation, sql, target, targetColumns, query, resolver))
+      }
+
+    } else if (simpleName == "CreateTableAsSelect" || simpleName == "ReplaceTableAsSelect") {
+      val query = PlanAccessors.plan(plan, "query").getOrElse(plan.children.head)
+      val operation =
+        if (simpleName == "CreateTableAsSelect") LineageOperation.CreateTableAsSelect
+        else LineageOperation.ReplaceTableAsSelect
+      Some(queryLineage(operation, sql, createTableTarget(plan), Nil, query, resolver))
+
+    } else if (simpleName == "InsertIntoStatement") {
+      val query = PlanAccessors.plan(plan, "query").getOrElse(plan.children.head)
+      val targetPlan = PlanAccessors.plan(plan, "table")
+      val overwrite = PlanAccessors.boolean(plan, "overwrite").getOrElse(false)
+      val operation =
+        if (overwrite) LineageOperation.InsertOverwrite else LineageOperation.InsertInto
+      val userCols = PlanAccessors.seq[String](plan, "userSpecifiedCols")
+      val targetColumns =
+        if (userCols.nonEmpty) userCols else targetPlan.map(_.output.map(_.name)).getOrElse(Nil)
+      Some(
+        queryLineage(
+          operation,
+          sql,
+          targetPlan.flatMap(resolver.targetRelationRef),
+          targetColumns,
+          query,
+          resolver))
+
+    } else if (isMerge(plan)) {
+      Some(mergeLineage(plan, sql, resolver))
+
+    } else if (simpleName.startsWith("UpdateTable") || simpleName.startsWith("UpdateIcebergTable")) {
+      Some(updateLineage(plan, sql, resolver))
+
+    } else if (simpleName.startsWith("DeleteFrom")) {
+      Some(deleteLineage(plan, sql, resolver))
+
+    } else if (simpleName == "CreateViewCommand") {
+      val query = PlanAccessors
+        .plan(plan, "plan")
+        .orElse(PlanAccessors.plan(plan, "child"))
+        .orElse(firstInnerPlan(plan))
+      query.map { q =>
+        queryLineage(
+          LineageOperation.CreateViewAsSelect,
+          sql,
+          viewTarget(plan),
+          Nil,
+          q,
+          resolver)
+      }
+
+    } else if (isV1Write(simpleName)) {
+      val query = PlanAccessors
+        .plan(plan, "query")
+        .orElse(firstInnerPlan(plan))
+      query.map { q =>
+        val target = v1WriteTarget(plan)
+        val overwrite = PlanAccessors.boolean(plan, "overwrite").getOrElse(false)
+        val operation =
+          if (simpleName.startsWith("Create")) LineageOperation.CreateTableAsSelect
+          else if (overwrite) LineageOperation.InsertOverwrite
+          else LineageOperation.InsertInto
+        queryLineage(operation, sql, target, Nil, q, resolver)
+      }
+
+    } else {
+      Some(queryLineage(LineageOperation.Select, sql, None, Nil, plan, resolver))
+    }
+  }
+  // scalastyle:on cyclomatic.complexity method.length
+
+  /** Lineage of a plan whose produced rows come from a single query subtree. */
+  private def queryLineage(
+      operation: String,
+      sql: Option[String],
+      target: Option[TableRef],
+      targetColumns: Seq[String],
+      query: LogicalPlan,
+      resolver: ColumnOriginResolver): SqlLineage = {
+    val origins = resolver.resolve(query)
+    val definitions = collectDefinitions(query, resolver)
+    // A row-level write appends internal row-tracking columns (`_file`, `_pos`, ...) to its query so
+    // Spark can locate the rows it rewrites. The target schema defines the real output columns.
+    val outputAttributes =
+      if (targetColumns.nonEmpty) query.output.take(targetColumns.size) else query.output
+    val columns = outputAttributes.zipWithIndex.map { case (attr, idx) =>
+      val expression = inline(attr, definitions)
+      ColumnLineage(
+        column = targetColumns.lift(idx).getOrElse(attr.name),
+        sources = origins.getOrElse(attr.exprId, Nil),
+        transformation = resolver.render(expression),
+        transformationType = resolver.classify(expression))
+    }
+    SqlLineage(
+      operation = operation,
+      sql = sql,
+      outputTable = target,
+      inputTables = inputTables(query, resolver),
+      columnLineage = columns,
+      conditions = conditions(query, origins, definitions, resolver))
+  }
+
+  /**
+   * Lineage of a `MERGE INTO` that the analyser already rewrote into a `ReplaceData`/`WriteDelta`
+   * over a `MergeRows` node (Spark 3.4+).
+   *
+   * The per-branch assignment lists of the original statement survive as one output expression row
+   * per branch, so each target column is folded back together from every branch that can produce it
+   * - the same shape [[mergeLineage]] reports for the un-rewritten node.
+   */
+  private def rewrittenMergeLineage(
+      operation: String,
+      sql: Option[String],
+      target: Option[TableRef],
+      targetColumns: Seq[String],
+      query: LogicalPlan,
+      mergeRows: LogicalPlan,
+      resolver: ColumnOriginResolver): SqlLineage = {
+    val origins = resolver.resolve(query)
+    val definitions = collectDefinitions(query, resolver)
+    val perBranch = ColumnOriginResolver.mergeBranches(mergeRows).flatMap {
+      case (_, outputs) =>
+        outputs.zipWithIndex.flatMap { case (value, idx) =>
+          targetColumns.lift(idx).map { name =>
+            val expression = inline(value, definitions)
+            ColumnLineage(
+              column = name,
+              sources = resolver.sourcesOf(value, origins),
+              transformation = resolver.render(expression),
+              transformationType = resolver.classify(expression))
+          }
+        }
+    }
+    SqlLineage(
+      operation = operation,
+      sql = sql,
+      outputTable = target,
+      inputTables = inputTables(query, resolver),
+      columnLineage = mergeColumns(perBranch),
+      conditions = conditions(query, origins, definitions, resolver))
+  }
+
+  private def mergeLineage(
+      plan: LogicalPlan,
+      sql: Option[String],
+      resolver: ColumnOriginResolver): SqlLineage = {    val target = PlanAccessors.plan(plan, "targetTable")
+    val source = PlanAccessors.plan(plan, "sourceTable")
+    val origins = resolver.resolve(plan)
+    val definitions = collectDefinitions(plan, resolver)
+
+    val actions = PlanAccessors.seq[AnyRef](plan, "matchedActions") ++
+      PlanAccessors.seq[AnyRef](plan, "notMatchedActions") ++
+      PlanAccessors.seq[AnyRef](plan, "notMatchedBySourceActions")
+
+    val perColumn = actions
+      .flatMap(action => PlanAccessors.seq[AnyRef](action, "assignments"))
+      .flatMap { assignment =>
+        for {
+          key <- PlanAccessors.expression(assignment, "key")
+          value <- PlanAccessors.expression(assignment, "value")
+        } yield {
+          val expression = inline(value, definitions)
+          val name = key match {
+            case named: NamedExpression => named.name
+            case other => resolver.render(other)
+          }
+          ColumnLineage(
+            column = name,
+            sources = resolver.sourcesOf(value, origins),
+            transformation = resolver.render(expression),
+            transformationType = resolver.classify(expression))
+        }
+      }
+
+    val mergeCondition = PlanAccessors.expression(plan, "mergeCondition").map { condition =>
+      ConditionLineage(
+        ConditionKind.MergeOn,
+        resolver.render(condition),
+        resolver.sourcesOf(condition, origins))
+    }
+    val inputs =
+      (target.toSeq ++ source.toSeq).flatMap(inputTables(_, resolver)).distinct
+
+    SqlLineage(
+      operation = LineageOperation.Merge,
+      sql = sql,
+      outputTable = target.flatMap(resolver.targetRelationRef),
+      inputTables = inputs,
+      columnLineage = mergeColumns(perColumn),
+      conditions = mergeCondition.toSeq ++
+        source.toSeq.flatMap(conditions(_, origins, definitions, resolver)))
+  }
+
+  private def updateLineage(
+      plan: LogicalPlan,
+      sql: Option[String],
+      resolver: ColumnOriginResolver): SqlLineage = {
+    val target = PlanAccessors.plan(plan, "table")
+    val origins = resolver.resolve(plan)
+    val definitions = collectDefinitions(plan, resolver)
+    val columns = PlanAccessors
+      .seq[AnyRef](plan, "assignments")
+      .flatMap { assignment =>
+        for {
+          key <- PlanAccessors.expression(assignment, "key")
+          value <- PlanAccessors.expression(assignment, "value")
+        } yield {
+          val expression = inline(value, definitions)
+          ColumnLineage(
+            column = key match {
+              case named: NamedExpression => named.name
+              case other => resolver.render(other)
+            },
+            sources = resolver.sourcesOf(value, origins),
+            transformation = resolver.render(expression),
+            transformationType = resolver.classify(expression))
+        }
+      }
+    SqlLineage(
+      operation = LineageOperation.Update,
+      sql = sql,
+      outputTable = target.flatMap(resolver.targetRelationRef),
+      inputTables = target.toSeq.flatMap(inputTables(_, resolver)),
+      columnLineage = columns,
+      conditions = conditionOf(plan, origins, resolver).toSeq)
+  }
+
+  private def deleteLineage(
+      plan: LogicalPlan,
+      sql: Option[String],
+      resolver: ColumnOriginResolver): SqlLineage = {
+    val target = PlanAccessors.plan(plan, "table").orElse(plan.children.headOption)
+    val origins = resolver.resolve(plan)
+    SqlLineage(
+      operation = LineageOperation.Delete,
+      sql = sql,
+      outputTable = target.flatMap(resolver.targetRelationRef),
+      inputTables = target.toSeq.flatMap(inputTables(_, resolver)),
+      columnLineage = Nil,
+      conditions = conditionOf(plan, origins, resolver).toSeq)
+  }
+
+  private def conditionOf(
+      plan: LogicalPlan,
+      origins: ColumnOriginResolver#OriginMap,
+      resolver: ColumnOriginResolver): Option[ConditionLineage] = {
+    val expression = PlanAccessors
+      .expression(plan, "condition")
+      .orElse(PlanAccessors.option[Expression](plan, "condition"))
+    expression.map { c =>
+      ConditionLineage(ConditionKind.Filter, resolver.render(c), resolver.sourcesOf(c, origins))
+    }
+  }
+
+  /** A target column can be assigned by several MERGE branches; fold them into one entry. */
+  private def mergeColumns(columns: Seq[ColumnLineage]): Seq[ColumnLineage] =
+    columns
+      .groupBy(_.column)
+      .toSeq
+      .sortBy { case (name, _) => columns.indexWhere(_.column == name) }
+      .map { case (name, entries) =>
+        ColumnLineage(
+          column = name,
+          sources = entries.flatMap(_.sources).distinct,
+          transformation = entries.map(_.transformation).distinct.mkString(" | "),
+          transformationType = entries.map(_.transformationType).distinct match {
+            case Seq(single) => single
+            case _ => TransformationType.Expression
+          })
+      }
+
+  /** Indirect lineage: columns that filter or group rows without being projected. */
+  private def conditions(
+      plan: LogicalPlan,
+      origins: ColumnOriginResolver#OriginMap,
+      definitions: Map[ExprId, Expression],
+      resolver: ColumnOriginResolver): Seq[ConditionLineage] =
+    allNodes(plan, resolver).flatMap {
+      case filter: Filter =>
+        Seq(condition(ConditionKind.Filter, filter.condition, origins, definitions, resolver))
+      case join: Join =>
+        join.condition
+          .map(c => condition(ConditionKind.Join, c, origins, definitions, resolver))
+          .toSeq
+      case aggregate: Aggregate if aggregate.groupingExpressions.nonEmpty =>
+        aggregate.groupingExpressions.map(g =>
+          condition(ConditionKind.GroupBy, g, origins, definitions, resolver))
+      case _ => Nil
+    }.filter(_.columns.nonEmpty).distinct
+
+  private def condition(
+      kind: String,
+      expression: Expression,
+      origins: ColumnOriginResolver#OriginMap,
+      definitions: Map[ExprId, Expression],
+      resolver: ColumnOriginResolver): ConditionLineage =
+    ConditionLineage(
+      kind,
+      resolver.render(inline(expression, definitions)),
+      resolver.sourcesOf(expression, origins))
+
+  /** Distinct tables read anywhere under `plan`, including inside subqueries. */
+  private def inputTables(plan: LogicalPlan, resolver: ColumnOriginResolver): Seq[TableRef] =
+    allNodes(plan, resolver).flatMap(resolver.relationRef).distinct
+
+  /**
+   * Every node of the plan, descending into subquery expressions as well as into children, and
+   * following `CTERelationRef` placeholders into the subtree they stand for.
+   */
+  private def allNodes(plan: LogicalPlan, resolver: ColumnOriginResolver): Seq[LogicalPlan] =
+    allNodes(plan, resolver.rootCteDefinitions ++ ColumnOriginResolver.cteDefinitions(plan), Set.empty)
+
+  private def allNodes(
+      plan: LogicalPlan,
+      cteDefs: Map[Long, LogicalPlan],
+      visitedCtes: Set[Long]): Seq[LogicalPlan] = {
+    val direct = plan.collect { case node => node }
+    val nested = direct.flatMap(_.subqueries).flatMap(allNodes(_, cteDefs, visitedCtes))
+    val expandedCtes = direct.flatMap { node =>
+      ColumnOriginResolver.cteReference(node, cteDefs) match {
+        case Some((id, definition)) if !visitedCtes.contains(id) =>
+          allNodes(definition, cteDefs, visitedCtes + id)
+        case _ => Nil
+      }
+    }
+    (direct ++ nested ++ expandedCtes).distinct
+  }
+
+  /**
+   * Collects the defining expression of every alias in the plan, so an output attribute can be
+   * expanded back into the full expression that produced it.
+   */
+  private def collectDefinitions(
+      plan: LogicalPlan,
+      resolver: ColumnOriginResolver): Map[ExprId, Expression] =
+    allNodes(plan, resolver).flatMap {
+      case project: Project => namedDefinitions(project.projectList)
+      case aggregate: Aggregate => namedDefinitions(aggregate.aggregateExpressions)
+      case window: Window => namedDefinitions(window.windowExpressions)
+      case _ => Nil
+    }.toMap
+
+  private def namedDefinitions(expressions: Seq[NamedExpression]): Seq[(ExprId, Expression)] =
+    expressions.collect {
+      case named if !named.isInstanceOf[AttributeReference] => named.exprId -> named
+    }
+
+  /**
+   * Substitutes attribute references by the expressions that defined them, so that
+   * `INSERT INTO t SELECT price * qty AS total` reports `(price * qty)` rather than the opaque
+   * `total` attribute Spark leaves on the write node.
+   *
+   * The cast the analyzer adds on top of a write projection to match the target schema is dropped:
+   * it is Spark plumbing rather than user intent, and keeping it would misreport a plain column copy
+   * as a computed column. Casts written by the user further down the expression tree are preserved.
+   */
+  private def inline(expression: Expression, definitions: Map[ExprId, Expression]): Expression =
+    stripCasts(inlineDefinitions(expression, definitions, 0))
+
+  private def inlineDefinitions(
+      expression: Expression,
+      definitions: Map[ExprId, Expression],
+      depth: Int): Expression = {
+    if (depth > MaxInlineDepth) {
+      return expression
+    }
+    val unaliased = expression match {
+      case named: NamedExpression if !named.isInstanceOf[AttributeReference] =>
+        named.children.headOption.getOrElse(named)
+      case other => other
+    }
+    unaliased match {
+      case attr: AttributeReference =>
+        definitions.get(attr.exprId) match {
+          case Some(definition) => inlineDefinitions(definition, definitions, depth + 1)
+          case None => attr
+        }
+      case other =>
+        other.mapChildren(child => inlineDefinitions(child, definitions, depth + 1))
+    }
+  }
+
+  private def stripCasts(expression: Expression): Expression = expression match {
+    case cast: Cast => stripCasts(cast.child)
+    case other if other.getClass.getSimpleName == "AnsiCast" =>
+      other.children.headOption.map(stripCasts).getOrElse(other)
+    case other => other
+  }
+
+  /**
+   * Commands hide their query subtree under `innerChildren` rather than `children`; the intermediate
+   * `Any` keeps scalac from choking on the existential `Seq[QueryPlan[_]]`.
+   */
+  private def firstInnerPlan(plan: LogicalPlan): Option[LogicalPlan] =
+    plan.innerChildren.toList.map(_.asInstanceOf[Any]).collectFirst { case p: LogicalPlan => p }
+
+  private def unwrapWithCte(plan: LogicalPlan): LogicalPlan =
+    if (plan.getClass.getSimpleName == "WithCTE") {
+      PlanAccessors.plan(plan, "plan").getOrElse(plan)
+    } else {
+      plan
+    }
+
+  private def isV2Write(plan: LogicalPlan): Boolean =
+    PlanAccessors.hasMethod(plan, "query") && PlanAccessors.hasMethod(plan, "isByName") &&
+      PlanAccessors.hasMethod(plan, "table")
+
+  private def isMerge(plan: LogicalPlan): Boolean =
+    PlanAccessors.hasMethod(plan, "targetTable") && PlanAccessors.hasMethod(plan, "sourceTable") &&
+      PlanAccessors.hasMethod(plan, "mergeCondition")
+
+  private def isV1Write(simpleName: String): Boolean =
+    simpleName == "InsertIntoHadoopFsRelationCommand" ||
+      simpleName == "InsertIntoHiveTable" ||
+      simpleName == "CreateDataSourceTableAsSelectCommand" ||
+      simpleName == "CreateHiveTableAsSelectCommand" ||
+      simpleName == "OptimizedCreateHiveTableAsSelectCommand"
+
+  /**
+   * Names a V2 write.
+   *
+   * Spark 3.4+ rewrites `UPDATE` / `DELETE` / `MERGE INTO` into a generic `ReplaceData` or
+   * `WriteDelta` while analysing, which would otherwise erase the statement the user actually wrote.
+   * Those nodes carry the connector's [[org.apache.spark.sql.connector.write.RowLevelOperation]],
+   * whose `command` still names the original operation, so it is preferred when present.
+   */
+  private def v2WriteOperation(plan: LogicalPlan, simpleName: String): String =
+    rowLevelCommand(plan).getOrElse(simpleName match {
+      case "AppendData" => LineageOperation.InsertInto
+      case "OverwriteByExpression" => LineageOperation.InsertOverwrite
+      case "OverwritePartitionsDynamic" => LineageOperation.InsertOverwritePartitions
+      case other => other.replaceAll("([a-z])([A-Z])", "$1_$2").toUpperCase
+    })
+
+  private def rowLevelCommand(plan: LogicalPlan): Option[String] =
+    PlanAccessors
+      .invoke[AnyRef](plan, "operation")
+      .flatMap(operation => PlanAccessors.invoke[AnyRef](operation, "command"))
+      .map(_.toString)
+      .collect {
+        case "DELETE" => LineageOperation.Delete
+        case "UPDATE" => LineageOperation.Update
+        case "MERGE" => LineageOperation.Merge
+      }
+
+  private def createTableTarget(plan: LogicalPlan): Option[TableRef] = {
+    val catalogName = PlanAccessors
+      .invoke[CatalogPlugin](plan, "catalog")
+      .orElse(PlanAccessors.plan(plan, "name").flatMap(PlanAccessors.invoke[CatalogPlugin](_, "catalog")))
+      .flatMap(c => Try(c.name()).toOption)
+    PlanAccessors
+      .invoke[Identifier](plan, "tableName")
+      .map(id => TableRef(catalogName, id.namespace().toSeq, id.name()))
+  }
+
+  private def viewTarget(plan: LogicalPlan): Option[TableRef] =
+    PlanAccessors
+      .invoke[org.apache.spark.sql.catalyst.TableIdentifier](plan, "name")
+      .map(id => TableRef(None, id.database.toSeq, id.table))
+
+  private def v1WriteTarget(plan: LogicalPlan): Option[TableRef] = {
+    val catalogTable = PlanAccessors
+      .option[CatalogTable](plan, "catalogTable")
+      .orElse(PlanAccessors.invoke[CatalogTable](plan, "table"))
+      .orElse(PlanAccessors.invoke[CatalogTable](plan, "tableDesc"))
+    catalogTable.map(t => TableRef(None, t.identifier.database.toSeq, t.identifier.table))
+  }
+
+  /** Exposed for callers that only need the produced attributes of a plan. */
+  private[lineage] def outputNames(output: Seq[Attribute]): Seq[String] = output.map(_.name)
+}

--- a/integrations/spark/spark-3.1/openhouse-spark-runtime/src/test/scala/com/linkedin/openhouse/spark/lineage/LineageTestSession.scala
+++ b/integrations/spark/spark-3.1/openhouse-spark-runtime/src/test/scala/com/linkedin/openhouse/spark/lineage/LineageTestSession.scala
@@ -1,0 +1,121 @@
+package com.linkedin.openhouse.spark.lineage
+
+import org.apache.spark.sql.SparkSession
+
+import java.nio.file.Files
+
+/**
+ * Shared Spark session for the lineage tests.
+ *
+ * Tables live in a throwaway Iceberg Hadoop warehouse under the `local` catalog, which mirrors how
+ * OpenHouse tables are exposed to Spark (a DataSourceV2 catalog) without requiring the /tables
+ * service to be up.
+ */
+object LineageTestSession {
+
+  lazy val spark: SparkSession = {
+    val warehouse = Files.createTempDirectory("openhouse-lineage-test").toString
+    val session = SparkSession
+      .builder()
+      .master("local[1]")
+      .appName("openhouse-lineage-test")
+      .config(
+        "spark.sql.extensions",
+        "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions," +
+          "com.linkedin.openhouse.spark.extensions.OpenhouseSparkSessionExtensions")
+      .config("spark.sql.catalog.local", "org.apache.iceberg.spark.SparkCatalog")
+      .config("spark.sql.catalog.local.type", "hadoop")
+      .config("spark.sql.catalog.local.warehouse", warehouse)
+      .config("spark.sql.warehouse.dir", warehouse + "/session")
+      .config("spark.ui.enabled", "false")
+      .getOrCreate()
+    createTables(session)
+    session
+  }
+
+  private def createTables(spark: SparkSession): Unit = {
+    spark.sql("CREATE NAMESPACE IF NOT EXISTS local.db")
+
+    spark.sql("""
+      CREATE TABLE IF NOT EXISTS local.db.orders (
+        order_id BIGINT,
+        customer_id BIGINT,
+        product_id BIGINT,
+        quantity INT,
+        unit_price DOUBLE,
+        discount DOUBLE,
+        region STRING,
+        order_date DATE
+      ) USING iceberg
+    """)
+
+    spark.sql("""
+      CREATE TABLE IF NOT EXISTS local.db.customers (
+        customer_id BIGINT,
+        customer_name STRING,
+        email STRING,
+        country STRING,
+        tier STRING
+      ) USING iceberg
+    """)
+
+    spark.sql("""
+      CREATE TABLE IF NOT EXISTS local.db.products (
+        product_id BIGINT,
+        product_name STRING,
+        category STRING,
+        list_price DOUBLE
+      ) USING iceberg
+    """)
+
+    spark.sql("""
+      CREATE TABLE IF NOT EXISTS local.db.order_facts (
+        order_id BIGINT,
+        customer_id BIGINT,
+        revenue DOUBLE,
+        region STRING
+      ) USING iceberg
+    """)
+
+    spark.sql("""
+      CREATE TABLE IF NOT EXISTS local.db.customer_360 (
+        customer_id BIGINT,
+        customer_name STRING,
+        lifetime_revenue DOUBLE,
+        order_count BIGINT,
+        load_id STRING
+      ) USING iceberg
+    """)
+
+    spark.sql("""
+      CREATE TABLE IF NOT EXISTS local.db.customer_updates (
+        customer_id BIGINT,
+        customer_name STRING,
+        revenue DOUBLE
+      ) USING iceberg
+    """)
+  }
+}
+
+/** Convenience helpers shared by the lineage test classes. */
+trait LineageTestHelpers {
+
+  protected def spark: SparkSession = LineageTestSession.spark
+
+  /** Analyses (but does not execute) `sql` and returns the extracted lineage. */
+  protected def lineageOf(sql: String): SqlLineage =
+    SqlLineageExtractor
+      .extractFromSql(spark, sql)
+      .getOrElse(throw new AssertionError(s"No lineage extracted for: $sql"))
+
+  protected def tableNames(lineage: SqlLineage): Set[String] =
+    lineage.inputTables.map(_.qualifiedName).toSet
+
+  protected def sourceNames(lineage: SqlLineage, column: String): Set[String] =
+    lineage.sourcesOf(column).map(_.qualifiedName).toSet
+
+  protected def conditionColumns(lineage: SqlLineage, kind: String): Set[String] =
+    lineage.conditions.filter(_.kind == kind).flatMap(_.columns).map(_.qualifiedName).toSet
+
+  protected def columnNames(lineage: SqlLineage): Seq[String] = lineage.columnLineage.map(_.column)
+}

--- a/integrations/spark/spark-3.1/openhouse-spark-runtime/src/test/scala/com/linkedin/openhouse/spark/lineage/OpenhouseLineageListenerTest.scala
+++ b/integrations/spark/spark-3.1/openhouse-spark-runtime/src/test/scala/com/linkedin/openhouse/spark/lineage/OpenhouseLineageListenerTest.scala
@@ -1,0 +1,131 @@
+package com.linkedin.openhouse.spark.lineage
+
+import org.apache.log4j.{Level, Logger, PatternLayout, WriterAppender}
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+import java.io.StringWriter
+
+/**
+ * Shows how lineage is captured for statements that actually run, which is how it would be wired in
+ * a cluster:
+ * {{{
+ *   --conf spark.sql.queryExecutionListeners=com.linkedin.openhouse.spark.lineage.OpenhouseLineageListener
+ * }}}
+ *
+ * The listener hands every statement to a [[LineageSink]]. Here the sink collects events in memory
+ * so they can be asserted on; in production it would be swapped for the Kafka publisher, and by
+ * default it is [[LogLineageSink]], which writes the lineage to the driver log.
+ */
+class OpenhouseLineageListenerTest extends LineageTestHelpers {
+
+  private val AwaitTimeoutMs = 30000L
+
+  @Test
+  def listenerCapturesLineageOfExecutedWriteStatements(): Unit = {
+    withListener { sink =>
+      spark.sql("""
+        CREATE TABLE IF NOT EXISTS local.db.listener_source
+        (id BIGINT, amount DOUBLE, region STRING) USING iceberg""")
+      spark.sql("INSERT INTO local.db.listener_source VALUES (1, 10.0, 'US'), (2, 20.0, 'EU')")
+      sink.clear()
+
+      spark.sql("""
+        CREATE TABLE local.db.listener_target USING iceberg AS
+        SELECT id, amount * 2 AS double_amount FROM local.db.listener_source WHERE region = 'US'""")
+
+      val lineage = await(sink, _.outputTable.exists(_.qualifiedName == "local.db.listener_target"))
+      assertEquals(LineageOperation.CreateTableAsSelect, lineage.operation)
+      assertEquals(Set("local.db.listener_source"), tableNames(lineage))
+      assertEquals(
+        Set("local.db.listener_source.amount"),
+        sourceNames(lineage, "double_amount"))
+      assertEquals(
+        Set("local.db.listener_source.region"),
+        conditionColumns(lineage, ConditionKind.Filter))
+    }
+  }
+
+  @Test
+  def listenerCapturesLineageOfExecutedReadStatements(): Unit = {
+    withListener { sink =>
+      spark.sql("""
+        CREATE TABLE IF NOT EXISTS local.db.listener_source
+        (id BIGINT, amount DOUBLE, region STRING) USING iceberg""")
+      sink.clear()
+
+      spark.sql("SELECT region, SUM(amount) AS total FROM local.db.listener_source GROUP BY region")
+        .collect()
+
+      val lineage = await(sink, l => tableNames(l).contains("local.db.listener_source"))
+      assertEquals(LineageOperation.Select, lineage.operation)
+      assertEquals(Set("local.db.listener_source.amount"), sourceNames(lineage, "total"))
+      assertEquals(
+        TransformationType.Aggregation,
+        lineage.columnLineageFor("total").get.transformationType)
+    }
+  }
+
+  @Test
+  def defaultSinkWritesOneJsonLinePerStatementToTheLog(): Unit = {
+    val lineage = lineageOf("""
+      INSERT INTO local.db.order_facts
+      SELECT order_id, customer_id, quantity * unit_price, region FROM local.db.orders""")
+
+    val captured = new StringWriter()
+    val appender = new WriterAppender(new PatternLayout("%m%n"), captured)
+    val logger = Logger.getLogger(classOf[LogLineageSink])
+    val originalLevel = logger.getLevel
+    logger.addAppender(appender)
+    logger.setLevel(Level.INFO)
+    try {
+      new LogLineageSink().emit(lineage)
+    } finally {
+      logger.removeAppender(appender)
+      logger.setLevel(originalLevel)
+    }
+
+    val logged = captured.toString
+    assertTrue(logged.contains("openhouse-lineage"), s"nothing logged, got '$logged'")
+    assertTrue(logged.contains("\"outputTable\":\"local.db.order_facts\""))
+    assertTrue(logged.contains("local.db.orders.unit_price"))
+    assertEquals(1, logged.trim.split("\n").length, "lineage must be a single log line")
+  }
+
+  @Test
+  def aFailingSinkNeverBreaksTheQueryThatProducedIt(): Unit = {
+    val exploding = new LineageSink {
+      override def emit(lineage: SqlLineage): Unit = throw new IllegalStateException("kafka down")
+    }
+    val listener = OpenhouseLineageListener.register(spark, exploding)
+    try {
+      val rows = spark.sql("SELECT 1 AS one FROM local.db.orders LIMIT 1").collect()
+      assertNotNull(rows)
+    } finally {
+      OpenhouseLineageListener.unregister(spark, listener)
+    }
+  }
+
+  private def withListener(body: InMemoryLineageSink => Unit): Unit = {
+    val sink = new InMemoryLineageSink
+    val listener = OpenhouseLineageListener.register(spark, sink)
+    try {
+      body(sink)
+    } finally {
+      OpenhouseLineageListener.unregister(spark, listener)
+    }
+  }
+
+  /** The listener bus is asynchronous, so poll until the expected event shows up. */
+  private def await(sink: InMemoryLineageSink, predicate: SqlLineage => Boolean): SqlLineage = {
+    val deadline = System.currentTimeMillis() + AwaitTimeoutMs
+    while (System.currentTimeMillis() < deadline) {
+      sink.events.find(predicate) match {
+        case Some(lineage) => return lineage
+        case None => Thread.sleep(50)
+      }
+    }
+    throw new AssertionError(
+      s"no matching lineage captured; saw ${sink.events.map(_.toJson).mkString("\n")}")
+  }
+}

--- a/integrations/spark/spark-3.1/openhouse-spark-runtime/src/test/scala/com/linkedin/openhouse/spark/lineage/SqlLineageExtractorTest.scala
+++ b/integrations/spark/spark-3.1/openhouse-spark-runtime/src/test/scala/com/linkedin/openhouse/spark/lineage/SqlLineageExtractorTest.scala
@@ -1,0 +1,380 @@
+package com.linkedin.openhouse.spark.lineage
+
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+/**
+ * Showcase of the lineage that can be recovered from a Spark SQL statement.
+ *
+ * Every test states a SQL shape and asserts exactly which table- and column-level facts the
+ * extractor is able to report for it: which tables were read, which table was written, which
+ * upstream columns each output column is derived from, through which expression, and which columns
+ * only influenced row selection.
+ *
+ * The statements are analysed, never executed, so none of them mutates the test warehouse.
+ */
+class SqlLineageExtractorTest extends LineageTestHelpers {
+
+  // ---------------------------------------------------------------------------------------------
+  // Reads
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  def plainSelectReportsInputTableAndIdentityColumns(): Unit = {
+    val lineage = lineageOf("SELECT order_id, quantity FROM local.db.orders")
+
+    assertEquals(LineageOperation.Select, lineage.operation)
+    assertEquals(None, lineage.outputTable)
+    assertEquals(Set("local.db.orders"), tableNames(lineage))
+    assertEquals(Seq("order_id", "quantity"), columnNames(lineage))
+    assertEquals(Set("local.db.orders.order_id"), sourceNames(lineage, "order_id"))
+    assertTrue(lineage.columnLineageFor("order_id").exists(_.isIdentity))
+  }
+
+  @Test
+  def selectStarExpandsToEveryColumnOfTheTable(): Unit = {
+    val lineage = lineageOf("SELECT * FROM local.db.customers")
+
+    assertEquals(
+      Seq("customer_id", "customer_name", "email", "country", "tier"),
+      columnNames(lineage))
+    assertEquals(Set("local.db.customers.email"), sourceNames(lineage, "email"))
+  }
+
+  @Test
+  def aliasKeepsTargetNameWhileSourceStaysTheOriginalColumn(): Unit = {
+    val lineage = lineageOf("SELECT customer_name AS full_name FROM local.db.customers")
+
+    assertEquals(Seq("full_name"), columnNames(lineage))
+    assertEquals(Set("local.db.customers.customer_name"), sourceNames(lineage, "full_name"))
+    assertEquals(TransformationType.Identity, lineage.columnLineage.head.transformationType)
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Column-level derivation
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  def computedColumnReportsEveryContributingColumnAndTheFormula(): Unit = {
+    val lineage = lineageOf(
+      "SELECT quantity * unit_price * (1 - discount) AS net_revenue FROM local.db.orders")
+
+    val revenue = lineage.columnLineage.head
+    assertEquals("net_revenue", revenue.column)
+    assertEquals(TransformationType.Expression, revenue.transformationType)
+    assertEquals(
+      Set(
+        "local.db.orders.quantity",
+        "local.db.orders.unit_price",
+        "local.db.orders.discount"),
+      revenue.sources.map(_.qualifiedName).toSet)
+    assertTrue(
+      revenue.transformation.contains("quantity") &&
+        revenue.transformation.contains("unit_price") &&
+        revenue.transformation.contains("discount"),
+      s"formula should name its inputs but was '${revenue.transformation}'")
+  }
+
+  @Test
+  def caseExpressionCollectsColumnsFromEveryBranch(): Unit = {
+    val lineage = lineageOf("""
+      SELECT CASE WHEN quantity > 100 THEN 'BULK'
+                  WHEN unit_price > 500 THEN 'PREMIUM'
+                  ELSE region END AS bucket
+      FROM local.db.orders""")
+
+    assertEquals(
+      Set("local.db.orders.quantity", "local.db.orders.unit_price", "local.db.orders.region"),
+      sourceNames(lineage, "bucket"))
+    assertTrue(lineage.columnLineage.head.transformation.startsWith("CASE WHEN"))
+  }
+
+  @Test
+  def literalColumnHasNoUpstreamColumn(): Unit = {
+    val lineage = lineageOf("SELECT order_id, 'batch-42' AS load_id FROM local.db.orders")
+
+    val loadId = lineage.columnLineageFor("load_id").get
+    assertEquals(TransformationType.Literal, loadId.transformationType)
+    assertTrue(loadId.sources.isEmpty)
+    assertEquals("'batch-42'", loadId.transformation)
+  }
+
+  @Test
+  def aggregateColumnsAreClassifiedAndGroupingKeysReportedAsIndirectLineage(): Unit = {
+    val lineage = lineageOf("""
+      SELECT region,
+             SUM(quantity * unit_price) AS revenue,
+             COUNT(DISTINCT customer_id) AS buyers
+      FROM local.db.orders
+      GROUP BY region""")
+
+    assertEquals(
+      TransformationType.Aggregation,
+      lineage.columnLineageFor("revenue").get.transformationType)
+    assertEquals(
+      Set("local.db.orders.quantity", "local.db.orders.unit_price"),
+      sourceNames(lineage, "revenue"))
+    assertEquals(Set("local.db.orders.customer_id"), sourceNames(lineage, "buyers"))
+    assertTrue(lineage.columnLineageFor("buyers").get.transformation.contains("count"))
+    assertEquals(Set("local.db.orders.region"), conditionColumns(lineage, ConditionKind.GroupBy))
+  }
+
+  @Test
+  def windowFunctionReportsPartitionAndOrderColumnsAsSources(): Unit = {
+    val lineage = lineageOf("""
+      SELECT order_id,
+             ROW_NUMBER() OVER (PARTITION BY customer_id ORDER BY order_date DESC) AS rn
+      FROM local.db.orders""")
+
+    val rn = lineage.columnLineageFor("rn").get
+    assertEquals(TransformationType.Window, rn.transformationType)
+    assertEquals(
+      Set("local.db.orders.customer_id", "local.db.orders.order_date"),
+      rn.sources.map(_.qualifiedName).toSet)
+    assertTrue(rn.transformation.contains("row_number"))
+  }
+
+  @Test
+  def nestedSubqueryIsFlattenedIntoASingleFormula(): Unit = {
+    val lineage = lineageOf("""
+      SELECT t.total * 2 AS doubled
+      FROM (SELECT quantity * unit_price AS total FROM local.db.orders) t""")
+
+    assertEquals(
+      Set("local.db.orders.quantity", "local.db.orders.unit_price"),
+      sourceNames(lineage, "doubled"))
+    val formula = lineage.columnLineage.head.transformation
+    assertTrue(
+      formula.contains("quantity") && formula.contains("unit_price") && formula.contains("2"),
+      s"intermediate alias should be inlined but was '$formula'")
+  }
+
+  @Test
+  def unionMergesSourcesOfBothBranchesIntoOneColumn(): Unit = {
+    val lineage = lineageOf("""
+      SELECT customer_id, country FROM local.db.customers
+      UNION ALL
+      SELECT customer_id, region FROM local.db.orders""")
+
+    assertEquals(Set("local.db.customers", "local.db.orders"), tableNames(lineage))
+    assertEquals(
+      Set("local.db.customers.country", "local.db.orders.region"),
+      sourceNames(lineage, "country"))
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Multi-table reads and indirect lineage
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  def joinReportsEveryInputTableAndTheJoinKeys(): Unit = {
+    val lineage = lineageOf("""
+      SELECT o.order_id, p.category, o.quantity * p.list_price AS list_revenue
+      FROM local.db.orders o
+      JOIN local.db.products p ON o.product_id = p.product_id
+      JOIN local.db.customers c ON o.customer_id = c.customer_id
+      WHERE c.tier = 'GOLD' AND p.category = 'BOOKS'""")
+
+    assertEquals(
+      Set("local.db.orders", "local.db.products", "local.db.customers"),
+      tableNames(lineage))
+    assertEquals(Set("local.db.products.category"), sourceNames(lineage, "category"))
+    assertEquals(
+      Set("local.db.orders.quantity", "local.db.products.list_price"),
+      sourceNames(lineage, "list_revenue"))
+
+    assertEquals(
+      Set(
+        "local.db.orders.product_id",
+        "local.db.products.product_id",
+        "local.db.orders.customer_id",
+        "local.db.customers.customer_id"),
+      conditionColumns(lineage, ConditionKind.Join))
+  }
+
+  @Test
+  def filterColumnsAreReportedSeparatelyFromProjectedColumns(): Unit = {
+    val lineage =
+      lineageOf("SELECT order_id FROM local.db.orders WHERE region = 'US' AND quantity > 10")
+
+    assertEquals(Set("local.db.orders.order_id"), sourceNames(lineage, "order_id"))
+    assertEquals(
+      Set("local.db.orders.region", "local.db.orders.quantity"),
+      conditionColumns(lineage, ConditionKind.Filter))
+  }
+
+  @Test
+  def subqueryInWhereClauseContributesItsTableAndFilterColumns(): Unit = {
+    val lineage = lineageOf("""
+      SELECT order_id FROM local.db.orders
+      WHERE customer_id IN (SELECT customer_id FROM local.db.customers WHERE tier = 'GOLD')""")
+
+    assertEquals(Set("local.db.orders", "local.db.customers"), tableNames(lineage))
+    assertTrue(
+      conditionColumns(lineage, ConditionKind.Filter).contains("local.db.customers.tier"),
+      "filter columns inside the subquery must be captured")
+  }
+
+  @Test
+  def cteLineageResolvesThroughToTheBaseTables(): Unit = {
+    val lineage = lineageOf("""
+      WITH big_orders AS (
+        SELECT customer_id, quantity * unit_price AS revenue
+        FROM local.db.orders WHERE quantity > 100
+      )
+      SELECT c.customer_name, SUM(b.revenue) AS lifetime_revenue
+      FROM big_orders b JOIN local.db.customers c ON b.customer_id = c.customer_id
+      GROUP BY c.customer_name""")
+
+    assertEquals(Set("local.db.orders", "local.db.customers"), tableNames(lineage))
+    assertEquals(Set("local.db.customers.customer_name"), sourceNames(lineage, "customer_name"))
+    assertEquals(
+      Set("local.db.orders.quantity", "local.db.orders.unit_price"),
+      sourceNames(lineage, "lifetime_revenue"))
+    assertTrue(
+      conditionColumns(lineage, ConditionKind.Filter).contains("local.db.orders.quantity"),
+      "a filter inside the CTE must still be reported")
+  }
+
+  @Test
+  def selfJoinKeepsBothSidesPointingAtTheSameTable(): Unit = {
+    val lineage = lineageOf("""
+      SELECT a.order_id, b.order_id AS previous_order_id
+      FROM local.db.orders a JOIN local.db.orders b ON a.customer_id = b.customer_id""")
+
+    assertEquals(Set("local.db.orders"), tableNames(lineage))
+    assertEquals(Set("local.db.orders.order_id"), sourceNames(lineage, "order_id"))
+    assertEquals(Set("local.db.orders.order_id"), sourceNames(lineage, "previous_order_id"))
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Writes
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  def insertIntoMapsQueryColumnsOntoTargetTableColumns(): Unit = {
+    val lineage = lineageOf("""
+      INSERT INTO local.db.order_facts
+      SELECT order_id, customer_id, quantity * unit_price, region FROM local.db.orders""")
+
+    assertEquals(LineageOperation.InsertInto, lineage.operation)
+    assertEquals(Some("local.db.order_facts"), lineage.outputTable.map(_.qualifiedName))
+    assertEquals(Set("local.db.orders"), tableNames(lineage))
+    // Column names come from the target table, not from the SELECT list.
+    assertEquals(Seq("order_id", "customer_id", "revenue", "region"), columnNames(lineage))
+    assertEquals(
+      Set("local.db.orders.quantity", "local.db.orders.unit_price"),
+      sourceNames(lineage, "revenue"))
+    assertTrue(lineage.columnLineageFor("region").exists(_.isIdentity))
+  }
+
+  @Test
+  def insertOverwriteIsDistinguishedFromInsertInto(): Unit = {
+    val lineage = lineageOf("""
+      INSERT OVERWRITE local.db.order_facts
+      SELECT order_id, customer_id, quantity * unit_price, region
+      FROM local.db.orders WHERE region = 'US'""")
+
+    assertEquals(LineageOperation.InsertOverwrite, lineage.operation)
+    assertEquals(Some("local.db.order_facts"), lineage.outputTable.map(_.qualifiedName))
+    assertEquals(Set("local.db.orders.region"), conditionColumns(lineage, ConditionKind.Filter))
+  }
+
+  @Test
+  def ctasReportsTheNewTableAndTheColumnsItIsBuiltFrom(): Unit = {
+    val lineage = lineageOf("""
+      CREATE TABLE local.db.ctas_target USING iceberg AS
+      SELECT o.order_id,
+             c.customer_name,
+             o.quantity * o.unit_price AS revenue
+      FROM local.db.orders o
+      JOIN local.db.customers c ON o.customer_id = c.customer_id
+      WHERE c.country = 'US'""")
+
+    assertEquals(LineageOperation.CreateTableAsSelect, lineage.operation)
+    assertEquals(Some("local.db.ctas_target"), lineage.outputTable.map(_.qualifiedName))
+    assertEquals(Set("local.db.orders", "local.db.customers"), tableNames(lineage))
+    assertEquals(Seq("order_id", "customer_name", "revenue"), columnNames(lineage))
+    assertEquals(Set("local.db.customers.customer_name"), sourceNames(lineage, "customer_name"))
+    assertEquals(
+      Set("local.db.orders.quantity", "local.db.orders.unit_price"),
+      sourceNames(lineage, "revenue"))
+    assertEquals(Set("local.db.customers.country"), conditionColumns(lineage, ConditionKind.Filter))
+  }
+
+  @Test
+  def mergeReportsPerColumnAssignmentsFromEveryBranch(): Unit = {
+    val lineage = lineageOf("""
+      MERGE INTO local.db.customer_360 t
+      USING local.db.customer_updates s
+      ON t.customer_id = s.customer_id
+      WHEN MATCHED THEN UPDATE SET t.lifetime_revenue = t.lifetime_revenue + s.revenue
+      WHEN NOT MATCHED THEN
+        INSERT (customer_id, customer_name, lifetime_revenue, order_count, load_id)
+        VALUES (s.customer_id, s.customer_name, s.revenue, 1, 'merge')""")
+
+    assertEquals(LineageOperation.Merge, lineage.operation)
+    assertEquals(Some("local.db.customer_360"), lineage.outputTable.map(_.qualifiedName))
+    // A MERGE reads the target as well as the source.
+    assertEquals(
+      Set("local.db.customer_360", "local.db.customer_updates"),
+      tableNames(lineage))
+    assertEquals(
+      Set("local.db.customer_360.lifetime_revenue", "local.db.customer_updates.revenue"),
+      sourceNames(lineage, "lifetime_revenue"))
+    assertEquals(
+      Set("local.db.customer_360.customer_id", "local.db.customer_updates.customer_id"),
+      conditionColumns(lineage, ConditionKind.MergeOn))
+  }
+
+  @Test
+  def updateReportsTheAssignedColumnAndThePredicate(): Unit = {
+    val lineage =
+      lineageOf("UPDATE local.db.order_facts SET revenue = revenue * 1.1 WHERE region = 'EU'")
+
+    assertEquals(LineageOperation.Update, lineage.operation)
+    assertEquals(Some("local.db.order_facts"), lineage.outputTable.map(_.qualifiedName))
+    val revenue = lineage.columnLineageFor("revenue").get
+    assertEquals(Set("local.db.order_facts.revenue"), revenue.sources.map(_.qualifiedName).toSet)
+    assertEquals(TransformationType.Expression, revenue.transformationType)
+    assertEquals(
+      Set("local.db.order_facts.region"),
+      conditionColumns(lineage, ConditionKind.Filter))
+  }
+
+  @Test
+  def deleteReportsOnlyTheTargetTableAndThePredicate(): Unit = {
+    val lineage = lineageOf("DELETE FROM local.db.order_facts WHERE region = 'APAC'")
+
+    assertEquals(LineageOperation.Delete, lineage.operation)
+    assertEquals(Some("local.db.order_facts"), lineage.outputTable.map(_.qualifiedName))
+    assertTrue(lineage.columnLineage.isEmpty)
+    assertEquals(
+      Set("local.db.order_facts.region"),
+      conditionColumns(lineage, ConditionKind.Filter))
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Statements that carry no lineage, and serialization
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  def statementsWithoutTablesProduceNoLineage(): Unit = {
+    assertTrue(SqlLineageExtractor.extractFromSql(spark, "SHOW NAMESPACES IN local").isEmpty)
+    assertTrue(SqlLineageExtractor.extractFromSql(spark, "SELECT 1").isEmpty)
+  }
+
+  @Test
+  def lineageSerializesToSingleLineJsonForEventEmission(): Unit = {
+    val lineage = lineageOf("""
+      INSERT INTO local.db.order_facts
+      SELECT order_id, customer_id, quantity * unit_price, region FROM local.db.orders""")
+
+    val json = lineage.toJson
+    assertFalse(json.contains("\n"), "payload must be a single line")
+    assertTrue(json.contains("\"operation\":\"INSERT_INTO\""))
+    assertTrue(json.contains("\"outputTable\":\"local.db.order_facts\""))
+    assertTrue(json.contains("\"inputTables\":[\"local.db.orders\"]"))
+    assertTrue(json.contains("\"local.db.orders.unit_price\""))
+  }
+}

--- a/integrations/spark/spark-3.5/openhouse-spark-runtime/build.gradle
+++ b/integrations/spark/spark-3.5/openhouse-spark-runtime/build.gradle
@@ -8,6 +8,19 @@ plugins {
 ext {
   icebergVersion = rootProject.ext.iceberg_1_5_version
   sparkVersion = '3.5.2'
+  // Spark 3.5 fails to initialise (ErrorClassesJsonReader) with the Jackson version the root build
+  // pins for the rest of the repo, so the test classpath - and only the test classpath - uses the
+  // version Spark 3.5 ships with. The sibling 3.5 itest/apps projects are exempted from that pin in
+  // the root build for the same reason.
+  testJacksonVersion = '2.15.2'
+}
+
+configurations.matching { it.name.toLowerCase().startsWith('test') }.configureEach {
+  resolutionStrategy.eachDependency { details ->
+    if (details.requested.group.startsWith('com.fasterxml.jackson')) {
+      details.useVersion testJacksonVersion
+    }
+  }
 }
 
 configurations {
@@ -71,6 +84,19 @@ shadowJar {
   mergeServiceFiles()
   archiveClassifier.set('uber')
   zip64 true
+}
+
+test {
+  // Spark needs these to run on JDK 9+.
+  if (JavaVersion.current() >= JavaVersion.VERSION_1_9) {
+    jvmArgs \
+        '--add-opens=java.base/java.nio=ALL-UNNAMED',
+        '--add-opens=java.base/java.util=ALL-UNNAMED',
+        '--add-opens=java.base/java.lang=ALL-UNNAMED',
+        '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED',
+        '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
+        '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED'
+  }
 }
 
 jar.enabled=true

--- a/integrations/spark/spark-3.5/openhouse-spark-runtime/src/test/scala/com/linkedin/openhouse/spark/lineage/SqlLineageExtractorTestSpark3_5.scala
+++ b/integrations/spark/spark-3.5/openhouse-spark-runtime/src/test/scala/com/linkedin/openhouse/spark/lineage/SqlLineageExtractorTestSpark3_5.scala
@@ -1,0 +1,226 @@
+package com.linkedin.openhouse.spark.lineage
+
+import org.apache.spark.sql.SparkSession
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+import java.nio.file.Files
+
+/**
+ * Runs the lineage extractor - compiled once against Spark 3.1 and repackaged into this artifact -
+ * against Spark 3.5.
+ *
+ * Several plan nodes changed shape between the two releases (`CreateTableAsSelect` swapped its
+ * constructor, `MergeIntoTable` gained an argument, CTEs are no longer inlined at analysis time), so
+ * this suite is the guard that the accessor-based extraction in `PlanAccessors` really is
+ * version-independent.
+ */
+class SqlLineageExtractorTestSpark3_5 {
+
+  private def spark: SparkSession = Spark35LineageTestSession.spark
+
+  private def lineageOf(sql: String): SqlLineage =
+    SqlLineageExtractor
+      .extractFromSql(spark, sql)
+      .getOrElse(throw new AssertionError(s"No lineage extracted for: $sql"))
+
+  private def tableNames(lineage: SqlLineage): Set[String] =
+    lineage.inputTables.map(_.qualifiedName).toSet
+
+  private def sourceNames(lineage: SqlLineage, column: String): Set[String] =
+    lineage.sourcesOf(column).map(_.qualifiedName).toSet
+
+  private def conditionColumns(lineage: SqlLineage, kind: String): Set[String] =
+    lineage.conditions.filter(_.kind == kind).flatMap(_.columns).map(_.qualifiedName).toSet
+
+  private def transformationOf(lineage: SqlLineage, column: String): String =
+    lineage.columnLineage
+      .find(_.column == column)
+      .map(_.transformation)
+      .getOrElse(throw new AssertionError(s"No column lineage for: $column"))
+
+  @Test
+  def selectLineageWorksOnSpark35(): Unit = {
+    val lineage = lineageOf("""
+      SELECT o.order_id, c.customer_name, o.quantity * o.unit_price AS revenue
+      FROM local.db.orders o
+      JOIN local.db.customers c ON o.customer_id = c.customer_id
+      WHERE c.tier = 'GOLD'""")
+
+    assertEquals(Set("local.db.orders", "local.db.customers"), tableNames(lineage))
+    assertEquals(
+      Set("local.db.orders.quantity", "local.db.orders.unit_price"),
+      sourceNames(lineage, "revenue"))
+    assertEquals(Set("local.db.customers.tier"), conditionColumns(lineage, ConditionKind.Filter))
+    assertEquals(
+      Set("local.db.orders.customer_id", "local.db.customers.customer_id"),
+      conditionColumns(lineage, ConditionKind.Join))
+  }
+
+  @Test
+  def ctasTargetIsResolvedDespiteTheChangedNodeSignature(): Unit = {
+    val lineage = lineageOf("""
+      CREATE TABLE local.db.ctas_target_35 USING iceberg AS
+      SELECT order_id, quantity * unit_price AS revenue FROM local.db.orders""")
+
+    assertEquals(LineageOperation.CreateTableAsSelect, lineage.operation)
+    assertEquals(Some("local.db.ctas_target_35"), lineage.outputTable.map(_.qualifiedName))
+    assertEquals(
+      Set("local.db.orders.quantity", "local.db.orders.unit_price"),
+      sourceNames(lineage, "revenue"))
+  }
+
+  @Test
+  def insertIntoMapsOntoTargetColumnsOnSpark35(): Unit = {
+    val lineage = lineageOf("""
+      INSERT INTO local.db.order_facts
+      SELECT order_id, customer_id, quantity * unit_price, region FROM local.db.orders""")
+
+    assertEquals(LineageOperation.InsertInto, lineage.operation)
+    assertEquals(Some("local.db.order_facts"), lineage.outputTable.map(_.qualifiedName))
+    assertEquals(Seq("order_id", "customer_id", "revenue", "region"), lineage.columnLineage.map(_.column))
+    assertEquals(
+      Set("local.db.orders.quantity", "local.db.orders.unit_price"),
+      sourceNames(lineage, "revenue"))
+  }
+
+  @Test
+  def mergeIsReadThroughAccessorsDespiteTheExtraArgument(): Unit = {
+    val lineage = lineageOf("""
+      MERGE INTO local.db.customer_360 t
+      USING local.db.customer_updates s
+      ON t.customer_id = s.customer_id
+      WHEN MATCHED THEN UPDATE SET t.lifetime_revenue = t.lifetime_revenue + s.revenue
+      WHEN NOT MATCHED THEN
+        INSERT (customer_id, customer_name, lifetime_revenue, order_count, load_id)
+        VALUES (s.customer_id, s.customer_name, s.revenue, 1, 'merge')""")
+
+    assertEquals(LineageOperation.Merge, lineage.operation)
+    assertEquals(Some("local.db.customer_360"), lineage.outputTable.map(_.qualifiedName))
+    assertEquals(
+      Set("local.db.customer_360", "local.db.customer_updates"),
+      tableNames(lineage))
+    assertEquals(
+      Set("local.db.customer_360.lifetime_revenue", "local.db.customer_updates.revenue"),
+      sourceNames(lineage, "lifetime_revenue"))
+    // Every branch that can assign the column is folded into one entry, exactly as on Spark 3.1:
+    // matched UPDATE, not-matched INSERT and the untouched carry-over of the existing row.
+    assertEquals(
+      Set("(lifetime_revenue + revenue)", "lifetime_revenue", "revenue"),
+      transformationOf(lineage, "lifetime_revenue").split(" \\| ").toSet)
+
+    // Spark 3.4+ rewrites MERGE into a join before lineage sees it, so the ON predicate arrives as a
+    // JOIN condition rather than the MERGE_ON that the un-rewritten Spark 3.1 node reports. Either
+    // way the same key columns are attributed.
+    assertEquals(
+      Set("local.db.customer_360.customer_id", "local.db.customer_updates.customer_id"),
+      conditionColumns(lineage, ConditionKind.Join))
+  }
+
+  @Test
+  def rewrittenRowLevelWritesDoNotLeakInternalRowTrackingColumns(): Unit = {
+    // The rewrite appends `_file` / `_pos` metadata columns to the query so Spark can locate the
+    // rows it replaces. They are not table columns and must not show up as lineage.
+    val lineage = lineageOf("DELETE FROM local.db.order_facts WHERE region = 'APAC'")
+
+    assertEquals(
+      Seq("order_id", "customer_id", "revenue", "region"),
+      lineage.columnLineage.map(_.column))
+  }
+
+  @Test
+  def cteReferencesAreLinkedBackToTheirDefinition(): Unit = {
+    // Spark 3.4+ keeps CTEs as CTERelationDef/CTERelationRef instead of inlining them at analysis.
+    val lineage = lineageOf("""
+      WITH big_orders AS (
+        SELECT customer_id, quantity * unit_price AS revenue
+        FROM local.db.orders WHERE quantity > 100
+      )
+      SELECT c.customer_name, SUM(b.revenue) AS lifetime_revenue
+      FROM big_orders b JOIN local.db.customers c ON b.customer_id = c.customer_id
+      GROUP BY c.customer_name""")
+
+    assertEquals(Set("local.db.orders", "local.db.customers"), tableNames(lineage))
+    assertEquals(
+      Set("local.db.orders.quantity", "local.db.orders.unit_price"),
+      sourceNames(lineage, "lifetime_revenue"))
+    // The filter inside the CTE body is indirect lineage of the outer statement.
+    assertEquals(
+      Set("local.db.orders.quantity"),
+      conditionColumns(lineage, ConditionKind.Filter))
+  }
+
+  @Test
+  def updateAndDeleteReportTargetAndPredicate(): Unit = {
+    val update =
+      lineageOf("UPDATE local.db.order_facts SET revenue = revenue * 1.1 WHERE region = 'EU'")
+    assertEquals(LineageOperation.Update, update.operation)
+    assertEquals(Some("local.db.order_facts"), update.outputTable.map(_.qualifiedName))
+    // Copy-on-write turns the UPDATE into a full rewrite of the matching files, so every column is
+    // reported: the assigned one through its formula, the rest as a conditional carry-over. The
+    // predicate column is a source of all of them, which is what actually decides their new value.
+    assertEquals(
+      Set("local.db.order_facts.revenue", "local.db.order_facts.region"),
+      sourceNames(update, "revenue"))
+    assertTrue(
+      transformationOf(update, "revenue").contains("revenue * "),
+      s"expected the assignment formula, got: ${transformationOf(update, "revenue")}")
+    assertEquals(
+      Set("local.db.order_facts.region"),
+      sourceNames(update, "order_id") -- Set("local.db.order_facts.order_id"))
+
+    val delete = lineageOf("DELETE FROM local.db.order_facts WHERE region = 'APAC'")
+    assertEquals(LineageOperation.Delete, delete.operation)
+    assertEquals(Some("local.db.order_facts"), delete.outputTable.map(_.qualifiedName))
+    assertEquals(
+      Set("local.db.order_facts.region"),
+      conditionColumns(delete, ConditionKind.Filter))
+  }
+}
+
+private object Spark35LineageTestSession {
+
+  lazy val spark: SparkSession = {
+    val warehouse = Files.createTempDirectory("openhouse-lineage-test-35").toString
+    val session = SparkSession
+      .builder()
+      .master("local[1]")
+      .appName("openhouse-lineage-test-3.5")
+      .config(
+        "spark.sql.extensions",
+        "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
+      .config("spark.sql.catalog.local", "org.apache.iceberg.spark.SparkCatalog")
+      .config("spark.sql.catalog.local.type", "hadoop")
+      .config("spark.sql.catalog.local.warehouse", warehouse)
+      .config("spark.sql.warehouse.dir", warehouse + "/session")
+      .config("spark.ui.enabled", "false")
+      .getOrCreate()
+    createTables(session)
+    session
+  }
+
+  private def createTables(spark: SparkSession): Unit = {
+    spark.sql("CREATE NAMESPACE IF NOT EXISTS local.db")
+    spark.sql("""
+      CREATE TABLE IF NOT EXISTS local.db.orders (
+        order_id BIGINT, customer_id BIGINT, quantity INT, unit_price DOUBLE, region STRING
+      ) USING iceberg""")
+    spark.sql("""
+      CREATE TABLE IF NOT EXISTS local.db.customers (
+        customer_id BIGINT, customer_name STRING, tier STRING
+      ) USING iceberg""")
+    spark.sql("""
+      CREATE TABLE IF NOT EXISTS local.db.order_facts (
+        order_id BIGINT, customer_id BIGINT, revenue DOUBLE, region STRING
+      ) USING iceberg""")
+    spark.sql("""
+      CREATE TABLE IF NOT EXISTS local.db.customer_360 (
+        customer_id BIGINT, customer_name STRING, lifetime_revenue DOUBLE,
+        order_count BIGINT, load_id STRING
+      ) USING iceberg""")
+    spark.sql("""
+      CREATE TABLE IF NOT EXISTS local.db.customer_updates (
+        customer_id BIGINT, customer_name STRING, revenue DOUBLE
+      ) USING iceberg""")
+  }
+}


### PR DESCRIPTION
## Summary

Extracts lineage from the analyzed logical plan of every statement and answers, per statement: which tables were read, which table was written, how each output column is calculated, and which columns decided the rows (indirect lineage from WHERE / JOIN ON / GROUP BY / MERGE ON).

Lineage goes to a LineageSink. LogLineageSink is the default and writes one JSON line per statement to the driver log; a Kafka publisher plugs in at the same seam. Enable it with:

  --conf spark.sql.queryExecutionListeners=com.linkedin.openhouse.spark.lineage.OpenhouseLineageListener

SqlLineageExtractor.extractFromSql analyses SQL text without running it.

The module is compiled against Spark 3.1 and repackaged into the Spark 3.5 runtime, so plan nodes are read through accessor methods rather than case-class patterns, whose fixed arity would break across the two releases. Two Spark 3.4+ analysis changes are handled explicitly: CTEs are no longer inlined, and UPDATE/DELETE/MERGE are rewritten into a generic ReplaceData/WriteDelta whose original command is recovered from the connector's RowLevelOperation.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Tests
- 22 showcase tests naming each SQL shape and the lineage it yields, plus 4 listener tests, on Spark 3.1.
- 7 cross-version tests rerunning a representative subset on Spark 3.5.
- Both shadow jars build.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
