### PR TITLE
Add jobs testing for RTAS

### DIFF
--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsForRtasTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsForRtasTest.java
@@ -3,7 +3,6 @@ package com.linkedin.openhouse.jobs.spark;
 import com.linkedin.openhouse.common.metrics.DefaultOtelConfig;
 import com.linkedin.openhouse.common.metrics.OtelEmitter;
 import com.linkedin.openhouse.jobs.util.AppsOtelEmitter;
-import com.linkedin.openhouse.jobs.util.SparkJobUtil;
 import com.linkedin.openhouse.tablestest.OpenHouseSparkITest;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -17,7 +16,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.Transaction;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
 import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Row;
@@ -144,15 +142,18 @@ public class OperationsForRtasTest extends OpenHouseSparkITest {
   }
 
   /**
-   * The delete is planned against a snapshot that an RTAS stales before it commits.
+   * The retention DELETE runs against a table replaced after the job's args were frozen.
    *
-   * <p>The retention job resolved the table and planned its delete against the pre-RTAS snapshot.
-   * The replace then moves the table's head. Nothing binds the delete to the snapshot it was
-   * planned on, so the writer rebases onto the replacement and the commit is accepted. It lands as
-   * a snapshot that deletes nothing, and the job reports success without applying retention.
+   * <p>The scheduler snapshots {@code policies.retention} and freezes it into the job's args. The
+   * replace lands before the job issues its DELETE, changing what the table holds. Spark plans and
+   * commits {@code DELETE FROM} inside a single statement, so there is no window for the replace to
+   * invalidate: by the time the write is validated, the scan behind it has already seen the
+   * replacement. Iceberg's conflict validations are bound to that scan, so nothing rejects a
+   * retention window that was authorized against a table which no longer exists. The frozen window
+   * is applied to the replacement's rows instead.
    *
-   * <p>A preflight check cannot cover this window, since it would have passed before the replace
-   * landed. Closing it needs the delete bound to the state that was validated.
+   * <p>A preflight check at job start cannot cover this, since it would have passed before the
+   * replace landed. Closing it needs the window bound to the state that was validated.
    */
   @Test
   public void testRetentionDeleteOnSnapshotStaledByRtas() throws Exception {
@@ -164,16 +165,12 @@ public class OperationsForRtasTest extends OpenHouseSparkITest {
       insertRows(ops, tableName, now, 0, 2);
       verifyRowCount(ops, tableName, 2);
 
-      // The retention job plans its delete against the current snapshot but has not committed yet.
-      Table preRtasTable = ops.getTable(tableName);
-      long preRtasSnapshotId = preRtasTable.currentSnapshot().snapshotId();
-      Transaction plannedDelete = preRtasTable.newTransaction();
-      plannedDelete
-          .newDelete()
-          .deleteFromRowFilter(SparkJobUtil.createDeleteFilter("ts", "", "day", 1, now))
-          .commit();
+      // The scheduler snapshots the policy here and launches the job, freezing
+      // `--columnName ts --granularity day --count 1`. The job plans against this snapshot.
+      long preRtasSnapshotId = ops.getTable(tableName).currentSnapshot().snapshotId();
 
-      // The replace lands first and stales that snapshot.
+      // The replace lands first and stales that snapshot. Its d5 row sits outside the window the
+      // job is holding, and was never covered by the policy the job was launched with.
       prepareSource(ops, sourceName, now, 0, 5);
       ops.spark()
           .sql(
@@ -185,35 +182,40 @@ public class OperationsForRtasTest extends OpenHouseSparkITest {
       Assertions.assertNotEquals(
           preRtasSnapshotId,
           rtasSnapshotId,
-          "Replace should have moved the table off the snapshot the delete was planned on");
+          "Replace should have moved the table off the snapshot the job planned on");
       verifyRowCount(ops, tableName, 2);
 
-      // The retention delete commits onto the staled snapshot instead of failing. The writer
-      // rebases onto the replacement, so by the time the request reaches the catalog it declares
-      // the post-RTAS metadata as its base and the CAS has nothing to reject.
+      // The job issues its DELETE with the frozen args. A metadata-only delete carries no snapshot
+      // validation, so the replace does not invalidate it.
       Assertions.assertDoesNotThrow(
-          plannedDelete::commitTransaction,
-          "Current behavior: a delete planned pre-RTAS rebases onto the replacement");
+          () -> ops.runRetention(tableName, "ts", "", "day", 1, false, "", now),
+          "Current behavior: Spark's DELETE FROM is not validated against the replace");
 
-      // It lands as a snapshot that deletes nothing. The files it planned to remove belong to the
-      // pre-RTAS table and are not part of the replacement, so the filter matches nothing.
+      // It commits on top of the replacement. Spark 3.1 / Iceberg 1.2 rewrites data files
+      // (`overwrite`, i.e. OverwriteFiles, the path that does expose validateFromSnapshot and
+      // validateNoConflictingData); Spark 3.5 / Iceberg 1.5 resolves the same predicate to a
+      // metadata-only `delete`. Neither rejects the write: the validations that exist are bound to
+      // the scan Spark just planned, which already saw the replacement, so no conflict is left to
+      // detect.
       Table afterDelete = ops.getTable(tableName);
       Assertions.assertNotEquals(
           rtasSnapshotId,
           afterDelete.currentSnapshot().snapshotId(),
-          "Staled delete should still have committed a snapshot");
-      verifyRowCount(ops, tableName, 2);
+          "Retention delete should have committed a snapshot");
+      Assertions.assertTrue(
+          Arrays.asList("delete", "overwrite").contains(afterDelete.currentSnapshot().operation()),
+          "Retention should have committed a write on top of the replacement, but was: "
+              + afterDelete.currentSnapshot().operation());
+      ops.spark().sql(String.format("REFRESH TABLE %s", tableName));
+      verifyRowCount(ops, tableName, 1);
       Assertions.assertEquals(
-          1,
+          0,
           ops.spark().sql(String.format("SELECT * FROM %s WHERE data = 'd5'", tableName)).count(),
-          "Surviving rows should be the replacement's, not the pre-RTAS table's");
+          "The replacement's out-of-window row is deleted by the stale config");
       Assertions.assertEquals(
-          1,
+          0,
           rowsOlderThan(ops, tableName, now.minusDays(1)),
-          "The row the stale 1-day config targeted is still there");
-      // So the job reports success having applied no retention at all this cycle, and the row its
-      // own config covers survives untouched. Silent, and invisible to a check that only runs at
-      // job start.
+          "Retention applied the frozen window to data it was never validated against");
     }
   }
 

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsForRtasTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsForRtasTest.java
@@ -3,7 +3,9 @@ package com.linkedin.openhouse.jobs.spark;
 import com.linkedin.openhouse.common.metrics.DefaultOtelConfig;
 import com.linkedin.openhouse.common.metrics.OtelEmitter;
 import com.linkedin.openhouse.jobs.util.AppsOtelEmitter;
+import com.linkedin.openhouse.jobs.util.SparkJobUtil;
 import com.linkedin.openhouse.tablestest.OpenHouseSparkITest;
+import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
@@ -14,9 +16,17 @@ import java.util.stream.StreamSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.OverwriteFiles;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Row;
 import org.assertj.core.util.Lists;
@@ -29,7 +39,10 @@ import org.junit.jupiter.api.Test;
  *
  * <p>Retention is the job that a replace can actually invalidate: the scheduler snapshots {@code
  * policies.retention} and freezes it into the job's CLI args, and {@link Operations#runRetention}
- * never re-reads the policy before issuing its DELETE. Two tests pin the ways that goes wrong. The
+ * never re-reads the policy before issuing its DELETE. Five tests pin the ways that goes wrong: the
+ * frozen config no longer describing the table, the replace changing what the DELETE lands on, the
+ * replace making the same config far more expensive to apply, and the two commit-time races that
+ * decide whether a DELETE holding a pre-replace base snapshot is rejected or waved through. The
  * remaining two cover snapshot expiration and orphan file deletion, which carry no such frozen
  * state and are expected to simply work on a replaced table.
  */
@@ -220,6 +233,354 @@ public class OperationsForRtasTest extends OpenHouseSparkITest {
   }
 
   /**
+   * Retention stops being a metadata-only delete once a replace drops the partitioning.
+   *
+   * <p>The table is partitioned by identity on the string {@code datepartition} column that
+   * retention is configured against, which is what makes the retention DELETE cheap: Iceberg can
+   * satisfy it by dropping whole partition files, without reading or rewriting a single row. The
+   * replace keeps the schema and the retention policy exactly as they were and only drops the
+   * partitioning, so nothing about the job's frozen args stops matching and nothing fails.
+   *
+   * <p>The cost changes anyway. {@code SparkTable.canDeleteWhere} refuses a metadata delete once
+   * {@code table.specs().size() > 1}, and it also requires the predicate to reference only identity
+   * partition sources. Dropping the partitioning trips both: the replace adds an unpartitioned spec
+   * alongside the original one, and leaves no identity source for {@code datepartition}. Spark
+   * falls back to a copy-on-write rewrite, so the same retention window that used to delete
+   * metadata now reads the surviving rows and writes them out again.
+   *
+   * <p>This is permanent, not transient. The extra spec stays in the table's metadata, so no later
+   * retention run recovers the metadata-only path.
+   */
+  @Test
+  public void testRetentionLosesMetadataOnlyDeleteAfterRtasDropsPartitioning() throws Exception {
+    final String tableName = "db.test_retention_metadata_only_after_rtas";
+    final String sourceName = "db.test_retention_metadata_only_after_rtas_source";
+    ZonedDateTime now = ZonedDateTime.now();
+    String today = DATE_FORMATTER.format(now);
+    String longAgo = DATE_FORMATTER.format(now.minusDays(40));
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      ops.spark().sql(String.format("DROP TABLE IF EXISTS %s", tableName)).show();
+      ops.spark()
+          .sql(
+              String.format(
+                  "CREATE TABLE %s (data string, datepartition string)"
+                      + " PARTITIONED BY (datepartition)",
+                  tableName))
+          .show();
+      ops.spark()
+          .sql(
+              String.format(
+                  "ALTER TABLE %s SET POLICY (RETENTION = 30d ON COLUMN datepartition"
+                      + " WHERE PATTERN = 'yyyy-MM-dd')",
+                  tableName));
+      ops.spark()
+          .sql(
+              String.format(
+                  "ALTER TABLE %s SET TBLPROPERTIES ('replace.enabled'='true')", tableName))
+          .show();
+      insertDatePartitionRows(ops, tableName, today, longAgo);
+      verifyRowCount(ops, tableName, 2);
+
+      Table beforeRtas = ops.getTable(tableName);
+      Types.StructType schemaBeforeRtas = beforeRtas.schema().asStruct();
+      Assertions.assertEquals(
+          1, beforeRtas.specs().size(), "Table should start with a single partition spec");
+      Assertions.assertEquals(
+          Collections.singletonList("datepartition"),
+          identityPartitionSources(beforeRtas),
+          "Retention column should be the identity partition source");
+
+      // First retention run, on the partitioned table. The predicate lines up with the identity
+      // partition, so Iceberg drops the stale partition's files without writing anything.
+      ops.runRetention(tableName, "datepartition", "yyyy-MM-dd", "day", 30, false, "", now);
+      Snapshot firstRetention = ops.getTable(tableName).currentSnapshot();
+      Assertions.assertEquals(
+          "delete",
+          firstRetention.operation(),
+          "Retention on the partitioned table should commit a metadata-only delete");
+      Assertions.assertEquals(
+          0,
+          addedDataFiles(firstRetention),
+          "A metadata-only delete must not write data files, but wrote: "
+              + firstRetention.summary());
+      ops.spark().sql(String.format("REFRESH TABLE %s", tableName));
+      verifyRowCount(ops, tableName, 1);
+
+      // The owner replaces the table, dropping the partitioning. The retention column and the
+      // policy that names it are untouched, so nothing revalidates and nothing warns.
+      ops.spark().sql(String.format("DROP TABLE IF EXISTS %s", sourceName)).show();
+      ops.spark()
+          .sql(String.format("CREATE TABLE %s (data string, datepartition string)", sourceName))
+          .show();
+      insertDatePartitionRows(ops, sourceName, today, longAgo);
+      ops.spark()
+          .sql(
+              String.format(
+                  "REPLACE TABLE %s USING iceberg AS SELECT data, datepartition FROM %s",
+                  tableName, sourceName));
+
+      Table afterRtas = ops.getTable(tableName);
+      Assertions.assertEquals(
+          schemaBeforeRtas,
+          afterRtas.schema().asStruct(),
+          "Replace should leave the schema intact");
+      Assertions.assertTrue(
+          afterRtas.spec().isUnpartitioned(), "Replace should have dropped the partitioning");
+      Assertions.assertEquals(
+          2,
+          afterRtas.specs().size(),
+          "Replace should retain the original spec alongside the unpartitioned one");
+      Assertions.assertTrue(
+          identityPartitionSources(afterRtas).isEmpty(),
+          "Replace should leave no identity partition source for the retention column");
+      ops.spark().sql(String.format("REFRESH TABLE %s", tableName));
+      verifyRowCount(ops, tableName, 2);
+
+      // Second retention run, same config against the same schema and the same rows. It still
+      // resolves and still deletes the right rows, but no longer as a metadata-only delete.
+      ops.runRetention(tableName, "datepartition", "yyyy-MM-dd", "day", 30, false, "", now);
+      Snapshot secondRetention = ops.getTable(tableName).currentSnapshot();
+      Assertions.assertEquals(
+          "overwrite",
+          secondRetention.operation(),
+          "Retention after the replace should degrade to a copy-on-write rewrite");
+      Assertions.assertTrue(
+          addedDataFiles(secondRetention) > 0,
+          "The rewrite should have rewritten the surviving rows, but wrote no files: "
+              + secondRetention.summary());
+      ops.spark().sql(String.format("REFRESH TABLE %s", tableName));
+      verifyRowCount(ops, tableName, 1);
+      Assertions.assertEquals(
+          0,
+          ops.spark()
+              .sql(String.format("SELECT * FROM %s WHERE datepartition = '%s'", tableName, longAgo))
+              .count(),
+          "Retention should still drop the out-of-window rows");
+    }
+  }
+
+  /**
+   * The replace lands after the retention DELETE has planned but before it commits.
+   *
+   * <p>{@link #testRetentionDeleteOnSnapshotStaledByRtas} covers the case where the replace is
+   * already visible when Spark plans, so there is nothing left to conflict with. This covers the
+   * genuine interleaving: Spark's copy-on-write DELETE is not atomic. {@code SparkMergeScan} pins
+   * {@code scan.snapshotId()} when the query is planned, the write job reads and rewrites files
+   * against that snapshot, and only then does {@code
+   * SparkWrite.CopyOnWriteMergeWrite.commitWithSerializableIsolation} build the {@code
+   * OverwriteFiles} and apply {@code validateFromSnapshot(scanSnapshotId)} plus {@code
+   * validateNoConflictingData}. A replace committed inside that window leaves the DELETE holding a
+   * stale base snapshot.
+   *
+   * <p>This replays that commit against a real replace. Spark cannot be driven into the window
+   * here, because the test fixture runs {@code local[1]} and a barrier that holds the only task
+   * slot would deadlock the replace's own job, so the commit is reconstructed with the same
+   * validations Spark configures.
+   *
+   * <p>What makes this different from an ordinary concurrent writer is that a replace resets the
+   * branch: its snapshot has no parent. Iceberg's conflict validation walks the ancestry backwards
+   * from the current snapshot to the starting one, so it cannot even enumerate what changed, and
+   * refuses the commit rather than guessing.
+   */
+  @Test
+  public void testRetentionDeleteCommitRejectedWhenRtasLandsMidFlight() throws Exception {
+    final String tableName = "db.test_retention_commit_races_rtas";
+    final String sourceName = "db.test_retention_commit_races_rtas_source";
+    ZonedDateTime now = ZonedDateTime.now();
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      prepareRetentionTable(ops, tableName, "1d");
+      insertRows(ops, tableName, now, 0, 2);
+      verifyRowCount(ops, tableName, 2);
+
+      // Spark plans the DELETE here: the scan snapshot and the set of files to rewrite are both
+      // pinned now, and stay pinned for the rest of the statement.
+      Table planned = ops.getTable(tableName);
+      long scanSnapshotId = planned.currentSnapshot().snapshotId();
+      Expression retentionFilter = SparkJobUtil.createDeleteFilter("ts", "", "day", 1, now);
+      List<DataFile> scannedFiles = planFiles(planned, retentionFilter);
+      Assertions.assertFalse(
+          scannedFiles.isEmpty(), "Retention should have planned at least one file to rewrite");
+
+      // The replace commits while the write job is still running.
+      prepareSource(ops, sourceName, now, 0, 5);
+      ops.spark()
+          .sql(
+              String.format(
+                  "REPLACE TABLE %s USING iceberg PARTITIONED BY (days(ts))"
+                      + " AS SELECT data, ts FROM %s",
+                  tableName, sourceName));
+      Table afterRtas = ops.getTable(tableName);
+      long rtasSnapshotId = afterRtas.currentSnapshot().snapshotId();
+      Assertions.assertNotEquals(
+          scanSnapshotId, rtasSnapshotId, "Replace should have staled the planned scan snapshot");
+      Assertions.assertNull(
+          afterRtas.currentSnapshot().parentId(),
+          "Replace should reset the branch, leaving its snapshot without a parent");
+
+      // The write job finishes and Spark commits, exactly as commitWithSerializableIsolation does.
+      OverwriteFiles overwrite = ops.getTable(tableName).newOverwrite();
+      scannedFiles.forEach(overwrite::deleteFile);
+      overwrite.validateFromSnapshot(scanSnapshotId);
+      overwrite.conflictDetectionFilter(retentionFilter);
+      overwrite.validateNoConflictingData();
+      overwrite.validateNoConflictingDeletes();
+
+      ValidationException e =
+          Assertions.assertThrows(
+              ValidationException.class,
+              overwrite::commit,
+              "A DELETE holding a pre-replace base snapshot must not be allowed to commit");
+      Assertions.assertTrue(
+          e.getMessage().contains("Cannot determine history"),
+          "Failure should report the broken ancestry, but was: " + e.getMessage());
+
+      // The rejection is clean: the replacement is still the current state, untouched.
+      Table afterFailure = ops.getTable(tableName);
+      Assertions.assertEquals(
+          rtasSnapshotId,
+          afterFailure.currentSnapshot().snapshotId(),
+          "Rejected commit should not have moved the table");
+      ops.spark().sql(String.format("REFRESH TABLE %s", tableName));
+      verifyRowCount(ops, tableName, 2);
+    }
+  }
+
+  /**
+   * The same race on the metadata-only delete path, which carries no validation at all.
+   *
+   * <p>{@link #testRetentionDeleteCommitRejectedWhenRtasLandsMidFlight} is only protected because
+   * Spark's copy-on-write commit opts into {@code validateFromSnapshot} and {@code
+   * validateNoConflictingData}. The metadata-only path opts into nothing: {@code
+   * SparkTable.deleteWhere} is a bare {@code newDelete().deleteFromRowFilter(expr).commit()}, with
+   * no base snapshot and no conflict detection. It simply re-resolves the frozen predicate against
+   * whatever metadata is current when it commits.
+   *
+   * <p>So a replace landing mid-flight is not merely undetected here, it is undetectable: the
+   * operation never recorded which state it was authorized against. What it deletes is decided
+   * entirely at commit time, so it drops the replacement's files while the file it was actually
+   * planned against survives untouched.
+   *
+   * <p>The uncomfortable pairing is that the cheap path is the unprotected one. A table partitioned
+   * by identity on its retention column keeps the metadata-only path across a replace, because the
+   * spec is reused and stays a single spec, and therefore keeps zero validation. The table in
+   * {@link #testRetentionLosesMetadataOnlyDeleteAfterRtasDropsPartitioning} loses that path and
+   * picks up serializable validation as a side effect of getting slower.
+   */
+  @Test
+  public void testRetentionMetadataOnlyDeleteCommitsAcrossRtasUnvalidated() throws Exception {
+    final String tableName = "db.test_retention_metadata_only_races_rtas";
+    final String sourceName = "db.test_retention_metadata_only_races_rtas_source";
+    ZonedDateTime now = ZonedDateTime.now();
+    String today = DATE_FORMATTER.format(now);
+    String longAgo = DATE_FORMATTER.format(now.minusDays(40));
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      ops.spark().sql(String.format("DROP TABLE IF EXISTS %s", tableName)).show();
+      ops.spark()
+          .sql(
+              String.format(
+                  "CREATE TABLE %s (data string, datepartition string)"
+                      + " PARTITIONED BY (datepartition)",
+                  tableName))
+          .show();
+      ops.spark()
+          .sql(
+              String.format(
+                  "ALTER TABLE %s SET POLICY (RETENTION = 30d ON COLUMN datepartition"
+                      + " WHERE PATTERN = 'yyyy-MM-dd')",
+                  tableName));
+      ops.spark()
+          .sql(
+              String.format(
+                  "ALTER TABLE %s SET TBLPROPERTIES ('replace.enabled'='true')", tableName))
+          .show();
+      insertDatePartitionRows(ops, tableName, today, longAgo);
+      verifyRowCount(ops, tableName, 2);
+
+      // Spark plans the DELETE. On this table the predicate resolves to a metadata delete, so the
+      // only thing carried forward is the predicate itself: no snapshot, no file list.
+      long scanSnapshotId = ops.getTable(tableName).currentSnapshot().snapshotId();
+      Expression retentionFilter =
+          SparkJobUtil.createDeleteFilter("datepartition", "yyyy-MM-dd", "day", 30, now);
+      List<String> plannedForDelete =
+          planFiles(ops.getTable(tableName), retentionFilter).stream()
+              .map(file -> file.path().toString())
+              .collect(Collectors.toList());
+      Assertions.assertFalse(
+          plannedForDelete.isEmpty(), "Retention should have planned a file to drop");
+
+      // The replace commits inside the window, keeping the same partitioning so the spec is reused
+      // and the delete stays on the metadata-only path.
+      ops.spark().sql(String.format("DROP TABLE IF EXISTS %s", sourceName)).show();
+      ops.spark()
+          .sql(String.format("CREATE TABLE %s (data string, datepartition string)", sourceName))
+          .show();
+      insertDatePartitionRows(ops, sourceName, today, longAgo);
+      ops.spark()
+          .sql(
+              String.format(
+                  "REPLACE TABLE %s USING iceberg PARTITIONED BY (datepartition)"
+                      + " AS SELECT data, datepartition FROM %s",
+                  tableName, sourceName));
+      Table afterRtas = ops.getTable(tableName);
+      Assertions.assertNotEquals(
+          scanSnapshotId,
+          afterRtas.currentSnapshot().snapshotId(),
+          "Replace should have staled the snapshot the delete was planned on");
+      Assertions.assertNull(
+          afterRtas.currentSnapshot().parentId(),
+          "Replace should reset the branch, leaving its snapshot without a parent");
+      Assertions.assertEquals(
+          1, afterRtas.specs().size(), "Replace should reuse the identical spec");
+      ops.spark().sql(String.format("REFRESH TABLE %s", tableName));
+      List<String> postRtasFiles = getDataFilePaths(ops, tableName);
+      Assertions.assertTrue(
+          Collections.disjoint(plannedForDelete, postRtasFiles),
+          "Replace should have rewritten every file the delete planned against");
+
+      // Spark commits, exactly as SparkTable.deleteWhere does. The broken ancestry that stops the
+      // copy-on-write commit is never consulted, because nothing ever recorded a starting point.
+      Assertions.assertDoesNotThrow(
+          () -> afterRtas.newDelete().deleteFromRowFilter(retentionFilter).commit(),
+          "The metadata-only path has no validation to reject a stale delete");
+
+      Snapshot committed = ops.getTable(tableName).currentSnapshot();
+      Assertions.assertEquals(
+          "delete", committed.operation(), "Should have committed a metadata-only delete");
+      Assertions.assertEquals(
+          0,
+          addedDataFiles(committed),
+          "A metadata-only delete must not write data files, but wrote: " + committed.summary());
+
+      // The delete landed on the replacement's files, not on the ones it was planned against. The
+      // file it was authorized to drop was never touched and is still on disk, held by the
+      // pre-replace snapshot that the replace left behind.
+      ops.spark().sql(String.format("REFRESH TABLE %s", tableName));
+      List<String> survivingFiles = getDataFilePaths(ops, tableName);
+      List<String> droppedFiles =
+          postRtasFiles.stream()
+              .filter(file -> !survivingFiles.contains(file))
+              .collect(Collectors.toList());
+      Assertions.assertFalse(droppedFiles.isEmpty(), "Retention should have dropped a file");
+      Assertions.assertTrue(
+          Collections.disjoint(droppedFiles, plannedForDelete),
+          "Retention dropped none of the files it planned against, but: " + droppedFiles);
+      assertFilesExist(
+          ops.fs(),
+          plannedForDelete,
+          true,
+          "The file retention was authorized to drop should be untouched");
+
+      verifyRowCount(ops, tableName, 1);
+      Assertions.assertEquals(
+          0,
+          ops.spark()
+              .sql(String.format("SELECT * FROM %s WHERE datepartition = '%s'", tableName, longAgo))
+              .count(),
+          "The frozen predicate was applied to the replacement's files");
+    }
+  }
+
+  /**
    * Snapshot expiration after a replace.
    *
    * <p>RTAS resets the branch to a single new snapshot but leaves the pre-RTAS snapshots in the
@@ -324,8 +685,7 @@ public class OperationsForRtasTest extends OpenHouseSparkITest {
       // First pass, before expiration. The replaced files are still reachable from the retained
       // snapshots, so OFD must leave them alone and only take the planted orphan.
       DeleteOrphanFiles.Result beforeExpiry =
-          ops.deleteOrphanFiles(
-              table, System.currentTimeMillis(), false, BACKUP_DIR, 5, false, 20000);
+          ops.deleteOrphanFiles(table, System.currentTimeMillis(), BACKUP_DIR, 1, false, 20000);
       List<String> orphansBeforeExpiry = Lists.newArrayList(beforeExpiry.orphanFileLocations());
       Assertions.assertTrue(
           orphansBeforeExpiry.stream().anyMatch(f -> f.endsWith(plantedOrphanName)),
@@ -343,8 +703,7 @@ public class OperationsForRtasTest extends OpenHouseSparkITest {
       // Second pass. The replaced files are now unreachable and get reclaimed.
       Table expired = ops.getTable(tableName);
       DeleteOrphanFiles.Result afterExpiry =
-          ops.deleteOrphanFiles(
-              expired, System.currentTimeMillis(), false, BACKUP_DIR, 5, false, 20000);
+          ops.deleteOrphanFiles(expired, System.currentTimeMillis(), BACKUP_DIR, 1, false, 20000);
       List<String> orphansAfterExpiry = Lists.newArrayList(afterExpiry.orphanFileLocations());
       Assertions.assertTrue(
           normalizePaths(orphansAfterExpiry).containsAll(normalizePaths(preRtasDataFiles)),
@@ -397,6 +756,34 @@ public class OperationsForRtasTest extends OpenHouseSparkITest {
                   tableName, dayLag, DATE_FORMATTER.format(now.minusDays(dayLag))))
           .show();
     }
+  }
+
+  private static List<DataFile> planFiles(Table table, Expression filter) throws IOException {
+    try (CloseableIterable<FileScanTask> tasks = table.newScan().filter(filter).planFiles()) {
+      return StreamSupport.stream(tasks.spliterator(), false)
+          .map(FileScanTask::file)
+          .collect(Collectors.toList());
+    }
+  }
+
+  private static void insertDatePartitionRows(Operations ops, String tableName, String... dates) {
+    for (String date : dates) {
+      ops.spark()
+          .sql(String.format("INSERT INTO %s VALUES ('d-%s', '%s')", tableName, date, date))
+          .show();
+    }
+  }
+
+  /** Source columns of the table's current spec that are partitioned by identity. */
+  private static List<String> identityPartitionSources(Table table) {
+    return table.spec().fields().stream()
+        .filter(field -> field.transform().isIdentity())
+        .map(field -> table.schema().findColumnName(field.sourceId()))
+        .collect(Collectors.toList());
+  }
+
+  private static long addedDataFiles(Snapshot snapshot) {
+    return Long.parseLong(snapshot.summary().getOrDefault(SnapshotSummary.ADDED_FILES_PROP, "0"));
   }
 
   private static void verifyRowCount(Operations ops, String tableName, int expectedRowCount) {

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsForRtasTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsForRtasTest.java
@@ -1,0 +1,458 @@
+package com.linkedin.openhouse.jobs.spark;
+
+import com.linkedin.openhouse.common.metrics.DefaultOtelConfig;
+import com.linkedin.openhouse.common.metrics.OtelEmitter;
+import com.linkedin.openhouse.jobs.util.AppsOtelEmitter;
+import com.linkedin.openhouse.jobs.util.SparkJobUtil;
+import com.linkedin.openhouse.tablestest.OpenHouseSparkITest;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.Transaction;
+import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.spark.sql.AnalysisException;
+import org.apache.spark.sql.Row;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Coverage for maintenance jobs running against a table that has been replaced by {@code REPLACE
+ * TABLE ... AS SELECT}.
+ *
+ * <p>Retention is the job that a replace can actually invalidate: the scheduler snapshots {@code
+ * policies.retention} and freezes it into the job's CLI args, and {@link Operations#runRetention}
+ * never re-reads the policy before issuing its DELETE. Two tests pin the ways that goes wrong. The
+ * remaining two cover snapshot expiration and orphan file deletion, which carry no such frozen
+ * state and are expected to simply work on a replaced table.
+ */
+@Slf4j
+public class OperationsForRtasTest extends OpenHouseSparkITest {
+  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+  private static final String BACKUP_DIR = ".backup";
+  private final OtelEmitter otelEmitter =
+      new AppsOtelEmitter(Arrays.asList(DefaultOtelConfig.getOpenTelemetry()));
+
+  /**
+   * Mismatch between the old retention config and the current schema.
+   *
+   * <p>The job was launched with {@code --columnName datepartition}. The replace drops that column,
+   * so the frozen args describe a schema the table no longer has. Nothing revalidates them, so the
+   * mismatch only surfaces when the generated DELETE fails to resolve.
+   *
+   * <p>Note the replace is only accepted because the policy was re-pointed at a surviving column
+   * first: OpenHouse rejects a replace that would leave {@code policies.retention} referencing a
+   * dropped column. It does not extend that protection to a job already holding the old config.
+   */
+  @Test
+  public void testRetentionConfigMismatchesSchemaAfterRtas() throws Exception {
+    final String tableName = "db.test_retention_config_schema_mismatch";
+    final String sourceName = "db.test_retention_config_schema_mismatch_source";
+    ZonedDateTime now = ZonedDateTime.now();
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      // Table retains on `datepartition`. Neither retention column is a partition field: a replace
+      // cannot drop a column the retained partition spec still binds to.
+      ops.spark().sql(String.format("DROP TABLE IF EXISTS %s", tableName)).show();
+      ops.spark()
+          .sql(
+              String.format(
+                  "CREATE TABLE %s (data string, datepartition string, newdate string, part string)"
+                      + " PARTITIONED BY (part)",
+                  tableName))
+          .show();
+      ops.spark()
+          .sql(
+              String.format(
+                  "ALTER TABLE %s SET POLICY (RETENTION = 30d ON COLUMN datepartition"
+                      + " WHERE PATTERN = 'yyyy-MM-dd')",
+                  tableName));
+      ops.spark()
+          .sql(
+              String.format(
+                  "ALTER TABLE %s SET TBLPROPERTIES ('replace.enabled'='true')", tableName))
+          .show();
+      String today = DATE_FORMATTER.format(now);
+      String longAgo = DATE_FORMATTER.format(now.minusDays(40));
+      ops.spark()
+          .sql(
+              String.format(
+                  "INSERT INTO %s VALUES ('d0', '%s', '%s', 'p0'), ('d40', '%s', '%s', 'p1')",
+                  tableName, today, today, longAgo, longAgo))
+          .show();
+      verifyRowCount(ops, tableName, 2);
+
+      // The scheduler snapshots the policy here and launches the job, freezing
+      // `--columnName datepartition --columnPattern yyyy-MM-dd --granularity day --count 30`.
+
+      // The owner migrates the retention column and replaces the table, dropping the old column.
+      ops.spark()
+          .sql(
+              String.format(
+                  "ALTER TABLE %s SET POLICY (RETENTION = 30d ON COLUMN newdate"
+                      + " WHERE PATTERN = 'yyyy-MM-dd')",
+                  tableName));
+      ops.spark().sql(String.format("DROP TABLE IF EXISTS %s", sourceName)).show();
+      ops.spark()
+          .sql(
+              String.format(
+                  "CREATE TABLE %s (data string, newdate string, part string)", sourceName))
+          .show();
+      ops.spark()
+          .sql(
+              String.format(
+                  "INSERT INTO %s VALUES ('d0', '%s', 'p0'), ('d40', '%s', 'p1')",
+                  sourceName, today, longAgo))
+          .show();
+      ops.spark()
+          .sql(
+              String.format(
+                  "REPLACE TABLE %s USING iceberg PARTITIONED BY (part)"
+                      + " AS SELECT data, newdate, part FROM %s",
+                  tableName, sourceName));
+      Table replaced = ops.getTable(tableName);
+      Assertions.assertNull(
+          replaced.schema().findField("datepartition"),
+          "Replace should have dropped the column the in-flight job was launched with");
+      Assertions.assertNotNull(
+          replaced.schema().findField("newdate"), "Replace should keep the new retention column");
+      verifyRowCount(ops, tableName, 2);
+
+      // The in-flight job runs with its frozen args, which no longer match the schema.
+      AnalysisException e =
+          Assertions.assertThrows(
+              AnalysisException.class,
+              () ->
+                  ops.runRetention(
+                      tableName, "datepartition", "yyyy-MM-dd", "day", 30, false, "", now),
+              "Retention should not resolve against a schema missing its configured column");
+      Assertions.assertTrue(
+          e.getMessage().contains("datepartition"),
+          "Failure should name the stale retention column, but was: " + e.getMessage());
+
+      // The mismatch is fatal rather than destructive: the replaced table is untouched.
+      verifyRowCount(ops, tableName, 2);
+    }
+  }
+
+  /**
+   * The delete is planned against a snapshot that an RTAS stales before it commits.
+   *
+   * <p>The retention job resolved the table and planned its delete against the pre-RTAS snapshot.
+   * The replace then moves the table's head. Nothing binds the delete to the snapshot it was
+   * planned on, so the writer rebases onto the replacement and the commit is accepted. It lands as
+   * a snapshot that deletes nothing, and the job reports success without applying retention.
+   *
+   * <p>A preflight check cannot cover this window, since it would have passed before the replace
+   * landed. Closing it needs the delete bound to the state that was validated.
+   */
+  @Test
+  public void testRetentionDeleteOnSnapshotStaledByRtas() throws Exception {
+    final String tableName = "db.test_retention_delete_on_staled_snapshot";
+    final String sourceName = "db.test_retention_delete_on_staled_snapshot_source";
+    ZonedDateTime now = ZonedDateTime.now();
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      prepareRetentionTable(ops, tableName, "1d");
+      insertRows(ops, tableName, now, 0, 2);
+      verifyRowCount(ops, tableName, 2);
+
+      // The retention job plans its delete against the current snapshot but has not committed yet.
+      Table preRtasTable = ops.getTable(tableName);
+      long preRtasSnapshotId = preRtasTable.currentSnapshot().snapshotId();
+      Transaction plannedDelete = preRtasTable.newTransaction();
+      plannedDelete
+          .newDelete()
+          .deleteFromRowFilter(SparkJobUtil.createDeleteFilter("ts", "", "day", 1, now))
+          .commit();
+
+      // The replace lands first and stales that snapshot.
+      prepareSource(ops, sourceName, now, 0, 5);
+      ops.spark()
+          .sql(
+              String.format(
+                  "REPLACE TABLE %s USING iceberg PARTITIONED BY (days(ts))"
+                      + " AS SELECT data, ts FROM %s",
+                  tableName, sourceName));
+      long rtasSnapshotId = ops.getTable(tableName).currentSnapshot().snapshotId();
+      Assertions.assertNotEquals(
+          preRtasSnapshotId,
+          rtasSnapshotId,
+          "Replace should have moved the table off the snapshot the delete was planned on");
+      verifyRowCount(ops, tableName, 2);
+
+      // The retention delete commits onto the staled snapshot instead of failing. The writer
+      // rebases onto the replacement, so by the time the request reaches the catalog it declares
+      // the post-RTAS metadata as its base and the CAS has nothing to reject.
+      Assertions.assertDoesNotThrow(
+          plannedDelete::commitTransaction,
+          "Current behavior: a delete planned pre-RTAS rebases onto the replacement");
+
+      // It lands as a snapshot that deletes nothing. The files it planned to remove belong to the
+      // pre-RTAS table and are not part of the replacement, so the filter matches nothing.
+      Table afterDelete = ops.getTable(tableName);
+      Assertions.assertNotEquals(
+          rtasSnapshotId,
+          afterDelete.currentSnapshot().snapshotId(),
+          "Staled delete should still have committed a snapshot");
+      verifyRowCount(ops, tableName, 2);
+      Assertions.assertEquals(
+          1,
+          ops.spark().sql(String.format("SELECT * FROM %s WHERE data = 'd5'", tableName)).count(),
+          "Surviving rows should be the replacement's, not the pre-RTAS table's");
+      Assertions.assertEquals(
+          1,
+          rowsOlderThan(ops, tableName, now.minusDays(1)),
+          "The row the stale 1-day config targeted is still there");
+      // So the job reports success having applied no retention at all this cycle, and the row its
+      // own config covers survives untouched. Silent, and invisible to a check that only runs at
+      // job start.
+    }
+  }
+
+  /**
+   * Snapshot expiration after a replace.
+   *
+   * <p>RTAS resets the branch to a single new snapshot but leaves the pre-RTAS snapshots in the
+   * table's snapshot list, where they keep the replaced data files alive. SE is what actually
+   * prunes them, so this checks it still runs against a replaced table and leaves the replacement's
+   * snapshot as the only survivor.
+   */
+  @Test
+  public void testSnapshotExpirationAfterRtas() throws Exception {
+    final String tableName = "db.test_se_after_rtas";
+    final String sourceName = "db.test_se_after_rtas_source";
+    ZonedDateTime now = ZonedDateTime.now();
+    long rtasSnapshotId;
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      prepareReplaceableTable(ops, tableName);
+      insertRows(ops, tableName, now, 0, 1, 2);
+      List<Long> preRtasSnapshotIds = getSnapshotIds(ops, tableName);
+      Assertions.assertEquals(3, preRtasSnapshotIds.size(), "One snapshot per insert");
+
+      prepareSource(ops, sourceName, now, 3, 4);
+      ops.spark()
+          .sql(
+              String.format(
+                  "REPLACE TABLE %s USING iceberg AS SELECT data, ts FROM %s",
+                  tableName, sourceName));
+
+      // The replace adds a snapshot and points the branch at it, but retains the old ones.
+      rtasSnapshotId = ops.getTable(tableName).currentSnapshot().snapshotId();
+      List<Long> afterRtasSnapshotIds = getSnapshotIds(ops, tableName);
+      Assertions.assertTrue(
+          afterRtasSnapshotIds.containsAll(preRtasSnapshotIds),
+          "Replace should retain the pre-RTAS snapshots, not drop them");
+      Assertions.assertEquals(
+          preRtasSnapshotIds.size() + 1,
+          afterRtasSnapshotIds.size(),
+          "Replace should have added exactly one snapshot");
+
+      Table table = ops.getTable(tableName);
+      ops.expireSnapshots(table, 0, "DAYS", 0);
+      checkSnapshots(table, Collections.singletonList(rtasSnapshotId));
+      for (long preRtasSnapshotId : preRtasSnapshotIds) {
+        Assertions.assertNull(
+            table.snapshot(preRtasSnapshotId),
+            "Pre-RTAS snapshot " + preRtasSnapshotId + " should have been expired");
+      }
+    }
+    // Restart the app so the assertions below go through a fresh catalog load.
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      Assertions.assertEquals(
+          Collections.singletonList(rtasSnapshotId),
+          getSnapshotIds(ops, tableName),
+          "Expiration should have persisted");
+      verifyRowCount(ops, tableName, 2);
+      Assertions.assertEquals(
+          2,
+          ops.spark()
+              .sql(String.format("SELECT * FROM %s WHERE data IN ('d3', 'd4')", tableName))
+              .count(),
+          "The replacement's rows should still be readable after expiration");
+    }
+  }
+
+  /**
+   * Orphan file deletion after a replace.
+   *
+   * <p>The replaced data files only become unreferenced once SE has expired the snapshots that
+   * still point at them, and SE runs with {@code cleanExpiredFiles(false)}, so it leaves them on
+   * disk. OFD is what reclaims them. This walks that chain and checks OFD does not touch the
+   * replacement's own files at any point along it.
+   */
+  @Test
+  public void testOrphanFileDeletionAfterRtas() throws Exception {
+    final String tableName = "db.test_ofd_after_rtas";
+    final String sourceName = "db.test_ofd_after_rtas_source";
+    final String plantedOrphanName = "data/test_orphan_file.orc";
+    ZonedDateTime now = ZonedDateTime.now();
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      prepareReplaceableTable(ops, tableName);
+      insertRows(ops, tableName, now, 0, 1, 2);
+      List<String> preRtasDataFiles = getDataFilePaths(ops, tableName);
+      Assertions.assertEquals(3, preRtasDataFiles.size(), "One data file per insert");
+
+      prepareSource(ops, sourceName, now, 3, 4);
+      ops.spark()
+          .sql(
+              String.format(
+                  "REPLACE TABLE %s USING iceberg AS SELECT data, ts FROM %s",
+                  tableName, sourceName));
+      List<String> postRtasDataFiles = getDataFilePaths(ops, tableName);
+      Assertions.assertFalse(
+          postRtasDataFiles.isEmpty(), "Replacement should have written its own data files");
+      Assertions.assertTrue(
+          Collections.disjoint(preRtasDataFiles, postRtasDataFiles),
+          "Replacement should not reuse the pre-RTAS data files");
+
+      Table table = ops.getTable(tableName);
+      FileSystem fs = ops.fs();
+      Path plantedOrphan = new Path(table.location(), plantedOrphanName);
+      fs.createNewFile(plantedOrphan);
+      assertFilesExist(fs, preRtasDataFiles, true, "Replaced files should still be on disk");
+
+      // First pass, before expiration. The replaced files are still reachable from the retained
+      // snapshots, so OFD must leave them alone and only take the planted orphan.
+      DeleteOrphanFiles.Result beforeExpiry =
+          ops.deleteOrphanFiles(
+              table, System.currentTimeMillis(), false, BACKUP_DIR, 5, false, 20000);
+      List<String> orphansBeforeExpiry = Lists.newArrayList(beforeExpiry.orphanFileLocations());
+      Assertions.assertTrue(
+          orphansBeforeExpiry.stream().anyMatch(f -> f.endsWith(plantedOrphanName)),
+          "Planted orphan should be detected: " + orphansBeforeExpiry);
+      Assertions.assertFalse(fs.exists(plantedOrphan), "Planted orphan should be removed");
+      assertFilesExist(
+          fs, preRtasDataFiles, true, "Files reachable from retained snapshots are not orphans");
+      assertFilesExist(fs, postRtasDataFiles, true, "Live files must survive OFD");
+
+      // Expiring the pre-RTAS snapshots is what orphans the replaced files. SE runs with
+      // cleanExpiredFiles(false), so they stay on disk for OFD to pick up.
+      ops.expireSnapshots(table, 0, "DAYS", 0);
+      assertFilesExist(fs, preRtasDataFiles, true, "SE should not delete files itself");
+
+      // Second pass. The replaced files are now unreachable and get reclaimed.
+      Table expired = ops.getTable(tableName);
+      DeleteOrphanFiles.Result afterExpiry =
+          ops.deleteOrphanFiles(
+              expired, System.currentTimeMillis(), false, BACKUP_DIR, 5, false, 20000);
+      List<String> orphansAfterExpiry = Lists.newArrayList(afterExpiry.orphanFileLocations());
+      Assertions.assertTrue(
+          normalizePaths(orphansAfterExpiry).containsAll(normalizePaths(preRtasDataFiles)),
+          "Replaced data files should be reported as orphans: " + orphansAfterExpiry);
+      assertFilesExist(fs, preRtasDataFiles, false, "Replaced data files should be reclaimed");
+      assertFilesExist(fs, postRtasDataFiles, true, "Live files must survive OFD");
+
+      verifyRowCount(ops, tableName, 2);
+      Assertions.assertEquals(
+          2,
+          ops.spark()
+              .sql(String.format("SELECT * FROM %s WHERE data IN ('d3', 'd4')", tableName))
+              .count(),
+          "The replacement should still be readable after its predecessor is reclaimed");
+    }
+  }
+
+  private static void prepareRetentionTable(Operations ops, String tableName, String retention) {
+    ops.spark().sql(String.format("DROP TABLE IF EXISTS %s", tableName)).show();
+    ops.spark()
+        .sql(
+            String.format(
+                "CREATE TABLE %s (data string, ts timestamp) PARTITIONED BY (days(ts))", tableName))
+        .show();
+    ops.spark()
+        .sql(String.format("ALTER TABLE %s SET POLICY (RETENTION=%s)", tableName, retention));
+    // RTAS is disabled by default; opt the table in before replacing it.
+    ops.spark()
+        .sql(
+            String.format("ALTER TABLE %s SET TBLPROPERTIES ('replace.enabled'='true')", tableName))
+        .show();
+  }
+
+  private static void prepareSource(
+      Operations ops, String sourceName, ZonedDateTime now, int... dayLags) {
+    ops.spark().sql(String.format("DROP TABLE IF EXISTS %s", sourceName)).show();
+    ops.spark()
+        .sql(String.format("CREATE TABLE %s (data string, ts timestamp)", sourceName))
+        .show();
+    insertRows(ops, sourceName, now, dayLags);
+  }
+
+  private static void insertRows(
+      Operations ops, String tableName, ZonedDateTime now, int... dayLags) {
+    for (int dayLag : dayLags) {
+      ops.spark()
+          .sql(
+              String.format(
+                  "INSERT INTO %s VALUES ('d%d', cast('%s' as timestamp))",
+                  tableName, dayLag, DATE_FORMATTER.format(now.minusDays(dayLag))))
+          .show();
+    }
+  }
+
+  private static void verifyRowCount(Operations ops, String tableName, int expectedRowCount) {
+    List<Row> resultRows =
+        ops.spark().sql(String.format("SELECT * FROM %s", tableName)).collectAsList();
+    Assertions.assertEquals(expectedRowCount, resultRows.size());
+  }
+
+  private static void prepareReplaceableTable(Operations ops, String tableName) {
+    ops.spark().sql(String.format("DROP TABLE IF EXISTS %s", tableName)).show();
+    ops.spark().sql(String.format("CREATE TABLE %s (data string, ts timestamp)", tableName)).show();
+    // RTAS is disabled by default; opt the table in before replacing it.
+    ops.spark()
+        .sql(
+            String.format("ALTER TABLE %s SET TBLPROPERTIES ('replace.enabled'='true')", tableName))
+        .show();
+  }
+
+  private static List<Long> getSnapshotIds(Operations ops, String tableName) {
+    return ops.spark().sql(String.format("SELECT * FROM %s.snapshots", tableName)).collectAsList()
+        .stream()
+        .map(r -> r.getLong(r.fieldIndex("snapshot_id")))
+        .collect(Collectors.toList());
+  }
+
+  private static List<String> getDataFilePaths(Operations ops, String tableName) {
+    return ops.spark().sql(String.format("SELECT file_path FROM %s.files", tableName))
+        .collectAsList().stream()
+        .map(r -> r.getString(0))
+        .collect(Collectors.toList());
+  }
+
+  private static void checkSnapshots(Table table, List<Long> expectedSnapshotIds) {
+    List<Long> foundSnapshotIds =
+        StreamSupport.stream(table.snapshots().spliterator(), false)
+            .map(Snapshot::snapshotId)
+            .collect(Collectors.toList());
+    Assertions.assertEquals(expectedSnapshotIds, foundSnapshotIds, "Incorrect list of snapshots");
+  }
+
+  /** Orphan locations carry a scheme, the {@code files} metadata table does not. */
+  private static List<String> normalizePaths(List<String> paths) {
+    return paths.stream().map(p -> new Path(p).toUri().getPath()).collect(Collectors.toList());
+  }
+
+  private static void assertFilesExist(
+      FileSystem fs, List<String> paths, boolean expected, String message) throws Exception {
+    for (String path : paths) {
+      Assertions.assertEquals(expected, fs.exists(new Path(path)), message + ": " + path);
+    }
+  }
+
+  private static long rowsOlderThan(Operations ops, String tableName, ZonedDateTime cutoff) {
+    return ops.spark()
+        .sql(
+            String.format(
+                "SELECT * FROM %s WHERE ts < cast('%s' as timestamp)",
+                tableName, DATE_FORMATTER.format(cutoff)))
+        .count();
+  }
+}

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -843,61 +843,6 @@ public class OperationsTest extends OpenHouseSparkITest {
   }
 
   @Test
-  public void testSnapshotsExpirationAfterReplaceTable() throws Exception {
-    final String tableName = "db.test_es_rtas";
-    final String sourceName = "db.test_es_rtas_source";
-    final int numInserts = 3;
-    final int maxAge = 0;
-    final String timeGranularity = "DAYS";
-
-    List<Long> snapshotIds;
-    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
-      // create source table with data
-      ops.spark()
-          .sql(
-              String.format(
-                  "CREATE TABLE %s (data string, ts timestamp) USING iceberg", sourceName));
-      ops.spark()
-          .sql(
-              String.format(
-                  "INSERT INTO %s VALUES ('a', current_timestamp()), ('b', current_timestamp())",
-                  sourceName));
-
-      // create original table and populate with multiple inserts to create snapshots
-      prepareTable(ops, tableName);
-      populateTable(ops, tableName, numInserts);
-
-      // RTAS is disabled by default; opt the table in before replacing it.
-      ops.spark()
-          .sql(
-              String.format(
-                  "ALTER TABLE %s SET TBLPROPERTIES ('replace.enabled'='true')", tableName));
-
-      // replace the table using RTAS
-      ops.spark()
-          .sql(
-              String.format(
-                  "REPLACE TABLE %s USING iceberg AS SELECT * FROM %s", tableName, sourceName));
-
-      Table table = ops.getTable(tableName);
-      snapshotIds = getSnapshotIds(ops, tableName);
-      // original inserts + RTAS snapshot (old snapshots are preserved but branch is reset)
-      Assertions.assertTrue(
-          snapshotIds.size() > 1, "Should have multiple snapshots after inserts and RTAS");
-
-      ops.expireSnapshots(table, maxAge, timeGranularity, 0);
-      // Only retain the last snapshot (the RTAS one)
-      checkSnapshots(table, snapshotIds.subList(snapshotIds.size() - 1, snapshotIds.size()));
-    }
-    // restart the app to reload catalog cache
-    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
-      checkSnapshots(
-          ops, tableName, snapshotIds.subList(snapshotIds.size() - 1, snapshotIds.size()));
-      ops.spark().sql(String.format("DROP TABLE IF EXISTS %s", sourceName));
-    }
-  }
-
-  @Test
   public void testSnapshotsExpirationWithFilesDeletion() throws Exception {
     final String tableName = "db.test_es_delete_files";
     final int numInserts = 5;

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/RtasPolicyPreservationTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/RtasPolicyPreservationTest.java
@@ -7,6 +7,7 @@ import com.linkedin.openhouse.tablestest.OpenHouseSparkITest;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.junit.jupiter.api.Assertions;
@@ -94,6 +95,43 @@ public class RtasPolicyPreservationTest extends OpenHouseSparkITest {
           before.getHistory().getMaxAge(),
           after.getHistory().getMaxAge(),
           "RTAS changed the history policy");
+
+      spark.sql("DROP TABLE IF EXISTS " + table);
+    }
+  }
+
+  @Test
+  public void testRtasFailsWhenRetentionColumnIsDropped() throws Exception {
+    try (SparkSession spark = getSparkSession()) {
+      String table = "openhouse.dbRtasPolicy.retentionColumnDropped";
+      spark.sql("DROP TABLE IF EXISTS " + table);
+      spark.sql("CREATE TABLE " + table + " (id bigint, name string) USING iceberg");
+      spark.sql("INSERT INTO " + table + " VALUES (1, '2024-01-01'), (2, '2024-01-02')");
+      spark.sql(
+          "ALTER TABLE "
+              + table
+              + " SET POLICY (RETENTION = 30d ON COLUMN name WHERE pattern = 'yyyy-MM-dd')");
+      spark.sql("ALTER TABLE " + table + " SET TBLPROPERTIES ('replace.enabled'='true')");
+
+      // The replace drops the column the retention policy depends on. Because policies are carried
+      // forward across a replace, the resulting table would have an unsatisfiable retention policy,
+      // so the replace must be rejected upfront rather than after the write.
+      BadRequestException exception =
+          Assertions.assertThrows(
+              BadRequestException.class,
+              () ->
+                  spark.sql(
+                      "REPLACE TABLE " + table + " USING iceberg AS SELECT id FROM " + table));
+      Assertions.assertTrue(
+          exception.getMessage().contains("retention policy is incompatible with the new schema"),
+          "Expected an incompatible-retention error but got: " + exception.getMessage());
+
+      // The rejected replace must leave the table untouched.
+      Policies after = getPolicies(spark, table);
+      Assertions.assertNotNull(
+          after.getRetention(), "a rejected RTAS must not change the table's retention policy");
+      Assertions.assertEquals(
+          2, spark.sql("SELECT * FROM " + table).collectAsList().size(), "data was replaced");
 
       spark.sql("DROP TABLE IF EXISTS " + table);
     }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/RetentionPolicySpecValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/RetentionPolicySpecValidator.java
@@ -9,6 +9,8 @@ import com.linkedin.openhouse.tables.api.spec.v0.request.components.TimePartitio
 import com.linkedin.openhouse.tables.common.DefaultColumnPattern;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.Optional;
+import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -34,57 +36,95 @@ public class RetentionPolicySpecValidator extends PolicySpecValidator {
   @Override
   public boolean validate(
       CreateUpdateTableRequestBody createUpdateTableRequestBody, TableUri tableUri) {
-    Retention retention = createUpdateTableRequestBody.getPolicies().getRetention();
-    TimePartitionSpec timePartitioning = createUpdateTableRequestBody.getTimePartitioning();
-    String schema = createUpdateTableRequestBody.getSchema();
+    Optional<Violation> violation =
+        findViolation(
+            createUpdateTableRequestBody.getPolicies().getRetention(),
+            createUpdateTableRequestBody.getTimePartitioning(),
+            createUpdateTableRequestBody.getSchema(),
+            tableUri);
+    if (violation.isPresent()) {
+      failureMessage = violation.get().getMessage();
+      errorField = violation.get().getField();
+      return false;
+    }
+    return true;
+  }
 
-    if (retention != null) {
-      // Two invalid case for timePartitioned table
-      if (timePartitioning != null) {
-        if (retention.getColumnPattern() != null) {
-          failureMessage =
-              String.format(
-                  "You can only specify retention column pattern on non-timestampPartitioned table (table[%s] is time-partitioned by[%s])",
-                  tableUri, timePartitioning.getColumnName());
-          return false;
-        }
-        if (!retention.getGranularity().equals(timePartitioning.getGranularity())) {
-          failureMessage =
-              String.format(
-                  "invalid policies retention granularity format for table %s. Policies granularity must be equal to or lesser than"
-                      + " time partition spec granularity",
-                  tableUri);
-          errorField = "retention";
-          return false;
-        }
-      }
+  /**
+   * Stateless equivalent of {@link #validate(CreateUpdateTableRequestBody, TableUri)} that checks a
+   * retention policy for compatibility with the given schema and time-partitioning spec. Callers
+   * that do not operate on a {@link CreateUpdateTableRequestBody}, such as the REPLACE TABLE path
+   * where retention is carried over from the existing table, should use this method.
+   *
+   * @param retention retention policy to check, a null retention is always compatible
+   * @param timePartitioning time-partitioning spec of the table, null when not time-partitioned
+   * @param schema Iceberg schema of the table in its JSON representation
+   * @param tableUri identifier of the table used in failure messages
+   * @return the {@link Violation} found, or {@link Optional#empty()} when retention is compatible
+   */
+  public Optional<Violation> findViolation(
+      Retention retention, TimePartitionSpec timePartitioning, String schema, TableUri tableUri) {
+    if (retention == null) {
+      return Optional.empty();
+    }
 
-      // invalid cases regarding the integrity of retention object.
-      if (!validateGranularityWithPattern(retention)) {
-        failureMessage =
-            String.format(
-                "Provided Retention Granularity[%s] is not supported with default pattern. "
-                    + "Please define pattern in retention config or use one of supported granularity: %s",
-                retention.getGranularity().name(), Arrays.toString(DefaultColumnPattern.values()));
-        return false;
+    // Two invalid case for timePartitioned table
+    if (timePartitioning != null) {
+      if (retention.getColumnPattern() != null) {
+        return Optional.of(
+            new Violation(
+                "",
+                String.format(
+                    "You can only specify retention column pattern on non-timestampPartitioned table (table[%s] is time-partitioned by[%s])",
+                    tableUri, timePartitioning.getColumnName())));
       }
-      if (!validatePatternIfPresent(retention, tableUri, schema)) {
-        failureMessage =
-            String.format(
-                "Provided pattern[%s] is not recognizable by OpenHouse for the table[%s]; Also please make sure the declared column is part of table schema.",
-                retention.getColumnPattern(), tableUri);
-        return false;
-      }
-      if (timePartitioning == null && retention.getColumnPattern() == null) {
-        failureMessage =
-            String.format(
-                "For non timestamp-partitioned table %s, column pattern in retention policy is mandatory",
-                tableUri);
-        return false;
+      if (!retention.getGranularity().equals(timePartitioning.getGranularity())) {
+        return Optional.of(
+            new Violation(
+                "retention",
+                String.format(
+                    "invalid policies retention granularity format for table %s. Policies granularity must be equal to or lesser than"
+                        + " time partition spec granularity",
+                    tableUri)));
       }
     }
 
-    return true;
+    // invalid cases regarding the integrity of retention object.
+    if (!validateGranularityWithPattern(retention)) {
+      return Optional.of(
+          new Violation(
+              "",
+              String.format(
+                  "Provided Retention Granularity[%s] is not supported with default pattern. "
+                      + "Please define pattern in retention config or use one of supported granularity: %s",
+                  retention.getGranularity().name(),
+                  Arrays.toString(DefaultColumnPattern.values()))));
+    }
+    if (!validatePatternIfPresent(retention, tableUri, schema)) {
+      return Optional.of(
+          new Violation(
+              "",
+              String.format(
+                  "Provided pattern[%s] is not recognizable by OpenHouse for the table[%s]; Also please make sure the declared column is part of table schema.",
+                  retention.getColumnPattern(), tableUri)));
+    }
+    if (timePartitioning == null && retention.getColumnPattern() == null) {
+      return Optional.of(
+          new Violation(
+              "",
+              String.format(
+                  "For non timestamp-partitioned table %s, column pattern in retention policy is mandatory",
+                  tableUri)));
+    }
+
+    return Optional.empty();
+  }
+
+  /** Immutable description of an incompatible retention policy. */
+  @Value
+  public static class Violation {
+    String field;
+    String message;
   }
 
   /**

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -12,6 +12,7 @@ import com.google.gson.GsonBuilder;
 import com.linkedin.openhouse.cluster.configs.ClusterProperties;
 import com.linkedin.openhouse.cluster.storage.StorageManager;
 import com.linkedin.openhouse.cluster.storage.selector.StorageSelector;
+import com.linkedin.openhouse.common.api.spec.TableUri;
 import com.linkedin.openhouse.common.api.validator.ValidatorConstants;
 import com.linkedin.openhouse.common.exception.InvalidSchemaEvolutionException;
 import com.linkedin.openhouse.common.exception.RequestValidationFailureException;
@@ -25,6 +26,7 @@ import com.linkedin.openhouse.internal.catalog.fileio.FileIOManager;
 import com.linkedin.openhouse.internal.catalog.model.SoftDeletedTableDto;
 import com.linkedin.openhouse.internal.catalog.model.SoftDeletedTablePrimaryKey;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.Policies;
+import com.linkedin.openhouse.tables.api.validator.impl.RetentionPolicySpecValidator;
 import com.linkedin.openhouse.tables.common.TableType;
 import com.linkedin.openhouse.tables.dto.mapper.TablesMapper;
 import com.linkedin.openhouse.tables.dto.mapper.iceberg.PartitionSpecMapper;
@@ -108,6 +110,8 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
 
   @Autowired PreservedKeyChecker preservedKeyChecker;
 
+  @Autowired RetentionPolicySpecValidator retentionPolicySpecValidator;
+
   @WithSpan("InternalRepository.save")
   @Timed(metricKey = MetricsConstant.REPO_TABLE_SAVE_TIME)
   @Override
@@ -157,6 +161,7 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
       // history, lock) that must survive a replace. Merge the existing table's policies with the
       // request's so RTAS consistently merges properties.
       tableDto = mergePoliciesFromExistingTable(tableIdentifier, tableDto);
+      validateRetentionPolicyForReplace(tableDto);
       PartitionSpec partitionSpec = partitionSpecMapper.toPartitionSpec(tableDto);
       log.info(
           "Replacing a user table: {} with schema: {} and partitionSpec: {}",
@@ -384,6 +389,40 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
         .toBuilder()
         .policies(mergePolicies(existingPolicies, requested.getPolicies()))
         .build();
+  }
+
+  /**
+   * A replace carries the existing table's retention policy over to the new schema, which can leave
+   * the policy pointing at a column that the new schema no longer has, or at a granularity that no
+   * longer matches the new time-partitioning. Reject such a replace upfront, at CREATE TABLE time,
+   * instead of letting the write proceed and fail at commit time.
+   *
+   * @param tableDto table state to be persisted, with policies already merged and the new schema
+   *     and time-partitioning applied
+   */
+  private void validateRetentionPolicyForReplace(TableDto tableDto) {
+    Policies policies = tableDto.getPolicies();
+    if (policies == null || policies.getRetention() == null) {
+      return;
+    }
+    TableUri tableUri =
+        TableUri.builder()
+            .tableId(tableDto.getTableId())
+            .databaseId(tableDto.getDatabaseId())
+            .clusterId(tableDto.getClusterId())
+            .build();
+    retentionPolicySpecValidator
+        .findViolation(
+            policies.getRetention(), tableDto.getTimePartitioning(), tableDto.getSchema(), tableUri)
+        .ifPresent(
+            violation -> {
+              throw new RequestValidationFailureException(
+                  String.format(
+                      "Replacing table %s is not allowed because its retention policy is incompatible with the new schema: %s. "
+                          + "Update the retention policy with 'ALTER TABLE ... SET POLICY (RETENTION=...)' before replacing the table, "
+                          + "or keep the columns the retention policy depends on in the new schema.",
+                      tableUri, violation.getMessage()));
+            });
   }
 
   /**

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/RepositoryTest.java
@@ -18,6 +18,7 @@ import com.linkedin.openhouse.tables.api.spec.v0.request.components.History;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.Policies;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.PolicyTag;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.Retention;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.RetentionColumnPattern;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.TimePartitionSpec;
 import com.linkedin.openhouse.tables.common.TableType;
 import com.linkedin.openhouse.tables.model.TableDto;
@@ -172,6 +173,8 @@ public class RepositoryTest {
             .toBuilder()
             .tableId("tblReplaceMergesPolicies")
             .tableVersion(INITIAL_TABLE_VERSION)
+            .timePartitioning(null)
+            .clustering(null)
             .tableProperties(props)
             .policies(TABLE_POLICIES_COMPLEX)
             .build();
@@ -509,6 +512,181 @@ public class RepositoryTest {
     TableDtoPrimaryKey pk =
         TableDtoPrimaryKey.builder()
             .tableId("tblReplacePreservesColumnTags")
+            .databaseId(TABLE_DTO.getDatabaseId())
+            .build();
+    openHouseInternalRepository.deleteById(pk);
+    Assertions.assertFalse(openHouseInternalRepository.existsById(pk));
+  }
+
+  @Test
+  public void testReplaceFailsWhenRetentionColumnDroppedFromSchema() {
+    // A table whose retention policy points at a column, with RTAS enabled.
+    Schema oldSchema =
+        new Schema(
+            required(1, "id", Types.StringType.get()),
+            required(2, "datepartition", Types.StringType.get()));
+    Map<String, String> props = new HashMap<>();
+    props.put(CatalogConstants.RTAS_ENABLED_TABLE_PROP, "true");
+    TableDto createDto =
+        TABLE_DTO
+            .toBuilder()
+            .tableId("tblReplaceDropsRetentionColumn")
+            .tableVersion(INITIAL_TABLE_VERSION)
+            .schema(SchemaParser.toJson(oldSchema, false))
+            .timePartitioning(null)
+            .clustering(null)
+            .tableProperties(props)
+            .policies(
+                Policies.builder()
+                    .retention(
+                        Retention.builder()
+                            .count(3)
+                            .granularity(TimePartitionSpec.Granularity.DAY)
+                            .columnPattern(
+                                RetentionColumnPattern.builder()
+                                    .columnName("datepartition")
+                                    .pattern("yyyy-MM-dd")
+                                    .build())
+                            .build())
+                    .build())
+            .build();
+    TableDto createdDto = openHouseInternalRepository.save(createDto);
+    Assertions.assertNotNull(createdDto.getPolicies().getRetention());
+
+    // RTAS whose new schema no longer has the retention column. The carried-over retention policy
+    // is unsatisfiable, so the staged replace must fail before any data is written.
+    TableDto stageReplaceDto =
+        createdDto
+            .toBuilder()
+            .tableVersion(createdDto.getTableLocation())
+            .schema(
+                SchemaParser.toJson(new Schema(required(1, "id", Types.StringType.get())), false))
+            .policies(null)
+            .stageReplace(true)
+            .build();
+
+    RequestValidationFailureException thrown =
+        Assertions.assertThrows(
+            RequestValidationFailureException.class,
+            () -> openHouseInternalRepository.save(stageReplaceDto));
+    Assertions.assertTrue(
+        thrown.getMessage().contains("retention policy is incompatible with the new schema"),
+        "Unexpected failure message: " + thrown.getMessage());
+
+    // Cleanup
+    TableDtoPrimaryKey pk =
+        TableDtoPrimaryKey.builder()
+            .tableId("tblReplaceDropsRetentionColumn")
+            .databaseId(TABLE_DTO.getDatabaseId())
+            .build();
+    openHouseInternalRepository.deleteById(pk);
+    Assertions.assertFalse(openHouseInternalRepository.existsById(pk));
+  }
+
+  @Test
+  public void testReplaceFailsWhenTimePartitioningDropped() {
+    // A time-partitioned table with a plain retention policy, with RTAS enabled.
+    Map<String, String> props = new HashMap<>();
+    props.put(CatalogConstants.RTAS_ENABLED_TABLE_PROP, "true");
+    TableDto createDto =
+        TABLE_DTO
+            .toBuilder()
+            .tableId("tblReplaceDropsTimePartitioning")
+            .tableVersion(INITIAL_TABLE_VERSION)
+            .tableProperties(props)
+            .policies(Policies.builder().retention(RETENTION_POLICY).build())
+            .build();
+    TableDto createdDto = openHouseInternalRepository.save(createDto);
+    Assertions.assertNotNull(createdDto.getPolicies().getRetention());
+
+    // RTAS that produces an unpartitioned table. Retention without a column pattern cannot be
+    // applied to an unpartitioned table, so the replace must fail.
+    TableDto stageReplaceDto =
+        createdDto
+            .toBuilder()
+            .tableVersion(createdDto.getTableLocation())
+            .timePartitioning(null)
+            .clustering(null)
+            .policies(null)
+            .stageReplace(true)
+            .build();
+
+    RequestValidationFailureException thrown =
+        Assertions.assertThrows(
+            RequestValidationFailureException.class,
+            () -> openHouseInternalRepository.save(stageReplaceDto));
+    Assertions.assertTrue(
+        thrown.getMessage().contains("retention policy is incompatible with the new schema"),
+        "Unexpected failure message: " + thrown.getMessage());
+
+    // Cleanup
+    TableDtoPrimaryKey pk =
+        TableDtoPrimaryKey.builder()
+            .tableId("tblReplaceDropsTimePartitioning")
+            .databaseId(TABLE_DTO.getDatabaseId())
+            .build();
+    openHouseInternalRepository.deleteById(pk);
+    Assertions.assertFalse(openHouseInternalRepository.existsById(pk));
+  }
+
+  @Test
+  public void testReplaceSucceedsWhenRetentionColumnRetained() {
+    // Same setup as testReplaceFailsWhenRetentionColumnDroppedFromSchema, except the new schema
+    // keeps the retention column. The replace must be allowed.
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.StringType.get()),
+            required(2, "datepartition", Types.StringType.get()));
+    Map<String, String> props = new HashMap<>();
+    props.put(CatalogConstants.RTAS_ENABLED_TABLE_PROP, "true");
+    Retention retention =
+        Retention.builder()
+            .count(3)
+            .granularity(TimePartitionSpec.Granularity.DAY)
+            .columnPattern(
+                RetentionColumnPattern.builder()
+                    .columnName("datepartition")
+                    .pattern("yyyy-MM-dd")
+                    .build())
+            .build();
+    TableDto createDto =
+        TABLE_DTO
+            .toBuilder()
+            .tableId("tblReplaceKeepsRetentionColumn")
+            .tableVersion(INITIAL_TABLE_VERSION)
+            .schema(SchemaParser.toJson(schema, false))
+            .timePartitioning(null)
+            .clustering(null)
+            .tableProperties(props)
+            .policies(Policies.builder().retention(retention).build())
+            .build();
+    TableDto createdDto = openHouseInternalRepository.save(createDto);
+
+    TableDto stageReplaceDto =
+        createdDto
+            .toBuilder()
+            .tableVersion(createdDto.getTableLocation())
+            .schema(
+                SchemaParser.toJson(
+                    new Schema(
+                        required(1, "id", Types.StringType.get()),
+                        required(2, "datepartition", Types.StringType.get()),
+                        required(3, "extra", Types.StringType.get())),
+                    false))
+            .policies(null)
+            .stageReplace(true)
+            .build();
+    TableDto replacedDto = openHouseInternalRepository.save(stageReplaceDto);
+
+    Assertions.assertEquals(
+        "datepartition",
+        replacedDto.getPolicies().getRetention().getColumnPattern().getColumnName(),
+        "RTAS should carry the still-valid retention policy forward");
+
+    // Cleanup
+    TableDtoPrimaryKey pk =
+        TableDtoPrimaryKey.builder()
+            .tableId("tblReplaceKeepsRetentionColumn")
             .databaseId(TABLE_DTO.getDatabaseId())
             .build();
     openHouseInternalRepository.deleteById(pk);

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesControllerTest.java
@@ -944,6 +944,53 @@ public class TablesControllerTest {
 
   @SneakyThrows
   @Test
+  public void testStagedReplaceFailsWhenRetentionIncompatibleWithNewSchema() {
+    // Table with RTAS enabled and a retention policy that relies on time-partitioning.
+    GetTableResponseBody baseTable =
+        TableModelConstants.buildGetTableResponseBodyWithDbTbl("d_sr_ret", "t_sr_ret");
+    Map<String, String> propsWithRtas = new HashMap<>(baseTable.getTableProperties());
+    propsWithRtas.put(CatalogConstants.RTAS_ENABLED_TABLE_PROP, "true");
+    GetTableResponseBody table =
+        baseTable
+            .toBuilder()
+            .tableProperties(propsWithRtas)
+            .policies(Policies.builder().retention(RETENTION_POLICY).build())
+            .build();
+    MvcResult createResult =
+        RequestAndValidateHelper.createTableAndValidateResponse(table, mvc, storageManager);
+    String originalTableLocation =
+        JsonPath.read(createResult.getResponse().getContentAsString(), "$.tableLocation");
+
+    // A stageReplace that drops time-partitioning leaves the carried-over retention policy
+    // unsatisfiable. It must fail here, at CREATE TABLE time, rather than at commit time after the
+    // whole write has been done.
+    mvc.perform(
+            MockMvcRequestBuilders.post(
+                    String.format(
+                        ValidationUtilities.CURRENT_MAJOR_VERSION_PREFIX + "/databases/%s/tables/",
+                        table.getDatabaseId()))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    buildCreateUpdateTableRequestBody(table)
+                        .toBuilder()
+                        .baseTableVersion(originalTableLocation)
+                        .timePartitioning(null)
+                        .policies(null)
+                        .stageReplace(true)
+                        .build()
+                        .toJson())
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest())
+        .andExpect(
+            jsonPath(
+                "$.message",
+                containsString("retention policy is incompatible with the new schema")));
+
+    RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, table);
+  }
+
+  @SneakyThrows
+  @Test
   public void testReplaceWithWapEnabledIsRejected() {
     // Enable RTAS and remove policy
     GetTableResponseBody baseTable =


### PR DESCRIPTION
## Summary
Added a test suite for running jobs on RTAS'ed tables.
- Retention case 1: Mismatch between old retention config and the current schema.
  - Jobs failed due to analysis error. The partition column was not found.
- Retention case 2: Patition spec removed without dropping the column
  - Jobs succeeded but spark delete will be converted from metadata-only delete to overwrite.
- Retention case 3: RTAS happens before Spark delete.
  - Jobs deleted the new data but it is a valid operation.
- Retention case 4: RTAS happens during Spark delete with overwrite.
  - Jobs failed because of the snapshot lineage validation.
- Retention case 5: RTAS happens during Spark delete with metadata-only delete.
  - Jobs deleted the new data but it is a valid operation.
- SE runs properly for post-RTAS table.
- OFD runs properly for post-RTAS table.

Also starts to reject RTAS command when the new schema mismatch the retention config.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
