### PR TITLE
Block stage-replace (RTAS) on locked tables

### DIFF
--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
@@ -111,6 +111,7 @@ public class TablesServiceImpl implements TablesService {
 
     // Special case handling
     if (tableDto.isPresent() && createUpdateTableRequestBody.isStageReplace()) {
+      checkIfLockPoliciesUpdated(tableDto.get(), createUpdateTableRequestBody);
       if (isTableLocked(tableDto.get())) {
         throw new UnsupportedClientOperationException(
             UnsupportedClientOperationException.Operation.LOCKED_TABLE_OPERATION,

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
@@ -111,6 +111,12 @@ public class TablesServiceImpl implements TablesService {
 
     // Special case handling
     if (tableDto.isPresent() && createUpdateTableRequestBody.isStageReplace()) {
+      if (isTableLocked(tableDto.get())) {
+        throw new UnsupportedClientOperationException(
+            UnsupportedClientOperationException.Operation.LOCKED_TABLE_OPERATION,
+            String.format(
+                "Table %s.%s is in locked state and cannot be replaced.", databaseId, tableId));
+      }
       // Check if table creator has the privilege to replace the table.
       authorizationUtils.checkReplaceTablePrivilege(tableDto.get(), tableCreatorUpdater);
     } else if (tableDto.isPresent()) {

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
@@ -20,6 +20,8 @@ import com.linkedin.openhouse.internal.catalog.model.SoftDeletedTablePrimaryKey;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateLockRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.UpdateAclPoliciesRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.LockState;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.Policies;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.TimePartitionSpec;
 import com.linkedin.openhouse.tables.authorization.AuthorizationHandler;
 import com.linkedin.openhouse.tables.authorization.Privileges;
@@ -845,6 +847,34 @@ public class TablesServiceTest {
     tablesService.deleteLock(created.getDatabaseId(), created.getTableId(), TEST_USER);
     Assertions.assertDoesNotThrow(
         () -> tablesService.putTable(stageReplaceRequestBody, TEST_USER, false));
+
+    tablesService.deleteTable(created.getDatabaseId(), created.getTableId(), TEST_USER);
+  }
+
+  @Test
+  public void testStageReplaceCannotSmuggleLockStateChange() {
+    TableDto tableDtoCopy =
+        TABLE_DTO
+            .toBuilder()
+            .tableProperties(ImmutableMap.of(CatalogConstants.RTAS_ENABLED_TABLE_PROP, "true"))
+            .policies(
+                Policies.builder().lockState(LockState.builder().locked(false).build()).build())
+            .build();
+    TableDto created = verifyPutTableRequest(tableDtoCopy, null, true);
+
+    // Table is not locked. A stage-replace request that also tries to flip the lock state to
+    // locked=true in the same call must be rejected, just like the ordinary update path already
+    // rejects lock-state changes via checkIfLockPoliciesUpdated.
+    CreateUpdateTableRequestBody stageReplaceWithLockChangeRequestBody =
+        buildCreateUpdateTableRequestBody(created)
+            .toBuilder()
+            .stageReplace(true)
+            .policies(
+                Policies.builder().lockState(LockState.builder().locked(true).build()).build())
+            .build();
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> tablesService.putTable(stageReplaceWithLockChangeRequestBody, TEST_USER, false));
 
     tablesService.deleteTable(created.getDatabaseId(), created.getTableId(), TEST_USER);
   }

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
@@ -18,6 +18,7 @@ import com.linkedin.openhouse.internal.catalog.model.HouseTable;
 import com.linkedin.openhouse.internal.catalog.model.SoftDeletedTableDto;
 import com.linkedin.openhouse.internal.catalog.model.SoftDeletedTablePrimaryKey;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateLockRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.UpdateAclPoliciesRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.TimePartitionSpec;
 import com.linkedin.openhouse.tables.authorization.AuthorizationHandler;
@@ -815,6 +816,37 @@ public class TablesServiceTest {
         () ->
             tablesService.deleteTable(
                 tableDtoCopy.getDatabaseId(), TABLE_DTO.getTableId(), TEST_USER));
+  }
+
+  @Test
+  public void testStageReplaceBlockedOnLockedTable() {
+    TableDto tableDtoCopy =
+        TABLE_DTO
+            .toBuilder()
+            .tableProperties(ImmutableMap.of(CatalogConstants.RTAS_ENABLED_TABLE_PROP, "true"))
+            .policies(null)
+            .build();
+    TableDto created = verifyPutTableRequest(tableDtoCopy, null, true);
+    tablesService.createLock(
+        created.getDatabaseId(),
+        created.getTableId(),
+        CreateUpdateLockRequestBody.builder().locked(true).expirationInDays(4).build(),
+        TEST_USER);
+
+    CreateUpdateTableRequestBody stageReplaceRequestBody =
+        buildCreateUpdateTableRequestBody(created).toBuilder().stageReplace(true).build();
+
+    // Stage-replace (CREATE OR REPLACE TABLE) must be rejected while the table is locked, just
+    // like the ordinary update path already is.
+    Assertions.assertThrows(
+        UnsupportedClientOperationException.class,
+        () -> tablesService.putTable(stageReplaceRequestBody, TEST_USER, false));
+
+    tablesService.deleteLock(created.getDatabaseId(), created.getTableId(), TEST_USER);
+    Assertions.assertDoesNotThrow(
+        () -> tablesService.putTable(stageReplaceRequestBody, TEST_USER, false));
+
+    tablesService.deleteTable(created.getDatabaseId(), created.getTableId(), TEST_USER);
   }
 
   @Test


### PR DESCRIPTION
## Summary

`TablesServiceImpl#putTable()` has two branches for an existing table:

- The **stage-replace** branch (`CREATE OR REPLACE TABLE ... AS SELECT`, i.e. `createUpdateTableRequestBody.isStageReplace()`), which only calls `authorizationUtils.checkReplaceTablePrivilege(...)`.
- The **ordinary update** branch, which calls `authorizationUtils.checkTableWritePathPrivileges(...)` **and** `isTableLocked(tableDto.get())`, throwing `UnsupportedClientOperationException(LOCKED_TABLE_OPERATION)` if the table is locked.

The stage-replace branch never checks `isTableLocked`. Locking a table is meant to prevent further mutation of its definition (used e.g. during migrations, freezes, or investigations), but a `CREATE OR REPLACE TABLE AS SELECT` from the table's own creator can silently replace the entire table definition (schema, partitioning, sort order, properties, location) while the table is locked — bypassing the lock entirely.

## Fix

Adds the same `isTableLocked()` check already used elsewhere in this method to the stage-replace branch, before the existing privilege check, throwing the same `UnsupportedClientOperationException(LOCKED_TABLE_OPERATION)` used by the other lock-enforced code paths in this class.

## Testing

Added `testStageReplaceBlockedOnLockedTable` to `TablesServiceTest` (e2e/h2 Spring-Boot-backed test), since there was no existing coverage of stage-replace at all in this test class:
- Creates a table with `replace.enabled=true`.
- Locks it, then asserts a stage-replace `putTable(...)` call throws `UnsupportedClientOperationException`.
- Unlocks it, then asserts the same stage-replace call now succeeds.

Ran locally:
- `./gradlew :services:tables:test --tests "com.linkedin.openhouse.tables.e2e.h2.TablesServiceTest"` — all 36 tests pass (including the new one), no regressions.
- `./gradlew :services:tables:test` (full module) — passes.
- `./gradlew :services:tables:spotlessJavaCheck` — passes.

## Notes

This is a draft PR — happy to iterate on this based on review.