### PR TITLE
Move orphan files to backup when a data manifest exists regardless of backup flag

### DIFF
--- a/apps/spark-3.5/src/test/java/com/linkedin/openhouse/jobs/spark/StreamResultsOrphanFilesDeletionTest.java
+++ b/apps/spark-3.5/src/test/java/com/linkedin/openhouse/jobs/spark/StreamResultsOrphanFilesDeletionTest.java
@@ -57,7 +57,7 @@ public class StreamResultsOrphanFilesDeletionTest extends OpenHouseSparkITest {
       }
       DeleteOrphanFiles.Result result =
           ops.deleteOrphanFiles(
-              table, System.currentTimeMillis(), false, BACKUP_DIR, 1, true, maxSampleSize);
+              table, System.currentTimeMillis(), BACKUP_DIR, 1, true, maxSampleSize);
       List<String> paths = Lists.newArrayList(result.orphanFileLocations().iterator());
       // Streaming mode caps returned paths at maxSampleSize
       Assertions.assertEquals(
@@ -86,7 +86,7 @@ public class StreamResultsOrphanFilesDeletionTest extends OpenHouseSparkITest {
       }
       DeleteOrphanFiles.Result result =
           ops.deleteOrphanFiles(
-              table, System.currentTimeMillis(), false, BACKUP_DIR, 1, false, maxSampleSize);
+              table, System.currentTimeMillis(), BACKUP_DIR, 1, false, maxSampleSize);
       List<String> paths = Lists.newArrayList(result.orphanFileLocations().iterator());
       // Non-streaming ignores maxSampleSize - returns all paths
       Assertions.assertEquals(

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/BatchedOrphanFilesDeletionSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/BatchedOrphanFilesDeletionSparkApp.java
@@ -254,8 +254,6 @@ public class BatchedOrphanFilesDeletionSparkApp extends BaseSparkApp {
             ops.deleteOrphanFiles(
                 table,
                 olderThanTimestampMillis,
-                Boolean.parseBoolean(
-                    table.properties().getOrDefault(AppConstants.BACKUP_ENABLED_KEY, "false")),
                 backupDir,
                 concurrentDeletes,
                 streamResults,

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -104,13 +104,16 @@ public final class Operations implements AutoCloseable {
   }
 
   /**
-   * Run DeleteOrphanFiles operation on the given table with time filter, moves data files to the
-   * given backup directory if backup is enabled. It moves files older than the provided timestamp.
+   * Run DeleteOrphanFiles operation on the given table with time filter. An orphan data file is
+   * moved to the given backup directory whenever a data manifest exists for its partition under
+   * that directory, otherwise it is deleted. The move happens regardless of whether backup is
+   * currently enabled for the OFD job: the presence of a manifest (written by a previous retention
+   * run with backup enabled) is what marks the files for preservation. It processes files older
+   * than the provided timestamp.
    */
   public DeleteOrphanFiles.Result deleteOrphanFiles(
       Table table,
       long olderThanTimestampMillis,
-      boolean backupEnabled,
       String backupDir,
       int concurrentDeletes,
       boolean streamResults,
@@ -144,9 +147,9 @@ public final class Operations implements AutoCloseable {
                 // files present in .backup dir should not be considered orphan
                 log.info("Skipped deleting backup file {}", file);
               } else if (file.contains(dataDirRoot.toString())
-                  && backupEnabled
                   && isExistBackupDataManifests(table, file, backupDir, dataManifestsCache)) {
-                // move data files to backup dir if backup is enabled
+                // move data files to backup dir when a data manifest exists for the partition,
+                // regardless of whether backup is currently enabled for the OFD job
                 Path backupFilePath = getTrashPath(table, file, backupDir);
                 log.info("Moving orphan file {} to {}", file, backupFilePath);
                 try {

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/OrphanFilesDeletionSparkApp.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/OrphanFilesDeletionSparkApp.java
@@ -60,21 +60,16 @@ public class OrphanFilesDeletionSparkApp extends BaseTableSparkApp {
     Table table = ops.getTable(fqtn);
     long olderThanTimestampMillis =
         System.currentTimeMillis() - TimeUnit.SECONDS.toMillis(ttlSeconds);
-    boolean backupEnabled =
-        Boolean.parseBoolean(
-            table.properties().getOrDefault(AppConstants.BACKUP_ENABLED_KEY, "false"));
     log.info(
-        "Orphan files deletion app start for table={} with olderThanTimestampMillis={} ttlSeconds={} backupEnabled={} and backupDir={}",
+        "Orphan files deletion app start for table={} with olderThanTimestampMillis={} ttlSeconds={} and backupDir={}",
         fqtn,
         olderThanTimestampMillis,
         ttlSeconds,
-        backupEnabled,
         backupDir);
     DeleteOrphanFiles.Result result =
         ops.deleteOrphanFiles(
             table,
             olderThanTimestampMillis,
-            backupEnabled,
             backupDir,
             concurrentDeletes,
             streamResults,

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -386,8 +386,7 @@ public class OperationsTest extends OpenHouseSparkITest {
       fs.createNewFile(orphanFilePath);
       fs.createNewFile(dataManifestPath);
       DeleteOrphanFiles.Result result =
-          ops.deleteOrphanFiles(
-              table, System.currentTimeMillis(), true, BACKUP_DIR, 5, false, 20000);
+          ops.deleteOrphanFiles(table, System.currentTimeMillis(), BACKUP_DIR, 5, false, 20000);
       List<String> orphanFiles = Lists.newArrayList(result.orphanFileLocations().iterator());
       Assertions.assertTrue(
           fs.exists(new Path(table.location(), new Path(BACKUP_DIR, testOrphanFileName))));
@@ -413,13 +412,12 @@ public class OperationsTest extends OpenHouseSparkITest {
       FileSystem fs = ops.fs();
       fs.createNewFile(orphanFilePath);
       fs.createNewFile(dataManifestPath);
-      ops.deleteOrphanFiles(table, System.currentTimeMillis(), true, BACKUP_DIR, 5, false, 20000);
+      ops.deleteOrphanFiles(table, System.currentTimeMillis(), BACKUP_DIR, 5, false, 20000);
       Path backupFilePath = new Path(table.location(), new Path(BACKUP_DIR, testOrphanFileName));
       Assertions.assertTrue(fs.exists(backupFilePath));
       // run delete operation again and verify that files in .backup are not listed as Orphan
       DeleteOrphanFiles.Result result =
-          ops.deleteOrphanFiles(
-              table, System.currentTimeMillis(), true, BACKUP_DIR, 5, false, 20000);
+          ops.deleteOrphanFiles(table, System.currentTimeMillis(), BACKUP_DIR, 5, false, 20000);
       List<String> orphanFiles = Lists.newArrayList(result.orphanFileLocations().iterator());
       Assertions.assertEquals(0, orphanFiles.size());
       Assertions.assertTrue(fs.exists(backupFilePath));
@@ -442,8 +440,7 @@ public class OperationsTest extends OpenHouseSparkITest {
       fs.createNewFile(orphanFilePath);
       fs.createNewFile(dataManifestPath);
       DeleteOrphanFiles.Result result =
-          ops.deleteOrphanFiles(
-              table, System.currentTimeMillis(), true, BACKUP_DIR, 5, false, 20000);
+          ops.deleteOrphanFiles(table, System.currentTimeMillis(), BACKUP_DIR, 5, false, 20000);
       List<String> orphanFiles = Lists.newArrayList(result.orphanFileLocations().iterator());
       Assertions.assertFalse(
           fs.exists(new Path(table.location(), new Path(BACKUP_DIR, testOrphanFileName))));
@@ -455,7 +452,12 @@ public class OperationsTest extends OpenHouseSparkITest {
   }
 
   @Test
-  public void testOrphanFilesDeletionBackupDisabled() throws Exception {
+  public void testOrphanFilesDeletionMovesToBackupWhenManifestExistsRegardlessOfBackupFlag()
+      throws Exception {
+    // Regression test: a user reduces retention with backup enabled (which writes a data manifest
+    // into the backup dir), then raises retention and disables backup. Partitions that already
+    // expired still have a data manifest under the backup dir. The OFD job must move those orphan
+    // files to backup rather than delete them, even though backup is no longer enabled.
     final String tableName = "db.test_ofd";
     final String testOrphanFileName = "data/test_orphan_file.orc";
     final int numInserts = 3;
@@ -470,10 +472,10 @@ public class OperationsTest extends OpenHouseSparkITest {
       fs.createNewFile(orphanFilePath);
       fs.createNewFile(dataManifestPath);
       DeleteOrphanFiles.Result result =
-          ops.deleteOrphanFiles(
-              table, System.currentTimeMillis(), false, BACKUP_DIR, 5, false, 20000);
+          ops.deleteOrphanFiles(table, System.currentTimeMillis(), BACKUP_DIR, 5, false, 20000);
       List<String> orphanFiles = Lists.newArrayList(result.orphanFileLocations().iterator());
-      Assertions.assertFalse(
+      // File is moved to backup (not deleted) because a data manifest exists for the partition.
+      Assertions.assertTrue(
           fs.exists(new Path(table.location(), new Path(BACKUP_DIR, testOrphanFileName))));
       Assertions.assertEquals(1, orphanFiles.size());
       Assertions.assertTrue(
@@ -496,8 +498,7 @@ public class OperationsTest extends OpenHouseSparkITest {
       FileSystem fs = ops.fs();
       fs.createNewFile(orphanFilePath);
       DeleteOrphanFiles.Result result =
-          ops.deleteOrphanFiles(
-              table, System.currentTimeMillis(), true, BACKUP_DIR, 5, false, 20000);
+          ops.deleteOrphanFiles(table, System.currentTimeMillis(), BACKUP_DIR, 5, false, 20000);
       List<String> orphanFiles = Lists.newArrayList(result.orphanFileLocations().iterator());
       Assertions.assertFalse(
           fs.exists(new Path(table.location(), new Path(BACKUP_DIR, testOrphanFileName))));
@@ -815,7 +816,7 @@ public class OperationsTest extends OpenHouseSparkITest {
       fs.createNewFile(dataManifestPath);
       log.info("Created orphan file {}", testOrphanFile1);
       log.info("Created orphan file {}", testOrphanFile2);
-      ops.deleteOrphanFiles(table, System.currentTimeMillis(), true, TRASH_DIR, 5, false, 20000);
+      ops.deleteOrphanFiles(table, System.currentTimeMillis(), TRASH_DIR, 5, false, 20000);
       Assertions.assertTrue(
           fs.exists(new Path(table.location(), (new Path(TRASH_DIR, testOrphanFile1)))));
       Assertions.assertTrue(


### PR DESCRIPTION
When retention is reduced with backup enabled, the retention app writes a data_manifest_*.json into the partition's backup directory to mark data files for preservation. Previously the orphan files deletion (OFD) job only moved those files to backup when the OFD backup flag was currently enabled. A user could reduce retention + enable backup (writing the manifest), then raise retention + disable backup; already-expired partitions still had a manifest, but OFD deleted their files instead of preserving them.

Decouple the rename decision from the OFD backup flag: an orphan data file is now moved to backup whenever a data manifest exists for its partition, ignoring whether backup is enabled for the OFD job. The now-unused backupEnabled parameter is removed from Operations.deleteOrphanFiles and its callers.

## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

## Changes

- [ ] Client-facing API Changes
- [x] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
