### PR TITLE
[default values] Implement ReadBridge.apply without an Iceberg fork

### DIFF
--- a/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
@@ -758,7 +758,7 @@ public class OpenHouseTableOperationsTest {
 
     Tasks.UnrecoverableException thrown =
         Assertions.assertThrows(Tasks.UnrecoverableException.class, ops::doRefresh);
-    Assertions.assertInstanceOf(IllegalStateException.class, thrown.getCause());
+    Assertions.assertInstanceOf(ReadBridgeException.class, thrown.getCause());
     Assertions.assertTrue(thrown.getMessage().contains("db.tbl"));
     verifyNoInteractions(mockFileIO);
   }

--- a/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
@@ -13,6 +13,8 @@ import com.linkedin.openhouse.gen.tables.client.model.PolicyTag;
 import com.linkedin.openhouse.gen.tables.client.model.Retention;
 import com.linkedin.openhouse.javaclient.exception.WebClientWithMessageException;
 import com.linkedin.openhouse.relocated.com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.openhouse.relocated.com.fasterxml.jackson.databind.node.ArrayNode;
+import com.linkedin.openhouse.relocated.com.fasterxml.jackson.databind.node.ObjectNode;
 import com.linkedin.openhouse.relocated.org.springframework.http.HttpStatus;
 import com.linkedin.openhouse.relocated.org.springframework.web.reactive.function.client.WebClientRequestException;
 import com.linkedin.openhouse.relocated.org.springframework.web.reactive.function.client.WebClientResponseException;
@@ -29,12 +31,14 @@ import org.apache.commons.compress.utils.Lists;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
@@ -577,6 +581,51 @@ public class OpenHouseTableOperationsTest {
     Assertions.assertSame(stamped, ops.currentConfig());
   }
 
+  /**
+   * Skip-reload after a GET that stops stamping must still send overlays from the bound config. The
+   * server drops them; the client must not strip the default-aware signal.
+   */
+  @Test
+  public void testDoRefreshSkipReloadStillSendsStampedDefaults() {
+    String location = writeTempMetadata();
+    Map<String, String> stamped =
+        Collections.singletonMap(ReadBridge.COLUMN_DEFAULT_PREFIX + "2", "\"US\"");
+
+    GetTableResponseBody withConfig = mock(GetTableResponseBody.class);
+    when(withConfig.getTableLocation()).thenReturn(location);
+    when(withConfig.getConfig()).thenReturn(stamped);
+
+    GetTableResponseBody withoutConfig = mock(GetTableResponseBody.class);
+    when(withoutConfig.getTableLocation()).thenReturn(location);
+    when(withoutConfig.getConfig()).thenReturn(null);
+
+    TableApi mockTableApi = mock(TableApi.class);
+    when(mockTableApi.getTableV1(anyString(), anyString()))
+        .thenReturn(Mono.just(withConfig))
+        .thenReturn(Mono.just(withoutConfig));
+
+    OpenHouseTableOperations ops = refreshableOps(mockTableApi, localFileIO());
+    ops.doRefresh();
+    Assertions.assertSame(stamped, ops.currentConfig());
+
+    ops.doRefresh();
+    Assertions.assertSame(stamped, ops.currentConfig());
+
+    TableMetadata commit =
+        tableWithSchema(
+            "file:/tmp/rb-signal-skip-reload",
+            new Schema(
+                NestedField.optional(1, "id", Types.IntegerType.get()),
+                NestedField.from(NestedField.optional(2, "country", Types.StringType.get()))
+                    .withInitialDefault(Expressions.lit("US"))
+                    .build()));
+    Assertions.assertEquals(
+        "US",
+        SchemaParser.fromJson(ops.constructMetadataRequestBody(null, commit).getSchema())
+            .findField(2)
+            .initialDefault());
+  }
+
   /** A later load from a new metadata location binds that response's config. */
   @Test
   public void testDoRefreshBindsNewConfigWhenLocationChanges() {
@@ -741,5 +790,73 @@ public class OpenHouseTableOperationsTest {
     Map<String, String> config = body.getConfig();
     Assertions.assertNotNull(config);
     Assertions.assertEquals("whatever", config.get("openhouse.unknown-feature"));
+  }
+
+  @Test
+  public void constructMetadataRequestBody_sendsStampedIdsKeepsUnstampedColumnDefaults() {
+    TableMetadata commit =
+        tableWithSchema(
+            "file:/tmp/rb-sanitize-ops-c",
+            new Schema(
+                NestedField.optional(1, "id", Types.IntegerType.get()),
+                NestedField.from(NestedField.optional(2, "country", Types.StringType.get()))
+                    .withInitialDefault(Expressions.lit("US"))
+                    .build(),
+                NestedField.from(NestedField.optional(3, "email", Types.StringType.get()))
+                    .withInitialDefault(Expressions.lit("none"))
+                    .build()));
+
+    OpenHouseTableOperations ops = refreshableOps(mock(TableApi.class));
+    ops.setCurrentConfig(
+        Collections.singletonMap(ReadBridge.COLUMN_DEFAULT_PREFIX + "2", "\"US\""));
+
+    CreateUpdateTableRequestBody body = ops.constructMetadataRequestBody(null, commit);
+    Schema sent = SchemaParser.fromJson(body.getSchema());
+
+    Assertions.assertEquals("US", sent.findField(2).initialDefault());
+    Assertions.assertEquals("none", sent.findField(3).initialDefault());
+    Assertions.assertEquals("email", sent.findField(3).name());
+  }
+
+  @Test
+  public void constructMetadataRequestBody_withoutConfigLeavesWriterDefaults() {
+    TableMetadata commit =
+        tableWithSchema(
+            "file:/tmp/rb-sanitize-create",
+            new Schema(
+                NestedField.from(NestedField.optional(1, "country", Types.StringType.get()))
+                    .withInitialDefault(Expressions.lit("US"))
+                    .build()));
+
+    CreateUpdateTableRequestBody body =
+        refreshableOps(mock(TableApi.class)).constructMetadataRequestBody(null, commit);
+
+    Assertions.assertEquals(
+        "US", SchemaParser.fromJson(body.getSchema()).findField(1).initialDefault());
+  }
+
+  /**
+   * {@link TableMetadata#newTableMetadata} reassigns ids and drops defaults. Put this schema back
+   * so PUT tests can see writer/overlay defaults.
+   */
+  private static TableMetadata tableWithSchema(String location, Schema schema) {
+    TableMetadata created =
+        TableMetadata.newTableMetadata(
+            schema, PartitionSpec.unpartitioned(), location, Collections.emptyMap());
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      ObjectNode root = (ObjectNode) mapper.readTree(TableMetadataParser.toJson(created));
+      Schema kept =
+          new Schema(
+              created.currentSchemaId(),
+              schema.columns(),
+              schema.getAliases(),
+              schema.identifierFieldIds());
+      ((ArrayNode) root.get("schemas")).set(0, mapper.readTree(SchemaParser.toJson(kept)));
+      return TableMetadataParser.fromJson(
+          created.metadataFileLocation(), mapper.writeValueAsString(root));
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
   }
 }

--- a/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
@@ -759,6 +759,9 @@ public class OpenHouseTableOperationsTest {
     Tasks.UnrecoverableException thrown =
         Assertions.assertThrows(Tasks.UnrecoverableException.class, ops::doRefresh);
     Assertions.assertInstanceOf(ReadBridgeException.class, thrown.getCause());
+    Assertions.assertEquals(
+        ReadBridgeException.Kind.UNUSABLE_CONFIG,
+        ((ReadBridgeException) thrown.getCause()).getKind());
     Assertions.assertTrue(thrown.getMessage().contains("db.tbl"));
     verifyNoInteractions(mockFileIO);
   }

--- a/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/ReadBridgeTest.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/ReadBridgeTest.java
@@ -44,14 +44,18 @@ class ReadBridgeTest {
     Map<String, String> config = new HashMap<>();
     config.put(PREFIX + "5", "\"US\"");
     config.put(PREFIX + "notAnInt", "\"x\"");
-    assertThrows(ReadBridgeException.class, () -> ReadBridge.from(config));
+    assertEquals(
+        ReadBridgeException.Kind.UNUSABLE_CONFIG,
+        assertThrows(ReadBridgeException.class, () -> ReadBridge.from(config)).getKind());
   }
 
   @Test
   void failsLoudOnKnownEntryWithUnparseableValue() {
     Map<String, String> config = new HashMap<>();
     config.put(PREFIX + "7", "{bad json");
-    assertThrows(ReadBridgeException.class, () -> ReadBridge.from(config));
+    assertEquals(
+        ReadBridgeException.Kind.UNUSABLE_CONFIG,
+        assertThrows(ReadBridgeException.class, () -> ReadBridge.from(config)).getKind());
   }
 
   @Test
@@ -135,7 +139,9 @@ class ReadBridgeTest {
   void applyFailsLoudWhenDefaultCannotBindToColumnType() {
     TableMetadata raw = newTable("file:/tmp/rb-bad-bind");
     Map<String, String> config = Collections.singletonMap(PREFIX + "1", "\"not-an-int\"");
-    assertThrows(ReadBridgeException.class, () -> ReadBridge.from(config).apply(raw));
+    ReadBridgeException thrown =
+        assertThrows(ReadBridgeException.class, () -> ReadBridge.from(config).apply(raw));
+    assertEquals(ReadBridgeException.Kind.CANNOT_BIND, thrown.getKind());
   }
 
   @Test

--- a/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/ReadBridgeTest.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/ReadBridgeTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.openhouse.javaclient;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -8,9 +9,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
-/** Decoder for {@link ReadBridge#from}. */
+/** Decoder and apply for {@link ReadBridge}. */
 class ReadBridgeTest {
 
   private static final String PREFIX = ReadBridge.COLUMN_DEFAULT_PREFIX;
@@ -21,16 +26,18 @@ class ReadBridgeTest {
     Map<String, String> config = new HashMap<>();
     config.put(PREFIX + "5", "\"US\"");
     config.put(PREFIX + "7", "0");
-    assertEquals(2, ReadBridge.from(config).columnDefaults().size());
-    assertEquals("US", ReadBridge.from(config).columnDefaults().get(5).asText());
-    assertEquals(0, ReadBridge.from(config).columnDefaults().get(7).asInt());
+    ReadBridge bridge = ReadBridge.from(config);
+    assertEquals(2, bridge.columnDefaults().size());
+    // Original JSON strings so apply can bind without a relocated JsonNode.
+    assertEquals("\"US\"", bridge.columnDefaults().get(5));
+    assertEquals("0", bridge.columnDefaults().get(7));
   }
 
   @Test
   void inertWhenConfigNullOrNoReadBridgeKeys() {
     assertSame(ReadBridge.INERT, ReadBridge.from(null));
     assertSame(ReadBridge.INERT, ReadBridge.from(Collections.singletonMap("other.key", "x")));
-    assertTrue(ReadBridge.INERT.columnDefaults().isEmpty());
+    assertTrue(ReadBridge.from(null).columnDefaults().isEmpty());
   }
 
   @Test
@@ -55,7 +62,111 @@ class ReadBridgeTest {
     Map<String, String> config = new HashMap<>();
     config.put(PREFIX + "5", "\"US\"");
     config.put("openhouse.read-bridge.some-future-feature.3", "{not a default}");
-    assertEquals(1, ReadBridge.from(config).columnDefaults().size());
-    assertEquals("US", ReadBridge.from(config).columnDefaults().get(5).asText());
+    ReadBridge bridge = ReadBridge.from(config);
+    assertEquals(1, bridge.columnDefaults().size());
+    assertEquals("\"US\"", bridge.columnDefaults().get(5));
+  }
+
+  @Test
+  void applyReturnsSameInstanceWhenNothingToBridge() {
+    TableMetadata raw = newTable("file:/tmp/rb-inert");
+    assertSame(raw, ReadBridge.INERT.apply(raw));
+    assertSame(raw, ReadBridge.from(Collections.singletonMap("other.key", "x")).apply(raw));
+  }
+
+  @Test
+  void applySetsInitialDefaultOnMatchingField() {
+    TableMetadata raw = newTable("file:/tmp/rb-apply");
+    Map<String, String> config = Collections.singletonMap(PREFIX + "2", "\"US\"");
+
+    TableMetadata bridged = ReadBridge.from(config).apply(raw);
+
+    assertEquals("US", bridged.schema().findField(2).initialDefault());
+    assertNull(bridged.schema().findField(1).initialDefault());
+    assertEquals(raw.uuid(), bridged.uuid());
+    assertEquals(raw.currentSchemaId(), bridged.currentSchemaId());
+    assertEquals(raw.metadataFileLocation(), bridged.metadataFileLocation());
+  }
+
+  @Test
+  void applyOverlaysEverySchemaId() {
+    Schema v0 =
+        new Schema(
+            0,
+            Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "country", Types.StringType.get()));
+    Schema v1 =
+        new Schema(
+            1,
+            Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "country", Types.StringType.get()),
+            Types.NestedField.optional(3, "region", Types.StringType.get()));
+    TableMetadata raw =
+        TableMetadata.buildFrom(
+                TableMetadata.newTableMetadata(
+                    v0,
+                    PartitionSpec.unpartitioned(),
+                    "file:/tmp/rb-multischema",
+                    Collections.emptyMap()))
+            .addSchema(v1, 3)
+            .setCurrentSchema(1)
+            .build();
+
+    Map<String, String> config = new HashMap<>();
+    config.put(PREFIX + "2", "\"US\"");
+    config.put(PREFIX + "3", "\"west\"");
+
+    TableMetadata bridged = ReadBridge.from(config).apply(raw);
+
+    assertEquals(2, bridged.schemas().size());
+    for (Schema schema : bridged.schemas()) {
+      assertEquals("US", schema.findField(2).initialDefault());
+    }
+    assertNull(bridged.schemasById().get(0).findField(3));
+    assertEquals("west", bridged.schemasById().get(1).findField(3).initialDefault());
+  }
+
+  @Test
+  void applyIgnoresFieldIdsAbsentFromAllSchemas() {
+    TableMetadata raw = newTable("file:/tmp/rb-gap");
+    Map<String, String> config = Collections.singletonMap(PREFIX + "99", "\"x\"");
+    assertSame(raw, ReadBridge.from(config).apply(raw));
+  }
+
+  @Test
+  void applyFailsLoudWhenDefaultCannotBindToColumnType() {
+    TableMetadata raw = newTable("file:/tmp/rb-bad-bind");
+    Map<String, String> config = Collections.singletonMap(PREFIX + "1", "\"not-an-int\"");
+    assertThrows(IllegalStateException.class, () -> ReadBridge.from(config).apply(raw));
+  }
+
+  @Test
+  void applySetsDefaultOnNestedStructField() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(
+                2,
+                "address",
+                Types.StructType.of(
+                    Types.NestedField.optional(3, "country", Types.StringType.get()))));
+    TableMetadata raw =
+        TableMetadata.newTableMetadata(
+            schema, PartitionSpec.unpartitioned(), "file:/tmp/rb-nested", Collections.emptyMap());
+    Map<String, String> config = Collections.singletonMap(PREFIX + "3", "\"US\"");
+
+    TableMetadata bridged = ReadBridge.from(config).apply(raw);
+
+    assertEquals(
+        "US", bridged.schema().findField(2).type().asStructType().field(3).initialDefault());
+  }
+
+  private static TableMetadata newTable(String location) {
+    Schema schema =
+        new Schema(
+            Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "country", Types.StringType.get()));
+    return TableMetadata.newTableMetadata(
+        schema, PartitionSpec.unpartitioned(), location, Collections.emptyMap());
   }
 }

--- a/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/ReadBridgeTest.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/ReadBridgeTest.java
@@ -21,20 +21,18 @@ class ReadBridgeTest {
   private static final String PREFIX = ReadBridge.COLUMN_DEFAULT_PREFIX;
 
   @Test
-  void decodesColumnDefaultsByFieldId() {
-    // Avoid naming JsonNode: it is relocated in the shaded client, and this module has no `var`.
+  void decodesColumnDefaultsByFieldId() throws ReadBridgeException {
     Map<String, String> config = new HashMap<>();
     config.put(PREFIX + "5", "\"US\"");
     config.put(PREFIX + "7", "0");
     ReadBridge bridge = ReadBridge.from(config);
     assertEquals(2, bridge.columnDefaults().size());
-    // Original JSON strings so apply can bind without a relocated JsonNode.
-    assertEquals("\"US\"", bridge.columnDefaults().get(5));
-    assertEquals("0", bridge.columnDefaults().get(7));
+    assertEquals("US", bridge.columnDefaults().get(5).asText());
+    assertEquals(0, bridge.columnDefaults().get(7).asInt());
   }
 
   @Test
-  void inertWhenConfigNullOrNoReadBridgeKeys() {
+  void inertWhenConfigNullOrNoReadBridgeKeys() throws ReadBridgeException {
     assertSame(ReadBridge.INERT, ReadBridge.from(null));
     assertSame(ReadBridge.INERT, ReadBridge.from(Collections.singletonMap("other.key", "x")));
     assertTrue(ReadBridge.from(null).columnDefaults().isEmpty());
@@ -46,36 +44,36 @@ class ReadBridgeTest {
     Map<String, String> config = new HashMap<>();
     config.put(PREFIX + "5", "\"US\"");
     config.put(PREFIX + "notAnInt", "\"x\"");
-    assertThrows(IllegalStateException.class, () -> ReadBridge.from(config));
+    assertThrows(ReadBridgeException.class, () -> ReadBridge.from(config));
   }
 
   @Test
   void failsLoudOnKnownEntryWithUnparseableValue() {
     Map<String, String> config = new HashMap<>();
     config.put(PREFIX + "7", "{bad json");
-    assertThrows(IllegalStateException.class, () -> ReadBridge.from(config));
+    assertThrows(ReadBridgeException.class, () -> ReadBridge.from(config));
   }
 
   @Test
-  void ignoresUnknownKeysWithoutFailing() {
+  void ignoresUnknownKeysWithoutFailing() throws ReadBridgeException {
     // Keys outside the prefix are ignored so a newer server stays readable.
     Map<String, String> config = new HashMap<>();
     config.put(PREFIX + "5", "\"US\"");
     config.put("openhouse.read-bridge.some-future-feature.3", "{not a default}");
     ReadBridge bridge = ReadBridge.from(config);
     assertEquals(1, bridge.columnDefaults().size());
-    assertEquals("\"US\"", bridge.columnDefaults().get(5));
+    assertEquals("US", bridge.columnDefaults().get(5).asText());
   }
 
   @Test
-  void applyReturnsSameInstanceWhenNothingToBridge() {
+  void applyReturnsSameInstanceWhenNothingToBridge() throws ReadBridgeException {
     TableMetadata raw = newTable("file:/tmp/rb-inert");
     assertSame(raw, ReadBridge.INERT.apply(raw));
     assertSame(raw, ReadBridge.from(Collections.singletonMap("other.key", "x")).apply(raw));
   }
 
   @Test
-  void applySetsInitialDefaultOnMatchingField() {
+  void applySetsInitialDefaultOnMatchingField() throws ReadBridgeException {
     TableMetadata raw = newTable("file:/tmp/rb-apply");
     Map<String, String> config = Collections.singletonMap(PREFIX + "2", "\"US\"");
 
@@ -89,7 +87,7 @@ class ReadBridgeTest {
   }
 
   @Test
-  void applyOverlaysEverySchemaId() {
+  void applyOverlaysEverySchemaId() throws ReadBridgeException {
     Schema v0 =
         new Schema(
             0,
@@ -127,7 +125,7 @@ class ReadBridgeTest {
   }
 
   @Test
-  void applyIgnoresFieldIdsAbsentFromAllSchemas() {
+  void applyIgnoresFieldIdsAbsentFromAllSchemas() throws ReadBridgeException {
     TableMetadata raw = newTable("file:/tmp/rb-gap");
     Map<String, String> config = Collections.singletonMap(PREFIX + "99", "\"x\"");
     assertSame(raw, ReadBridge.from(config).apply(raw));
@@ -137,11 +135,11 @@ class ReadBridgeTest {
   void applyFailsLoudWhenDefaultCannotBindToColumnType() {
     TableMetadata raw = newTable("file:/tmp/rb-bad-bind");
     Map<String, String> config = Collections.singletonMap(PREFIX + "1", "\"not-an-int\"");
-    assertThrows(IllegalStateException.class, () -> ReadBridge.from(config).apply(raw));
+    assertThrows(ReadBridgeException.class, () -> ReadBridge.from(config).apply(raw));
   }
 
   @Test
-  void applySetsDefaultOnNestedStructField() {
+  void applySetsDefaultOnNestedStructField() throws ReadBridgeException {
     Schema schema =
         new Schema(
             Types.NestedField.optional(1, "id", Types.IntegerType.get()),

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -272,6 +272,11 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
     return createUpdateTableRequestBody;
   }
 
+  @VisibleForTesting
+  void setCurrentConfig(Map<String, String> value) {
+    config.set(value);
+  }
+
   /**
    * If request is coming from replication process, createUpdateTableRequestBody.tableType should be
    * REPLICA_TABLE Replication process requests are identified based on difference between table

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -138,7 +138,7 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
   /**
    * Decode {@code fetched}, then read the metadata file, then overlay.
    *
-   * <p>Decode first so a bad config never hits storage. {@link IllegalStateException} is wrapped as
+   * <p>Decode first so a bad config never hits storage. {@link ReadBridgeException} is wrapped as
    * {@link Tasks.UnrecoverableException} so Iceberg's retry loop does not re-read the file. The
    * wrap includes {@link #tableName()} so a Spark job over many tables can tell which one failed.
    */
@@ -146,18 +146,18 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
     final ReadBridge bridge;
     try {
       bridge = ReadBridge.from(fetched);
-    } catch (IllegalStateException e) {
+    } catch (ReadBridgeException e) {
       throw unrecoverableBridge(e);
     }
     TableMetadata raw = TableMetadataParser.read(io(), metadataLocation);
     try {
       return bridge.apply(raw);
-    } catch (IllegalStateException e) {
+    } catch (ReadBridgeException e) {
       throw unrecoverableBridge(e);
     }
   }
 
-  private Tasks.UnrecoverableException unrecoverableBridge(IllegalStateException e) {
+  private Tasks.UnrecoverableException unrecoverableBridge(ReadBridgeException e) {
     return new Tasks.UnrecoverableException(
         "read-bridge: unusable config for table " + tableName(), e);
   }

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/ReadBridge.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/ReadBridge.java
@@ -3,12 +3,13 @@ package com.linkedin.openhouse.javaclient;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.StreamSupport;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 
@@ -37,62 +38,60 @@ final class ReadBridge {
   private static final String ID = "id";
   private static final String INITIAL_DEFAULT = "initial-default";
 
-  /** JSON strings, not JsonNodes — Jackson is relocated in the shaded client. */
-  private final Map<Integer, String> columnDefaults;
+  private final Map<Integer, JsonNode> columnDefaults;
 
-  private ReadBridge(Map<Integer, String> columnDefaults) {
+  private ReadBridge(Map<Integer, JsonNode> columnDefaults) {
     this.columnDefaults = columnDefaults;
   }
 
   /**
    * Decode stamped config. Returns {@link #INERT} when there is nothing to apply.
    *
-   * @throws IllegalStateException if a key this client owns is malformed
+   * @throws ReadBridgeException if a key this client owns is malformed
    */
-  static ReadBridge from(Map<String, String> config) {
-    Map<Integer, String> columnDefaults = decodeColumnDefaults(config);
+  static ReadBridge from(Map<String, String> config) throws ReadBridgeException {
+    Map<Integer, JsonNode> columnDefaults = decodeColumnDefaults(config);
     return columnDefaults.isEmpty() ? INERT : new ReadBridge(columnDefaults);
   }
 
   /** Overlay onto {@code raw}, or return it unchanged. */
-  TableMetadata apply(TableMetadata raw) {
+  TableMetadata apply(TableMetadata raw) throws ReadBridgeException {
     if (columnDefaults.isEmpty()) {
       return raw;
     }
     ObjectNode root = metadataJson(raw);
     boolean changed = false;
     for (JsonNode field : fieldObjects(root)) {
-      String defaultJson = columnDefaults.get(field.get(ID).asInt());
-      if (defaultJson != null) {
-        ((ObjectNode) field).set(INITIAL_DEFAULT, readTree(defaultJson));
+      JsonNode defaultValue = columnDefaults.get(field.get(ID).asInt());
+      if (defaultValue != null) {
+        ((ObjectNode) field).set(INITIAL_DEFAULT, defaultValue);
         changed = true;
       }
     }
     return changed ? fromMetadataJson(raw, root) : raw;
   }
 
-  Map<Integer, String> columnDefaults() {
+  Map<Integer, JsonNode> columnDefaults() {
     return columnDefaults;
   }
 
   /** Decode {@code column-default.<fieldId>} entries. Unknown keys are ignored. */
-  private static Map<Integer, String> decodeColumnDefaults(Map<String, String> config) {
+  private static Map<Integer, JsonNode> decodeColumnDefaults(Map<String, String> config)
+      throws ReadBridgeException {
     if (config == null) {
       return Collections.emptyMap();
     }
-    Map<Integer, String> byFieldId = new HashMap<>();
+    Map<Integer, JsonNode> byFieldId = new HashMap<>();
     for (Map.Entry<String, String> entry : config.entrySet()) {
       if (!entry.getKey().startsWith(COLUMN_DEFAULT_PREFIX)) {
         continue;
       }
       try {
         int fieldId = Integer.parseInt(entry.getKey().substring(COLUMN_DEFAULT_PREFIX.length()));
-        // Validate JSON; keep the original string so apply can bind without a relocated JsonNode.
-        MAPPER.readTree(entry.getValue());
-        byFieldId.put(fieldId, entry.getValue());
-      } catch (RuntimeException | JsonProcessingException e) {
+        byFieldId.put(fieldId, MAPPER.readTree(entry.getValue()));
+      } catch (NumberFormatException | JsonProcessingException e) {
         // Known keys are stamped as int field-id + JSON; anything else is a bug.
-        throw new IllegalStateException(
+        throw new ReadBridgeException(
             "read-bridge: unusable "
                 + COLUMN_DEFAULT_PREFIX
                 + " entry "
@@ -106,46 +105,38 @@ final class ReadBridge {
   }
 
   /** Schema field objects are the JSON nodes that carry {@code id}. */
-  private static List<JsonNode> fieldObjects(ObjectNode metadata) {
-    JsonNode schemas = metadata.get(SCHEMAS);
-    if (schemas == null || !schemas.isArray()) {
-      throw new IllegalStateException(
-          "read-bridge: metadata JSON missing required '" + SCHEMAS + "' array");
-    }
-    List<JsonNode> fields = new ArrayList<>();
-    for (JsonNode schema : schemas) {
-      List<JsonNode> found = schema.findParents(ID);
-      if (found != null) {
-        fields.addAll(found);
-      }
-    }
+  private static JsonNode fieldObjects(ObjectNode metadata) {
+    ArrayNode fields = MAPPER.createArrayNode();
+    StreamSupport.stream(metadata.get(SCHEMAS).spliterator(), false)
+        .map(schema -> schema.findParents(ID))
+        .flatMap(List::stream)
+        .forEach(fields::add);
     return fields;
   }
 
-  private static ObjectNode metadataJson(TableMetadata metadata) {
-    JsonNode root = readTree(TableMetadataParser.toJson(metadata));
-    if (root == null || !root.isObject()) {
-      throw new IllegalStateException("read-bridge: table metadata JSON is not an object");
+  private static ObjectNode metadataJson(TableMetadata metadata) throws ReadBridgeException {
+    try {
+      return (ObjectNode) readTree(TableMetadataParser.toJson(metadata));
+    } catch (RuntimeException e) {
+      throw new ReadBridgeException("read-bridge: failed to parse table metadata JSON", e);
     }
-    return (ObjectNode) root;
   }
 
-  private static TableMetadata fromMetadataJson(TableMetadata metadata, ObjectNode root) {
+  private static TableMetadata fromMetadataJson(TableMetadata metadata, ObjectNode root)
+      throws ReadBridgeException {
     try {
       return TableMetadataParser.fromJson(
           metadata.metadataFileLocation(), MAPPER.writeValueAsString(root));
-    } catch (IllegalStateException e) {
-      throw e;
-    } catch (RuntimeException | JsonProcessingException e) {
-      throw new IllegalStateException("read-bridge: failed to rebuild table metadata schemas", e);
+    } catch (JsonProcessingException | RuntimeException e) {
+      throw new ReadBridgeException("read-bridge: failed to rebuild table metadata schemas", e);
     }
   }
 
-  private static JsonNode readTree(String json) {
+  private static JsonNode readTree(String json) throws ReadBridgeException {
     try {
       return MAPPER.readTree(json);
     } catch (JsonProcessingException e) {
-      throw new IllegalStateException("read-bridge: invalid json", e);
+      throw new ReadBridgeException("read-bridge: invalid json", e);
     }
   }
 }

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/ReadBridge.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/ReadBridge.java
@@ -3,10 +3,14 @@ package com.linkedin.openhouse.javaclient;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
 
 /**
  * Overlays server-stamped read-time behavior from table {@code config} onto loaded Iceberg
@@ -21,14 +25,19 @@ final class ReadBridge {
   /** Same prefix the server encoder stamps. */
   static final String COLUMN_DEFAULT_PREFIX = "openhouse.read-bridge.column-default.";
 
-  /** {@link #apply} is a no-op. */
+  /** Nothing to overlay. */
   static final ReadBridge INERT = new ReadBridge(Collections.emptyMap());
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
-  private final Map<Integer, JsonNode> columnDefaults;
+  private static final String SCHEMAS = "schemas";
+  private static final String ID = "id";
+  private static final String INITIAL_DEFAULT = "initial-default";
 
-  private ReadBridge(Map<Integer, JsonNode> columnDefaults) {
+  /** JSON strings, not JsonNodes — Jackson is relocated in the shaded client. */
+  private final Map<Integer, String> columnDefaults;
+
+  private ReadBridge(Map<Integer, String> columnDefaults) {
     this.columnDefaults = columnDefaults;
   }
 
@@ -38,7 +47,7 @@ final class ReadBridge {
    * @throws IllegalStateException if a key this client owns is malformed
    */
   static ReadBridge from(Map<String, String> config) {
-    Map<Integer, JsonNode> columnDefaults = columnDefaults(config);
+    Map<Integer, String> columnDefaults = decodeColumnDefaults(config);
     return columnDefaults.isEmpty() ? INERT : new ReadBridge(columnDefaults);
   }
 
@@ -47,26 +56,37 @@ final class ReadBridge {
     if (columnDefaults.isEmpty()) {
       return raw;
     }
-    // TODO(read-bridge): overlay columnDefaults onto schemas.
-    return raw;
+    ObjectNode root = metadataJson(raw);
+    boolean changed = false;
+    for (JsonNode field : fieldObjects(root)) {
+      String defaultJson = columnDefaults.get(field.get(ID).asInt());
+      if (defaultJson != null) {
+        ((ObjectNode) field).set(INITIAL_DEFAULT, readTree(defaultJson));
+        changed = true;
+      }
+    }
+    return changed ? fromMetadataJson(raw, root) : raw;
   }
 
-  Map<Integer, JsonNode> columnDefaults() {
+  Map<Integer, String> columnDefaults() {
     return columnDefaults;
   }
 
-  private static Map<Integer, JsonNode> columnDefaults(Map<String, String> config) {
+  /** Decode {@code column-default.<fieldId>} entries. Unknown keys are ignored. */
+  private static Map<Integer, String> decodeColumnDefaults(Map<String, String> config) {
     if (config == null) {
       return Collections.emptyMap();
     }
-    Map<Integer, JsonNode> byFieldId = new HashMap<>();
+    Map<Integer, String> byFieldId = new HashMap<>();
     for (Map.Entry<String, String> entry : config.entrySet()) {
       if (!entry.getKey().startsWith(COLUMN_DEFAULT_PREFIX)) {
         continue;
       }
       try {
         int fieldId = Integer.parseInt(entry.getKey().substring(COLUMN_DEFAULT_PREFIX.length()));
-        byFieldId.put(fieldId, MAPPER.readTree(entry.getValue()));
+        // Validate JSON; keep the original string so apply can bind without a relocated JsonNode.
+        MAPPER.readTree(entry.getValue());
+        byFieldId.put(fieldId, entry.getValue());
       } catch (RuntimeException | JsonProcessingException e) {
         // Known keys are stamped as int field-id + JSON; anything else is a bug.
         throw new IllegalStateException(
@@ -80,5 +100,49 @@ final class ReadBridge {
       }
     }
     return byFieldId;
+  }
+
+  /** Schema field objects are the JSON nodes that carry {@code id}. */
+  private static List<JsonNode> fieldObjects(ObjectNode metadata) {
+    JsonNode schemas = metadata.get(SCHEMAS);
+    if (schemas == null || !schemas.isArray()) {
+      throw new IllegalStateException(
+          "read-bridge: metadata JSON missing required '" + SCHEMAS + "' array");
+    }
+    List<JsonNode> fields = new ArrayList<>();
+    for (JsonNode schema : schemas) {
+      List<JsonNode> found = schema.findParents(ID);
+      if (found != null) {
+        fields.addAll(found);
+      }
+    }
+    return fields;
+  }
+
+  private static ObjectNode metadataJson(TableMetadata metadata) {
+    JsonNode root = readTree(TableMetadataParser.toJson(metadata));
+    if (root == null || !root.isObject()) {
+      throw new IllegalStateException("read-bridge: table metadata JSON is not an object");
+    }
+    return (ObjectNode) root;
+  }
+
+  private static TableMetadata fromMetadataJson(TableMetadata metadata, ObjectNode root) {
+    try {
+      return TableMetadataParser.fromJson(
+          metadata.metadataFileLocation(), MAPPER.writeValueAsString(root));
+    } catch (IllegalStateException e) {
+      throw e;
+    } catch (RuntimeException | JsonProcessingException e) {
+      throw new IllegalStateException("read-bridge: failed to rebuild table metadata schemas", e);
+    }
+  }
+
+  private static JsonNode readTree(String json) {
+    try {
+      return MAPPER.readTree(json);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException("read-bridge: invalid json", e);
+    }
   }
 }

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/ReadBridge.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/ReadBridge.java
@@ -3,12 +3,12 @@ package com.linkedin.openhouse.javaclient;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
@@ -35,7 +35,15 @@ final class ReadBridge {
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   private static final String SCHEMAS = "schemas";
+  private static final String FIELDS = "fields";
   private static final String ID = "id";
+  private static final String TYPE = "type";
+  private static final String STRUCT = "struct";
+  private static final String LIST = "list";
+  private static final String MAP = "map";
+  private static final String ELEMENT = "element";
+  private static final String KEY = "key";
+  private static final String VALUE = "value";
   private static final String INITIAL_DEFAULT = "initial-default";
 
   private final Map<Integer, JsonNode> columnDefaults;
@@ -61,14 +69,28 @@ final class ReadBridge {
     }
     ObjectNode root = metadataJson(raw);
     boolean changed = false;
-    for (JsonNode field : fieldObjects(root)) {
+    for (ObjectNode field : fieldObjects(root).collect(Collectors.toList())) {
       JsonNode defaultValue = columnDefaults.get(field.get(ID).asInt());
       if (defaultValue != null) {
-        ((ObjectNode) field).set(INITIAL_DEFAULT, defaultValue);
+        field.set(INITIAL_DEFAULT, defaultValue);
         changed = true;
       }
     }
-    return changed ? fromMetadataJson(raw, root) : raw;
+    if (!changed) {
+      return raw;
+    }
+    final String json;
+    try {
+      json = MAPPER.writeValueAsString(root);
+    } catch (JsonProcessingException e) {
+      throw ReadBridgeException.unusableMetadata(
+          "read-bridge: failed to serialize patched metadata", e);
+    }
+    try {
+      return TableMetadataParser.fromJson(raw.metadataFileLocation(), json);
+    } catch (RuntimeException e) {
+      throw ReadBridgeException.cannotBind(e);
+    }
   }
 
   Map<Integer, JsonNode> columnDefaults() {
@@ -90,8 +112,7 @@ final class ReadBridge {
         int fieldId = Integer.parseInt(entry.getKey().substring(COLUMN_DEFAULT_PREFIX.length()));
         byFieldId.put(fieldId, MAPPER.readTree(entry.getValue()));
       } catch (NumberFormatException | JsonProcessingException e) {
-        // Known keys are stamped as int field-id + JSON; anything else is a bug.
-        throw new ReadBridgeException(
+        throw ReadBridgeException.unusableConfig(
             "read-bridge: unusable "
                 + COLUMN_DEFAULT_PREFIX
                 + " entry "
@@ -104,31 +125,40 @@ final class ReadBridge {
     return byFieldId;
   }
 
-  /** Schema field objects are the JSON nodes that carry {@code id}. */
-  private static JsonNode fieldObjects(ObjectNode metadata) {
-    ArrayNode fields = MAPPER.createArrayNode();
-    StreamSupport.stream(metadata.get(SCHEMAS).spliterator(), false)
-        .map(schema -> schema.findParents(ID))
-        .flatMap(List::stream)
-        .forEach(fields::add);
-    return fields;
+  /** NestedField objects under every schema-id: {@code schemas[].fields}, then nested types. */
+  private static Stream<ObjectNode> fieldObjects(ObjectNode metadata) {
+    return StreamSupport.stream(metadata.get(SCHEMAS).spliterator(), false)
+        .flatMap(ReadBridge::nestedFields);
+  }
+
+  private static Stream<ObjectNode> nestedFields(JsonNode type) {
+    if (!type.isObject()) {
+      return Stream.empty();
+    }
+    switch (type.get(TYPE).asText()) {
+      case STRUCT:
+        return fieldsOf(type.get(FIELDS));
+      case LIST:
+        return nestedFields(type.get(ELEMENT));
+      case MAP:
+        return Stream.concat(nestedFields(type.get(KEY)), nestedFields(type.get(VALUE)));
+      default:
+        return Stream.empty();
+    }
+  }
+
+  private static Stream<ObjectNode> fieldsOf(JsonNode fields) {
+    return StreamSupport.stream(fields.spliterator(), false)
+        .map(field -> (ObjectNode) field)
+        .flatMap(field -> Stream.concat(Stream.of(field), nestedFields(field.get(TYPE))));
   }
 
   private static ObjectNode metadataJson(TableMetadata metadata) throws ReadBridgeException {
     try {
       return (ObjectNode) readTree(TableMetadataParser.toJson(metadata));
     } catch (RuntimeException e) {
-      throw new ReadBridgeException("read-bridge: failed to parse table metadata JSON", e);
-    }
-  }
-
-  private static TableMetadata fromMetadataJson(TableMetadata metadata, ObjectNode root)
-      throws ReadBridgeException {
-    try {
-      return TableMetadataParser.fromJson(
-          metadata.metadataFileLocation(), MAPPER.writeValueAsString(root));
-    } catch (JsonProcessingException | RuntimeException e) {
-      throw new ReadBridgeException("read-bridge: failed to rebuild table metadata schemas", e);
+      throw ReadBridgeException.unusableMetadata(
+          "read-bridge: failed to parse table metadata JSON", e);
     }
   }
 
@@ -136,7 +166,7 @@ final class ReadBridge {
     try {
       return MAPPER.readTree(json);
     } catch (JsonProcessingException e) {
-      throw new ReadBridgeException("read-bridge: invalid json", e);
+      throw ReadBridgeException.unusableMetadata("read-bridge: invalid json", e);
     }
   }
 }

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/ReadBridge.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/ReadBridge.java
@@ -19,6 +19,9 @@ import org.apache.iceberg.TableMetadataParser;
  * <p>Keys: {@code openhouse.read-bridge.column-default.<fieldId> = <single-value-json>}. {@link
  * #from} decodes; {@link #apply} overlays. Unknown keys are ignored. A malformed known entry throws
  * — that is an encoder or transport bug, not a missing default.
+ *
+ * <p>Overlays stay on the wire so the server can treat {@code initial-default} as the default-aware
+ * signal; the server drops them before persist.
  */
 final class ReadBridge {
 

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/ReadBridgeException.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/ReadBridgeException.java
@@ -7,7 +7,33 @@ package com.linkedin.openhouse.javaclient;
  */
 class ReadBridgeException extends Exception {
 
-  ReadBridgeException(String message, Throwable cause) {
+  enum Kind {
+    UNUSABLE_CONFIG,
+    CANNOT_BIND,
+    UNUSABLE_METADATA
+  }
+
+  private final Kind kind;
+
+  ReadBridgeException(Kind kind, String message, Throwable cause) {
     super(message, cause);
+    this.kind = kind;
+  }
+
+  Kind getKind() {
+    return kind;
+  }
+
+  static ReadBridgeException unusableConfig(String message, Throwable cause) {
+    return new ReadBridgeException(Kind.UNUSABLE_CONFIG, message, cause);
+  }
+
+  static ReadBridgeException cannotBind(Throwable cause) {
+    return new ReadBridgeException(
+        Kind.CANNOT_BIND, "read-bridge: default cannot bind to column type", cause);
+  }
+
+  static ReadBridgeException unusableMetadata(String message, Throwable cause) {
+    return new ReadBridgeException(Kind.UNUSABLE_METADATA, message, cause);
   }
 }

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/ReadBridgeException.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/ReadBridgeException.java
@@ -1,0 +1,13 @@
+package com.linkedin.openhouse.javaclient;
+
+/**
+ * Checked failure from {@link ReadBridge#from} or {@link ReadBridge#apply}. {@link
+ * OpenHouseTableOperations#loadMetadata} wraps it as Iceberg's {@code Tasks.UnrecoverableException}
+ * so the metadata read is not retried.
+ */
+class ReadBridgeException extends Exception {
+
+  ReadBridgeException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}


### PR DESCRIPTION
## Summary

Depends on [#678](https://github.com/linkedin/openhouse/pull/678) (server handshake + drop), stacked on [#674](https://github.com/linkedin/openhouse/pull/674) → [#668](https://github.com/linkedin/openhouse/pull/668) → [#645](https://github.com/linkedin/openhouse/pull/645).

Finish the **client** half of the column-default read bridge: turn server-stamped `config` into Iceberg `NestedField.initialDefault` at metadata load — **without forking Iceberg**.

#678 lands first so apply is never in tree without the drop. Overlays sit on `metadata.schema()`; the first write after a bridged load would persist them unless the server already strips them.

| Step | Where | What |
|---|---|---|
| Decode | `ReadBridge.from(config)` in `doRefresh` / before IO | Parse `openhouse.read-bridge.column-default.<fieldId>` (kept from #668, off the retry path) |
| Apply | `ReadBridge.apply(raw)` in `loadMetadata` | Overlay defaults onto **every** schema-id, then rebuild metadata |

## How apply works

Patch `initial-default` onto schema field objects by field-id in metadata JSON. No Iceberg fork.

**Failure policy (mirrors the server encoder):**

| Case | Behavior |
|---|---|
| No read-bridge keys / inert bridge | Return `raw` unchanged |
| Field-id absent from a schema | Capability gap → leave that field NULL |
| Default cannot bind to column type | Fail loud (`IllegalStateException`) |
| Malformed known config entry | Fail loud (decode; already unrecoverable for retries via #668) |
| Unknown `openhouse.read-bridge.*` key | Ignore (forward compatible) |

**Semantics notes:**
- Overlay hits **all** schema-ids (time-travel / tags / branches), not only current.
- Decode keeps validated JSON **strings** (shade-safe bind at apply time).
- Current stamp wins — no default history; missing ids on older schemas are gaps, not errors.

## Changes

- [x] New Features — `ReadBridge.apply` overlays `initialDefault`
- [x] Tests — `ReadBridgeTest`: single/multi-schema overlay, nested fields, gaps, fail-loud bind, inert path; `OpenHouseTableOperationsTest`: PUT still sends stamped `initial-default`

## Testing Done

- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- Local: `./gradlew :integrations:java:iceberg-1.2:openhouse-java-itest:test --tests '*ReadBridgeTest' --tests '*OpenHouseTableOperationsTest'`

## Additional Information

- [x] Large PR broken into smaller PRs, and PR plan linked in the description.

### Stack

1. [#645](https://github.com/linkedin/openhouse/pull/645) — substrate (seam + encode + decode hook)
2. [#668](https://github.com/linkedin/openhouse/pull/668) — decode off Iceberg’s retry path
3. [#674](https://github.com/linkedin/openhouse/pull/674) — policy / ramp in OpenHouse
4. [#678](https://github.com/linkedin/openhouse/pull/678) — handshake + drop on the server
5. **This PR** — `ReadBridge.apply`
6. [#681](https://github.com/linkedin/openhouse/pull/681) — Spark catalog itest (overlay)