### PR TITLE
Enforce column-level ACLs on tagged columns

### DIFF
--- a/infra/recipes/docker-compose/common/opa/data.json
+++ b/infra/recipes/docker-compose/common/opa/data.json
@@ -15,6 +15,12 @@
     ],
     "TABLE_CREATOR": [
       "CREATE_TABLE"
+    ],
+    "PII_VIEWER": [
+      "SELECT_PII"
+    ],
+    "HC_VIEWER": [
+      "SELECT_HC"
     ]
   }
 }

--- a/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/mapper/PrivilegesTest.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/mapper/PrivilegesTest.java
@@ -1,0 +1,51 @@
+package com.linkedin.openhouse.javaclient.mapper;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class PrivilegesTest {
+
+  @Test
+  public void testColumnLevelPrivilegesMapToRoles() {
+    Assertions.assertEquals(Privileges.SELECT_PII, Privileges.fromPrivilege("SELECT PII"));
+    Assertions.assertEquals("PII_VIEWER", Privileges.fromPrivilege("SELECT PII").getRole());
+    Assertions.assertEquals(Privileges.SELECT_HC, Privileges.fromPrivilege("SELECT HC"));
+    Assertions.assertEquals("HC_VIEWER", Privileges.fromPrivilege("SELECT HC").getRole());
+  }
+
+  @Test
+  public void testColumnLevelRolesMapBackToPrivileges() {
+    Assertions.assertEquals("SELECT PII", Privileges.fromRole("PII_VIEWER").getPrivilege());
+    Assertions.assertEquals("SELECT HC", Privileges.fromRole("HC_VIEWER").getPrivilege());
+  }
+
+  @Test
+  public void testTableLevelPrivilegesAreUnchanged() {
+    Assertions.assertEquals("TABLE_VIEWER", Privileges.fromPrivilege("SELECT").getRole());
+    Assertions.assertEquals("ACL_EDITOR", Privileges.fromPrivilege("MANAGE GRANTS").getRole());
+    Assertions.assertEquals("TABLE_ADMIN", Privileges.fromPrivilege("ALTER").getRole());
+    Assertions.assertEquals("TABLE_CREATOR", Privileges.fromPrivilege("CREATE TABLE").getRole());
+  }
+
+  /**
+   * An unmapped privilege used to surface as a bare NoSuchElementException, which said nothing
+   * about what went wrong. "SELECTPII" is what the parser produced before column level grants were
+   * fixed, so it is the most likely thing to arrive here.
+   */
+  @Test
+  public void testUnknownPrivilegeIsRejectedWithContext() {
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class, () -> Privileges.fromPrivilege("SELECTPII"));
+    Assertions.assertTrue(exception.getMessage().contains("SELECTPII"));
+    Assertions.assertTrue(exception.getMessage().contains("SELECT PII"));
+  }
+
+  @Test
+  public void testUnknownRoleIsRejectedWithContext() {
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class, () -> Privileges.fromRole("NOT_A_ROLE"));
+    Assertions.assertTrue(exception.getMessage().contains("NOT_A_ROLE"));
+  }
+}

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
@@ -4,6 +4,7 @@ import static com.linkedin.openhouse.javaclient.OpenHouseTableOperations.*;
 
 import com.linkedin.openhouse.client.ssl.HttpConnectionStrategy;
 import com.linkedin.openhouse.client.ssl.TablesApiClientFactory;
+import com.linkedin.openhouse.javaclient.api.SupportsColumnEntitlements;
 import com.linkedin.openhouse.javaclient.api.SupportsGrantRevoke;
 import com.linkedin.openhouse.javaclient.builder.ClusteringSpecBuilder;
 import com.linkedin.openhouse.javaclient.builder.TimePartitionSpecBuilder;
@@ -19,12 +20,14 @@ import com.linkedin.openhouse.tables.client.model.CreateUpdateTableRequestBody;
 import com.linkedin.openhouse.tables.client.model.GetAclPoliciesResponseBody;
 import com.linkedin.openhouse.tables.client.model.GetAllDatabasesResponseBody;
 import com.linkedin.openhouse.tables.client.model.GetAllTablesResponseBody;
+import com.linkedin.openhouse.tables.client.model.GetColumnEntitlementsResponseBody;
 import com.linkedin.openhouse.tables.client.model.GetTableResponseBody;
 import com.linkedin.openhouse.tables.client.model.UpdateAclPoliciesRequestBody;
 import java.net.MalformedURLException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.net.ssl.SSLException;
@@ -70,7 +73,7 @@ import reactor.core.publisher.Mono;
  */
 @Slf4j
 public class OpenHouseCatalog extends BaseMetastoreCatalog
-    implements Configurable, SupportsNamespaces, SupportsGrantRevoke {
+    implements Configurable, SupportsNamespaces, SupportsGrantRevoke, SupportsColumnEntitlements {
 
   private TableApi tableApi;
 
@@ -463,6 +466,35 @@ public class OpenHouseCatalog extends BaseMetastoreCatalog
 
     log.debug("Calling getTableAclPolicies succeeded");
     return aclPolicies;
+  }
+
+  @Override
+  public ColumnEntitlementsDto getColumnEntitlements(TableIdentifier tableIdentifier) {
+    log.info("Calling getColumnEntitlements with identifier: {}", tableIdentifier.toString());
+    if (tableIdentifier.namespace().levels().length > 1) {
+      throw new ValidationException(
+          "Input namespace has more than one levels "
+              + String.join(".", tableIdentifier.namespace().levels()));
+    }
+    GetColumnEntitlementsResponseBody responseBody =
+        tableApi
+            .getColumnEntitlementsV1(tableIdentifier.namespace().toString(), tableIdentifier.name())
+            .onErrorResume(
+                WebClientResponseException.class,
+                e -> Mono.error(new WebClientResponseWithMessageException(e)))
+            .onErrorResume(
+                WebClientRequestException.class,
+                e -> Mono.error(new WebClientRequestWithMessageException(e)))
+            .blockOptional()
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Empty column entitlements response for " + tableIdentifier));
+
+    log.debug("Calling getColumnEntitlements succeeded");
+    return new ColumnEntitlementsDto(
+        Optional.ofNullable(responseBody.getGrantedTags()).orElse(Collections.emptyList()),
+        Optional.ofNullable(responseBody.getRestrictedColumns()).orElse(Collections.emptyList()));
   }
 
   @Override

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/api/SupportsColumnEntitlements.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/api/SupportsColumnEntitlements.java
@@ -1,0 +1,36 @@
+package com.linkedin.openhouse.javaclient.api;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.apache.iceberg.catalog.TableIdentifier;
+
+/**
+ * Catalogs implementing this interface can resolve the column-level read entitlements of the
+ * calling principal, which lets a query engine mask the columns the caller is not allowed to read.
+ *
+ * <p>The catalog is the policy decision point: it owns both the policy tags attached to columns and
+ * the grants held by principals, so the engine never has to reason about roles or tags itself.
+ */
+public interface SupportsColumnEntitlements {
+
+  @AllArgsConstructor
+  @Getter
+  @EqualsAndHashCode
+  class ColumnEntitlementsDto {
+    /** Policy tags present on the table that the caller is entitled to read. */
+    List<String> grantedTags;
+
+    /** Columns the caller must not read; the engine is expected to mask or reject them. */
+    List<String> restrictedColumns;
+  }
+
+  /**
+   * Resolves the calling principal's column entitlements on an OH table.
+   *
+   * @param tableIdentifier identifier for the table, ex: db.table
+   * @return granted tags and restricted columns for the caller
+   */
+  ColumnEntitlementsDto getColumnEntitlements(TableIdentifier tableIdentifier);
+}

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/mapper/Privileges.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/mapper/Privileges.java
@@ -1,6 +1,7 @@
 package com.linkedin.openhouse.javaclient.mapper;
 
 import java.util.Arrays;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -11,7 +12,9 @@ public enum Privileges {
   DESCRIBE("DESCRIBE", "TABLE_VIEWER"),
   GRANT_REVOKE("MANAGE GRANTS", "ACL_EDITOR"),
   ALTER("ALTER", "TABLE_ADMIN"),
-  CREATE_TABLE("CREATE TABLE", "TABLE_CREATOR");
+  CREATE_TABLE("CREATE TABLE", "TABLE_CREATOR"),
+  SELECT_PII("SELECT PII", "PII_VIEWER"),
+  SELECT_HC("SELECT HC", "HC_VIEWER");
 
   private final String privilege;
   private final String role;
@@ -20,13 +23,26 @@ public enum Privileges {
     return Arrays.stream(Privileges.values())
         .filter(x -> x.getPrivilege().equals(privilegeString))
         .findFirst()
-        .get();
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    String.format(
+                        "Unsupported privilege '%s', expected one of %s",
+                        privilegeString, supportedPrivileges())));
   }
 
   public static Privileges fromRole(String roleString) {
     return Arrays.stream(Privileges.values())
         .filter(x -> x.getRole().equals(roleString))
         .findFirst()
-        .get();
+        .orElseThrow(
+            () -> new IllegalArgumentException(String.format("Unsupported role '%s'", roleString)));
+  }
+
+  private static String supportedPrivileges() {
+    return Arrays.stream(Privileges.values())
+        .map(Privileges::getPrivilege)
+        .distinct()
+        .collect(Collectors.joining(", "));
   }
 }

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/ColumnAclStatementTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/ColumnAclStatementTest.java
@@ -1,0 +1,285 @@
+package com.linkedin.openhouse.spark.statementtest;
+
+import com.google.common.collect.ImmutableList;
+import com.linkedin.openhouse.javaclient.api.SupportsColumnEntitlements;
+import java.nio.file.Files;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+/** Verifies that columns the principal is not entitled to read are masked out of query results. */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ColumnAclStatementTest {
+
+  private static final String TAGGED_POLICIES =
+      "{\"columnTags\":{\"ssn\":{\"tags\":[\"PII\"]},\"salary\":{\"tags\":[\"HC\"]}}}";
+
+  private static SparkSession spark = null;
+
+  @Test
+  public void testRestrictedColumnIsMasked() {
+    ColumnAclHadoopCatalog.restrictedColumns = ImmutableList.of("ssn");
+
+    List<Row> rows = spark.sql("SELECT id, ssn, salary FROM openhouse.db.tagged").collectAsList();
+
+    Assertions.assertEquals(1, rows.size());
+    Assertions.assertEquals(1L, rows.get(0).getLong(0));
+    Assertions.assertTrue(rows.get(0).isNullAt(1), "Restricted column should be masked");
+    Assertions.assertEquals(100L, rows.get(0).getLong(2), "Granted column should be readable");
+  }
+
+  @Test
+  public void testMultipleRestrictedColumnsAreMasked() {
+    ColumnAclHadoopCatalog.restrictedColumns = ImmutableList.of("ssn", "salary");
+
+    List<Row> rows = spark.sql("SELECT * FROM openhouse.db.tagged").collectAsList();
+
+    Assertions.assertEquals(1, rows.size());
+    Assertions.assertEquals(1L, rows.get(0).getLong(0));
+    Assertions.assertTrue(rows.get(0).isNullAt(1));
+    Assertions.assertTrue(rows.get(0).isNullAt(2));
+  }
+
+  @Test
+  public void testMaskingIsCaseInsensitiveOnColumnName() {
+    ColumnAclHadoopCatalog.restrictedColumns = ImmutableList.of("SSN");
+
+    List<Row> rows = spark.sql("SELECT ssn FROM openhouse.db.tagged").collectAsList();
+
+    Assertions.assertTrue(rows.get(0).isNullAt(0));
+  }
+
+  @Test
+  public void testNothingRestrictedLeavesResultsIntact() {
+    ColumnAclHadoopCatalog.restrictedColumns = ImmutableList.of();
+
+    List<Row> rows = spark.sql("SELECT id, ssn, salary FROM openhouse.db.tagged").collectAsList();
+
+    Assertions.assertEquals("123-45-6789", rows.get(0).getString(1));
+    Assertions.assertEquals(100L, rows.get(0).getLong(2));
+  }
+
+  /**
+   * A filter on a restricted column must be evaluated against the mask, not against the stored
+   * value, otherwise the value could be recovered by probing it one predicate at a time.
+   */
+  @Test
+  public void testFilterOnRestrictedColumnMatchesNothing() {
+    ColumnAclHadoopCatalog.restrictedColumns = ImmutableList.of("ssn");
+
+    List<Row> rows =
+        spark.sql("SELECT id FROM openhouse.db.tagged WHERE ssn = '123-45-6789'").collectAsList();
+
+    Assertions.assertTrue(rows.isEmpty(), "Restricted column must not be usable as a predicate");
+  }
+
+  /** Masking must survive being carried through another table, e.g. via CTAS. */
+  @Test
+  public void testCtasCopiesMaskedValues() {
+    ColumnAclHadoopCatalog.restrictedColumns = ImmutableList.of("ssn");
+
+    spark.sql(
+        "CREATE TABLE openhouse.db.copied USING iceberg AS SELECT * FROM openhouse.db.tagged");
+    List<Row> rows = spark.sql("SELECT id, ssn FROM openhouse.db.copied").collectAsList();
+
+    Assertions.assertEquals(1, rows.size());
+    Assertions.assertTrue(rows.get(0).isNullAt(1), "Restricted column must not be copied out");
+  }
+
+  /** Writes must land in the table untouched; only the query feeding them is subject to masking. */
+  @Test
+  public void testInsertIntoRestrictedColumnIsNotMasked() {
+    ColumnAclHadoopCatalog.restrictedColumns = ImmutableList.of("ssn");
+
+    spark.sql("INSERT INTO openhouse.db.tagged VALUES (2, '987-65-4321', 200)");
+
+    ColumnAclHadoopCatalog.restrictedColumns = ImmutableList.of();
+    List<Row> rows = spark.sql("SELECT ssn FROM openhouse.db.tagged WHERE id = 2").collectAsList();
+    Assertions.assertEquals("987-65-4321", rows.get(0).getString(0));
+  }
+
+  /** A table without column tags must not trigger a catalog call at all. */
+  @Test
+  public void testUntaggedTableIsNotResolved() {
+    ColumnAclHadoopCatalog.restrictedColumns = ImmutableList.of("ssn");
+    ColumnAclHadoopCatalog.resolveCount = 0;
+
+    List<Row> rows = spark.sql("SELECT id, ssn FROM openhouse.db.untagged").collectAsList();
+
+    Assertions.assertEquals("123-45-6789", rows.get(0).getString(1));
+    Assertions.assertEquals(0, ColumnAclHadoopCatalog.resolveCount);
+  }
+
+  /**
+   * A tagged table read while column ACLs are switched off must still be masked once re-enabled.
+   */
+  @Test
+  public void testDisabledConfigSkipsMasking() {
+    ColumnAclHadoopCatalog.restrictedColumns = ImmutableList.of("ssn");
+    spark.conf().set("spark.openhouse.columnAcl.enabled", "false");
+    try {
+      List<Row> rows = spark.sql("SELECT ssn FROM openhouse.db.tagged").collectAsList();
+      Assertions.assertEquals("123-45-6789", rows.get(0).getString(0));
+    } finally {
+      spark.conf().set("spark.openhouse.columnAcl.enabled", "true");
+    }
+  }
+
+  /** A tagged table in a catalog that cannot resolve entitlements must fail rather than expose. */
+  @Test
+  public void testTaggedTableInCatalogWithoutEntitlementsFails() {
+    Exception exception =
+        Assertions.assertThrows(
+            Exception.class, () -> spark.sql("SELECT ssn FROM nonacl.db.tagged").collectAsList());
+
+    Assertions.assertTrue(
+        messageChain(exception).contains("cannot resolve column entitlements"),
+        "Expected a fail-closed error, got: " + messageChain(exception));
+  }
+
+  /** Joining on a restricted column must compare masks, not the underlying values. */
+  @Test
+  public void testJoinOnRestrictedColumnMatchesNothing() {
+    ColumnAclHadoopCatalog.restrictedColumns = ImmutableList.of("ssn");
+
+    List<Row> rows =
+        spark
+            .sql(
+                "SELECT l.id FROM openhouse.db.tagged l JOIN openhouse.db.tagged r "
+                    + "ON l.ssn = r.ssn")
+            .collectAsList();
+
+    Assertions.assertTrue(rows.isEmpty());
+  }
+
+  /** Aggregates must see the mask, so a restricted column contributes nothing. */
+  @Test
+  public void testAggregateOverRestrictedColumn() {
+    ColumnAclHadoopCatalog.restrictedColumns = ImmutableList.of("ssn");
+
+    List<Row> rows =
+        spark
+            .sql("SELECT count(ssn) AS c, count(id) AS i FROM openhouse.db.tagged")
+            .collectAsList();
+
+    Assertions.assertEquals(0L, rows.get(0).getLong(0));
+    Assertions.assertEquals(1L, rows.get(0).getLong(1));
+  }
+
+  /** Masking must not be escapable by wrapping the read in a subquery or CTE. */
+  @Test
+  public void testMaskingSurvivesSubquery() {
+    ColumnAclHadoopCatalog.restrictedColumns = ImmutableList.of("ssn");
+
+    List<Row> rows =
+        spark
+            .sql(
+                "WITH t AS (SELECT id, ssn FROM openhouse.db.tagged) "
+                    + "SELECT ssn FROM t WHERE id = 1")
+            .collectAsList();
+
+    Assertions.assertTrue(rows.get(0).isNullAt(0));
+  }
+
+  /** The DataFrame API resolves against an already analyzed plan, so masking must be stable. */
+  @Test
+  public void testMaskingIsStableAcrossDataFrameOperations() {
+    ColumnAclHadoopCatalog.restrictedColumns = ImmutableList.of("ssn");
+
+    List<Row> rows = spark.table("openhouse.db.tagged").select("ssn", "salary").collectAsList();
+
+    Assertions.assertTrue(rows.get(0).isNullAt(0));
+    Assertions.assertEquals(100L, rows.get(0).getLong(1));
+  }
+
+  private static String messageChain(Throwable throwable) {
+    StringBuilder builder = new StringBuilder();
+    for (Throwable current = throwable; current != null; current = current.getCause()) {
+      builder.append(current.getMessage()).append('\n');
+    }
+    return builder.toString();
+  }
+
+  @SneakyThrows
+  @BeforeAll
+  public void setupSpark() {
+    Path unittest = new Path(Files.createTempDirectory("unittest").toString());
+    Path nonAclWarehouse = new Path(Files.createTempDirectory("nonacl").toString());
+    spark =
+        SparkSession.builder()
+            .master("local[2]")
+            .config(
+                "spark.sql.extensions",
+                ("org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,"
+                    + "com.linkedin.openhouse.spark.extensions.OpenhouseSparkSessionExtensions"))
+            .config("spark.sql.catalog.openhouse", "org.apache.iceberg.spark.SparkCatalog")
+            .config(
+                "spark.sql.catalog.openhouse.catalog-impl",
+                "com.linkedin.openhouse.spark.statementtest.ColumnAclStatementTest$ColumnAclHadoopCatalog")
+            .config("spark.sql.catalog.openhouse.warehouse", unittest.toString())
+            // A catalog with no notion of column entitlements, used to check the fail-closed path.
+            .config("spark.sql.catalog.nonacl", "org.apache.iceberg.spark.SparkCatalog")
+            .config("spark.sql.catalog.nonacl.type", "hadoop")
+            .config("spark.sql.catalog.nonacl.warehouse", nonAclWarehouse.toString())
+            // The resolver caches decisions, which would otherwise leak between test cases.
+            .config("spark.openhouse.columnAcl.cacheTtlSeconds", "0")
+            .getOrCreate();
+  }
+
+  @BeforeEach
+  public void setup() {
+    ColumnAclHadoopCatalog.restrictedColumns = ImmutableList.of();
+    ColumnAclHadoopCatalog.resolveCount = 0;
+    spark.sql(
+        String.format(
+            "CREATE TABLE openhouse.db.tagged (id bigint, ssn string, salary bigint) USING iceberg "
+                + "TBLPROPERTIES ('openhouse.tableId'='tagged', 'policies'='%s')",
+            TAGGED_POLICIES));
+    spark.sql("INSERT INTO openhouse.db.tagged VALUES (1, '123-45-6789', 100)");
+    spark.sql(
+        "CREATE TABLE openhouse.db.untagged (id bigint, ssn string) USING iceberg "
+            + "TBLPROPERTIES ('openhouse.tableId'='untagged')");
+    spark.sql("INSERT INTO openhouse.db.untagged VALUES (1, '123-45-6789')");
+    spark.sql(
+        String.format(
+            "CREATE TABLE nonacl.db.tagged (id bigint, ssn string) USING iceberg "
+                + "TBLPROPERTIES ('openhouse.tableId'='tagged', 'policies'='%s')",
+            TAGGED_POLICIES));
+  }
+
+  @AfterEach
+  public void tearDown() {
+    spark.sql("DROP TABLE IF EXISTS openhouse.db.tagged");
+    spark.sql("DROP TABLE IF EXISTS openhouse.db.untagged");
+    spark.sql("DROP TABLE IF EXISTS openhouse.db.copied");
+    spark.sql("DROP TABLE IF EXISTS nonacl.db.tagged");
+  }
+
+  @AfterAll
+  public void tearDownSpark() {
+    spark.close();
+  }
+
+  public static class ColumnAclHadoopCatalog extends HadoopCatalog
+      implements SupportsColumnEntitlements {
+    public static List<String> restrictedColumns = ImmutableList.of();
+    public static int resolveCount = 0;
+
+    @Override
+    public ColumnEntitlementsDto getColumnEntitlements(TableIdentifier tableIdentifier) {
+      resolveCount++;
+      return new ColumnEntitlementsDto(ImmutableList.of(), restrictedColumns);
+    }
+  }
+}

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/GrantRevokeStatementTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/statementtest/GrantRevokeStatementTest.java
@@ -48,6 +48,28 @@ public class GrantRevokeStatementTest {
   }
 
   @Test
+  public void testGrantColumnLevelPrivilege() {
+    for (String privilege : ImmutableList.of("SELECT PII", "SELECT HC")) {
+      spark.sql(String.format("GRANT %s ON TABLE openhouse.db.table TO sraikar", privilege));
+      assertPlanValid(true, "TABLE", "db.table", privilege, "sraikar");
+    }
+  }
+
+  @Test
+  public void testRevokeColumnLevelPrivilege() {
+    for (String privilege : ImmutableList.of("SELECT PII", "SELECT HC")) {
+      spark.sql(String.format("REVOKE %s ON TABLE openhouse.db.table FROM sraikar", privilege));
+      assertPlanValid(false, "TABLE", "db.table", privilege, "sraikar");
+    }
+  }
+
+  @Test
+  public void testGrantColumnLevelPrivilegeLowerCase() {
+    spark.sql("grant select pii on table openhouse.db.table to sraikar");
+    assertPlanValid(true, "TABLE", "db.table", "SELECT PII", "sraikar");
+  }
+
+  @Test
   public void testSimpleGrantLowerCase() {
     spark.sql("grant select on table openhouse.db.table to sraikar");
     assertPlanValid(true, "TABLE", "db.table", "SELECT", "sraikar");

--- a/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/acl/ColumnAclRule.scala
+++ b/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/acl/ColumnAclRule.scala
@@ -1,0 +1,120 @@
+package com.linkedin.openhouse.spark.acl
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, ExprId, Literal, NamedExpression}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project, V2WriteCommand}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreeNodeTag
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+
+/**
+ * Masks the columns of an OpenHouse table that the current principal is not entitled to read.
+ *
+ * Every restricted column is replaced by a typed `NULL` directly above the relation that produces
+ * it, which is the only position that closes the whole surface at once: filters, joins, aggregates
+ * and `CREATE TABLE AS SELECT` all consume the masked values, so a restricted column cannot leak
+ * through `WHERE ssn = '...'` or by being copied into another table. Masking the final projection
+ * instead would leave every one of those paths open.
+ *
+ * The masks deliberately carry fresh expression ids, and every reference above the relation is
+ * repointed at them. Reusing the original ids would make the masking projection indistinguishable
+ * from its child, and the optimizer discards such projections as redundant.
+ *
+ * Because masking happens at the relation, a restricted column referenced explicitly and one merely
+ * covered by `SELECT *` are indistinguishable here; both yield `NULL` rather than an error.
+ */
+case class ColumnAclRule(spark: SparkSession) extends Rule[LogicalPlan] {
+
+  private lazy val resolver: ColumnEntitlementsResolver =
+    new ColumnEntitlementsResolver(
+      spark.conf
+        .get(ColumnAclRule.CacheTtlSecondsConf, ColumnAclRule.CacheTtlSecondsDefault)
+        .toLong * 1000L)
+
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    if (!enabled) plan else rewrite(plan)._1
+  }
+
+  private def enabled: Boolean =
+    spark.conf.get(ColumnAclRule.EnabledConf, ColumnAclRule.EnabledDefault).toBoolean
+
+  /**
+   * Rewrites `plan`, returning it alongside the masks introduced underneath it, keyed by the
+   * expression id each one replaces so that ancestors can be repointed at them.
+   */
+  private def rewrite(plan: LogicalPlan): (LogicalPlan, Map[ExprId, Attribute]) = plan match {
+    // The write target denotes the destination schema rather than data being read, and it has to
+    // remain a NamedRelation, so only the query feeding the write is rewritten. Row level commands
+    // that genuinely read the target do so through relations inside that query.
+    case write: V2WriteCommand =>
+      val (query, masked) = rewrite(write.query)
+      (repoint(write.withNewQuery(query), masked), masked)
+
+    case relation: DataSourceV2Relation =>
+      mask(relation)
+
+    case other =>
+      val rewritten = other.children.map(rewrite)
+      val masked = rewritten.flatMap(_._2).toMap
+      (repoint(other.withNewChildren(rewritten.map(_._1)), masked), masked)
+  }
+
+  private def mask(relation: DataSourceV2Relation): (LogicalPlan, Map[ExprId, Attribute]) = {
+    val unmasked = (relation, Map.empty[ExprId, Attribute])
+    if (relation.getTagValue(ColumnAclRule.MaskedTag).isDefined) {
+      return unmasked
+    }
+    val identifier = relation.identifier.orNull
+    val catalog = relation.catalog.orNull
+    if (identifier == null || catalog == null || relation.table == null) {
+      return unmasked
+    }
+
+    val restricted = resolver.restrictedColumns(catalog, identifier, relation.table)
+    if (restricted.isEmpty) {
+      return unmasked
+    }
+
+    val projectList: Seq[NamedExpression] = relation.output.map { attr =>
+      if (restricted.exists(_.equalsIgnoreCase(attr.name))) {
+        Alias(Literal(null, attr.dataType), attr.name)(qualifier = attr.qualifier)
+      } else {
+        attr
+      }
+    }
+    val masked = projectList
+      .zip(relation.output)
+      .collect { case (alias: Alias, attr) => attr.exprId -> alias.toAttribute }
+      .toMap
+
+    relation.setTagValue(ColumnAclRule.MaskedTag, true)
+    (Project(projectList, relation), masked)
+  }
+
+  /** Points this node's own references at the masks that replaced them further down the plan. */
+  private def repoint(plan: LogicalPlan, masked: Map[ExprId, Attribute]): LogicalPlan = {
+    if (masked.isEmpty) {
+      plan
+    } else {
+      plan.transformExpressions {
+        case attr: AttributeReference if masked.contains(attr.exprId) => masked(attr.exprId)
+      }
+    }
+  }
+}
+
+object ColumnAclRule {
+
+  /** Set to false to stop masking restricted columns, e.g. while debugging a policy. */
+  val EnabledConf = "spark.openhouse.columnAcl.enabled"
+
+  val EnabledDefault = "true"
+
+  /** How long a resolved entitlement is reused before the catalog is asked again. */
+  val CacheTtlSecondsConf = "spark.openhouse.columnAcl.cacheTtlSeconds"
+
+  val CacheTtlSecondsDefault = "30"
+
+  /** Marks relations already wrapped in a mask so repeated analysis does not stack projections. */
+  private val MaskedTag = TreeNodeTag[Boolean]("openhouse.columnAcl.masked")
+}

--- a/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/acl/ColumnEntitlementsResolver.scala
+++ b/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/acl/ColumnEntitlementsResolver.scala
@@ -1,0 +1,116 @@
+package com.linkedin.openhouse.spark.acl
+
+import java.util.concurrent.ConcurrentHashMap
+
+import com.linkedin.openhouse.javaclient.api.SupportsColumnEntitlements
+import com.linkedin.openhouse.spark.sql.execution.datasources.v2.mapper.IcebergCatalogMapper
+import org.apache.iceberg.spark.Spark3Util
+import org.apache.spark.sql.connector.catalog.{CatalogPlugin, Identifier, Table, TableCatalog}
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
+
+/**
+ * Resolves which columns of an OpenHouse table the current principal must not read.
+ *
+ * The catalog is the policy decision point: it holds both the policy tags attached to columns and
+ * the grants held by principals, and returns the already-resolved answer. Spark only applies it.
+ */
+private[acl] class ColumnEntitlementsResolver(cacheTtlMillis: Long) {
+
+  private val log = LoggerFactory.getLogger(classOf[ColumnEntitlementsResolver])
+
+  private val cache = new ConcurrentHashMap[String, ColumnEntitlementsResolver.CacheEntry]()
+
+  /**
+   * Restricted columns for `identifier`, or an empty set when the table carries no column tags.
+   *
+   * Tables without tags are answered locally from the table properties, so the common case costs
+   * no catalog round trip and deployments whose catalog predates column ACLs keep working.
+   */
+  def restrictedColumns(
+      catalog: CatalogPlugin,
+      identifier: Identifier,
+      table: Table): Set[String] = {
+    if (!ColumnEntitlementsResolver.isEligible(table)) {
+      Set.empty
+    } else {
+      val key = s"${catalog.name()}.${identifier.toString}"
+      val now = System.currentTimeMillis()
+      Option(cache.get(key)).filter(_.expiresAt > now) match {
+        case Some(entry) => entry.restrictedColumns
+        case None =>
+          val resolved = fetch(catalog, identifier)
+          if (cacheTtlMillis > 0) {
+            cache.put(key, ColumnEntitlementsResolver.CacheEntry(resolved, now + cacheTtlMillis))
+          }
+          resolved
+      }
+    }
+  }
+
+  /**
+   * Asks the catalog for the caller's entitlements.
+   *
+   * Failures are propagated rather than swallowed: the table is known to carry restricted columns,
+   * so being unable to establish what the caller may read must not result in reading everything.
+   */
+  private def fetch(catalog: CatalogPlugin, identifier: Identifier): Set[String] = {
+    val icebergCatalog = catalog match {
+      case tableCatalog: TableCatalog => IcebergCatalogMapper.toIcebergCatalog(tableCatalog)
+      case _ => null
+    }
+    icebergCatalog match {
+      case entitlements: SupportsColumnEntitlements =>
+        val dto =
+          entitlements.getColumnEntitlements(Spark3Util.identifierToTableIdentifier(identifier))
+        val restricted =
+          Option(dto.getRestrictedColumns).map(_.asScala.toSet).getOrElse(Set.empty[String])
+        if (restricted.nonEmpty) {
+          log.info(
+            s"OpenHouse column ACL restricts columns [${restricted.mkString(", ")}] on table " +
+              s"$identifier for the current principal")
+        }
+        restricted
+      case _ =>
+        throw new IllegalStateException(
+          s"Table '$identifier' carries column policy tags but catalog '${catalog.name()}' cannot " +
+            "resolve column entitlements, so restricted columns cannot be masked")
+    }
+  }
+}
+
+private[acl] object ColumnEntitlementsResolver {
+
+  private val PoliciesProperty = "policies"
+
+  private val TableIdProperty = "openhouse.tableId"
+
+  private val ColumnTagsField = "columnTags"
+
+  case class CacheEntry(restrictedColumns: Set[String], expiresAt: Long)
+
+  /**
+   * Whether the table is an OpenHouse table that declares at least one column policy tag.
+   *
+   * Restricting this to OpenHouse tables keeps tables from other catalogs, which have no notion of
+   * column entitlements, out of the fail closed path below.
+   *
+   * The tag check is deliberately textual and errs towards `true`: a false positive only costs a
+   * catalog call, whereas a false negative would skip masking altogether.
+   */
+  def isEligible(table: Table): Boolean = {
+    val properties = Option(table.properties())
+    properties.exists(_.containsKey(TableIdProperty)) && properties
+      .flatMap(props => Option(props.get(PoliciesProperty)))
+      .exists { value =>
+        val index = value.indexOf(ColumnTagsField)
+        if (index < 0) {
+          false
+        } else {
+          val remainder = value.substring(index + ColumnTagsField.length).replaceAll("[\"\\s:]", "")
+          !remainder.startsWith("{}") && !remainder.startsWith("null")
+        }
+      }
+  }
+}

--- a/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/extensions/OpenhouseSparkSessionExtensions.scala
+++ b/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/extensions/OpenhouseSparkSessionExtensions.scala
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.spark.extensions
 
+import com.linkedin.openhouse.spark.acl.ColumnAclRule
 import com.linkedin.openhouse.spark.sql.catalyst.parser.extensions.OpenhouseSparkSqlExtensionsParser
 import com.linkedin.openhouse.spark.sql.execution.datasources.v2.OpenhouseDataSourceV2Strategy
 import org.apache.spark.sql.SparkSessionExtensions
@@ -8,5 +9,6 @@ class OpenhouseSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
   override def apply(extensions: SparkSessionExtensions): Unit = {
     extensions.injectParser { case (_, parser) => new OpenhouseSparkSqlExtensionsParser(parser) }
     extensions.injectPlannerStrategy( spark => OpenhouseDataSourceV2Strategy(spark))
+    extensions.injectPostHocResolutionRule( spark => ColumnAclRule(spark))
   }
 }

--- a/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensionsAstBuilder.scala
+++ b/integrations/spark/spark-3.1/openhouse-spark-runtime/src/main/scala/com/linkedin/openhouse/spark/sql/catalyst/parser/extensions/OpenhouseSqlExtensionsAstBuilder.scala
@@ -76,7 +76,21 @@ class OpenhouseSqlExtensionsAstBuilder (delegate: ParserInterface) extends Openh
   }
 
   override def visitPrivilege(ctx: PrivilegeContext): String = {
-    ctx.getText.toUpperCase
+    if (ctx.columnLevelPrivilege() != null) {
+      typedVisit[String](ctx.columnLevelPrivilege())
+    } else {
+      ctx.getText.toUpperCase
+    }
+  }
+
+  /**
+   * Renders a column-level privilege as `SELECT <TAG>`.
+   *
+   * The tokens cannot be recovered with `ctx.getText` because whitespace is emitted on the hidden
+   * channel, which would collapse `SELECT PII` into `SELECTPII`.
+   */
+  override def visitColumnLevelPrivilege(ctx: ColumnLevelPrivilegeContext): String = {
+    s"${ctx.SELECT().getText.toUpperCase} ${ctx.policyTag().getText.toUpperCase}"
   }
 
   override def visitGrantableResource(ctx: GrantableResourceContext): (GrantableResourceType, Seq[String]) = {

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/TablesApiHandler.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/TablesApiHandler.java
@@ -7,6 +7,7 @@ import com.linkedin.openhouse.tables.api.spec.v0.request.UpdateAclPoliciesReques
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAclPoliciesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllSoftDeletedTablesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllTablesResponseBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetColumnEntitlementsResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
 import java.util.List;
 
@@ -150,6 +151,18 @@ public interface TablesApiHandler {
    */
   ApiResponse<GetAclPoliciesResponseBody> getAclPoliciesForUserPrincipal(
       String databaseId, String tableId, String actingPrincipal, String userPrincipal);
+
+  /**
+   * Function to resolve the column-level read entitlements of actingPrincipal on a Table Resource
+   * identified by tableId in a given databaseId.
+   *
+   * @param databaseId
+   * @param tableId
+   * @param actingPrincipal authenticated caller whose entitlements are resolved
+   * @return granted policy tags and restricted columns for the caller
+   */
+  ApiResponse<GetColumnEntitlementsResponseBody> getColumnEntitlements(
+      String databaseId, String tableId, String actingPrincipal);
 
   /**
    * @param databaseId

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/impl/OpenHouseTablesApiHandler.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/impl/OpenHouseTablesApiHandler.java
@@ -9,6 +9,7 @@ import com.linkedin.openhouse.tables.api.spec.v0.request.UpdateAclPoliciesReques
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAclPoliciesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllSoftDeletedTablesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllTablesResponseBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetColumnEntitlementsResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
 import com.linkedin.openhouse.tables.api.validator.TablesApiValidator;
 import com.linkedin.openhouse.tables.dto.mapper.TablesMapper;
@@ -174,6 +175,16 @@ public class OpenHouseTablesApiHandler implements TablesApiHandler {
                         .stream()
                         .collect(Collectors.toList()))
                 .build())
+        .build();
+  }
+
+  @Override
+  public ApiResponse<GetColumnEntitlementsResponseBody> getColumnEntitlements(
+      String databaseId, String tableId, String actingPrincipal) {
+    tablesApiValidator.validateGetAclPolicies(databaseId, tableId);
+    return ApiResponse.<GetColumnEntitlementsResponseBody>builder()
+        .httpStatus(HttpStatus.OK)
+        .responseBody(tableService.getColumnEntitlements(databaseId, tableId, actingPrincipal))
         .build();
   }
 

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/response/GetColumnEntitlementsResponseBody.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/response/GetColumnEntitlementsResponseBody.java
@@ -1,0 +1,37 @@
+package com.linkedin.openhouse.tables.api.spec.v0.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.Gson;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Effective column-level read entitlements of the authenticated caller on a table.
+ *
+ * <p>The catalog resolves the caller's grants against the policy tags carried by the table's
+ * columns and returns the outcome, so that query engines never have to reason about roles
+ * themselves.
+ */
+@Builder
+@Value
+public class GetColumnEntitlementsResponseBody {
+  @Schema(
+      description = "Policy tags present on the table that the caller is entitled to read",
+      example = "[\"PII\"]")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private List<String> grantedTags;
+
+  @Schema(
+      description =
+          "Columns the caller is not entitled to read. A tagged column is restricted unless the "
+              + "caller holds a grant for every tag on that column.",
+      example = "[\"ssn\"]")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private List<String> restrictedColumns;
+
+  public String toJson() {
+    return new Gson().toJson(this);
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/authorization/Privileges.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/authorization/Privileges.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.tables.authorization;
 
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -16,7 +17,9 @@ public enum Privileges {
   UPDATE_ACL(Privilege.UPDATE_ACL),
   SYSTEM_ADMIN(Privilege.SYSTEM_ADMIN),
   LOCK_ADMIN(Privilege.LOCK_ADMIN),
-  SELECT(Privilege.SELECT);
+  SELECT(Privilege.SELECT),
+  SELECT_PII(Privilege.SELECT_PII),
+  SELECT_HC(Privilege.SELECT_HC);
 
   private String privilege;
 
@@ -33,6 +36,23 @@ public enum Privileges {
     return privilege;
   }
 
+  /**
+   * Resolves the column-level read privilege guarding columns tagged with {@code tagName}, e.g.
+   * {@code PII} maps to {@link #SELECT_PII}.
+   *
+   * @param tagName name of a {@link
+   *     com.linkedin.openhouse.tables.api.spec.v0.request.components.PolicyTag.Tag}
+   * @return the privilege guarding the tag
+   */
+  public static Privileges forPolicyTag(String tagName) {
+    try {
+      return Privileges.valueOf("SELECT_" + tagName.toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          String.format("No column-level privilege is defined for policy tag '%s'", tagName), e);
+    }
+  }
+
   public static class Privilege {
     public static final String CREATE_TABLE = "CREATE_TABLE";
     public static final String UPDATE_TABLE_METADATA = "UPDATE_TABLE_METADATA";
@@ -43,6 +63,16 @@ public enum Privileges {
     public static final String LOCK_ADMIN = "LOCK_ADMIN";
 
     public static final String SELECT = "SELECT";
+
+    /**
+     * Column-level read privileges. Each one authorizes reading the columns carrying the
+     * correspondingly named policy tag, see {@link
+     * com.linkedin.openhouse.tables.api.spec.v0.request.components.PolicyTag.Tag}.
+     */
+    public static final String SELECT_PII = "SELECT_PII";
+
+    public static final String SELECT_HC = "SELECT_HC";
+
     private static final Set<String> SUPPORTED_PRIVILEGES =
         Stream.of(Privileges.values()).map(Privileges::getPrivilege).collect(Collectors.toSet());
 

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/TablesController.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/TablesController.java
@@ -9,6 +9,7 @@ import com.linkedin.openhouse.tables.api.spec.v0.request.UpdateAclPoliciesReques
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAclPoliciesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllSoftDeletedTablesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllTablesResponseBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetColumnEntitlementsResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
 import com.linkedin.openhouse.tables.authorization.Privileges;
 import io.swagger.v3.oas.annotations.Operation;
@@ -362,6 +363,38 @@ public class TablesController {
     com.linkedin.openhouse.common.api.spec.ApiResponse<GetAclPoliciesResponseBody> apiResponse =
         tablesApiHandler.getAclPoliciesForUserPrincipal(
             databaseId, tableId, extractAuthenticatedUserPrincipal(), principal);
+    return new ResponseEntity<>(
+        apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
+  }
+
+  @Operation(
+      summary = "Get column entitlements for the caller on a Table",
+      description =
+          "Resolves the authenticated caller's grants against the policy tags on the table's "
+              + "columns and returns the granted tags plus the columns the caller may not read. "
+              + "Query engines use this to mask restricted columns.",
+      tags = {"Table"})
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "ColumnEntitlements GET: OK"),
+        @ApiResponse(responseCode = "400", description = "ColumnEntitlements GET: BAD_REQUEST"),
+        @ApiResponse(responseCode = "401", description = "ColumnEntitlements GET: UNAUTHORIZED"),
+        @ApiResponse(responseCode = "403", description = "ColumnEntitlements GET: FORBIDDEN"),
+        @ApiResponse(responseCode = "404", description = "ColumnEntitlements GET: TABLE_NOT_FOUND")
+      })
+  @GetMapping(
+      value = {
+        "/v0/databases/{databaseId}/tables/{tableId}/columnEntitlements",
+        "/v1/databases/{databaseId}/tables/{tableId}/columnEntitlements"
+      },
+      produces = {"application/json"})
+  public ResponseEntity<GetColumnEntitlementsResponseBody> getColumnEntitlements(
+      @Parameter(description = "Database ID", required = true) @PathVariable String databaseId,
+      @Parameter(description = "Table ID", required = true) @PathVariable String tableId) {
+    com.linkedin.openhouse.common.api.spec.ApiResponse<GetColumnEntitlementsResponseBody>
+        apiResponse =
+            tablesApiHandler.getColumnEntitlements(
+                databaseId, tableId, extractAuthenticatedUserPrincipal());
     return new ResponseEntity<>(
         apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
   }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesService.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesService.java
@@ -4,6 +4,7 @@ import com.linkedin.openhouse.internal.catalog.model.SoftDeletedTableDto;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateLockRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.UpdateAclPoliciesRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetColumnEntitlementsResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.components.AclPolicy;
 import com.linkedin.openhouse.tables.model.TableDto;
 import java.util.List;
@@ -139,6 +140,18 @@ public interface TablesService {
    */
   List<AclPolicy> getAclPolicies(
       String databaseId, String tableId, String actingPrincipal, String userPrincipal);
+
+  /**
+   * Given a databaseId and tableId, resolve the column-level read entitlements of actingPrincipal
+   * against the policy tags carried by the table's columns.
+   *
+   * @param databaseId
+   * @param tableId
+   * @param actingPrincipal authenticated caller whose entitlements are resolved
+   * @return granted policy tags and the columns the caller may not read
+   */
+  GetColumnEntitlementsResponseBody getColumnEntitlements(
+      String databaseId, String tableId, String actingPrincipal);
 
   /**
    * @param databaseId

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
@@ -16,6 +16,8 @@ import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableReques
 import com.linkedin.openhouse.tables.api.spec.v0.request.UpdateAclPoliciesRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.LockState;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.Policies;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.PolicyTag;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetColumnEntitlementsResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.components.AclPolicy;
 import com.linkedin.openhouse.tables.authorization.AuthorizationHandler;
 import com.linkedin.openhouse.tables.authorization.Privileges;
@@ -27,9 +29,15 @@ import com.linkedin.openhouse.tables.repository.OpenHouseInternalRepository;
 import com.linkedin.openhouse.tables.utils.AuthorizationUtils;
 import com.linkedin.openhouse.tables.utils.TableUUIDGenerator;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
@@ -324,6 +332,53 @@ public class TablesServiceImpl implements TablesService {
       String databaseId, String tableId, String actingPrincipal, String userPrincipal) {
     TableDto tableDto = getTableOrThrow(databaseId, tableId);
     return authorizationHandler.listAclPolicies(tableDto, userPrincipal);
+  }
+
+  @Override
+  public GetColumnEntitlementsResponseBody getColumnEntitlements(
+      String databaseId, String tableId, String actingPrincipal) {
+    TableDto tableDto = getTableOrThrow(databaseId, tableId);
+    authorizationUtils.checkTablePrivilege(
+        tableDto, actingPrincipal, Privileges.GET_TABLE_METADATA);
+
+    Map<String, PolicyTag> columnTags =
+        Optional.ofNullable(tableDto.getPolicies())
+            .map(Policies::getColumnTags)
+            .orElse(Collections.emptyMap());
+
+    Set<String> grantedTags =
+        columnTags.values().stream()
+            .flatMap(policyTag -> tagsOf(policyTag).stream())
+            .distinct()
+            .filter(
+                tag ->
+                    authorizationHandler.checkAccessDecision(
+                        actingPrincipal, tableDto, Privileges.forPolicyTag(tag)))
+            .collect(Collectors.toCollection(TreeSet::new));
+
+    // A column is readable only when every tag it carries has been granted; tags are additive
+    // restrictions rather than alternatives.
+    List<String> restrictedColumns =
+        columnTags.entrySet().stream()
+            .filter(entry -> !tagsOf(entry.getValue()).isEmpty())
+            .filter(entry -> !grantedTags.containsAll(tagsOf(entry.getValue())))
+            .map(Map.Entry::getKey)
+            .sorted()
+            .collect(Collectors.toList());
+
+    return GetColumnEntitlementsResponseBody.builder()
+        .grantedTags(new ArrayList<>(grantedTags))
+        .restrictedColumns(restrictedColumns)
+        .build();
+  }
+
+  /** Tag names carried by a {@link PolicyTag}, tolerating partially populated policy documents. */
+  private static Set<String> tagsOf(PolicyTag policyTag) {
+    return Optional.ofNullable(policyTag).map(PolicyTag::getTags).orElse(Collections.emptySet())
+        .stream()
+        .filter(Objects::nonNull)
+        .map(Enum::name)
+        .collect(Collectors.toCollection(TreeSet::new));
   }
 
   /**

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
@@ -19,7 +19,9 @@ import com.linkedin.openhouse.internal.catalog.model.SoftDeletedTableDto;
 import com.linkedin.openhouse.internal.catalog.model.SoftDeletedTablePrimaryKey;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateLockRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.UpdateAclPoliciesRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.PolicyTag;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.TimePartitionSpec;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetColumnEntitlementsResponseBody;
 import com.linkedin.openhouse.tables.authorization.AuthorizationHandler;
 import com.linkedin.openhouse.tables.authorization.Privileges;
 import com.linkedin.openhouse.tables.common.TableType;
@@ -35,6 +37,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.UUID;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Types;
@@ -496,6 +501,101 @@ public class TablesServiceTest {
         () ->
             tablesService.getAclPolicies(
                 TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER, TEST_USER_PRINCIPAL));
+  }
+
+  @Test
+  public void testGetColumnEntitlementsOnUntaggedTable() {
+    verifyPutTableRequest(TABLE_DTO, null, true);
+
+    GetColumnEntitlementsResponseBody response =
+        tablesService.getColumnEntitlements(
+            TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER);
+
+    Assertions.assertTrue(response.getGrantedTags().isEmpty());
+    Assertions.assertTrue(response.getRestrictedColumns().isEmpty());
+
+    tablesService.deleteTable(TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER);
+  }
+
+  @Test
+  public void testGetColumnEntitlementsWithAllTagsGranted() {
+    verifyPutTableRequest(taggedTable(), null, true);
+
+    GetColumnEntitlementsResponseBody response =
+        tablesService.getColumnEntitlements(
+            TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER);
+
+    Assertions.assertEquals(Arrays.asList("HC", "PII"), response.getGrantedTags());
+    Assertions.assertTrue(response.getRestrictedColumns().isEmpty());
+
+    tablesService.deleteTable(TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER);
+  }
+
+  @Test
+  public void testGetColumnEntitlementsRestrictsColumnsWithDeniedTag() {
+    verifyPutTableRequest(taggedTable(), null, true);
+    denyPrivilege(Privileges.SELECT_PII);
+
+    GetColumnEntitlementsResponseBody response =
+        tablesService.getColumnEntitlements(
+            TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER);
+
+    Assertions.assertEquals(Collections.singletonList("HC"), response.getGrantedTags());
+    // Both the PII-only column and the column carrying PII alongside a granted tag are restricted.
+    Assertions.assertEquals(Arrays.asList("both", "ssn"), response.getRestrictedColumns());
+
+    tablesService.deleteTable(TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER);
+  }
+
+  @Test
+  public void testGetColumnEntitlementsRestrictsEverythingWhenAllTagsDenied() {
+    verifyPutTableRequest(taggedTable(), null, true);
+    denyPrivilege(Privileges.SELECT_PII);
+    denyPrivilege(Privileges.SELECT_HC);
+
+    GetColumnEntitlementsResponseBody response =
+        tablesService.getColumnEntitlements(
+            TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER);
+
+    Assertions.assertTrue(response.getGrantedTags().isEmpty());
+    Assertions.assertEquals(
+        Arrays.asList("both", "salary", "ssn"), response.getRestrictedColumns());
+
+    tablesService.deleteTable(TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER);
+  }
+
+  @Test
+  public void testGetColumnEntitlementsOnTableThatDoesNotExist() {
+    Assertions.assertThrows(
+        NoSuchUserTableException.class,
+        () ->
+            tablesService.getColumnEntitlements(
+                TABLE_DTO.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER));
+  }
+
+  /** A table whose columns carry one PII column, one HC column and one column carrying both. */
+  private TableDto taggedTable() {
+    Map<String, PolicyTag> columnTags = new HashMap<>();
+    columnTags.put(
+        "ssn", PolicyTag.builder().tags(Collections.singleton(PolicyTag.Tag.PII)).build());
+    columnTags.put(
+        "salary", PolicyTag.builder().tags(Collections.singleton(PolicyTag.Tag.HC)).build());
+    columnTags.put(
+        "both",
+        PolicyTag.builder()
+            .tags(new HashSet<>(Arrays.asList(PolicyTag.Tag.PII, PolicyTag.Tag.HC)))
+            .build());
+    return TABLE_DTO
+        .toBuilder()
+        .policies(TABLE_POLICIES.toBuilder().columnTags(columnTags).build())
+        .build();
+  }
+
+  private void denyPrivilege(Privileges privilege) {
+    Mockito.when(
+            authorizationHandler.checkAccessDecision(
+                Mockito.any(), (TableDto) Mockito.any(), Mockito.eq(privilege)))
+        .thenReturn(false);
   }
 
   @Test

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/MockTablesApiHandler.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/MockTablesApiHandler.java
@@ -17,6 +17,7 @@ import com.linkedin.openhouse.tables.api.spec.v0.request.UpdateAclPoliciesReques
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAclPoliciesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllSoftDeletedTablesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllTablesResponseBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetColumnEntitlementsResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetSoftDeletedTableResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
 import java.util.ArrayList;
@@ -217,6 +218,26 @@ public class MockTablesApiHandler implements TablesApiHandler {
         return ApiResponse.<GetAclPoliciesResponseBody>builder()
             .httpStatus(HttpStatus.OK)
             .responseBody(RequestConstants.TEST_GET_ACL_POLICIES_RESPONSE_BODY)
+            .build();
+      case "d400":
+        throw new RequestValidationFailureException();
+      case "d404":
+        throw new NoSuchUserTableException(databaseId, "");
+      case "d503":
+        throw new AuthorizationServiceException("Internal authz service not available");
+      default:
+        return null;
+    }
+  }
+
+  @Override
+  public ApiResponse<GetColumnEntitlementsResponseBody> getColumnEntitlements(
+      String databaseId, String tableId, String actingPrincipal) {
+    switch (databaseId) {
+      case "d200":
+        return ApiResponse.<GetColumnEntitlementsResponseBody>builder()
+            .httpStatus(HttpStatus.OK)
+            .responseBody(RequestConstants.TEST_GET_COLUMN_ENTITLEMENTS_RESPONSE_BODY)
             .build();
       case "d400":
         throw new RequestValidationFailureException();

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/RequestConstants.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/RequestConstants.java
@@ -9,6 +9,7 @@ import com.linkedin.openhouse.tables.api.spec.v0.request.components.Policies;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAclPoliciesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllDatabasesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllTablesResponseBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetColumnEntitlementsResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetDatabaseResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.components.AclPolicy;
@@ -140,4 +141,10 @@ public final class RequestConstants {
 
   public static final CreateUpdateLockRequestBody TEST_UPDATE_LOCK_POLICIES_REQUEST_BODY =
       CreateUpdateLockRequestBody.builder().locked(true).message("").build();
+
+  public static final GetColumnEntitlementsResponseBody TEST_GET_COLUMN_ENTITLEMENTS_RESPONSE_BODY =
+      GetColumnEntitlementsResponseBody.builder()
+          .grantedTags(Collections.singletonList("HC"))
+          .restrictedColumns(Collections.singletonList("ssn"))
+          .build();
 }


### PR DESCRIPTION
## Summary
Column policy tags were metadata only: `ALTER TABLE ... MODIFY COLUMN c SET TAG=(PII)` recorded a tag that nothing ever consulted, and the grammar rule for `GRANT SELECT PII` was unreachable in practice because `visitPrivilege` read the context with `getText`, which drops the whitespace ANTLR puts on the hidden channel and produced `SELECTPII`. That string matched no privilege and failed a `findFirst().get()` with a bare NoSuchElementException. Tagging a column therefore protected nothing.

Make the tags enforceable end to end. The catalog is the decision point: it owns both the tags and the grants, so a new `columnEntitlements` endpoint resolves the caller's grants against the tags on each column and returns the columns the caller may not read. A column is restricted unless every tag on it is granted, since tags are additive restrictions rather than alternatives. Grants are expressed with the existing role machinery via PII_VIEWER and HC_VIEWER, so custom roles and OPA policies keep working unchanged.

Spark applies the decision by replacing each restricted column with a typed NULL directly above the relation that produces it. This is the only position that closes the whole surface at once: filters, joins, aggregates and CTAS all consume the masked values, so a restricted column cannot be recovered by probing it with `WHERE ssn = '...'` or by copying it into another table. Masking the final projection would leave every one of those paths open. Write targets are left alone, so INSERT still stores real values.

Restricted columns read as NULL rather than raising, because at the relation an explicit reference and one merely covered by `SELECT *` are indistinguishable, and failing would break `SELECT *` on any tagged table.

Tables without tags are answered from local table properties, so the common case costs no extra call and deployments whose catalog predates this endpoint keep working. A tagged table whose catalog cannot resolve entitlements fails the query rather than exposing the columns.

This remains a trusted-engine model: reading the underlying files directly still bypasses masking, as it already does for table-level ACLs.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
