### PR TITLE
[dataloader] Cap hatchling below 1.30 so wheels stay publishable

### DIFF
--- a/integrations/python/dataloader/pyproject.toml
+++ b/integrations/python/dataloader/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+# hatchling 1.30 emits Metadata-Version 2.5; released twine and PyPI still
+# reject it (main publish has been red since that default). Lift once both
+# accept 2.5.
+requires = ["hatchling>=1.27,<1.30", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
## Summary

[Build and Publish Python](https://github.com/linkedin/openhouse/actions/runs/32384180035) on `main` fails at `make package-check`:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

hatchling 1.30 emits Metadata-Version 2.5. Released twine (6.2) and PyPI still only accept 2.4, so the dataloader wheel is built and then rejected. Same failure on the #645 merge; Java publish is unaffected.

Cap `[build-system] requires` to `hatchling>=1.27,<1.30`. Lift the cap once twine and PyPI accept 2.5.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

Pin only. No dataloader runtime change.

## Testing Done

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [x] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Local `uv build` + `uv run --extra dev twine check dist/*`:

- wheel METADATA is `Metadata-Version: 2.4`
- twine: PASSED on sdist and wheel

No unit-test change: this is a build-backend pin, not library behavior.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.