### PR TITLE
Add metrics for HCR misconfigured tables

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -13,6 +13,8 @@ import com.linkedin.openhouse.common.stats.model.IcebergTableStats;
 import com.linkedin.openhouse.jobs.util.AppConstants;
 import com.linkedin.openhouse.jobs.util.SparkJobUtil;
 import com.linkedin.openhouse.jobs.util.TableStatsCollector;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -64,6 +66,8 @@ import scala.collection.JavaConverters;
 public final class Operations implements AutoCloseable {
   // assume that catalog name is fixed
   private static final String CATALOG = "openhouse";
+
+  private static final String METRICS_SCOPE = Operations.class.getName();
 
   private final SparkSession spark;
 
@@ -344,6 +348,14 @@ public final class Operations implements AutoCloseable {
           .findFirst()
           .ifPresent(
               task -> {
+                // Misconfigured table: the retention filter does not align with the partitioning,
+                // so the delete cannot be metadata-only. Emit a metric tagged with the table name
+                // so the misconfiguration can be alerted on instead of only failing the job.
+                otelEmitter.count(
+                    METRICS_SCOPE,
+                    AppConstants.HCR_MISCONFIGURED_TABLE_COUNT,
+                    1,
+                    Attributes.of(AttributeKey.stringKey(AppConstants.TABLE_NAME), fqtn));
                 throw new IllegalStateException(
                     String.format(
                         "Retention with backup enabled requires a metadata-only delete for table %s, "

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -353,7 +353,7 @@ public final class Operations implements AutoCloseable {
                 // so the misconfiguration can be alerted on instead of only failing the job.
                 otelEmitter.count(
                     METRICS_SCOPE,
-                    AppConstants.HCR_MISCONFIGURED_TABLE_COUNT,
+                    AppConstants.RETENTION_POLICY_MISCONFIGURED_TABLE_COUNT,
                     1,
                     Attributes.of(AttributeKey.stringKey(AppConstants.TABLE_NAME), fqtn));
                 throw new IllegalStateException(

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/AppConstants.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/AppConstants.java
@@ -20,6 +20,7 @@ public final class AppConstants {
   public static final String REWRITTEN_DATA_FILE_COUNT = "rewritten_data_file_count";
   public static final String REWRITTEN_DATA_FILE_BYTES = "rewritten_data_file_bytes";
   public static final String REWRITTEN_DATA_FILE_GROUP_COUNT = "rewritten_data_file_group_count";
+  public static final String HCR_MISCONFIGURED_TABLE_COUNT = "hcr_misconfigured_table_count";
 
   // Openhouse jobs status tags
   public static final String STATUS = "status";

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/AppConstants.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/util/AppConstants.java
@@ -20,7 +20,8 @@ public final class AppConstants {
   public static final String REWRITTEN_DATA_FILE_COUNT = "rewritten_data_file_count";
   public static final String REWRITTEN_DATA_FILE_BYTES = "rewritten_data_file_bytes";
   public static final String REWRITTEN_DATA_FILE_GROUP_COUNT = "rewritten_data_file_group_count";
-  public static final String HCR_MISCONFIGURED_TABLE_COUNT = "hcr_misconfigured_table_count";
+  public static final String RETENTION_POLICY_MISCONFIGURED_TABLE_COUNT =
+      "retention_policy_misconfigured_table_count";
 
   // Openhouse jobs status tags
   public static final String STATUS = "status";

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -14,6 +14,8 @@ import com.linkedin.openhouse.tables.client.model.Policies;
 import com.linkedin.openhouse.tables.client.model.Retention;
 import com.linkedin.openhouse.tables.client.model.TimePartitionSpec;
 import com.linkedin.openhouse.tablestest.OpenHouseSparkITest;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
@@ -43,6 +45,8 @@ import org.apache.spark.sql.Row;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 
 @Slf4j
 public class OperationsTest extends OpenHouseSparkITest {
@@ -312,7 +316,8 @@ public class OperationsTest extends OpenHouseSparkITest {
   @Test
   public void testRetentionWithBackupFailsWhenColumnPatternMismatchesPartition() throws Exception {
     final String tableName = "db.test_retention_backup_pattern_mismatch";
-    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+    OtelEmitter spyEmitter = Mockito.spy(otelEmitter);
+    try (Operations ops = Operations.withCatalog(getSparkSession(), spyEmitter)) {
       // The table is partitioned on `datepartition`, but retention will filter
       // on `time_col` using a pattern unrelated to the partitioning. For each
       // file's per-file min/max to actually straddle the cutoff (and produce
@@ -352,6 +357,14 @@ public class OperationsTest extends OpenHouseSparkITest {
       Assertions.assertTrue(
           ex.getMessage().contains("metadata-only delete"),
           "Expected metadata-only delete error, got: " + ex.getMessage());
+      // The misconfiguration is alertable: a metric tagged with the table name is emitted.
+      Mockito.verify(spyEmitter)
+          .count(
+              ArgumentMatchers.anyString(),
+              ArgumentMatchers.eq(AppConstants.HCR_MISCONFIGURED_TABLE_COUNT),
+              ArgumentMatchers.eq(1L),
+              ArgumentMatchers.eq(
+                  Attributes.of(AttributeKey.stringKey(AppConstants.TABLE_NAME), tableName)));
       // DELETE should not have executed: all 4 rows remain.
       verifyRowCount(ops, tableName, 4);
     }

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -361,7 +361,7 @@ public class OperationsTest extends OpenHouseSparkITest {
       Mockito.verify(spyEmitter)
           .count(
               ArgumentMatchers.anyString(),
-              ArgumentMatchers.eq(AppConstants.HCR_MISCONFIGURED_TABLE_COUNT),
+              ArgumentMatchers.eq(AppConstants.RETENTION_POLICY_MISCONFIGURED_TABLE_COUNT),
               ArgumentMatchers.eq(1L),
               ArgumentMatchers.eq(
                   Attributes.of(AttributeKey.stringKey(AppConstants.TABLE_NAME), tableName)));


### PR DESCRIPTION
## Summary
Emit a Counter metrics for HCR misconfigured tables. Add fqtn as an attribute.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
