### PR TITLE
[views] Add /v1 views REST contract, controller, handler and validation

### DIFF
--- a/cluster/configs/src/main/java/com/linkedin/openhouse/cluster/configs/ClusterProperties.java
+++ b/cluster/configs/src/main/java/com/linkedin/openhouse/cluster/configs/ClusterProperties.java
@@ -98,7 +98,7 @@ public class ClusterProperties {
   private List<String> allowedClientNameValues;
 
   /**
-   * View SQL dialects this deployment accepts on the /v2 views API. A representation, and the
+   * View SQL dialects this deployment accepts on the /v1 views API. A representation, and the
    * source dialect naming one, is rejected unless its dialect is listed here. Defaults to Spark
    * only; supporting another engine is a configuration change rather than a code change.
    */

--- a/cluster/configs/src/main/java/com/linkedin/openhouse/cluster/configs/ClusterProperties.java
+++ b/cluster/configs/src/main/java/com/linkedin/openhouse/cluster/configs/ClusterProperties.java
@@ -96,4 +96,12 @@ public class ClusterProperties {
   // string
   @Value("${cluster.tables.allowed-client-name-values:}")
   private List<String> allowedClientNameValues;
+
+  /**
+   * View SQL dialects this deployment accepts on the /v2 views API. A representation, and the
+   * source dialect naming one, is rejected unless its dialect is listed here. Defaults to Spark
+   * only; supporting another engine is a configuration change rather than a code change.
+   */
+  @Value("${cluster.tables.views.supported-dialects:spark}")
+  private List<String> viewsSupportedDialects;
 }

--- a/services/common/src/main/java/com/linkedin/openhouse/common/api/validator/ApiValidatorUtil.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/api/validator/ApiValidatorUtil.java
@@ -1,7 +1,12 @@
 package com.linkedin.openhouse.common.api.validator;
 
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.ALPHA_NUM_UNDERSCORE_ERROR_MSG;
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.ALPHA_NUM_UNDERSCORE_REGEX;
+
 import java.util.List;
 import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import org.apache.commons.lang3.StringUtils;
 
 public final class ApiValidatorUtil {
   /**
@@ -43,6 +48,40 @@ public final class ApiValidatorUtil {
       validationFailures.add(
           String.format(
               "sortBy : provided %s, does not support multiple sort fields or directions", sortBy));
+    }
+  }
+
+  /**
+   * Common method to run bean validation on a request object and append one formatted message per
+   * violation to the running list of validation failures.
+   *
+   * @param validator
+   * @param object
+   * @param validationFailures
+   */
+  public static <T> void collectViolations(
+      Validator validator, T object, List<String> validationFailures) {
+    for (ConstraintViolation<T> violation : validator.validate(object)) {
+      validationFailures.add(String.format("%s : %s", getField(violation), violation.getMessage()));
+    }
+  }
+
+  /**
+   * Common method to validate that an identifier is present and contains only the characters
+   * allowed by {@link ValidatorConstants#ALPHA_NUM_UNDERSCORE_REGEX}. At most one failure is
+   * reported: an absent identifier is not additionally reported as malformed.
+   *
+   * @param fieldName
+   * @param value
+   * @param validationFailures
+   */
+  public static void validateIdentifier(
+      String fieldName, String value, List<String> validationFailures) {
+    if (StringUtils.isEmpty(value)) {
+      validationFailures.add(String.format("%s : Cannot be empty", fieldName));
+    } else if (!value.matches(ALPHA_NUM_UNDERSCORE_REGEX)) {
+      validationFailures.add(
+          String.format("%s : provided %s, %s", fieldName, value, ALPHA_NUM_UNDERSCORE_ERROR_MSG));
     }
   }
 }

--- a/services/common/src/main/java/com/linkedin/openhouse/common/api/validator/ApiValidatorUtil.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/api/validator/ApiValidatorUtil.java
@@ -61,9 +61,9 @@ public final class ApiValidatorUtil {
    */
   public static <T> void collectViolations(
       Validator validator, T object, List<String> validationFailures) {
-    for (ConstraintViolation<T> violation : validator.validate(object)) {
-      validationFailures.add(String.format("%s : %s", getField(violation), violation.getMessage()));
-    }
+    validator.validate(object).stream()
+        .map(violation -> String.format("%s : %s", getField(violation), violation.getMessage()))
+        .forEachOrdered(message -> validationFailures.add(message));
   }
 
   /**

--- a/services/common/src/main/java/com/linkedin/openhouse/common/api/validator/ValidatorConstants.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/api/validator/ValidatorConstants.java
@@ -23,9 +23,6 @@ public final class ValidatorConstants {
   /** The only view representation type accepted by the /v2 views API. */
   public static final String SQL_VIEW_REPRESENTATION_TYPE = "sql";
 
-  /** The only view SQL dialect accepted by the /v2 views API in M1. */
-  public static final String SPARK_VIEW_DIALECT = "spark";
-
   /**
    * Maximum length of a view or database identifier on the /v2 views API. Mirrors the
    * {@code @Size(max = 128)} bean constraint on the request body identifiers so a path identifier

--- a/services/common/src/main/java/com/linkedin/openhouse/common/api/validator/ValidatorConstants.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/api/validator/ValidatorConstants.java
@@ -19,4 +19,27 @@ public final class ValidatorConstants {
       "Only alphanumerics, hyphen and underscore supported";
   public static final int MAX_ALLOWED_CLUSTERING_COLUMNS = 4;
   public static final String INITIAL_TABLE_VERSION = "INITIAL_VERSION";
+
+  /** The only view representation type accepted by the /v2 views API. */
+  public static final String SQL_VIEW_REPRESENTATION_TYPE = "sql";
+
+  /** The only view SQL dialect accepted by the /v2 views API in M1. */
+  public static final String SPARK_VIEW_DIALECT = "spark";
+
+  /**
+   * Maximum length of a view or database identifier on the /v2 views API. Mirrors the
+   * {@code @Size(max = 128)} bean constraint on the request body identifiers so a path identifier
+   * cannot bypass the limit the body enforces.
+   */
+  public static final int MAX_VIEW_IDENTIFIER_LENGTH = 128;
+
+  /**
+   * Maximum size of a single view representation's SQL text, in UTF-8 bytes. Counted in bytes
+   * rather than characters because the limit protects storage and transport, and a {@code @Size}
+   * bean constraint would instead count UTF-16 characters and let a multibyte payload through.
+   */
+  public static final int MAX_VIEW_SQL_BYTES = 256 * 1024;
+
+  /** Maximum size of a view schema document, in UTF-8 bytes. See {@link #MAX_VIEW_SQL_BYTES}. */
+  public static final int MAX_VIEW_SCHEMA_BYTES = 512 * 1024;
 }

--- a/services/common/src/main/java/com/linkedin/openhouse/common/api/validator/ValidatorConstants.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/api/validator/ValidatorConstants.java
@@ -20,11 +20,11 @@ public final class ValidatorConstants {
   public static final int MAX_ALLOWED_CLUSTERING_COLUMNS = 4;
   public static final String INITIAL_TABLE_VERSION = "INITIAL_VERSION";
 
-  /** The only view representation type accepted by the /v2 views API. */
+  /** The only view representation type accepted by the /v1 views API. */
   public static final String SQL_VIEW_REPRESENTATION_TYPE = "sql";
 
   /**
-   * Maximum length of a view or database identifier on the /v2 views API. Mirrors the
+   * Maximum length of a view or database identifier on the /v1 views API. Mirrors the
    * {@code @Size(max = 128)} bean constraint on the request body identifiers so a path identifier
    * cannot bypass the limit the body enforces.
    */

--- a/services/common/src/main/java/com/linkedin/openhouse/common/audit/ServiceAuditAspect.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/audit/ServiceAuditAspect.java
@@ -13,6 +13,8 @@ import com.linkedin.openhouse.common.audit.model.ServiceName;
 import com.linkedin.openhouse.common.metrics.MetricsConstant;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -41,6 +43,13 @@ public class ServiceAuditAspect {
   @Autowired private ClusterProperties clusterProperties;
 
   @Autowired private AuditHandler<ServiceAuditEvent> serviceAuditHandler;
+
+  /**
+   * Redactors contributed by the running service, if any. Left empty when the service registers
+   * none, in which case the payload is audited exactly as it was sent.
+   */
+  @Autowired(required = false)
+  private List<ServiceAuditPayloadRedactor> payloadRedactors = Collections.emptyList();
 
   private static final MetricsReporter METRICS_REPORTER =
       MetricsReporter.of(MetricsConstant.SERVICE_AUDIT);
@@ -140,9 +149,12 @@ public class ServiceAuditAspect {
       if (wrapper != null) {
         String requestPayloadStr =
             new String(wrapper.getContentAsByteArray(), StandardCharsets.UTF_8);
-        requestPayload = JsonParser.parseString(requestPayloadStr);
+        requestPayload = redactSensitiveValues(request, JsonParser.parseString(requestPayloadStr));
       }
     } catch (Exception e) {
+      // Fail closed. A payload that could not be parsed or could not be redacted is dropped rather
+      // than audited raw, so a broken redactor cannot leak the values it was meant to remove.
+      requestPayload = null;
       log.error("Exception during parsing request payload:\n", e);
       METRICS_REPORTER.count(MetricsConstant.FAILED_PARSING_REQUEST_PAYLOAD);
     }
@@ -180,6 +192,25 @@ public class ServiceAuditAspect {
         .stacktrace(stacktrace)
         .cause(cause)
         .build();
+  }
+
+  /**
+   * Apply every registered redactor that claims this request. With no redactor registered — the
+   * case for every service that has not contributed one — the parsed payload is returned unchanged,
+   * so existing audit payloads are byte-identical.
+   */
+  private JsonElement redactSensitiveValues(
+      HttpServletRequest request, JsonElement requestPayload) {
+    if (requestPayload == null || payloadRedactors == null) {
+      return requestPayload;
+    }
+    JsonElement redacted = requestPayload;
+    for (ServiceAuditPayloadRedactor redactor : payloadRedactors) {
+      if (redactor.appliesTo(request)) {
+        redacted = redactor.redact(redacted);
+      }
+    }
+    return redacted;
   }
 
   private ServiceName getServiceNameFromRequestURI(String uri) {

--- a/services/common/src/main/java/com/linkedin/openhouse/common/audit/ServiceAuditPayloadRedactor.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/audit/ServiceAuditPayloadRedactor.java
@@ -1,0 +1,37 @@
+package com.linkedin.openhouse.common.audit;
+
+import com.google.gson.JsonElement;
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Extension point that removes sensitive values from a request payload before {@link
+ * ServiceAuditAspect} writes it into a {@link
+ * com.linkedin.openhouse.common.audit.model.ServiceAuditEvent}.
+ *
+ * <p>The aspect audits the complete cached request body of every controller call, so a route whose
+ * body carries content that must not be retained has to opt out here. Only the mechanism lives in
+ * {@code services/common}: each service contributes its own beans and names its own fields, and a
+ * service that contributes none has its payload audited exactly as before.
+ *
+ * <p>Implementations are handed the parsed payload and must not mutate it. Returning a modified
+ * copy keeps a redactor from observing another redactor's half-rewritten tree, and keeps the
+ * decision to drop the payload entirely with the aspect.
+ */
+public interface ServiceAuditPayloadRedactor {
+
+  /**
+   * Marker written in place of a redacted value. Implementations replace the value and keep the
+   * key, so an auditor can still see that the field was present in the request.
+   */
+  String REDACTED_VALUE = "[REDACTED]";
+
+  /** @return whether this redactor owns {@code request}. */
+  boolean appliesTo(HttpServletRequest request);
+
+  /**
+   * @param requestPayload the parsed request body, which may be any {@link JsonElement} the caller
+   *     sent, including a non-object or {@link com.google.gson.JsonNull}.
+   * @return a redacted copy, or the argument unchanged when there is nothing to redact.
+   */
+  JsonElement redact(JsonElement requestPayload);
+}

--- a/services/common/src/main/java/com/linkedin/openhouse/common/exception/CodedApiException.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/exception/CodedApiException.java
@@ -1,0 +1,29 @@
+package com.linkedin.openhouse.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Base class for exceptions that already know the HTTP status they should map to.
+ *
+ * <p>This is deliberately a bare seam. It carries no error-code vocabulary of its own: a subclass
+ * in a downstream service owns whatever taxonomy it needs and reduces that taxonomy to an {@link
+ * HttpStatus} here. That keeps {@code services/common} free of any service-specific enum while
+ * still letting {@link com.linkedin.openhouse.common.exception.handler.OpenHouseExceptionHandler}
+ * map the exception to a response with a single handler.
+ *
+ * <p>The status is the only thing that reaches the wire. The error body shape is unchanged, so no
+ * subclass taxonomy is serialized.
+ */
+public abstract class CodedApiException extends RuntimeException {
+
+  protected CodedApiException(String message) {
+    super(message);
+  }
+
+  protected CodedApiException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  /** @return the HTTP status this failure maps to. */
+  public abstract HttpStatus getHttpStatus();
+}

--- a/services/common/src/main/java/com/linkedin/openhouse/common/exception/handler/OpenHouseExceptionHandler.java
+++ b/services/common/src/main/java/com/linkedin/openhouse/common/exception/handler/OpenHouseExceptionHandler.java
@@ -3,6 +3,7 @@ package com.linkedin.openhouse.common.exception.handler;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.linkedin.openhouse.common.api.spec.ErrorResponseBody;
 import com.linkedin.openhouse.common.exception.AlreadyExistsException;
+import com.linkedin.openhouse.common.exception.CodedApiException;
 import com.linkedin.openhouse.common.exception.EntityConcurrentModificationException;
 import com.linkedin.openhouse.common.exception.InvalidSchemaEvolutionException;
 import com.linkedin.openhouse.common.exception.InvalidTableMetadataException;
@@ -96,6 +97,30 @@ public class OpenHouseExceptionHandler extends ResponseEntityExceptionHandler {
             .message(resourceGatedByToggledOnFeatureException.getMessage())
             .stacktrace(getAbbreviatedStackTrace(resourceGatedByToggledOnFeatureException))
             .cause(getExceptionCause(resourceGatedByToggledOnFeatureException))
+            .build();
+    return buildResponseEntity(errorResponseBody);
+  }
+
+  /**
+   * Generic mapping for any exception that already knows its own HTTP status. The status comes from
+   * {@link CodedApiException#getHttpStatus()}; the body is the existing unchanged {@link
+   * ErrorResponseBody}, so no service-specific error taxonomy reaches the wire.
+   *
+   * <p>Spring selects the most specific handler, so declaring this does not change the mapping of
+   * any exception already handled above.
+   */
+  @Hidden
+  @ExceptionHandler(CodedApiException.class)
+  protected ResponseEntity<ErrorResponseBody> handleCodedApiException(
+      CodedApiException codedApiException) {
+    HttpStatus httpStatus = codedApiException.getHttpStatus();
+    ErrorResponseBody errorResponseBody =
+        ErrorResponseBody.builder()
+            .status(httpStatus)
+            .error(httpStatus.getReasonPhrase())
+            .message(codedApiException.getMessage())
+            .stacktrace(getAbbreviatedStackTrace(codedApiException))
+            .cause(getExceptionCause(codedApiException))
             .build();
     return buildResponseEntity(errorResponseBody);
   }

--- a/services/common/src/test/java/com/linkedin/openhouse/common/api/validator/ApiValidatorUtilTest.java
+++ b/services/common/src/test/java/com/linkedin/openhouse/common/api/validator/ApiValidatorUtilTest.java
@@ -1,0 +1,125 @@
+package com.linkedin.openhouse.common.api.validator;
+
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.ALPHA_NUM_UNDERSCORE_ERROR_MSG;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Path;
+import javax.validation.Validator;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class ApiValidatorUtilTest {
+
+  /** Stand-in root bean, only used for the simple name that {@code getField} derives. */
+  private static final class SampleRequestBody {}
+
+  @Test
+  public void testValidateIdentifierAcceptsLegalIdentifier() {
+    List<String> validationFailures = new ArrayList<>();
+    ApiValidatorUtil.validateIdentifier("databaseId", "db_1", validationFailures);
+    Assertions.assertEquals(Collections.emptyList(), validationFailures);
+  }
+
+  @Test
+  public void testValidateIdentifierRejectsEmpty() {
+    List<String> validationFailures = new ArrayList<>();
+    ApiValidatorUtil.validateIdentifier("databaseId", "", validationFailures);
+    Assertions.assertEquals(
+        Collections.singletonList("databaseId : Cannot be empty"), validationFailures);
+  }
+
+  @Test
+  public void testValidateIdentifierRejectsNull() {
+    List<String> validationFailures = new ArrayList<>();
+    ApiValidatorUtil.validateIdentifier("tableId", null, validationFailures);
+    Assertions.assertEquals(
+        Collections.singletonList("tableId : Cannot be empty"), validationFailures);
+  }
+
+  @Test
+  public void testValidateIdentifierRejectsIllegalCharacters() {
+    List<String> validationFailures = new ArrayList<>();
+    ApiValidatorUtil.validateIdentifier("tableId", "t#1", validationFailures);
+    Assertions.assertEquals(
+        Collections.singletonList("tableId : provided t#1, " + ALPHA_NUM_UNDERSCORE_ERROR_MSG),
+        validationFailures);
+  }
+
+  @Test
+  public void testValidateIdentifierAppendsWithoutClearing() {
+    List<String> validationFailures = new ArrayList<>();
+    validationFailures.add("pre-existing failure");
+    ApiValidatorUtil.validateIdentifier("databaseId", "d$b", validationFailures);
+    Assertions.assertEquals(
+        Arrays.asList(
+            "pre-existing failure", "databaseId : provided d$b, " + ALPHA_NUM_UNDERSCORE_ERROR_MSG),
+        validationFailures);
+  }
+
+  @Test
+  public void testCollectViolationsFormatsEachViolation() {
+    SampleRequestBody requestBody = new SampleRequestBody();
+    Set<ConstraintViolation<SampleRequestBody>> violations = new LinkedHashSet<>();
+    violations.add(violation(requestBody, "tableId", "must not be empty"));
+    violations.add(violation(requestBody, "", "must be a consistent request"));
+
+    Validator validator = Mockito.mock(Validator.class);
+    Mockito.when(validator.validate(requestBody)).thenReturn(violations);
+
+    List<String> validationFailures = new ArrayList<>();
+    validationFailures.add("pre-existing failure");
+    ApiValidatorUtil.collectViolations(validator, requestBody, validationFailures);
+
+    Assertions.assertEquals(
+        Arrays.asList(
+            "pre-existing failure",
+            "SampleRequestBody.tableId : must not be empty",
+            "SampleRequestBody : must be a consistent request"),
+        validationFailures);
+  }
+
+  @Test
+  public void testCollectViolationsAddsNothingWhenBeanIsValid() {
+    SampleRequestBody requestBody = new SampleRequestBody();
+    Validator validator = Mockito.mock(Validator.class);
+    Mockito.when(validator.validate(requestBody)).thenReturn(Collections.emptySet());
+
+    List<String> validationFailures = new ArrayList<>();
+    ApiValidatorUtil.collectViolations(validator, requestBody, validationFailures);
+
+    Assertions.assertEquals(Collections.emptyList(), validationFailures);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ConstraintViolation<SampleRequestBody> violation(
+      SampleRequestBody rootBean, String propertyPath, String message) {
+    ConstraintViolation<SampleRequestBody> violation = Mockito.mock(ConstraintViolation.class);
+    Mockito.when(violation.getRootBean()).thenReturn(rootBean);
+    Mockito.when(violation.getPropertyPath()).thenReturn(path(propertyPath));
+    Mockito.when(violation.getMessage()).thenReturn(message);
+    return violation;
+  }
+
+  /** {@code getField} only reads the string form of a path, so an empty node list is enough. */
+  private static Path path(String value) {
+    return new Path() {
+      @Override
+      public Iterator<Node> iterator() {
+        return Collections.<Node>emptyList().iterator();
+      }
+
+      @Override
+      public String toString() {
+        return value;
+      }
+    };
+  }
+}

--- a/services/common/src/test/java/com/linkedin/openhouse/common/api/validator/ApiValidatorUtilTest.java
+++ b/services/common/src/test/java/com/linkedin/openhouse/common/api/validator/ApiValidatorUtilTest.java
@@ -98,6 +98,17 @@ public class ApiValidatorUtilTest {
     Assertions.assertEquals(Collections.emptyList(), validationFailures);
   }
 
+  /** A null destination is tolerated as long as the bean is valid and nothing is appended. */
+  @Test
+  public void testCollectViolationsToleratesNullDestinationWhenBeanIsValid() {
+    SampleRequestBody requestBody = new SampleRequestBody();
+    Validator validator = Mockito.mock(Validator.class);
+    Mockito.when(validator.validate(requestBody)).thenReturn(Collections.emptySet());
+
+    Assertions.assertDoesNotThrow(
+        () -> ApiValidatorUtil.collectViolations(validator, requestBody, null));
+  }
+
   @SuppressWarnings("unchecked")
   private static ConstraintViolation<SampleRequestBody> violation(
       SampleRequestBody rootBean, String propertyPath, String message) {

--- a/services/common/src/test/java/com/linkedin/openhouse/common/exception/handler/CodedApiExceptionHandlerTest.java
+++ b/services/common/src/test/java/com/linkedin/openhouse/common/exception/handler/CodedApiExceptionHandlerTest.java
@@ -1,0 +1,130 @@
+package com.linkedin.openhouse.common.exception.handler;
+
+import com.linkedin.openhouse.common.api.spec.ErrorResponseBody;
+import com.linkedin.openhouse.common.exception.CodedApiException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Direct coverage of the generic {@link CodedApiException} mapping added to {@link
+ * OpenHouseExceptionHandler}.
+ *
+ * <p>Deliberately free of any downstream vocabulary: {@code services/common} has no dependency on
+ * {@code services/tables}, so this test builds anonymous coded exceptions rather than referencing a
+ * view error code. That the view taxonomy reduces to these statuses is a tables-side concern.
+ *
+ * <p>This test lives in the handler's own package so the {@code protected} handler method is
+ * reachable without reflection.
+ */
+public class CodedApiExceptionHandlerTest {
+
+  /**
+   * Every status a downstream taxonomy currently reduces to, plus two it does not, proving the
+   * handler forwards whatever the exception reports rather than mapping a known set.
+   */
+  private enum RepresentativeStatus {
+    BAD_REQUEST(HttpStatus.BAD_REQUEST),
+    NOT_FOUND(HttpStatus.NOT_FOUND),
+    CONFLICT(HttpStatus.CONFLICT),
+    UNPROCESSABLE_ENTITY(HttpStatus.UNPROCESSABLE_ENTITY),
+    SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE),
+    FORBIDDEN(HttpStatus.FORBIDDEN),
+    GATEWAY_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT);
+
+    private final HttpStatus httpStatus;
+
+    RepresentativeStatus(HttpStatus httpStatus) {
+      this.httpStatus = httpStatus;
+    }
+  }
+
+  private static final String FIXED_MESSAGE = "a fixed redacted failure message";
+
+  private final OpenHouseExceptionHandler handler = new OpenHouseExceptionHandler();
+
+  private static CodedApiException codedException(HttpStatus httpStatus, Throwable cause) {
+    return new CodedApiException(FIXED_MESSAGE, cause) {
+      @Override
+      public HttpStatus getHttpStatus() {
+        return httpStatus;
+      }
+    };
+  }
+
+  @ParameterizedTest
+  @EnumSource(RepresentativeStatus.class)
+  public void codedExceptionKeepsItsOwnStatusAndMessage(RepresentativeStatus representativeStatus) {
+    HttpStatus expected = representativeStatus.httpStatus;
+
+    ResponseEntity<ErrorResponseBody> response =
+        handler.handleCodedApiException(codedException(expected, null));
+
+    Assertions.assertEquals(
+        expected,
+        response.getStatusCode(),
+        "The response status must come from the exception, not from a fixed mapping.");
+
+    ErrorResponseBody body = response.getBody();
+    Assertions.assertNotNull(body);
+    Assertions.assertEquals(expected, body.getStatus());
+    Assertions.assertEquals(expected.getReasonPhrase(), body.getError());
+    Assertions.assertEquals(
+        FIXED_MESSAGE,
+        body.getMessage(),
+        "The message is copied verbatim: the handler must not decorate it, because callers rely on"
+            + " it staying redacted.");
+    Assertions.assertNotNull(body.getStacktrace());
+  }
+
+  @Test
+  public void codedExceptionCarriesItsCauseIntoTheBody() {
+    ResponseEntity<ErrorResponseBody> withCause =
+        handler.handleCodedApiException(
+            codedException(
+                HttpStatus.SERVICE_UNAVAILABLE, new IllegalStateException("downstream")));
+    Assertions.assertNotNull(withCause.getBody());
+    Assertions.assertTrue(
+        withCause.getBody().getCause().contains("downstream"),
+        "A wrapped root cause must survive into the error body.");
+
+    ResponseEntity<ErrorResponseBody> withoutCause =
+        handler.handleCodedApiException(codedException(HttpStatus.NOT_FOUND, null));
+    Assertions.assertNotNull(withoutCause.getBody());
+    Assertions.assertNotNull(
+        withoutCause.getBody().getCause(),
+        "A cause-less exception still populates the field rather than omitting it.");
+  }
+
+  /**
+   * The generic handler exists precisely so that a downstream taxonomy does not have to widen the
+   * shared error body. If a new field ever appears here, that decision has been reversed and needs
+   * its own review.
+   */
+  @Test
+  public void errorResponseBodyShapeIsUnchanged() {
+    Set<String> expectedFields =
+        new LinkedHashSet<>(Arrays.asList("status", "error", "message", "stacktrace", "cause"));
+
+    Set<String> actualFields =
+        Arrays.stream(ErrorResponseBody.class.getDeclaredFields())
+            .filter(field -> !field.isSynthetic())
+            .filter(field -> !Modifier.isStatic(field.getModifiers()))
+            .map(Field::getName)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+
+    Assertions.assertEquals(
+        expectedFields,
+        actualFields,
+        "No error code or other new field may be added to the shared error body.");
+  }
+}

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/validator/impl/OpenHouseJobTablesHtsApiValidator.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/validator/impl/OpenHouseJobTablesHtsApiValidator.java
@@ -9,7 +9,6 @@ import com.linkedin.openhouse.housetables.api.spec.model.JobKey;
 import com.linkedin.openhouse.housetables.api.validator.HouseTablesApiValidator;
 import java.util.ArrayList;
 import java.util.List;
-import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -66,10 +65,7 @@ public class OpenHouseJobTablesHtsApiValidator implements HouseTablesApiValidato
   public void validatePutEntity(Job entity) {
     List<String> validationFailures = new ArrayList<>();
 
-    for (ConstraintViolation<Job> violation : validator.validate(entity)) {
-      validationFailures.add(
-          String.format("%s : %s", ApiValidatorUtil.getField(violation), violation.getMessage()));
-    }
+    ApiValidatorUtil.collectViolations(validator, entity, validationFailures);
 
     if (!validationFailures.isEmpty()) {
       throw new RequestValidationFailureException(validationFailures);

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/validator/impl/OpenHouseUserTableHtsApiValidator.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/validator/impl/OpenHouseUserTableHtsApiValidator.java
@@ -9,7 +9,6 @@ import com.linkedin.openhouse.housetables.api.spec.model.UserTableKey;
 import com.linkedin.openhouse.housetables.api.validator.HouseTablesApiValidator;
 import java.util.ArrayList;
 import java.util.List;
-import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -70,10 +69,7 @@ public class OpenHouseUserTableHtsApiValidator
   public void validatePutEntity(UserTable userTable) {
     List<String> validationFailures = new ArrayList<>();
 
-    for (ConstraintViolation<UserTable> violation : validator.validate(userTable)) {
-      validationFailures.add(
-          String.format("%s : %s", ApiValidatorUtil.getField(violation), violation.getMessage()));
-    }
+    ApiValidatorUtil.collectViolations(validator, userTable, validationFailures);
 
     if (!validationFailures.isEmpty()) {
       throw new RequestValidationFailureException(validationFailures);

--- a/services/jobs/src/main/java/com/linkedin/openhouse/jobs/api/validator/impl/OpenHouseJobsApiValidator.java
+++ b/services/jobs/src/main/java/com/linkedin/openhouse/jobs/api/validator/impl/OpenHouseJobsApiValidator.java
@@ -9,8 +9,6 @@ import com.linkedin.openhouse.jobs.api.spec.request.CreateJobRequestBody;
 import com.linkedin.openhouse.jobs.api.validator.JobsApiValidator;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -22,12 +20,7 @@ public class OpenHouseJobsApiValidator implements JobsApiValidator {
   @Override
   public void validateCreateJob(CreateJobRequestBody createJobRequestBody) {
     List<String> validationFailures = new ArrayList<>();
-    Set<ConstraintViolation<CreateJobRequestBody>> violationSet =
-        validator.validate(createJobRequestBody);
-    for (ConstraintViolation<CreateJobRequestBody> violation : violationSet) {
-      validationFailures.add(
-          String.format("%s : %s", ApiValidatorUtil.getField(violation), violation.getMessage()));
-    }
+    ApiValidatorUtil.collectViolations(validator, createJobRequestBody, validationFailures);
     if (!createJobRequestBody.getJobName().matches(ALPHA_NUM_UNDERSCORE_REGEX_HYPHEN_ALLOW)) {
       validationFailures.add(
           String.format(

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/ViewsApiHandler.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/ViewsApiHandler.java
@@ -6,7 +6,7 @@ import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllViewsResponseBod
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetViewResponseBody;
 
 /**
- * Layer between the /v2 views REST routes and the view service. Implementations hold no business
+ * Layer between the /v1 views REST routes and the view service. Implementations hold no business
  * logic: they validate, map, delegate, map back and pick a status.
  */
 public interface ViewsApiHandler {

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/ViewsApiHandler.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/ViewsApiHandler.java
@@ -1,0 +1,73 @@
+package com.linkedin.openhouse.tables.api.handler;
+
+import com.linkedin.openhouse.common.api.spec.ApiResponse;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateViewRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllViewsResponseBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetViewResponseBody;
+
+/**
+ * Layer between the /v2 views REST routes and the view service. Implementations hold no business
+ * logic: they validate, map, delegate, map back and pick a status.
+ */
+public interface ViewsApiHandler {
+
+  /**
+   * Read a single view.
+   *
+   * @param databaseId database identifier
+   * @param viewId view identifier
+   * @param actingPrincipal authenticated user
+   * @return 200 with the view pointer
+   */
+  ApiResponse<GetViewResponseBody> getView(
+      String databaseId, String viewId, String actingPrincipal);
+
+  /**
+   * List views in a database.
+   *
+   * @param databaseId database identifier
+   * @param page zero-based page index
+   * @param size page size
+   * @param sortBy optional single sort field
+   * @param actingPrincipal authenticated user
+   * @return 200 with a page of sparse identifier-only view bodies
+   */
+  ApiResponse<GetAllViewsResponseBody> getAllViews(
+      String databaseId, int page, int size, String sortBy, String actingPrincipal);
+
+  /**
+   * Create a view.
+   *
+   * @param databaseId database identifier
+   * @param requestBody the create request
+   * @param actingPrincipal authenticated user
+   * @return 201 with the created view pointer
+   */
+  ApiResponse<GetViewResponseBody> createView(
+      String databaseId, CreateUpdateViewRequestBody requestBody, String actingPrincipal);
+
+  /**
+   * Replace a view, creating it when it does not exist.
+   *
+   * @param databaseId database identifier
+   * @param viewId view identifier
+   * @param requestBody the update request
+   * @param actingPrincipal authenticated user
+   * @return 201 when the call created the view, otherwise 200
+   */
+  ApiResponse<GetViewResponseBody> updateView(
+      String databaseId,
+      String viewId,
+      CreateUpdateViewRequestBody requestBody,
+      String actingPrincipal);
+
+  /**
+   * Delete a view.
+   *
+   * @param databaseId database identifier
+   * @param viewId view identifier
+   * @param actingPrincipal authenticated user
+   * @return 204 with no body
+   */
+  ApiResponse<Void> deleteView(String databaseId, String viewId, String actingPrincipal);
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/ViewsApiHandler.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/ViewsApiHandler.java
@@ -8,11 +8,19 @@ import com.linkedin.openhouse.tables.api.spec.v0.response.GetViewResponseBody;
 /**
  * Layer between the /v1 views REST routes and the view service. Implementations hold no business
  * logic: they validate, map, delegate, map back and pick a status.
+ *
+ * <p>Authentication and authorization failures surface as HTTP 401 and 403. Operation-specific
+ * failure outcomes are listed below; endpoint-wide server and gateway failures are documented by
+ * {@link com.linkedin.openhouse.tables.controller.ViewsController}. A write-side 5xx response may
+ * leave the commit outcome unknown and must not be retried blindly.
  */
 public interface ViewsApiHandler {
 
   /**
    * Read a single view.
+   *
+   * <p>Failure outcomes: 400 for invalid identifiers; 404 for a missing database/view or disabled
+   * views.
    *
    * @param databaseId database identifier
    * @param viewId view identifier
@@ -24,6 +32,9 @@ public interface ViewsApiHandler {
 
   /**
    * List views in a database.
+   *
+   * <p>Failure outcomes: 400 for invalid identifiers or pagination parameters; 404 for a missing
+   * database or disabled views.
    *
    * @param databaseId database identifier
    * @param page zero-based page index
@@ -38,6 +49,9 @@ public interface ViewsApiHandler {
   /**
    * Create a view.
    *
+   * <p>Failure outcomes: 400 for an invalid request; 404 for a missing database or disabled views;
+   * 409 for an occupied name. Status 422 is reserved for admission rejection.
+   *
    * @param databaseId database identifier
    * @param requestBody the create request
    * @param actingPrincipal authenticated user
@@ -48,6 +62,10 @@ public interface ViewsApiHandler {
 
   /**
    * Replace a view, creating it when it does not exist.
+   *
+   * <p>Failure outcomes: 400 for an invalid request; 404 for a missing database or disabled views;
+   * 409 for a name collision or stale base metadata location. Status 422 is reserved for admission
+   * rejection.
    *
    * @param databaseId database identifier
    * @param viewId view identifier
@@ -63,6 +81,9 @@ public interface ViewsApiHandler {
 
   /**
    * Delete a view.
+   *
+   * <p>Failure outcomes: 400 for invalid identifiers; 404 for a missing database/view or disabled
+   * views.
    *
    * @param databaseId database identifier
    * @param viewId view identifier

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/impl/OpenHouseViewsApiHandler.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/impl/OpenHouseViewsApiHandler.java
@@ -1,0 +1,94 @@
+package com.linkedin.openhouse.tables.api.handler.impl;
+
+import com.linkedin.openhouse.cluster.configs.ClusterProperties;
+import com.linkedin.openhouse.common.api.spec.ApiResponse;
+import com.linkedin.openhouse.tables.api.handler.ViewsApiHandler;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateViewRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllViewsResponseBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetViewResponseBody;
+import com.linkedin.openhouse.tables.api.validator.ViewsApiValidator;
+import com.linkedin.openhouse.tables.dto.mapper.ViewsMapper;
+import com.linkedin.openhouse.tables.model.ViewDto;
+import com.linkedin.openhouse.tables.services.ViewsService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.util.Pair;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+/**
+ * Default /v2 views API handler. The flow is strictly validate, map, delegate to the service, map
+ * back, and pick a status: no business logic, no response serialization and no feature gating live
+ * here.
+ */
+@Component
+public class OpenHouseViewsApiHandler implements ViewsApiHandler {
+
+  @Autowired private ViewsApiValidator viewsApiValidator;
+
+  @Autowired private ViewsService viewsService;
+
+  @Autowired private ViewsMapper viewsMapper;
+
+  @Autowired private ClusterProperties clusterProperties;
+
+  @Override
+  public ApiResponse<GetViewResponseBody> getView(
+      String databaseId, String viewId, String actingPrincipal) {
+    viewsApiValidator.validateGetView(databaseId, viewId);
+    ViewDto viewDto = viewsService.getView(databaseId, viewId, actingPrincipal);
+    return ApiResponse.<GetViewResponseBody>builder()
+        .httpStatus(HttpStatus.OK)
+        .responseBody(viewsMapper.toGetViewResponseBody(viewDto))
+        .build();
+  }
+
+  @Override
+  public ApiResponse<GetAllViewsResponseBody> getAllViews(
+      String databaseId, int page, int size, String sortBy, String actingPrincipal) {
+    viewsApiValidator.validateGetAllViews(databaseId, page, size, sortBy);
+    return ApiResponse.<GetAllViewsResponseBody>builder()
+        .httpStatus(HttpStatus.OK)
+        .responseBody(
+            GetAllViewsResponseBody.builder()
+                .pageResults(
+                    viewsMapper.toGetViewResponseBodyPage(
+                        viewsService.getAllViews(databaseId, page, size, sortBy, actingPrincipal)))
+                .build())
+        .build();
+  }
+
+  @Override
+  public ApiResponse<GetViewResponseBody> createView(
+      String databaseId, CreateUpdateViewRequestBody requestBody, String actingPrincipal) {
+    viewsApiValidator.validateCreateView(
+        clusterProperties.getClusterName(), databaseId, requestBody);
+    Pair<ViewDto, Boolean> putResult = viewsService.putView(requestBody, actingPrincipal, true);
+    return ApiResponse.<GetViewResponseBody>builder()
+        .httpStatus(HttpStatus.CREATED)
+        .responseBody(viewsMapper.toGetViewResponseBody(putResult.getFirst()))
+        .build();
+  }
+
+  @Override
+  public ApiResponse<GetViewResponseBody> updateView(
+      String databaseId,
+      String viewId,
+      CreateUpdateViewRequestBody requestBody,
+      String actingPrincipal) {
+    viewsApiValidator.validateUpdateView(
+        clusterProperties.getClusterName(), databaseId, viewId, requestBody);
+    Pair<ViewDto, Boolean> putResult = viewsService.putView(requestBody, actingPrincipal, false);
+    HttpStatus httpStatus = putResult.getSecond() ? HttpStatus.CREATED : HttpStatus.OK;
+    return ApiResponse.<GetViewResponseBody>builder()
+        .httpStatus(httpStatus)
+        .responseBody(viewsMapper.toGetViewResponseBody(putResult.getFirst()))
+        .build();
+  }
+
+  @Override
+  public ApiResponse<Void> deleteView(String databaseId, String viewId, String actingPrincipal) {
+    viewsApiValidator.validateDeleteView(databaseId, viewId);
+    viewsService.deleteView(databaseId, viewId, actingPrincipal);
+    return ApiResponse.<Void>builder().httpStatus(HttpStatus.NO_CONTENT).build();
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/impl/OpenHouseViewsApiHandler.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/impl/OpenHouseViewsApiHandler.java
@@ -16,7 +16,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 /**
- * Default /v2 views API handler. The flow is strictly validate, map, delegate to the service, map
+ * Default /v1 views API handler. The flow is strictly validate, map, delegate to the service, map
  * back, and pick a status: no business logic, no response serialization and no feature gating live
  * here.
  */

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/CreateUpdateViewRequestBody.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/CreateUpdateViewRequestBody.java
@@ -1,0 +1,113 @@
+package com.linkedin.openhouse.tables.api.spec.v0.request;
+
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.*;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.google.gson.Gson;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.ViewRepresentation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.Map;
+import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Request body for POST and PUT on /v2/databases/{databaseId}/views. Nullable fields are omitted
+ * from the serialized payload rather than emitted as JSON null, so an omitted {@code
+ * baseViewVersion} on create stays absent on the wire.
+ */
+@Builder(toBuilder = true)
+@EqualsAndHashCode
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CreateUpdateViewRequestBody {
+
+  @Schema(
+      description = "Unique Resource identifier for a view within a Database",
+      example = "my_view")
+  @NotEmpty(message = "viewId cannot be empty")
+  @Size(max = 128)
+  @Pattern(regexp = ALPHA_NUM_UNDERSCORE_REGEX, message = ALPHA_NUM_UNDERSCORE_ERROR_MSG)
+  private String viewId;
+
+  @Schema(
+      description = "Unique Resource identifier for the Database containing the View",
+      example = "my_database")
+  @NotEmpty(message = "databaseId cannot be empty")
+  @Size(max = 128)
+  @Pattern(regexp = ALPHA_NUM_UNDERSCORE_REGEX, message = ALPHA_NUM_UNDERSCORE_ERROR_MSG)
+  private String databaseId;
+
+  @Schema(
+      description = "Unique Resource identifier for the Cluster containing the Database",
+      example = "my_cluster")
+  @NotEmpty(message = "clusterId cannot be empty")
+  @Pattern(
+      regexp = ALPHA_NUM_UNDERSCORE_REGEX_HYPHEN_ALLOW,
+      message = ALPHA_NUM_UNDERSCORE_ERROR_MSG_HYPHEN_ALLOW)
+  private String clusterId;
+
+  @Schema(
+      description = "Schema of the view. OpenHouse views use Iceberg schema specification",
+      example =
+          "{\"type\": \"struct\", "
+              + "\"fields\": [{\"id\": 1,\"required\": true,\"name\": \"id\",\"type\": \"string\"}, "
+              + "{\"id\": 2,\"required\": true,\"name\": \"name\",\"type\": \"string\"}]}")
+  @NotEmpty(message = "schema cannot be empty")
+  private String schema;
+
+  @Schema(
+      description = "Engine-specific representations of the view definition",
+      example = "[{\"type\": \"sql\", \"sql\": \"SELECT 1\", \"dialect\": \"spark\"}]")
+  @NotEmpty(message = "representations cannot be empty")
+  @Valid
+  private List<ViewRepresentation> representations;
+
+  @Schema(description = "Dialect of the representation the view was authored in", example = "spark")
+  @NotEmpty(message = "sourceDialect cannot be empty")
+  private String sourceDialect;
+
+  @Schema(
+      nullable = true,
+      description = "Catalog used to resolve unqualified identifiers in the view SQL",
+      example = "openhouse")
+  private String defaultCatalog;
+
+  @Schema(
+      nullable = true,
+      description = "Namespace used to resolve unqualified identifiers in the view SQL",
+      example = "[\"my_database\"]")
+  private List<String> defaultNamespace;
+
+  @Schema(nullable = true, description = "View properties", example = "{\"key\": \"value\"}")
+  private Map<String, String> viewProperties;
+
+  /**
+   * Route-sensitive: absent or {@code INITIAL_VERSION} on create, and the current metadata pointer
+   * on replace. Intentionally carries no bean constraint because the rule differs per HTTP verb and
+   * is owned by the verb-aware view validator.
+   */
+  @Schema(
+      nullable = true,
+      description = "The version of the view that the current update is based upon")
+  private String baseViewVersion;
+
+  /**
+   * Uses default Gson null handling rather than {@code serializeNulls()} so this stays consistent
+   * with the class-level {@link JsonInclude.Include#NON_NULL}: an omitted nullable field is absent
+   * from the payload, not present as JSON null.
+   */
+  public String toJson() {
+    return new Gson().toJson(this);
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/CreateUpdateViewRequestBody.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/CreateUpdateViewRequestBody.java
@@ -20,7 +20,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * Request body for POST and PUT on /v2/databases/{databaseId}/views. Nullable fields are omitted
+ * Request body for POST and PUT on /v1/databases/{databaseId}/views. Nullable fields are omitted
  * from the serialized payload rather than emitted as JSON null, so an omitted {@code
  * baseViewVersion} on create stays absent on the wire.
  */

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/CreateUpdateViewRequestBody.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/CreateUpdateViewRequestBody.java
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 /**
  * Request body for POST and PUT on /v1/databases/{databaseId}/views. Nullable fields are omitted
  * from the serialized payload rather than emitted as JSON null, so an omitted {@code
- * baseViewVersion} on create stays absent on the wire.
+ * baseMetadataLocation} on create stays absent on the wire.
  */
 @Builder(toBuilder = true)
 @EqualsAndHashCode
@@ -93,14 +93,22 @@ public class CreateUpdateViewRequestBody {
   private Map<String, String> viewProperties;
 
   /**
-   * Route-sensitive: absent or {@code INITIAL_VERSION} on create, and the current metadata pointer
-   * on replace. Intentionally carries no bean constraint because the rule differs per HTTP verb and
-   * is owned by the verb-aware view validator.
+   * Verb-sensitive: POST accepts it omitted or set to the {@code INITIAL_VERSION} sentinel, while
+   * PUT — including a PUT that creates the view — always requires a nonblank value. Intentionally
+   * carries no bean constraint because the rule differs per HTTP verb and is owned by the
+   * verb-aware view validator.
    */
   @Schema(
       nullable = true,
-      description = "The version of the view that the current update is based upon")
-  private String baseViewVersion;
+      description =
+          "Location of the metadata file this update is expected to be based upon: the"
+              + " metadataLocation a GET on the view returned. This is a file location, not a"
+              + " numeric Iceberg or JPA version. POST accepts it omitted, null or set to exactly"
+              + " the INITIAL_VERSION sentinel and rejects any other value. PUT, including a PUT"
+              + " that creates the view, requires a nonblank value and treats it as an opaque"
+              + " string.",
+      example = "file:/tmp/openhouse/my_database/my_view/metadata/00000-abc.metadata.json")
+  private String baseMetadataLocation;
 
   /**
    * Uses default Gson null handling rather than {@code serializeNulls()} so this stays consistent

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/ViewRepresentation.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/ViewRepresentation.java
@@ -1,0 +1,38 @@
+package com.linkedin.openhouse.tables.api.spec.v0.request.components;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotEmpty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * ViewRepresentation is the entity holding a single engine-specific representation of a view in the
+ * /views API request body. SQL text is stored opaquely; this class carries no parsing, translation
+ * or dialect-support logic. Byte-size, representation-type and dialect-support rules are owned by
+ * the manual view validator.
+ */
+@Builder(toBuilder = true)
+@EqualsAndHashCode
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ViewRepresentation {
+
+  @Schema(description = "Type of the view representation", example = "sql")
+  @NotEmpty(message = "type cannot be empty")
+  private String type;
+
+  @Schema(
+      description = "Opaque SQL text of the view representation. The server never parses it.",
+      example = "SELECT id, name FROM my_database.my_table")
+  @NotEmpty(message = "sql cannot be empty")
+  private String sql;
+
+  @Schema(description = "SQL dialect the representation is written in", example = "spark")
+  @NotEmpty(message = "dialect cannot be empty")
+  private String dialect;
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/ViewRepresentation.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/ViewRepresentation.java
@@ -11,9 +11,9 @@ import lombok.NoArgsConstructor;
 
 /**
  * ViewRepresentation is the entity holding a single engine-specific representation of a view in the
- * /views API request body. SQL text is stored opaquely; this class carries no parsing, translation
- * or dialect-support logic. Byte-size, representation-type and dialect-support rules are owned by
- * the manual view validator.
+ * /views API request body. SQL text is carried as opaque text; this class holds no parsing,
+ * translation or dialect-support logic. Byte-size, representation-type and dialect-support rules
+ * are owned by the manual view validator.
  */
 @Builder(toBuilder = true)
 @EqualsAndHashCode
@@ -27,7 +27,9 @@ public class ViewRepresentation {
   private String type;
 
   @Schema(
-      description = "Opaque SQL text of the view representation. The server never parses it.",
+      description =
+          "SQL text of the view representation. This endpoint accepts it as opaque text: it is"
+              + " stored as sent and is not parsed or rewritten here.",
       example = "SELECT id, name FROM my_database.my_table")
   @NotEmpty(message = "sql cannot be empty")
   private String sql;

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/response/GetAllViewsResponseBody.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/response/GetAllViewsResponseBody.java
@@ -1,0 +1,25 @@
+package com.linkedin.openhouse.tables.api.spec.v0.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.Gson;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Value;
+import org.springframework.data.domain.Page;
+
+/**
+ * List contract for views. Paginated from the first release, so there is no unpaginated legacy
+ * {@code results} field to deprecate later.
+ */
+@Builder
+@Value
+public class GetAllViewsResponseBody {
+
+  @Schema(description = "Page of View objects in a database", example = "")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private Page<GetViewResponseBody> pageResults;
+
+  public String toJson() {
+    return new Gson().toJson(this);
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/response/GetAllViewsResponseBody.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/response/GetAllViewsResponseBody.java
@@ -7,10 +7,7 @@ import lombok.Builder;
 import lombok.Value;
 import org.springframework.data.domain.Page;
 
-/**
- * List contract for views. Paginated from the first release, so there is no unpaginated legacy
- * {@code results} field to deprecate later.
- */
+/** Paginated view identifiers and page metadata. */
 @Builder
 @Value
 public class GetAllViewsResponseBody {

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/response/GetViewResponseBody.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/response/GetViewResponseBody.java
@@ -1,0 +1,62 @@
+package com.linkedin.openhouse.tables.api.spec.v0.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.Gson;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Read contract for a view. Deliberately pointer-only: the SQL, schema, representations, version
+ * history, UUID, properties and resolution context live in the view metadata file and never appear
+ * in an item or list response.
+ */
+@Builder(toBuilder = true)
+@Value
+public class GetViewResponseBody {
+
+  @Schema(
+      description = "Unique Resource identifier for a view within a Database",
+      example = "my_view")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private String viewId;
+
+  @Schema(
+      description = "Unique Resource identifier for the Database containing the View",
+      example = "my_database")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private String databaseId;
+
+  @Schema(
+      description = "Unique Resource identifier for the Cluster containing the Database",
+      example = "my_cluster")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private String clusterId;
+
+  @Schema(
+      description = "Fully Qualified Resource URI for the view",
+      example = "my_cluster.my_database.my_view")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private String viewUri;
+
+  @Schema(
+      description = "Location of the view metadata in File System / Blob Store",
+      example =
+          "<fs>://<hostname>/<openhouse_namespace>/<database_name>/<viewUUID>/metadata/<uuid>.metadata.json")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private String metadataLocation;
+
+  @Schema(description = "Current Version of the View.", example = "")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private String viewVersion;
+
+  @Schema(
+      description = "View creation epoch time measured in UTC in milliseconds of a view.",
+      example = "1651002318265")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private long creationTime;
+
+  public String toJson() {
+    return new Gson().toJson(this);
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/response/GetViewResponseBody.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/response/GetViewResponseBody.java
@@ -7,9 +7,9 @@ import lombok.Builder;
 import lombok.Value;
 
 /**
- * Read contract for a view. Deliberately pointer-only: the SQL, schema, representations, version
- * history, UUID, properties and resolution context live in the view metadata file and never appear
- * in an item or list response.
+ * Read contract for a view. Pointer-only today: this response omits the definition fields. The SQL,
+ * schema, representations, version history, UUID, properties and resolution context live in the
+ * view metadata file and are not returned by the item or list response in this milestone.
  */
 @Builder(toBuilder = true)
 @Value

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/response/GetViewResponseBody.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/response/GetViewResponseBody.java
@@ -7,9 +7,8 @@ import lombok.Builder;
 import lombok.Value;
 
 /**
- * Read contract for a view. Pointer-only today: this response omits the definition fields. The SQL,
- * schema, representations, version history, UUID, properties and resolution context live in the
- * view metadata file and are not returned by the item or list response in this milestone.
+ * Pointer-only read contract for a view. SQL, schema, representations, version history, UUID,
+ * properties and resolution context are read from the metadata file, not this response.
  */
 @Builder(toBuilder = true)
 @Value

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/ViewsApiValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/ViewsApiValidator.java
@@ -3,7 +3,7 @@ package com.linkedin.openhouse.tables.api.validator;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateViewRequestBody;
 
 /**
- * Structural validation for the /v2 views API. No SQL is parsed, translated or validated against an
+ * Structural validation for the /v1 views API. No SQL is parsed, translated or validated against an
  * engine here: view SQL stays opaque and semantic rejection belongs to a later admission step.
  *
  * <p>Every method throws {@link

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/ViewsApiValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/ViewsApiValidator.java
@@ -1,0 +1,61 @@
+package com.linkedin.openhouse.tables.api.validator;
+
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateViewRequestBody;
+
+/**
+ * Structural validation for the /v2 views API. No SQL is parsed, translated or validated against an
+ * engine here: view SQL stays opaque and semantic rejection belongs to a later admission step.
+ *
+ * <p>Every method throws {@link
+ * com.linkedin.openhouse.tables.exception.ViewRequestValidationFailureException} carrying all
+ * accumulated failures joined with {@code "; "}.
+ */
+public interface ViewsApiValidator {
+
+  /**
+   * Validate a request to read a single view.
+   *
+   * @param databaseId path database identifier
+   * @param viewId path view identifier
+   */
+  void validateGetView(String databaseId, String viewId);
+
+  /**
+   * Validate a request to list views in a database.
+   *
+   * @param databaseId path database identifier
+   * @param page zero-based page index
+   * @param size page size
+   * @param sortBy optional single sort field
+   */
+  void validateGetAllViews(String databaseId, int page, int size, String sortBy);
+
+  /**
+   * Validate a POST request to create a view.
+   *
+   * @param clusterId name of the serving cluster
+   * @param databaseId path database identifier
+   * @param requestBody the create request
+   */
+  void validateCreateView(
+      String clusterId, String databaseId, CreateUpdateViewRequestBody requestBody);
+
+  /**
+   * Validate a PUT request to replace or create a view.
+   *
+   * @param clusterId name of the serving cluster
+   * @param databaseId path database identifier
+   * @param viewId path view identifier
+   * @param requestBody the update request
+   */
+  void validateUpdateView(
+      String clusterId, String databaseId, String viewId, CreateUpdateViewRequestBody requestBody);
+
+  /**
+   * Validate a request to delete a view.
+   *
+   * @param databaseId path database identifier
+   * @param viewId path view identifier
+   */
+  void validateDeleteView(String databaseId, String viewId);
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/ViewsApiValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/ViewsApiValidator.java
@@ -4,7 +4,7 @@ import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateViewRequest
 
 /**
  * Structural validation for the /v1 views API. No SQL is parsed, translated or validated against an
- * engine here: view SQL stays opaque and semantic rejection belongs to a later admission step.
+ * engine here: view SQL stays opaque and semantic rejection belongs to admission.
  *
  * <p>Every method throws {@link
  * com.linkedin.openhouse.tables.exception.ViewRequestValidationFailureException} carrying all

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/IcebergSnapshotsApiValidatorImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/IcebergSnapshotsApiValidatorImpl.java
@@ -10,7 +10,6 @@ import com.linkedin.openhouse.tables.api.validator.IcebergSnapshotsApiValidator;
 import com.linkedin.openhouse.tables.api.validator.TablesApiValidator;
 import java.util.ArrayList;
 import java.util.List;
-import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -20,10 +19,6 @@ public class IcebergSnapshotsApiValidatorImpl implements IcebergSnapshotsApiVali
   @Autowired private TablesApiValidator tablesApiValidator;
   @Autowired private Validator validator;
 
-  // Suppression needed as checkstyle and spotless doesn't agree to each other in terms of whether
-  // `:` should be
-  // in the same line with the for-loop main body or not.
-  @SuppressWarnings("checkstyle:OperatorWrap")
   @Override
   public void validatePutSnapshots(
       String clusterId,
@@ -31,11 +26,7 @@ public class IcebergSnapshotsApiValidatorImpl implements IcebergSnapshotsApiVali
       String tableId,
       IcebergSnapshotsRequestBody icebergSnapshotsRequestBody) {
     List<String> validationFailures = new ArrayList<>();
-    for (ConstraintViolation<IcebergSnapshotsRequestBody> violation :
-        validator.validate(icebergSnapshotsRequestBody)) {
-      validationFailures.add(
-          String.format("%s : %s", ApiValidatorUtil.getField(violation), violation.getMessage()));
-    }
+    ApiValidatorUtil.collectViolations(validator, icebergSnapshotsRequestBody, validationFailures);
 
     // Only iff all constraints are fulfilled will it be safe to proceed to rest of check
     if (validationFailures.isEmpty()) {

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/OpenHouseDatabasesApiValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/OpenHouseDatabasesApiValidator.java
@@ -1,17 +1,12 @@
 package com.linkedin.openhouse.tables.api.validator.impl;
 
-import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.ALPHA_NUM_UNDERSCORE_ERROR_MSG;
-import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.ALPHA_NUM_UNDERSCORE_REGEX;
-
 import com.linkedin.openhouse.common.api.validator.ApiValidatorUtil;
 import com.linkedin.openhouse.common.exception.RequestValidationFailureException;
 import com.linkedin.openhouse.tables.api.spec.v0.request.UpdateAclPoliciesRequestBody;
 import com.linkedin.openhouse.tables.api.validator.DatabasesApiValidator;
 import java.util.ArrayList;
 import java.util.List;
-import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
-import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -20,16 +15,11 @@ public class OpenHouseDatabasesApiValidator implements DatabasesApiValidator {
 
   @Autowired private Validator validator;
 
-  @SuppressWarnings("checkstyle:OperatorWrap")
   @Override
   public void validateUpdateAclPolicies(
       String databaseId, UpdateAclPoliciesRequestBody updateAclPoliciesRequestBody) {
     List<String> validationFailures = new ArrayList<>();
-    for (ConstraintViolation<UpdateAclPoliciesRequestBody> violation :
-        validator.validate(updateAclPoliciesRequestBody)) {
-      validationFailures.add(
-          String.format("%s : %s", ApiValidatorUtil.getField(violation), violation.getMessage()));
-    }
+    ApiValidatorUtil.collectViolations(validator, updateAclPoliciesRequestBody, validationFailures);
     if (!validationFailures.isEmpty()) {
       throw new RequestValidationFailureException(validationFailures);
     }
@@ -55,12 +45,7 @@ public class OpenHouseDatabasesApiValidator implements DatabasesApiValidator {
 
   private void validateDatabaseId(String databaseId) {
     List<String> validationFailures = new ArrayList<>();
-    if (StringUtils.isEmpty(databaseId)) {
-      validationFailures.add("databaseId : Cannot be empty");
-    } else if (!databaseId.matches(ALPHA_NUM_UNDERSCORE_REGEX)) {
-      validationFailures.add(
-          String.format("databaseId provided: %s, %s", databaseId, ALPHA_NUM_UNDERSCORE_ERROR_MSG));
-    }
+    ApiValidatorUtil.validateIdentifier("databaseId", databaseId, validationFailures);
     if (!validationFailures.isEmpty()) {
       throw new RequestValidationFailureException(validationFailures);
     }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/OpenHouseTablesApiValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/OpenHouseTablesApiValidator.java
@@ -25,10 +25,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.SortOrder;
@@ -102,18 +100,13 @@ public class OpenHouseTablesApiValidator implements TablesApiValidator {
     }
   }
 
-  @SuppressWarnings("checkstyle:OperatorWrap")
   @Override
   public void validateCreateTable(
       String clusterId,
       String databaseId,
       CreateUpdateTableRequestBody createUpdateTableRequestBody) {
     List<String> validationFailures = new ArrayList<>();
-    for (ConstraintViolation<CreateUpdateTableRequestBody> violation :
-        validator.validate(createUpdateTableRequestBody)) {
-      validationFailures.add(
-          String.format("%s : %s", ApiValidatorUtil.getField(violation), violation.getMessage()));
-    }
+    ApiValidatorUtil.collectViolations(validator, createUpdateTableRequestBody, validationFailures);
     if (!createUpdateTableRequestBody.getClusterId().equals(clusterId)) {
       validationFailures.add(
           String.format(
@@ -236,7 +229,6 @@ public class OpenHouseTablesApiValidator implements TablesApiValidator {
     }
   }
 
-  @SuppressWarnings("checkstyle:OperatorWrap")
   @Override
   public void validateUpdateTable(
       String clusterId,
@@ -244,11 +236,7 @@ public class OpenHouseTablesApiValidator implements TablesApiValidator {
       String tableId,
       CreateUpdateTableRequestBody createUpdateTableRequestBody) {
     List<String> validationFailures = new ArrayList<>();
-    for (ConstraintViolation<CreateUpdateTableRequestBody> violation :
-        validator.validate(createUpdateTableRequestBody)) {
-      validationFailures.add(
-          String.format("%s : %s", ApiValidatorUtil.getField(violation), violation.getMessage()));
-    }
+    ApiValidatorUtil.collectViolations(validator, createUpdateTableRequestBody, validationFailures);
     if (!createUpdateTableRequestBody.getClusterId().equals(clusterId)) {
       validationFailures.add(
           String.format(
@@ -337,7 +325,6 @@ public class OpenHouseTablesApiValidator implements TablesApiValidator {
     }
   }
 
-  @SuppressWarnings("checkstyle:OperatorWrap")
   @Override
   public void validateUpdateAclPolicies(
       String databaseId,
@@ -345,11 +332,7 @@ public class OpenHouseTablesApiValidator implements TablesApiValidator {
       UpdateAclPoliciesRequestBody updateAclPoliciesRequestBody) {
     List<String> validationFailures = new ArrayList<>();
 
-    for (ConstraintViolation<UpdateAclPoliciesRequestBody> violation :
-        validator.validate(updateAclPoliciesRequestBody)) {
-      validationFailures.add(
-          String.format("%s : %s", ApiValidatorUtil.getField(violation), violation.getMessage()));
-    }
+    ApiValidatorUtil.collectViolations(validator, updateAclPoliciesRequestBody, validationFailures);
     if (!validationFailures.isEmpty()) {
       throw new RequestValidationFailureException(validationFailures);
     }
@@ -524,22 +507,11 @@ public class OpenHouseTablesApiValidator implements TablesApiValidator {
   }
 
   private void validateDatabaseId(String databaseId, List<String> validationFailures) {
-    if (StringUtils.isEmpty(databaseId)) {
-      validationFailures.add("databaseId : Cannot be empty");
-    } else if (!databaseId.matches(ALPHA_NUM_UNDERSCORE_REGEX)) {
-      validationFailures.add(
-          String.format(
-              "databaseId : provided %s, %s", databaseId, ALPHA_NUM_UNDERSCORE_ERROR_MSG));
-    }
+    ApiValidatorUtil.validateIdentifier("databaseId", databaseId, validationFailures);
   }
 
   private void validateTableId(String tableId, List<String> validationFailures) {
-    if (StringUtils.isEmpty(tableId)) {
-      validationFailures.add("tableId : Cannot be empty");
-    } else if (!tableId.matches(ALPHA_NUM_UNDERSCORE_REGEX)) {
-      validationFailures.add(
-          String.format("tableId : provided %s, %s", tableId, ALPHA_NUM_UNDERSCORE_ERROR_MSG));
-    }
+    ApiValidatorUtil.validateIdentifier("tableId", tableId, validationFailures);
   }
 
   private void validateSortOrder(String sortOrder, String schema, List<String> validationFailures) {

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/OpenHouseViewsApiValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/OpenHouseViewsApiValidator.java
@@ -6,9 +6,9 @@ import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.INI
 import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.MAX_VIEW_IDENTIFIER_LENGTH;
 import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.MAX_VIEW_SCHEMA_BYTES;
 import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.MAX_VIEW_SQL_BYTES;
-import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.SPARK_VIEW_DIALECT;
 import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.SQL_VIEW_REPRESENTATION_TYPE;
 
+import com.linkedin.openhouse.cluster.configs.ClusterProperties;
 import com.linkedin.openhouse.common.api.validator.ApiValidatorUtil;
 import com.linkedin.openhouse.common.schema.IcebergSchemaHelper;
 import com.linkedin.openhouse.internal.catalog.mapper.HouseTableSerdeUtils;
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -30,6 +31,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+import javax.annotation.PostConstruct;
 import javax.validation.Validator;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -57,6 +59,35 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
   private static final String POLICIES_PROPERTY_KEY = "policies";
 
   @Autowired private Validator validator;
+
+  @Autowired private ClusterProperties clusterProperties;
+
+  /**
+   * The dialects this deployment accepts, normalized once at startup. Configured values are
+   * lowercased and deduplicated so a comma-separated property is compared the same way whatever
+   * spacing or casing it was written with, while a caller's dialect still has to match exactly in
+   * lowercase, as it always has.
+   *
+   * <p>A {@link LinkedHashSet} over sorted values rather than the {@link TreeSet} that sorted them:
+   * a comparator-ordered set rejects a {@code null} lookup, and a representation may legally reach
+   * the membership test with no dialect at all.
+   */
+  private Set<String> supportedDialects;
+
+  /** Fixed, server-owned text: the configured set never contains caller-supplied payload. */
+  private String supportedDialectsText;
+
+  @PostConstruct
+  void resolveSupportedDialects() {
+    Set<String> sorted =
+        clusterProperties.getViewsSupportedDialects().stream()
+            .filter(StringUtils::isNotBlank)
+            .map(dialect -> dialect.trim().toLowerCase(Locale.ROOT))
+            .collect(Collectors.toCollection(TreeSet::new));
+    supportedDialects = Collections.unmodifiableSet(new LinkedHashSet<>(sorted));
+    supportedDialectsText = String.join(", ", supportedDialects);
+    log.info("Views API accepting the configured view dialects: {}", supportedDialectsText);
+  }
 
   @Override
   public void validateGetView(String databaseId, String viewId) {
@@ -218,6 +249,12 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
     }
   }
 
+  /**
+   * Every representation must name a dialect this deployment supports. There is deliberately no
+   * rule on how many representations a request may carry: {@link #validateUniqueDialects} already
+   * rejects an ambiguous request, so a request carrying one representation per supported dialect is
+   * well formed and is accepted.
+   */
   private void validateRepresentations(
       Optional<List<ViewRepresentation>> maybeRepresentations, ViewValidationFailures failures) {
     if (!maybeRepresentations.isPresent()) {
@@ -225,9 +262,6 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
       return;
     }
     List<ViewRepresentation> representations = maybeRepresentations.get();
-    if (representations.size() != 1) {
-      failures.addGeneric("representations : must contain exactly one representation");
-    }
     for (int index = 0; index < representations.size(); index++) {
       ViewRepresentation representation = representations.get(index);
       if (representation == null) {
@@ -239,10 +273,11 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
             String.format(
                 "representations[%d].type : must be '%s'", index, SQL_VIEW_REPRESENTATION_TYPE));
       }
-      if (!SPARK_VIEW_DIALECT.equals(representation.getDialect())) {
+      if (!supportedDialects.contains(representation.getDialect())) {
         failures.addDialect(
             String.format(
-                "representations[%d].dialect : only '%s' is supported", index, SPARK_VIEW_DIALECT));
+                "representations[%d].dialect : must be one of the supported dialects: %s",
+                index, supportedDialectsText));
       }
       validateRepresentationSql(index, representation.getSql(), failures);
     }
@@ -292,6 +327,11 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
     }
   }
 
+  /**
+   * The source dialect carries two separate obligations: it must name a dialect this deployment
+   * supports, and it must name one of the representations actually supplied. The first is about
+   * what the server can serve, the second about what this request defines.
+   */
   private void validateSourceDialect(
       Optional<String> maybeSourceDialect,
       Optional<List<ViewRepresentation>> maybeRepresentations,
@@ -301,9 +341,10 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
       return;
     }
     String sourceDialect = maybeSourceDialect.get();
-    if (!SPARK_VIEW_DIALECT.equals(sourceDialect)) {
+    if (!supportedDialects.contains(sourceDialect)) {
       failures.addDialect(
-          String.format("sourceDialect : only '%s' is supported", SPARK_VIEW_DIALECT));
+          String.format(
+              "sourceDialect : must be one of the supported dialects: %s", supportedDialectsText));
       return;
     }
     // Only meaningful when at least one usable representation was supplied. With none, the missing

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/OpenHouseViewsApiValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/OpenHouseViewsApiValidator.java
@@ -28,7 +28,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
-import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -104,17 +103,16 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
   }
 
   /** Rules shared by POST and PUT. Verb-specific base-version rules are applied by the caller. */
-  @SuppressWarnings("checkstyle:OperatorWrap")
   private void validateBody(
       String clusterId,
       String databaseId,
       CreateUpdateViewRequestBody requestBody,
       ViewValidationFailures failures) {
-    for (ConstraintViolation<CreateUpdateViewRequestBody> violation :
-        validator.validate(requestBody)) {
-      failures.addGeneric(
-          String.format("%s : %s", ApiValidatorUtil.getField(violation), violation.getMessage()));
-    }
+    // Bean violations stay in the generic category, so they are collected into a plain list first
+    // and then forwarded, rather than influencing the error-code precedence.
+    List<String> beanViolations = new ArrayList<>();
+    ApiValidatorUtil.collectViolations(validator, requestBody, beanViolations);
+    beanViolations.forEach(failures::addGeneric);
     if (requestBody.getClusterId() != null && !requestBody.getClusterId().equals(clusterId)) {
       failures.addGeneric(
           String.format(
@@ -392,23 +390,20 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
   }
 
   private void validateDatabaseId(String databaseId, ViewValidationFailures failures) {
-    if (StringUtils.isEmpty(databaseId)) {
-      failures.addGeneric("databaseId : Cannot be empty");
-    } else if (!databaseId.matches(ALPHA_NUM_UNDERSCORE_REGEX)) {
-      failures.addGeneric(
-          String.format(
-              "databaseId : provided %s, %s", databaseId, ALPHA_NUM_UNDERSCORE_ERROR_MSG));
+    List<String> identifierFailures = new ArrayList<>();
+    ApiValidatorUtil.validateIdentifier("databaseId", databaseId, identifierFailures);
+    if (!identifierFailures.isEmpty()) {
+      identifierFailures.forEach(failures::addGeneric);
     } else if (databaseId.length() > MAX_VIEW_IDENTIFIER_LENGTH) {
       failures.addGeneric(identifierTooLong("databaseId"));
     }
   }
 
   private void validateViewId(String viewId, ViewValidationFailures failures) {
-    if (StringUtils.isEmpty(viewId)) {
-      failures.addGeneric("viewId : Cannot be empty");
-    } else if (!viewId.matches(ALPHA_NUM_UNDERSCORE_REGEX)) {
-      failures.addGeneric(
-          String.format("viewId : provided %s, %s", viewId, ALPHA_NUM_UNDERSCORE_ERROR_MSG));
+    List<String> identifierFailures = new ArrayList<>();
+    ApiValidatorUtil.validateIdentifier("viewId", viewId, identifierFailures);
+    if (!identifierFailures.isEmpty()) {
+      identifierFailures.forEach(failures::addGeneric);
     } else if (viewId.length() > MAX_VIEW_IDENTIFIER_LENGTH) {
       failures.addGeneric(identifierTooLong("viewId"));
     }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/OpenHouseViewsApiValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/OpenHouseViewsApiValidator.java
@@ -39,7 +39,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
- * Structural validation of /v2 views requests.
+ * Structural validation of /v1 views requests.
  *
  * <p><b>Security invariant:</b> no message built here interpolates SQL text, schema text or a
  * {@code baseViewVersion} token. Messages are copied verbatim into the error response body and into

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/OpenHouseViewsApiValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/OpenHouseViewsApiValidator.java
@@ -1,0 +1,474 @@
+package com.linkedin.openhouse.tables.api.validator.impl;
+
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.ALPHA_NUM_UNDERSCORE_ERROR_MSG;
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.ALPHA_NUM_UNDERSCORE_REGEX;
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.INITIAL_TABLE_VERSION;
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.MAX_VIEW_IDENTIFIER_LENGTH;
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.MAX_VIEW_SCHEMA_BYTES;
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.MAX_VIEW_SQL_BYTES;
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.SPARK_VIEW_DIALECT;
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.SQL_VIEW_REPRESENTATION_TYPE;
+
+import com.linkedin.openhouse.common.api.validator.ApiValidatorUtil;
+import com.linkedin.openhouse.common.schema.IcebergSchemaHelper;
+import com.linkedin.openhouse.internal.catalog.mapper.HouseTableSerdeUtils;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateViewRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.ViewRepresentation;
+import com.linkedin.openhouse.tables.api.validator.ViewsApiValidator;
+import com.linkedin.openhouse.tables.exception.ViewErrorCode;
+import com.linkedin.openhouse.tables.exception.ViewRequestValidationFailureException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Structural validation of /v2 views requests.
+ *
+ * <p><b>Security invariant:</b> no message built here interpolates SQL text, schema text or a
+ * {@code baseViewVersion} token. Messages are copied verbatim into the error response body and into
+ * service audit events, so every payload-derived failure uses a fixed redacted message.
+ *
+ * <p>SQL is opaque: nothing here parses, translates or engine-validates a view definition.
+ */
+@Slf4j
+@Component
+public class OpenHouseViewsApiValidator implements ViewsApiValidator {
+
+  /**
+   * Exact server-owned property key. {@code InternalRepositoryUtils.POLICIES_KEY} carries the same
+   * literal but is {@code protected} in another package, so it cannot be referenced from here; the
+   * {@code openhouse.} prefix check does reuse its canonical predicate.
+   */
+  private static final String POLICIES_PROPERTY_KEY = "policies";
+
+  @Autowired private Validator validator;
+
+  @Override
+  public void validateGetView(String databaseId, String viewId) {
+    ViewValidationFailures failures = new ViewValidationFailures();
+    validateDatabaseId(databaseId, failures);
+    validateViewId(viewId, failures);
+    failures.throwIfPresent();
+  }
+
+  @Override
+  public void validateGetAllViews(String databaseId, int page, int size, String sortBy) {
+    ViewValidationFailures failures = new ViewValidationFailures();
+    validateDatabaseId(databaseId, failures);
+    ApiValidatorUtil.validatePageable(page, size, sortBy, failures.getMessages());
+    failures.throwIfPresent();
+  }
+
+  @Override
+  public void validateCreateView(
+      String clusterId, String databaseId, CreateUpdateViewRequestBody requestBody) {
+    ViewValidationFailures failures = new ViewValidationFailures();
+    validateBody(clusterId, databaseId, requestBody, failures);
+    validateCreateBaseViewVersion(requestBody.getBaseViewVersion(), failures);
+    failures.throwIfPresent();
+  }
+
+  @Override
+  public void validateUpdateView(
+      String clusterId, String databaseId, String viewId, CreateUpdateViewRequestBody requestBody) {
+    ViewValidationFailures failures = new ViewValidationFailures();
+    validateBody(clusterId, databaseId, requestBody, failures);
+    if (requestBody.getViewId() != null && !requestBody.getViewId().equals(viewId)) {
+      failures.addGeneric(
+          String.format(
+              "viewId : provided %s, doesn't match with the RequestBody %s",
+              viewId, requestBody.getViewId()));
+    }
+    validateUpdateBaseViewVersion(requestBody.getBaseViewVersion(), failures);
+    failures.throwIfPresent();
+  }
+
+  @Override
+  public void validateDeleteView(String databaseId, String viewId) {
+    // Identifier rules are identical to a read, so reuse them.
+    validateGetView(databaseId, viewId);
+  }
+
+  /** Rules shared by POST and PUT. Verb-specific base-version rules are applied by the caller. */
+  @SuppressWarnings("checkstyle:OperatorWrap")
+  private void validateBody(
+      String clusterId,
+      String databaseId,
+      CreateUpdateViewRequestBody requestBody,
+      ViewValidationFailures failures) {
+    for (ConstraintViolation<CreateUpdateViewRequestBody> violation :
+        validator.validate(requestBody)) {
+      failures.addGeneric(
+          String.format("%s : %s", ApiValidatorUtil.getField(violation), violation.getMessage()));
+    }
+    if (requestBody.getClusterId() != null && !requestBody.getClusterId().equals(clusterId)) {
+      failures.addGeneric(
+          String.format(
+              "clusterId : provided %s, doesn't match with the server cluster %s",
+              requestBody.getClusterId(), clusterId));
+    }
+    if (requestBody.getDatabaseId() != null && !requestBody.getDatabaseId().equals(databaseId)) {
+      failures.addGeneric(
+          String.format(
+              "databaseId : provided %s, doesn't match with the RequestBody %s",
+              databaseId, requestBody.getDatabaseId()));
+    }
+    validateSchema(requestBody.getSchema(), failures);
+    validateRepresentations(requestBody.getRepresentations(), failures);
+    validateUniqueDialects(requestBody.getRepresentations(), failures);
+    validateSourceDialect(
+        requestBody.getSourceDialect(), requestBody.getRepresentations(), failures);
+    validateDefaultCatalog(requestBody.getDefaultCatalog(), failures);
+    validateDefaultNamespace(requestBody.getDefaultNamespace(), failures);
+    validateViewProperties(requestBody.getViewProperties(), failures);
+  }
+
+  /**
+   * Parse the schema with Iceberg. Iceberg already rejects duplicate field ids and malformed JSON,
+   * so this only has to wrap the failure; there is deliberately no separate duplicate-id check.
+   *
+   * <p>The size rule runs first and short-circuits parsing, so an oversized document is never fed
+   * to the parser.
+   */
+  private void validateSchema(String schema, ViewValidationFailures failures) {
+    if (StringUtils.isEmpty(schema)) {
+      // An absent schema is already reported by bean validation.
+      return;
+    }
+    if (utf8Size(schema) > MAX_VIEW_SCHEMA_BYTES) {
+      failures.addSchema(
+          String.format("schema : exceeds maximum UTF-8 size of %d bytes", MAX_VIEW_SCHEMA_BYTES));
+      return;
+    }
+    try {
+      IcebergSchemaHelper.getSchemaFromSchemaJson(schema);
+    } catch (Exception e) {
+      // Only the exception type is logged: the parser message can echo the caller's schema text.
+      log.warn("Rejected a view request with an unparseable Iceberg schema: {}", e.getClass());
+      failures.addSchema(
+          "schema : must be valid Iceberg schema JSON; Spark StructType JSON is not supported");
+    }
+  }
+
+  private void validateRepresentations(
+      List<ViewRepresentation> representations, ViewValidationFailures failures) {
+    if (representations == null || representations.isEmpty()) {
+      // An absent or empty list is already reported by bean validation.
+      return;
+    }
+    if (representations.size() != 1) {
+      failures.addGeneric("representations : must contain exactly one representation");
+    }
+    for (int index = 0; index < representations.size(); index++) {
+      ViewRepresentation representation = representations.get(index);
+      if (representation == null) {
+        failures.addGeneric(String.format("representations[%d] : cannot be null", index));
+        continue;
+      }
+      if (!SQL_VIEW_REPRESENTATION_TYPE.equals(representation.getType())) {
+        failures.addGeneric(
+            String.format(
+                "representations[%d].type : must be '%s'", index, SQL_VIEW_REPRESENTATION_TYPE));
+      }
+      if (!SPARK_VIEW_DIALECT.equals(representation.getDialect())) {
+        failures.addDialect(
+            String.format(
+                "representations[%d].dialect : only '%s' is supported", index, SPARK_VIEW_DIALECT));
+      }
+      validateRepresentationSql(index, representation.getSql(), failures);
+    }
+  }
+
+  /**
+   * SQL is opaque, so the only rule is a size ceiling. It is counted in UTF-8 bytes rather than
+   * characters, which is what a {@code @Size} bean constraint would have counted.
+   */
+  private void validateRepresentationSql(int index, String sql, ViewValidationFailures failures) {
+    if (StringUtils.isEmpty(sql)) {
+      // An absent SQL text is already reported by bean validation.
+      return;
+    }
+    if (utf8Size(sql) > MAX_VIEW_SQL_BYTES) {
+      failures.addGeneric(
+          String.format(
+              "representations[%d].sql : exceeds maximum UTF-8 size of %d bytes",
+              index, MAX_VIEW_SQL_BYTES));
+    }
+  }
+
+  /**
+   * Dialects identify a representation, so two representations claiming the same dialect are
+   * ambiguous. Compared case-insensitively: {@code SPARK} and {@code spark} name the same engine,
+   * and rejecting the pair as duplicates is more useful than reporting only the casing failure.
+   */
+  private void validateUniqueDialects(
+      List<ViewRepresentation> representations, ViewValidationFailures failures) {
+    if (representations == null) {
+      return;
+    }
+    Set<String> seen = new HashSet<>();
+    Set<String> duplicates = new TreeSet<>();
+    for (ViewRepresentation representation : representations) {
+      if (representation == null || StringUtils.isEmpty(representation.getDialect())) {
+        continue;
+      }
+      String normalized = representation.getDialect().toLowerCase(Locale.ROOT);
+      if (!seen.add(normalized)) {
+        duplicates.add(normalized);
+      }
+    }
+    if (!duplicates.isEmpty()) {
+      failures.addDialect(
+          String.format(
+              "representations : dialects must be unique, duplicated: %s",
+              String.join(", ", duplicates)));
+    }
+  }
+
+  private void validateSourceDialect(
+      String sourceDialect,
+      List<ViewRepresentation> representations,
+      ViewValidationFailures failures) {
+    if (StringUtils.isEmpty(sourceDialect)) {
+      // An absent source dialect is already reported by bean validation.
+      return;
+    }
+    if (!SPARK_VIEW_DIALECT.equals(sourceDialect)) {
+      failures.addDialect(
+          String.format("sourceDialect : only '%s' is supported", SPARK_VIEW_DIALECT));
+      return;
+    }
+    // Only meaningful when at least one usable representation was supplied. With none, the missing
+    // or null representation is already reported, and adding a second message here would both
+    // duplicate that diagnosis and promote a malformed body to the more specific dialect code.
+    List<ViewRepresentation> suppliedRepresentations =
+        representations == null
+            ? Collections.emptyList()
+            : representations.stream().filter(Objects::nonNull).collect(Collectors.toList());
+    if (suppliedRepresentations.isEmpty()) {
+      return;
+    }
+    if (suppliedRepresentations.stream()
+        .noneMatch(representation -> sourceDialect.equals(representation.getDialect()))) {
+      failures.addDialect("sourceDialect : does not name a supplied representation");
+    }
+  }
+
+  /**
+   * The resolution catalog is optional, but supplying a blank or unbounded one is a client bug
+   * rather than an omission, so it is rejected instead of silently ignored.
+   */
+  private void validateDefaultCatalog(String defaultCatalog, ViewValidationFailures failures) {
+    if (defaultCatalog == null) {
+      return;
+    }
+    if (StringUtils.isBlank(defaultCatalog)) {
+      failures.addGeneric("defaultCatalog : cannot be blank when provided");
+    } else if (defaultCatalog.length() > MAX_VIEW_IDENTIFIER_LENGTH) {
+      failures.addGeneric(
+          String.format(
+              "defaultCatalog : exceeds the maximum length of %d characters",
+              MAX_VIEW_IDENTIFIER_LENGTH));
+    }
+  }
+
+  /**
+   * Namespace segments follow the same identifier rules as a database id. Messages are indexed but
+   * fixed: the offending segment is never echoed, keeping every payload-derived message redacted.
+   */
+  private void validateDefaultNamespace(
+      List<String> defaultNamespace, ViewValidationFailures failures) {
+    if (defaultNamespace == null) {
+      return;
+    }
+    if (defaultNamespace.isEmpty()) {
+      failures.addGeneric("defaultNamespace : cannot be empty when provided");
+      return;
+    }
+    for (int index = 0; index < defaultNamespace.size(); index++) {
+      String segment = defaultNamespace.get(index);
+      if (StringUtils.isBlank(segment)) {
+        failures.addGeneric(String.format("defaultNamespace[%d] : cannot be blank", index));
+      } else if (!segment.matches(ALPHA_NUM_UNDERSCORE_REGEX)) {
+        failures.addGeneric(
+            String.format("defaultNamespace[%d] : %s", index, ALPHA_NUM_UNDERSCORE_ERROR_MSG));
+      } else if (segment.length() > MAX_VIEW_IDENTIFIER_LENGTH) {
+        failures.addGeneric(
+            String.format(
+                "defaultNamespace[%d] : exceeds the maximum length of %d characters",
+                index, MAX_VIEW_IDENTIFIER_LENGTH));
+      }
+    }
+  }
+
+  /**
+   * View properties are user-owned, with two exceptions carved out for the server: the {@code
+   * openhouse.} namespace, whose canonical case-sensitive predicate is reused from the internal
+   * catalog, and the exact key {@code policies}. Case sensitivity is deliberate and inherited: a
+   * user property such as {@code OpenHouse.myTeam} stays legal.
+   *
+   * <p>Property keys are user-authored identifiers rather than payload text, so listing the
+   * offending keys is intentional and does not breach the SQL/schema/token redaction invariant.
+   */
+  private void validateViewProperties(
+      Map<String, String> viewProperties, ViewValidationFailures failures) {
+    if (viewProperties == null || viewProperties.isEmpty()) {
+      return;
+    }
+    boolean blankKey = false;
+    Set<String> nullValueKeys = new TreeSet<>();
+    Set<String> reservedKeys = new TreeSet<>();
+    for (Map.Entry<String, String> property : viewProperties.entrySet()) {
+      String key = property.getKey();
+      if (StringUtils.isBlank(key)) {
+        blankKey = true;
+        continue;
+      }
+      if (property.getValue() == null) {
+        nullValueKeys.add(key);
+      }
+      if (HouseTableSerdeUtils.IS_OH_PREFIXED.test(key) || POLICIES_PROPERTY_KEY.equals(key)) {
+        reservedKeys.add(key);
+      }
+    }
+    if (blankKey) {
+      failures.addGeneric("viewProperties : property keys cannot be blank");
+    }
+    if (!nullValueKeys.isEmpty()) {
+      failures.addGeneric(
+          String.format(
+              "viewProperties : property values cannot be null, keys: %s",
+              String.join(", ", nullValueKeys)));
+    }
+    if (!reservedKeys.isEmpty()) {
+      failures.addGeneric(
+          String.format(
+              "viewProperties : reserved keys are not allowed: %s",
+              String.join(", ", reservedKeys)));
+    }
+  }
+
+  /** Counts UTF-8 bytes, not UTF-16 characters. */
+  private static int utf8Size(String value) {
+    return value.getBytes(StandardCharsets.UTF_8).length;
+  }
+
+  /**
+   * POST accepts an omitted base version or the table-style {@code INITIAL_VERSION} token, matching
+   * both the Iceberg client, which always sends the initial token on create, and callers that omit
+   * the field entirely.
+   */
+  private void validateCreateBaseViewVersion(
+      String baseViewVersion, ViewValidationFailures failures) {
+    if (baseViewVersion != null && !INITIAL_TABLE_VERSION.equals(baseViewVersion)) {
+      failures.addGeneric(
+          "baseViewVersion : must be omitted or " + INITIAL_TABLE_VERSION + " on POST create");
+    }
+  }
+
+  /**
+   * PUT requires a base version but treats it as fully opaque: no path, scheme, suffix or length
+   * rule is applied, so the service alone decides whether the token is current.
+   */
+  private void validateUpdateBaseViewVersion(
+      String baseViewVersion, ViewValidationFailures failures) {
+    if (StringUtils.isBlank(baseViewVersion)) {
+      failures.addGeneric("baseViewVersion : is required and cannot be blank on PUT");
+    }
+  }
+
+  private void validateDatabaseId(String databaseId, ViewValidationFailures failures) {
+    if (StringUtils.isEmpty(databaseId)) {
+      failures.addGeneric("databaseId : Cannot be empty");
+    } else if (!databaseId.matches(ALPHA_NUM_UNDERSCORE_REGEX)) {
+      failures.addGeneric(
+          String.format(
+              "databaseId : provided %s, %s", databaseId, ALPHA_NUM_UNDERSCORE_ERROR_MSG));
+    } else if (databaseId.length() > MAX_VIEW_IDENTIFIER_LENGTH) {
+      failures.addGeneric(identifierTooLong("databaseId"));
+    }
+  }
+
+  private void validateViewId(String viewId, ViewValidationFailures failures) {
+    if (StringUtils.isEmpty(viewId)) {
+      failures.addGeneric("viewId : Cannot be empty");
+    } else if (!viewId.matches(ALPHA_NUM_UNDERSCORE_REGEX)) {
+      failures.addGeneric(
+          String.format("viewId : provided %s, %s", viewId, ALPHA_NUM_UNDERSCORE_ERROR_MSG));
+    } else if (viewId.length() > MAX_VIEW_IDENTIFIER_LENGTH) {
+      failures.addGeneric(identifierTooLong("viewId"));
+    }
+  }
+
+  /**
+   * Deliberately omits the offending value. Every other identifier message echoes it, but an
+   * over-long identifier is by definition large and the message is copied into the error body and
+   * into service audit events.
+   */
+  private static String identifierTooLong(String field) {
+    return String.format(
+        "%s : exceeds the maximum length of %d characters", field, MAX_VIEW_IDENTIFIER_LENGTH);
+  }
+
+  /**
+   * Accumulates failure messages in discovery order while separately remembering whether a schema
+   * or dialect rule failed, so the thrown exception can carry the most specific internal code.
+   *
+   * <p>Precedence is schema, then dialect, then the generic definition code. All three map to 400,
+   * so the choice is observable only to internal callers and tests.
+   */
+  private static final class ViewValidationFailures {
+    private final List<String> messages = new ArrayList<>();
+    private boolean schemaFailure;
+    private boolean dialectFailure;
+
+    private List<String> getMessages() {
+      return messages;
+    }
+
+    private void addGeneric(String message) {
+      messages.add(message);
+    }
+
+    private void addSchema(String message) {
+      schemaFailure = true;
+      messages.add(message);
+    }
+
+    private void addDialect(String message) {
+      dialectFailure = true;
+      messages.add(message);
+    }
+
+    private void throwIfPresent() {
+      if (messages.isEmpty()) {
+        return;
+      }
+      throw new ViewRequestValidationFailureException(errorCode(), messages);
+    }
+
+    private ViewErrorCode errorCode() {
+      if (schemaFailure) {
+        return ViewErrorCode.UNSUPPORTED_VIEW_SCHEMA;
+      }
+      if (dialectFailure) {
+        return ViewErrorCode.UNSUPPORTED_VIEW_DIALECT;
+      }
+      return ViewErrorCode.INVALID_VIEW_DEFINITION;
+    }
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/OpenHouseViewsApiValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/OpenHouseViewsApiValidator.java
@@ -15,8 +15,9 @@ import com.linkedin.openhouse.internal.catalog.mapper.HouseTableSerdeUtils;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateViewRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.ViewRepresentation;
 import com.linkedin.openhouse.tables.api.validator.ViewsApiValidator;
-import com.linkedin.openhouse.tables.exception.ViewErrorCode;
 import com.linkedin.openhouse.tables.exception.ViewRequestValidationFailureException;
+import com.linkedin.openhouse.tables.exception.ViewValidationErrorCode;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -25,6 +26,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -77,7 +79,9 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
       String clusterId, String databaseId, CreateUpdateViewRequestBody requestBody) {
     ViewValidationFailures failures = new ViewValidationFailures();
     validateBody(clusterId, databaseId, requestBody, failures);
-    validateCreateBaseViewVersion(requestBody.getBaseViewVersion(), failures);
+    // POST distinguishes only "supplied" from "omitted": a supplied-but-blank token is a value the
+    // rule below has to reject, not an absence.
+    validateCreateBaseViewVersion(suppliedField(requestBody.getBaseViewVersion()), failures);
     failures.throwIfPresent();
   }
 
@@ -92,7 +96,7 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
               "viewId : provided %s, doesn't match with the RequestBody %s",
               viewId, requestBody.getViewId()));
     }
-    validateUpdateBaseViewVersion(requestBody.getBaseViewVersion(), failures);
+    validateUpdateBaseViewVersion(nonBlankField(requestBody.getBaseViewVersion()), failures);
     failures.throwIfPresent();
   }
 
@@ -102,7 +106,20 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
     validateGetView(databaseId, viewId);
   }
 
-  /** Rules shared by POST and PUT. Verb-specific base-version rules are applied by the caller. */
+  /**
+   * Rules shared by POST and PUT. Verb-specific base-version rules are applied by the caller.
+   *
+   * <p>This is the one place absence is decided. Every nullable field of the request body is
+   * converted here to an explicit {@link Optional}, so no rule below re-derives what "not supplied"
+   * means for its own field. The two list fields are normalized differently on purpose:
+   *
+   * <ul>
+   *   <li>{@code representations}: an omitted list and an empty list are the same client mistake
+   *       and are both already reported by bean validation, so an empty list collapses to absent.
+   *   <li>{@code defaultNamespace}: the field is optional, but an explicitly empty list is a
+   *       distinct client error with its own message, so it stays present.
+   * </ul>
+   */
   private void validateBody(
       String clusterId,
       String databaseId,
@@ -125,14 +142,45 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
               "databaseId : provided %s, doesn't match with the RequestBody %s",
               databaseId, requestBody.getDatabaseId()));
     }
-    validateSchema(requestBody.getSchema(), failures);
-    validateRepresentations(requestBody.getRepresentations(), failures);
-    validateUniqueDialects(requestBody.getRepresentations(), failures);
-    validateSourceDialect(
-        requestBody.getSourceDialect(), requestBody.getRepresentations(), failures);
-    validateDefaultCatalog(requestBody.getDefaultCatalog(), failures);
-    validateDefaultNamespace(requestBody.getDefaultNamespace(), failures);
-    validateViewProperties(requestBody.getViewProperties(), failures);
+
+    Optional<String> schema = nonEmptyField(requestBody.getSchema());
+    Optional<List<ViewRepresentation>> representations =
+        nonEmptyField(requestBody.getRepresentations());
+    Optional<String> sourceDialect = nonEmptyField(requestBody.getSourceDialect());
+    Optional<String> defaultCatalog = suppliedField(requestBody.getDefaultCatalog());
+    Optional<List<String>> defaultNamespace = suppliedField(requestBody.getDefaultNamespace());
+    Optional<Map<String, String>> viewProperties = nonEmptyField(requestBody.getViewProperties());
+
+    validateSchema(schema, failures);
+    validateRepresentations(representations, failures);
+    validateUniqueDialects(representations, failures);
+    validateSourceDialect(sourceDialect, representations, failures);
+    validateDefaultCatalog(defaultCatalog, failures);
+    validateDefaultNamespace(defaultNamespace, failures);
+    validateViewProperties(viewProperties, failures);
+  }
+
+  /** Present whenever the caller supplied the field at all, including as a blank or empty value. */
+  private static <T> Optional<T> suppliedField(T value) {
+    return Optional.ofNullable(value);
+  }
+
+  /** Absent when the field was omitted or supplied empty; the two are equivalent to every rule. */
+  private static Optional<String> nonEmptyField(String value) {
+    return Optional.ofNullable(value).filter(StringUtils::isNotEmpty);
+  }
+
+  private static <T> Optional<List<T>> nonEmptyField(List<T> value) {
+    return Optional.ofNullable(value).filter(list -> !list.isEmpty());
+  }
+
+  private static <K, V> Optional<Map<K, V>> nonEmptyField(Map<K, V> value) {
+    return Optional.ofNullable(value).filter(map -> !map.isEmpty());
+  }
+
+  /** Absent when the field was omitted or supplied blank; the two are equivalent to every rule. */
+  private static Optional<String> nonBlankField(String value) {
+    return Optional.ofNullable(value).filter(StringUtils::isNotBlank);
   }
 
   /**
@@ -141,12 +189,20 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
    *
    * <p>The size rule runs first and short-circuits parsing, so an oversized document is never fed
    * to the parser.
+   *
+   * <p>Only the two failures Iceberg raises for caller-supplied text are caught. {@code
+   * SchemaParser} reports a structurally valid document that is not an Iceberg schema — including
+   * the Spark {@code StructType} shape and duplicate field ids — as an {@link
+   * IllegalArgumentException}, and text that is not JSON at all as an {@link UncheckedIOException}
+   * wrapping Jackson's parse failure. Anything else is a server fault and must propagate as a 500
+   * rather than be reported to the caller as a bad request.
    */
-  private void validateSchema(String schema, ViewValidationFailures failures) {
-    if (StringUtils.isEmpty(schema)) {
+  private void validateSchema(Optional<String> maybeSchema, ViewValidationFailures failures) {
+    if (!maybeSchema.isPresent()) {
       // An absent schema is already reported by bean validation.
       return;
     }
+    String schema = maybeSchema.get();
     if (utf8Size(schema) > MAX_VIEW_SCHEMA_BYTES) {
       failures.addSchema(
           String.format("schema : exceeds maximum UTF-8 size of %d bytes", MAX_VIEW_SCHEMA_BYTES));
@@ -154,7 +210,7 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
     }
     try {
       IcebergSchemaHelper.getSchemaFromSchemaJson(schema);
-    } catch (Exception e) {
+    } catch (IllegalArgumentException | UncheckedIOException e) {
       // Only the exception type is logged: the parser message can echo the caller's schema text.
       log.warn("Rejected a view request with an unparseable Iceberg schema: {}", e.getClass());
       failures.addSchema(
@@ -163,11 +219,12 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
   }
 
   private void validateRepresentations(
-      List<ViewRepresentation> representations, ViewValidationFailures failures) {
-    if (representations == null || representations.isEmpty()) {
+      Optional<List<ViewRepresentation>> maybeRepresentations, ViewValidationFailures failures) {
+    if (!maybeRepresentations.isPresent()) {
       // An absent or empty list is already reported by bean validation.
       return;
     }
+    List<ViewRepresentation> representations = maybeRepresentations.get();
     if (representations.size() != 1) {
       failures.addGeneric("representations : must contain exactly one representation");
     }
@@ -214,10 +271,8 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
    * and rejecting the pair as duplicates is more useful than reporting only the casing failure.
    */
   private void validateUniqueDialects(
-      List<ViewRepresentation> representations, ViewValidationFailures failures) {
-    if (representations == null) {
-      return;
-    }
+      Optional<List<ViewRepresentation>> maybeRepresentations, ViewValidationFailures failures) {
+    List<ViewRepresentation> representations = maybeRepresentations.orElse(Collections.emptyList());
     Set<String> seen = new HashSet<>();
     Set<String> duplicates = new TreeSet<>();
     for (ViewRepresentation representation : representations) {
@@ -238,13 +293,14 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
   }
 
   private void validateSourceDialect(
-      String sourceDialect,
-      List<ViewRepresentation> representations,
+      Optional<String> maybeSourceDialect,
+      Optional<List<ViewRepresentation>> maybeRepresentations,
       ViewValidationFailures failures) {
-    if (StringUtils.isEmpty(sourceDialect)) {
+    if (!maybeSourceDialect.isPresent()) {
       // An absent source dialect is already reported by bean validation.
       return;
     }
+    String sourceDialect = maybeSourceDialect.get();
     if (!SPARK_VIEW_DIALECT.equals(sourceDialect)) {
       failures.addDialect(
           String.format("sourceDialect : only '%s' is supported", SPARK_VIEW_DIALECT));
@@ -254,9 +310,9 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
     // or null representation is already reported, and adding a second message here would both
     // duplicate that diagnosis and promote a malformed body to the more specific dialect code.
     List<ViewRepresentation> suppliedRepresentations =
-        representations == null
-            ? Collections.emptyList()
-            : representations.stream().filter(Objects::nonNull).collect(Collectors.toList());
+        maybeRepresentations.orElse(Collections.emptyList()).stream()
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
     if (suppliedRepresentations.isEmpty()) {
       return;
     }
@@ -270,10 +326,12 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
    * The resolution catalog is optional, but supplying a blank or unbounded one is a client bug
    * rather than an omission, so it is rejected instead of silently ignored.
    */
-  private void validateDefaultCatalog(String defaultCatalog, ViewValidationFailures failures) {
-    if (defaultCatalog == null) {
+  private void validateDefaultCatalog(
+      Optional<String> maybeDefaultCatalog, ViewValidationFailures failures) {
+    if (!maybeDefaultCatalog.isPresent()) {
       return;
     }
+    String defaultCatalog = maybeDefaultCatalog.get();
     if (StringUtils.isBlank(defaultCatalog)) {
       failures.addGeneric("defaultCatalog : cannot be blank when provided");
     } else if (defaultCatalog.length() > MAX_VIEW_IDENTIFIER_LENGTH) {
@@ -289,10 +347,11 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
    * fixed: the offending segment is never echoed, keeping every payload-derived message redacted.
    */
   private void validateDefaultNamespace(
-      List<String> defaultNamespace, ViewValidationFailures failures) {
-    if (defaultNamespace == null) {
+      Optional<List<String>> maybeDefaultNamespace, ViewValidationFailures failures) {
+    if (!maybeDefaultNamespace.isPresent()) {
       return;
     }
+    List<String> defaultNamespace = maybeDefaultNamespace.get();
     if (defaultNamespace.isEmpty()) {
       failures.addGeneric("defaultNamespace : cannot be empty when provided");
       return;
@@ -323,10 +382,11 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
    * offending keys is intentional and does not breach the SQL/schema/token redaction invariant.
    */
   private void validateViewProperties(
-      Map<String, String> viewProperties, ViewValidationFailures failures) {
-    if (viewProperties == null || viewProperties.isEmpty()) {
+      Optional<Map<String, String>> maybeViewProperties, ViewValidationFailures failures) {
+    if (!maybeViewProperties.isPresent()) {
       return;
     }
+    Map<String, String> viewProperties = maybeViewProperties.get();
     boolean blankKey = false;
     Set<String> nullValueKeys = new TreeSet<>();
     Set<String> reservedKeys = new TreeSet<>();
@@ -367,12 +427,12 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
 
   /**
    * POST accepts an omitted base version or the table-style {@code INITIAL_VERSION} token, matching
-   * both the Iceberg client, which always sends the initial token on create, and callers that omit
-   * the field entirely.
+   * both the Iceberg client, which sends the initial token on create, and callers that omit the
+   * field entirely.
    */
   private void validateCreateBaseViewVersion(
-      String baseViewVersion, ViewValidationFailures failures) {
-    if (baseViewVersion != null && !INITIAL_TABLE_VERSION.equals(baseViewVersion)) {
+      Optional<String> baseViewVersion, ViewValidationFailures failures) {
+    if (baseViewVersion.isPresent() && !INITIAL_TABLE_VERSION.equals(baseViewVersion.get())) {
       failures.addGeneric(
           "baseViewVersion : must be omitted or " + INITIAL_TABLE_VERSION + " on POST create");
     }
@@ -381,10 +441,13 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
   /**
    * PUT requires a base version but treats it as fully opaque: no path, scheme, suffix or length
    * rule is applied, so the service alone decides whether the token is current.
+   *
+   * <p>The caller normalizes a blank token to absent, because a token of whitespace is
+   * indistinguishable from an omitted one to every rule here.
    */
   private void validateUpdateBaseViewVersion(
-      String baseViewVersion, ViewValidationFailures failures) {
-    if (StringUtils.isBlank(baseViewVersion)) {
+      Optional<String> baseViewVersion, ViewValidationFailures failures) {
+    if (!baseViewVersion.isPresent()) {
       failures.addGeneric("baseViewVersion : is required and cannot be blank on PUT");
     }
   }
@@ -456,14 +519,14 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
       throw new ViewRequestValidationFailureException(errorCode(), messages);
     }
 
-    private ViewErrorCode errorCode() {
+    private ViewValidationErrorCode errorCode() {
       if (schemaFailure) {
-        return ViewErrorCode.UNSUPPORTED_VIEW_SCHEMA;
+        return ViewValidationErrorCode.UNSUPPORTED_VIEW_SCHEMA;
       }
       if (dialectFailure) {
-        return ViewErrorCode.UNSUPPORTED_VIEW_DIALECT;
+        return ViewValidationErrorCode.UNSUPPORTED_VIEW_DIALECT;
       }
-      return ViewErrorCode.INVALID_VIEW_DEFINITION;
+      return ViewValidationErrorCode.INVALID_VIEW_DEFINITION;
     }
   }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/OpenHouseViewsApiValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/validator/impl/OpenHouseViewsApiValidator.java
@@ -42,8 +42,8 @@ import org.springframework.stereotype.Component;
  * Structural validation of /v1 views requests.
  *
  * <p><b>Security invariant:</b> no message built here interpolates SQL text, schema text or a
- * {@code baseViewVersion} token. Messages are copied verbatim into the error response body and into
- * service audit events, so every payload-derived failure uses a fixed redacted message.
+ * {@code baseMetadataLocation} token. Messages are copied verbatim into the error response body and
+ * into service audit events, so every payload-derived failure uses a fixed redacted message.
  *
  * <p>SQL is opaque: nothing here parses, translates or engine-validates a view definition.
  */
@@ -112,7 +112,8 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
     validateBody(clusterId, databaseId, requestBody, failures);
     // POST distinguishes only "supplied" from "omitted": a supplied-but-blank token is a value the
     // rule below has to reject, not an absence.
-    validateCreateBaseViewVersion(suppliedField(requestBody.getBaseViewVersion()), failures);
+    validateCreateBaseMetadataLocation(
+        suppliedField(requestBody.getBaseMetadataLocation()), failures);
     failures.throwIfPresent();
   }
 
@@ -127,7 +128,8 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
               "viewId : provided %s, doesn't match with the RequestBody %s",
               viewId, requestBody.getViewId()));
     }
-    validateUpdateBaseViewVersion(nonBlankField(requestBody.getBaseViewVersion()), failures);
+    validateUpdateBaseMetadataLocation(
+        nonBlankField(requestBody.getBaseMetadataLocation()), failures);
     failures.throwIfPresent();
   }
 
@@ -467,29 +469,30 @@ public class OpenHouseViewsApiValidator implements ViewsApiValidator {
   }
 
   /**
-   * POST accepts an omitted base version or the table-style {@code INITIAL_VERSION} token, matching
-   * both the Iceberg client, which sends the initial token on create, and callers that omit the
-   * field entirely.
+   * POST accepts an omitted base metadata location or the table-style {@code INITIAL_VERSION}
+   * token, matching both the Iceberg client, which sends the initial token on create, and callers
+   * that omit the field entirely.
    */
-  private void validateCreateBaseViewVersion(
-      Optional<String> baseViewVersion, ViewValidationFailures failures) {
-    if (baseViewVersion.isPresent() && !INITIAL_TABLE_VERSION.equals(baseViewVersion.get())) {
+  private void validateCreateBaseMetadataLocation(
+      Optional<String> baseMetadataLocation, ViewValidationFailures failures) {
+    if (baseMetadataLocation.isPresent()
+        && !INITIAL_TABLE_VERSION.equals(baseMetadataLocation.get())) {
       failures.addGeneric(
-          "baseViewVersion : must be omitted or " + INITIAL_TABLE_VERSION + " on POST create");
+          "baseMetadataLocation : must be omitted or " + INITIAL_TABLE_VERSION + " on POST create");
     }
   }
 
   /**
-   * PUT requires a base version but treats it as fully opaque: no path, scheme, suffix or length
-   * rule is applied, so the service alone decides whether the token is current.
+   * PUT requires a base metadata location but treats it as fully opaque: no path, scheme, suffix or
+   * length rule is applied, so the service alone decides whether the location is current.
    *
-   * <p>The caller normalizes a blank token to absent, because a token of whitespace is
+   * <p>The caller normalizes a blank location to absent, because a location of whitespace is
    * indistinguishable from an omitted one to every rule here.
    */
-  private void validateUpdateBaseViewVersion(
-      Optional<String> baseViewVersion, ViewValidationFailures failures) {
-    if (!baseViewVersion.isPresent()) {
-      failures.addGeneric("baseViewVersion : is required and cannot be blank on PUT");
+  private void validateUpdateBaseMetadataLocation(
+      Optional<String> baseMetadataLocation, ViewValidationFailures failures) {
+    if (!baseMetadataLocation.isPresent()) {
+      failures.addGeneric("baseMetadataLocation : is required and cannot be blank on PUT");
     }
   }
 

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/ViewRequestPayloadRedactor.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/ViewRequestPayloadRedactor.java
@@ -35,10 +35,10 @@ public class ViewRequestPayloadRedactor implements ServiceAuditPayloadRedactor {
   static final String SQL_FIELD = "sql";
 
   /** The view collection route, which POST creates against. */
-  private static final String VIEW_COLLECTION_PATTERN = "/v2/databases/*/views";
+  private static final String VIEW_COLLECTION_PATTERN = "/v1/databases/*/views";
 
   /** The view item route, which PUT replaces against. */
-  private static final String VIEW_ITEM_PATTERN = "/v2/databases/*/views/*";
+  private static final String VIEW_ITEM_PATTERN = "/v1/databases/*/views/*";
 
   private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
 

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/ViewRequestPayloadRedactor.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/ViewRequestPayloadRedactor.java
@@ -1,0 +1,74 @@
+package com.linkedin.openhouse.tables.audit;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.linkedin.openhouse.common.audit.ServiceAuditPayloadRedactor;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+
+/**
+ * Keeps view definitions out of service audit events.
+ *
+ * <p>{@link com.linkedin.openhouse.common.audit.ServiceAuditAspect} audits the complete cached
+ * request body of every controller call, which for the view create and replace routes would retain
+ * the caller's full SQL text and schema document. This replaces {@code schema} and every {@code
+ * representations[*].sql} value with {@link #REDACTED_VALUE} before the event is built. The keys
+ * are kept, so an auditor still sees that the fields were sent.
+ *
+ * <p>Scoped by request URI rather than by field name on purpose. {@code
+ * CreateUpdateTableRequestBody} also carries a {@code schema}, and redacting by name alone would
+ * silently change table, database and snapshot audit payloads. Matching the view routes leaves
+ * every other route's payload exactly as it was.
+ *
+ * <p>Every field that is not part of the view definition — {@code viewId}, {@code databaseId},
+ * {@code clusterId}, {@code sourceDialect}, {@code defaultCatalog}, {@code defaultNamespace},
+ * {@code viewProperties} and {@code baseViewVersion} — is left intact, so an audit event still
+ * identifies what was operated on and by whom.
+ */
+@Component
+public class ViewRequestPayloadRedactor implements ServiceAuditPayloadRedactor {
+
+  static final String SCHEMA_FIELD = "schema";
+  static final String REPRESENTATIONS_FIELD = "representations";
+  static final String SQL_FIELD = "sql";
+
+  /** The view collection route, which POST creates against. */
+  private static final String VIEW_COLLECTION_PATTERN = "/v2/databases/*/views";
+
+  /** The view item route, which PUT replaces against. */
+  private static final String VIEW_ITEM_PATTERN = "/v2/databases/*/views/*";
+
+  private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
+
+  @Override
+  public boolean appliesTo(HttpServletRequest request) {
+    String uri = request.getRequestURI();
+    return uri != null
+        && (PATH_MATCHER.match(VIEW_COLLECTION_PATTERN, uri)
+            || PATH_MATCHER.match(VIEW_ITEM_PATTERN, uri));
+  }
+
+  @Override
+  public JsonElement redact(JsonElement requestPayload) {
+    if (requestPayload == null || !requestPayload.isJsonObject()) {
+      // A bodyless request parses to JsonNull, and a malformed body can be any other element.
+      // Neither carries a view definition, so there is nothing to remove.
+      return requestPayload;
+    }
+    JsonObject redacted = requestPayload.deepCopy().getAsJsonObject();
+    if (redacted.has(SCHEMA_FIELD)) {
+      redacted.add(SCHEMA_FIELD, new JsonPrimitive(REDACTED_VALUE));
+    }
+    JsonElement representations = redacted.get(REPRESENTATIONS_FIELD);
+    if (representations != null && representations.isJsonArray()) {
+      for (JsonElement representation : representations.getAsJsonArray()) {
+        if (representation.isJsonObject() && representation.getAsJsonObject().has(SQL_FIELD)) {
+          representation.getAsJsonObject().add(SQL_FIELD, new JsonPrimitive(REDACTED_VALUE));
+        }
+      }
+    }
+    return redacted;
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/ViewRequestPayloadRedactor.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/audit/ViewRequestPayloadRedactor.java
@@ -24,7 +24,7 @@ import org.springframework.util.AntPathMatcher;
  *
  * <p>Every field that is not part of the view definition — {@code viewId}, {@code databaseId},
  * {@code clusterId}, {@code sourceDialect}, {@code defaultCatalog}, {@code defaultNamespace},
- * {@code viewProperties} and {@code baseViewVersion} — is left intact, so an audit event still
+ * {@code viewProperties} and {@code baseMetadataLocation} — is left intact, so an audit event still
  * identifies what was operated on and by whom.
  */
 @Component

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/authorization/Privileges.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/authorization/Privileges.java
@@ -16,7 +16,11 @@ public enum Privileges {
   UPDATE_ACL(Privilege.UPDATE_ACL),
   SYSTEM_ADMIN(Privilege.SYSTEM_ADMIN),
   LOCK_ADMIN(Privilege.LOCK_ADMIN),
-  SELECT(Privilege.SELECT);
+  SELECT(Privilege.SELECT),
+  CREATE_VIEW(Privilege.CREATE_VIEW),
+  LIST_VIEW(Privilege.LIST_VIEW),
+  UPDATE_VIEW_METADATA(Privilege.UPDATE_VIEW_METADATA),
+  DELETE_VIEW(Privilege.DELETE_VIEW);
 
   private String privilege;
 
@@ -43,6 +47,20 @@ public enum Privileges {
     public static final String LOCK_ADMIN = "LOCK_ADMIN";
 
     public static final String SELECT = "SELECT";
+
+    /**
+     * View privileges. Reads of a single view reuse {@link #SELECT}; the remaining view operations
+     * get their own constants so a later authorization implementation can grant them independently
+     * of the table privileges.
+     */
+    public static final String CREATE_VIEW = "CREATE_VIEW";
+
+    public static final String LIST_VIEW = "LIST_VIEW";
+
+    public static final String UPDATE_VIEW_METADATA = "UPDATE_VIEW_METADATA";
+
+    public static final String DELETE_VIEW = "DELETE_VIEW";
+
     private static final Set<String> SUPPORTED_PRIVILEGES =
         Stream.of(Privileges.values()).map(Privileges::getPrivilege).collect(Collectors.toSet());
 

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/ViewsController.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/ViewsController.java
@@ -25,8 +25,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * Controller for the Views API. Views are a new resource, so they mount under {@code /v2} and break
- * no existing client: {@code /v1/databases/{databaseId}/tables/{tableId}} stays table-only.
+ * Controller for the Views API. Views are a new resource under {@code /v1}, alongside every other
+ * OpenHouse resource, and break no existing client: they occupy their own {@code views} path
+ * segment, and {@code /v1/databases/{databaseId}/tables/{tableId}} stays table-only.
  *
  * <p>The controller is registered regardless of whether views are enabled, and holds no business
  * logic. Request bodies are deliberately not annotated with {@code @Valid}: the view validator
@@ -53,7 +54,7 @@ public class ViewsController {
         @ApiResponse(responseCode = "503", description = "View GET: SERVICE_UNAVAILABLE")
       })
   @GetMapping(
-      value = {"/v2/databases/{databaseId}/views/{viewId}"},
+      value = {"/v1/databases/{databaseId}/views/{viewId}"},
       produces = {"application/json"})
   @Secured(value = Privileges.Privilege.SELECT)
   public ResponseEntity<GetViewResponseBody> getView(
@@ -81,7 +82,7 @@ public class ViewsController {
         @ApiResponse(responseCode = "503", description = "View SEARCH: SERVICE_UNAVAILABLE")
       })
   @GetMapping(
-      value = {"/v2/databases/{databaseId}/views"},
+      value = {"/v1/databases/{databaseId}/views"},
       produces = {"application/json"})
   @Secured(value = Privileges.Privilege.LIST_VIEW)
   public ResponseEntity<GetAllViewsResponseBody> getAllViews(
@@ -114,7 +115,7 @@ public class ViewsController {
         @ApiResponse(responseCode = "503", description = "View POST: SERVICE_UNAVAILABLE")
       })
   @PostMapping(
-      value = {"/v2/databases/{databaseId}/views"},
+      value = {"/v1/databases/{databaseId}/views"},
       produces = {"application/json"},
       consumes = {"application/json"})
   @Secured(value = Privileges.Privilege.CREATE_VIEW)
@@ -154,7 +155,7 @@ public class ViewsController {
         @ApiResponse(responseCode = "503", description = "View PUT: SERVICE_UNAVAILABLE")
       })
   @PutMapping(
-      value = {"/v2/databases/{databaseId}/views/{viewId}"},
+      value = {"/v1/databases/{databaseId}/views/{viewId}"},
       produces = {"application/json"},
       consumes = {"application/json"})
   @Secured(value = Privileges.Privilege.UPDATE_VIEW_METADATA)
@@ -191,7 +192,7 @@ public class ViewsController {
         @ApiResponse(responseCode = "503", description = "View DELETE: SERVICE_UNAVAILABLE")
       })
   @DeleteMapping(
-      value = {"/v2/databases/{databaseId}/views/{viewId}"},
+      value = {"/v1/databases/{databaseId}/views/{viewId}"},
       produces = {"application/json"})
   @Secured(value = Privileges.Privilege.DELETE_VIEW)
   public ResponseEntity<Void> deleteView(

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/ViewsController.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/ViewsController.java
@@ -28,9 +28,10 @@ import org.springframework.web.bind.annotation.RestController;
  * Controller for the Views API. Views are a new resource, so they mount under {@code /v2} and break
  * no existing client: {@code /v1/databases/{databaseId}/tables/{tableId}} stays table-only.
  *
- * <p>The controller is always registered and holds no business logic. Request bodies are
- * deliberately not annotated with {@code @Valid}: the view validator accumulates every structural
- * failure and reports them together, which Spring's fail-fast binding cannot do.
+ * <p>The controller is registered regardless of whether views are enabled, and holds no business
+ * logic. Request bodies are deliberately not annotated with {@code @Valid}: the view validator
+ * accumulates every structural failure and reports them together, which Spring's fail-fast binding
+ * cannot do.
  */
 @RestController
 public class ViewsController {

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/ViewsController.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/ViewsController.java
@@ -1,0 +1,206 @@
+package com.linkedin.openhouse.tables.controller;
+
+import static com.linkedin.openhouse.common.security.AuthenticationUtils.*;
+
+import com.linkedin.openhouse.tables.api.handler.ViewsApiHandler;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateViewRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllViewsResponseBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetViewResponseBody;
+import com.linkedin.openhouse.tables.authorization.Privileges;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller for the Views API. Views are a new resource, so they mount under {@code /v2} and break
+ * no existing client: {@code /v1/databases/{databaseId}/tables/{tableId}} stays table-only.
+ *
+ * <p>The controller is always registered and holds no business logic. Request bodies are
+ * deliberately not annotated with {@code @Valid}: the view validator accumulates every structural
+ * failure and reports them together, which Spring's fail-fast binding cannot do.
+ */
+@RestController
+public class ViewsController {
+
+  @Autowired private ViewsApiHandler viewsApiHandler;
+
+  @Operation(
+      summary = "Get View in a Database",
+      description =
+          "Returns a View resource identified by viewId in the database identified by databaseId.",
+      tags = {"View"})
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "View GET: OK"),
+        @ApiResponse(responseCode = "400", description = "View GET: BAD_REQUEST"),
+        @ApiResponse(responseCode = "401", description = "View GET: UNAUTHORIZED"),
+        @ApiResponse(responseCode = "403", description = "View GET: FORBIDDEN"),
+        @ApiResponse(responseCode = "404", description = "View GET: NOT_FOUND"),
+        @ApiResponse(responseCode = "503", description = "View GET: SERVICE_UNAVAILABLE")
+      })
+  @GetMapping(
+      value = {"/v2/databases/{databaseId}/views/{viewId}"},
+      produces = {"application/json"})
+  @Secured(value = Privileges.Privilege.SELECT)
+  public ResponseEntity<GetViewResponseBody> getView(
+      @Parameter(description = "Database ID", required = true) @PathVariable String databaseId,
+      @Parameter(description = "View ID", required = true) @PathVariable String viewId) {
+
+    com.linkedin.openhouse.common.api.spec.ApiResponse<GetViewResponseBody> apiResponse =
+        viewsApiHandler.getView(databaseId, viewId, extractAuthenticatedUserPrincipal());
+
+    return new ResponseEntity<>(
+        apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
+  }
+
+  @Operation(
+      summary = "Search Views in a Database",
+      description = "Returns a Page of View resources present in a database.",
+      tags = {"View"})
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "View SEARCH: OK"),
+        @ApiResponse(responseCode = "400", description = "View SEARCH: BAD_REQUEST"),
+        @ApiResponse(responseCode = "401", description = "View SEARCH: UNAUTHORIZED"),
+        @ApiResponse(responseCode = "403", description = "View SEARCH: FORBIDDEN"),
+        @ApiResponse(responseCode = "404", description = "View SEARCH: NOT_FOUND"),
+        @ApiResponse(responseCode = "503", description = "View SEARCH: SERVICE_UNAVAILABLE")
+      })
+  @GetMapping(
+      value = {"/v2/databases/{databaseId}/views"},
+      produces = {"application/json"})
+  @Secured(value = Privileges.Privilege.LIST_VIEW)
+  public ResponseEntity<GetAllViewsResponseBody> getAllViews(
+      @Parameter(description = "Database ID", required = true) @PathVariable String databaseId,
+      @RequestParam(required = false, defaultValue = "0") int page,
+      @RequestParam(required = false, defaultValue = "50") int size,
+      @RequestParam(required = false) String sortBy) {
+
+    com.linkedin.openhouse.common.api.spec.ApiResponse<GetAllViewsResponseBody> apiResponse =
+        viewsApiHandler.getAllViews(
+            databaseId, page, size, sortBy, extractAuthenticatedUserPrincipal());
+
+    return new ResponseEntity<>(
+        apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
+  }
+
+  @Operation(
+      summary = "Create a View",
+      description = "Creates and returns a View resource in a database identified by databaseId",
+      tags = {"View"})
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "201", description = "View POST: CREATED"),
+        @ApiResponse(responseCode = "400", description = "View POST: BAD_REQUEST"),
+        @ApiResponse(responseCode = "401", description = "View POST: UNAUTHORIZED"),
+        @ApiResponse(responseCode = "403", description = "View POST: FORBIDDEN"),
+        @ApiResponse(responseCode = "404", description = "View POST: DB_NOT_FOUND"),
+        @ApiResponse(responseCode = "409", description = "View POST: VIEW_EXISTS"),
+        @ApiResponse(responseCode = "422", description = "View POST: UNPROCESSABLE_ENTITY"),
+        @ApiResponse(responseCode = "503", description = "View POST: SERVICE_UNAVAILABLE")
+      })
+  @PostMapping(
+      value = {"/v2/databases/{databaseId}/views"},
+      produces = {"application/json"},
+      consumes = {"application/json"})
+  @Secured(value = Privileges.Privilege.CREATE_VIEW)
+  public ResponseEntity<GetViewResponseBody> createView(
+      @Parameter(description = "Database ID", required = true) @PathVariable String databaseId,
+      @Parameter(
+              description = "Request containing details of the View to be created",
+              required = true,
+              schema = @Schema(implementation = CreateUpdateViewRequestBody.class))
+          @RequestBody
+          CreateUpdateViewRequestBody createUpdateViewRequestBody) {
+
+    com.linkedin.openhouse.common.api.spec.ApiResponse<GetViewResponseBody> apiResponse =
+        viewsApiHandler.createView(
+            databaseId, createUpdateViewRequestBody, extractAuthenticatedUserPrincipal());
+
+    return new ResponseEntity<>(
+        apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
+  }
+
+  @Operation(
+      summary = "Update a View",
+      description =
+          "Updates or creates a View and returns the View resource. If the view does not exist, it "
+              + "will be created. If the view exists, it will be replaced.",
+      tags = {"View"})
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "View PUT: UPDATED"),
+        @ApiResponse(responseCode = "201", description = "View PUT: CREATED"),
+        @ApiResponse(responseCode = "400", description = "View PUT: BAD_REQUEST"),
+        @ApiResponse(responseCode = "401", description = "View PUT: UNAUTHORIZED"),
+        @ApiResponse(responseCode = "403", description = "View PUT: FORBIDDEN"),
+        @ApiResponse(responseCode = "404", description = "View PUT: DB_NOT_FOUND"),
+        @ApiResponse(responseCode = "409", description = "View PUT: CONFLICT"),
+        @ApiResponse(responseCode = "422", description = "View PUT: UNPROCESSABLE_ENTITY"),
+        @ApiResponse(responseCode = "503", description = "View PUT: SERVICE_UNAVAILABLE")
+      })
+  @PutMapping(
+      value = {"/v2/databases/{databaseId}/views/{viewId}"},
+      produces = {"application/json"},
+      consumes = {"application/json"})
+  @Secured(value = Privileges.Privilege.UPDATE_VIEW_METADATA)
+  public ResponseEntity<GetViewResponseBody> updateView(
+      @Parameter(description = "Database ID", required = true) @PathVariable String databaseId,
+      @Parameter(description = "View ID", required = true) @PathVariable String viewId,
+      @Parameter(
+              description = "Request containing details of the View to be created/updated",
+              required = true,
+              schema = @Schema(implementation = CreateUpdateViewRequestBody.class))
+          @RequestBody
+          CreateUpdateViewRequestBody createUpdateViewRequestBody) {
+
+    com.linkedin.openhouse.common.api.spec.ApiResponse<GetViewResponseBody> apiResponse =
+        viewsApiHandler.updateView(
+            databaseId, viewId, createUpdateViewRequestBody, extractAuthenticatedUserPrincipal());
+
+    return new ResponseEntity<>(
+        apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
+  }
+
+  @Operation(
+      summary = "Drop a View",
+      description =
+          "Drops a View resource identified by viewId in the database identified by databaseId.",
+      tags = {"View"})
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "204", description = "View DELETE: NO_CONTENT"),
+        @ApiResponse(responseCode = "400", description = "View DELETE: BAD_REQUEST"),
+        @ApiResponse(responseCode = "401", description = "View DELETE: UNAUTHORIZED"),
+        @ApiResponse(responseCode = "403", description = "View DELETE: FORBIDDEN"),
+        @ApiResponse(responseCode = "404", description = "View DELETE: VIEW_NOT_FOUND"),
+        @ApiResponse(responseCode = "503", description = "View DELETE: SERVICE_UNAVAILABLE")
+      })
+  @DeleteMapping(
+      value = {"/v2/databases/{databaseId}/views/{viewId}"},
+      produces = {"application/json"})
+  @Secured(value = Privileges.Privilege.DELETE_VIEW)
+  public ResponseEntity<Void> deleteView(
+      @Parameter(description = "Database ID", required = true) @PathVariable String databaseId,
+      @Parameter(description = "View ID", required = true) @PathVariable String viewId) {
+
+    com.linkedin.openhouse.common.api.spec.ApiResponse<Void> apiResponse =
+        viewsApiHandler.deleteView(databaseId, viewId, extractAuthenticatedUserPrincipal());
+
+    return new ResponseEntity<>(
+        apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/ViewsController.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/ViewsController.java
@@ -25,14 +25,14 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * Controller for the Views API. Views are a new resource under {@code /v1}, alongside every other
- * OpenHouse resource, and break no existing client: they occupy their own {@code views} path
- * segment, and {@code /v1/databases/{databaseId}/tables/{tableId}} stays table-only.
+ * Controller for {@code /v1/databases/{databaseId}/views}. Table routes are separate.
  *
  * <p>The controller is registered regardless of whether views are enabled, and holds no business
- * logic. Request bodies are deliberately not annotated with {@code @Valid}: the view validator
- * accumulates every structural failure and reports them together, which Spring's fail-fast binding
- * cannot do.
+ * logic. Request bodies are validated by the view validator, which accumulates structural failures
+ * before reporting them.
+ *
+ * <p>The endpoint contract includes gateway-generated 502 and 504 responses. These are distinct
+ * from service-generated failures and may not carry the service's error body.
  */
 @RestController
 public class ViewsController {
@@ -51,7 +51,16 @@ public class ViewsController {
         @ApiResponse(responseCode = "401", description = "View GET: UNAUTHORIZED"),
         @ApiResponse(responseCode = "403", description = "View GET: FORBIDDEN"),
         @ApiResponse(responseCode = "404", description = "View GET: NOT_FOUND"),
-        @ApiResponse(responseCode = "503", description = "View GET: SERVICE_UNAVAILABLE")
+        @ApiResponse(responseCode = "500", description = "View GET: Unexpected service failure"),
+        @ApiResponse(
+            responseCode = "502",
+            description = "View GET: Gateway received an invalid upstream response"),
+        @ApiResponse(
+            responseCode = "503",
+            description = "View GET: Service or dependency unavailable"),
+        @ApiResponse(
+            responseCode = "504",
+            description = "View GET: Gateway timed out waiting for upstream")
       })
   @GetMapping(
       value = {"/v1/databases/{databaseId}/views/{viewId}"},
@@ -79,7 +88,16 @@ public class ViewsController {
         @ApiResponse(responseCode = "401", description = "View SEARCH: UNAUTHORIZED"),
         @ApiResponse(responseCode = "403", description = "View SEARCH: FORBIDDEN"),
         @ApiResponse(responseCode = "404", description = "View SEARCH: NOT_FOUND"),
-        @ApiResponse(responseCode = "503", description = "View SEARCH: SERVICE_UNAVAILABLE")
+        @ApiResponse(responseCode = "500", description = "View SEARCH: Unexpected service failure"),
+        @ApiResponse(
+            responseCode = "502",
+            description = "View SEARCH: Gateway received an invalid upstream response"),
+        @ApiResponse(
+            responseCode = "503",
+            description = "View SEARCH: Service or dependency unavailable"),
+        @ApiResponse(
+            responseCode = "504",
+            description = "View SEARCH: Gateway timed out waiting for upstream")
       })
   @GetMapping(
       value = {"/v1/databases/{databaseId}/views"},
@@ -101,7 +119,9 @@ public class ViewsController {
 
   @Operation(
       summary = "Create a View",
-      description = "Creates and returns a View resource in a database identified by databaseId",
+      description =
+          "Creates and returns a View resource in a database identified by databaseId. A 5xx "
+              + "response may leave the commit outcome unknown and must not be retried blindly.",
       tags = {"View"})
   @ApiResponses(
       value = {
@@ -112,7 +132,16 @@ public class ViewsController {
         @ApiResponse(responseCode = "404", description = "View POST: DB_NOT_FOUND"),
         @ApiResponse(responseCode = "409", description = "View POST: VIEW_EXISTS"),
         @ApiResponse(responseCode = "422", description = "View POST: UNPROCESSABLE_ENTITY"),
-        @ApiResponse(responseCode = "503", description = "View POST: SERVICE_UNAVAILABLE")
+        @ApiResponse(responseCode = "500", description = "View POST: Unexpected service failure"),
+        @ApiResponse(
+            responseCode = "502",
+            description = "View POST: Gateway received an invalid upstream response"),
+        @ApiResponse(
+            responseCode = "503",
+            description = "View POST: Service unavailable or commit outcome unknown"),
+        @ApiResponse(
+            responseCode = "504",
+            description = "View POST: Gateway timed out waiting for upstream")
       })
   @PostMapping(
       value = {"/v1/databases/{databaseId}/views"},
@@ -140,7 +169,8 @@ public class ViewsController {
       summary = "Update a View",
       description =
           "Updates or creates a View and returns the View resource. If the view does not exist, it "
-              + "will be created. If the view exists, it will be replaced.",
+              + "will be created. If the view exists, it will be replaced. A 5xx response may leave "
+              + "the commit outcome unknown and must not be retried blindly.",
       tags = {"View"})
   @ApiResponses(
       value = {
@@ -152,7 +182,16 @@ public class ViewsController {
         @ApiResponse(responseCode = "404", description = "View PUT: DB_NOT_FOUND"),
         @ApiResponse(responseCode = "409", description = "View PUT: CONFLICT"),
         @ApiResponse(responseCode = "422", description = "View PUT: UNPROCESSABLE_ENTITY"),
-        @ApiResponse(responseCode = "503", description = "View PUT: SERVICE_UNAVAILABLE")
+        @ApiResponse(responseCode = "500", description = "View PUT: Unexpected service failure"),
+        @ApiResponse(
+            responseCode = "502",
+            description = "View PUT: Gateway received an invalid upstream response"),
+        @ApiResponse(
+            responseCode = "503",
+            description = "View PUT: Service unavailable or commit outcome unknown"),
+        @ApiResponse(
+            responseCode = "504",
+            description = "View PUT: Gateway timed out waiting for upstream")
       })
   @PutMapping(
       value = {"/v1/databases/{databaseId}/views/{viewId}"},
@@ -189,7 +228,16 @@ public class ViewsController {
         @ApiResponse(responseCode = "401", description = "View DELETE: UNAUTHORIZED"),
         @ApiResponse(responseCode = "403", description = "View DELETE: FORBIDDEN"),
         @ApiResponse(responseCode = "404", description = "View DELETE: VIEW_NOT_FOUND"),
-        @ApiResponse(responseCode = "503", description = "View DELETE: SERVICE_UNAVAILABLE")
+        @ApiResponse(responseCode = "500", description = "View DELETE: Unexpected service failure"),
+        @ApiResponse(
+            responseCode = "502",
+            description = "View DELETE: Gateway received an invalid upstream response"),
+        @ApiResponse(
+            responseCode = "503",
+            description = "View DELETE: Service or dependency unavailable"),
+        @ApiResponse(
+            responseCode = "504",
+            description = "View DELETE: Gateway timed out waiting for upstream")
       })
   @DeleteMapping(
       value = {"/v1/databases/{databaseId}/views/{viewId}"},

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/ViewsMapper.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/ViewsMapper.java
@@ -8,7 +8,7 @@ import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
 import org.springframework.data.domain.Page;
 
-/** Mapper between the /v2 views wire models and {@link ViewDto}. */
+/** Mapper between the /v1 views wire models and {@link ViewDto}. */
 @Mapper(componentModel = "spring")
 public interface ViewsMapper {
 

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/ViewsMapper.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/ViewsMapper.java
@@ -1,0 +1,67 @@
+package com.linkedin.openhouse.tables.dto.mapper;
+
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateViewRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetViewResponseBody;
+import com.linkedin.openhouse.tables.model.ViewDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.springframework.data.domain.Page;
+
+/** Mapper between the /v2 views wire models and {@link ViewDto}. */
+@Mapper(componentModel = "spring")
+public interface ViewsMapper {
+
+  /**
+   * Transform a create/update request into a {@link ViewDto} for the service layer.
+   *
+   * <p>The caller-supplied {@code baseViewVersion} is stored as {@code viewVersion} so the service
+   * can compare it against the current pointer later, mirroring how {@code TablesMapper} stores
+   * {@code baseTableVersion} as {@code tableVersion}. Server-owned pointer fields are left unset:
+   * only the service can populate them.
+   *
+   * @param requestBody source request
+   * @return a new immutable {@link ViewDto}
+   */
+  @Mappings({
+    @Mapping(source = "viewId", target = "viewId"),
+    @Mapping(source = "databaseId", target = "databaseId"),
+    @Mapping(source = "clusterId", target = "clusterId"),
+    @Mapping(source = "schema", target = "schema"),
+    @Mapping(source = "representations", target = "representations"),
+    @Mapping(source = "sourceDialect", target = "sourceDialect"),
+    @Mapping(source = "defaultCatalog", target = "defaultCatalog"),
+    @Mapping(source = "defaultNamespace", target = "defaultNamespace"),
+    @Mapping(source = "viewProperties", target = "viewProperties"),
+    @Mapping(
+        source = "baseViewVersion",
+        target = "viewVersion"), /* store base version to check later */
+    @Mapping(target = "viewUri", ignore = true),
+    @Mapping(target = "metadataLocation", ignore = true),
+    @Mapping(target = "viewCreator", ignore = true),
+    @Mapping(target = "creationTime", ignore = true),
+    @Mapping(target = "lastModifiedTime", ignore = true)
+  })
+  ViewDto toViewDto(CreateUpdateViewRequestBody requestBody);
+
+  /**
+   * Transform a {@link ViewDto} into the pointer-only read contract. Definition fields on the DTO
+   * have no counterpart on the response by design and are dropped here.
+   *
+   * @param viewDto source dto
+   * @return the response body forwarded to the client
+   */
+  GetViewResponseBody toGetViewResponseBody(ViewDto viewDto);
+
+  /**
+   * Transform a page of {@link ViewDto} into a page of response bodies, preserving the page
+   * metadata. List DTOs carry identifiers only, so the resulting response bodies are intentionally
+   * sparse.
+   *
+   * @param viewDtoPage source page
+   * @return a page of sparse response bodies
+   */
+  default Page<GetViewResponseBody> toGetViewResponseBodyPage(Page<ViewDto> viewDtoPage) {
+    return viewDtoPage.map(this::toGetViewResponseBody);
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/ViewsMapper.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/ViewsMapper.java
@@ -15,10 +15,10 @@ public interface ViewsMapper {
   /**
    * Transform a create/update request into a {@link ViewDto} for the service layer.
    *
-   * <p>The caller-supplied {@code baseViewVersion} is stored as {@code viewVersion} so the service
-   * can compare it against the current pointer later, mirroring how {@code TablesMapper} stores
-   * {@code baseTableVersion} as {@code tableVersion}. Server-owned pointer fields are left unset:
-   * only the service can populate them.
+   * <p>The caller-supplied {@code baseMetadataLocation} is stored as {@code viewVersion} so the
+   * service can compare it against the current pointer later, mirroring how {@code TablesMapper}
+   * stores {@code baseTableVersion} as {@code tableVersion}. Server-owned pointer fields are left
+   * unset: only the service can populate them.
    *
    * @param requestBody source request
    * @return a new immutable {@link ViewDto}
@@ -34,7 +34,7 @@ public interface ViewsMapper {
     @Mapping(source = "defaultNamespace", target = "defaultNamespace"),
     @Mapping(source = "viewProperties", target = "viewProperties"),
     @Mapping(
-        source = "baseViewVersion",
+        source = "baseMetadataLocation",
         target = "viewVersion"), /* store base version to check later */
     @Mapping(target = "viewUri", ignore = true),
     @Mapping(target = "metadataLocation", ignore = true),

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/ViewsMapper.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/dto/mapper/ViewsMapper.java
@@ -16,9 +16,8 @@ public interface ViewsMapper {
    * Transform a create/update request into a {@link ViewDto} for the service layer.
    *
    * <p>The caller-supplied {@code baseMetadataLocation} is stored as {@code viewVersion} so the
-   * service can compare it against the current pointer later, mirroring how {@code TablesMapper}
-   * stores {@code baseTableVersion} as {@code tableVersion}. Server-owned pointer fields are left
-   * unset: only the service can populate them.
+   * service can compare it against the current pointer. Server-owned pointer fields are left unset:
+   * only the service can populate them.
    *
    * @param requestBody source request
    * @return a new immutable {@link ViewDto}
@@ -33,9 +32,7 @@ public interface ViewsMapper {
     @Mapping(source = "defaultCatalog", target = "defaultCatalog"),
     @Mapping(source = "defaultNamespace", target = "defaultNamespace"),
     @Mapping(source = "viewProperties", target = "viewProperties"),
-    @Mapping(
-        source = "baseMetadataLocation",
-        target = "viewVersion"), /* store base version to check later */
+    @Mapping(source = "baseMetadataLocation", target = "viewVersion"),
     @Mapping(target = "viewUri", ignore = true),
     @Mapping(target = "metadataLocation", ignore = true),
     @Mapping(target = "viewCreator", ignore = true),

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/exception/ViewApiException.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/exception/ViewApiException.java
@@ -1,6 +1,7 @@
 package com.linkedin.openhouse.tables.exception;
 
 import com.linkedin.openhouse.common.exception.CodedApiException;
+import java.util.Objects;
 import org.springframework.http.HttpStatus;
 
 /**
@@ -14,19 +15,27 @@ import org.springframework.http.HttpStatus;
  * <p>Messages carried by this exception are copied verbatim into the error response body and into
  * service audit events, so callers must never interpolate SQL text, schema text or a base version
  * token into them.
+ *
+ * <p>The code is required. Without the null check the failure would surface only when {@link
+ * #getHttpStatus()} is called, which happens inside the exception handler: the resulting {@code
+ * NullPointerException} would be reported as a generic 500 instead of the status the throwing site
+ * intended. Rejecting the null at construction keeps the fault at its origin.
  */
 public class ViewApiException extends CodedApiException {
+
+  private static final String ERROR_CODE_REQUIRED =
+      "ViewApiException requires a non-null ViewErrorCode: it selects the response status";
 
   private final ViewErrorCode errorCode;
 
   public ViewApiException(ViewErrorCode errorCode, String message) {
     super(message);
-    this.errorCode = errorCode;
+    this.errorCode = Objects.requireNonNull(errorCode, ERROR_CODE_REQUIRED);
   }
 
   public ViewApiException(ViewErrorCode errorCode, String message, Throwable cause) {
     super(message, cause);
-    this.errorCode = errorCode;
+    this.errorCode = Objects.requireNonNull(errorCode, ERROR_CODE_REQUIRED);
   }
 
   public ViewErrorCode getErrorCode() {

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/exception/ViewApiException.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/exception/ViewApiException.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 import org.springframework.http.HttpStatus;
 
 /**
- * Failure of a /v2 views API operation, carrying the internal {@link ViewErrorCode} that selects
+ * Failure of a /v1 views API operation, carrying the internal {@link ViewErrorCode} that selects
  * the response status.
  *
  * <p>The code is deliberately tables-local and never serialized: {@link #getHttpStatus()} is the

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/exception/ViewApiException.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/exception/ViewApiException.java
@@ -1,0 +1,40 @@
+package com.linkedin.openhouse.tables.exception;
+
+import com.linkedin.openhouse.common.exception.CodedApiException;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Failure of a /v2 views API operation, carrying the internal {@link ViewErrorCode} that selects
+ * the response status.
+ *
+ * <p>The code is deliberately tables-local and never serialized: {@link #getHttpStatus()} is the
+ * only thing {@code services/common} sees, which keeps the error body shape unchanged. The typed
+ * {@link #getErrorCode()} getter exists so unit tests can assert the internal taxonomy directly.
+ *
+ * <p>Messages carried by this exception are copied verbatim into the error response body and into
+ * service audit events, so callers must never interpolate SQL text, schema text or a base version
+ * token into them.
+ */
+public class ViewApiException extends CodedApiException {
+
+  private final ViewErrorCode errorCode;
+
+  public ViewApiException(ViewErrorCode errorCode, String message) {
+    super(message);
+    this.errorCode = errorCode;
+  }
+
+  public ViewApiException(ViewErrorCode errorCode, String message, Throwable cause) {
+    super(message, cause);
+    this.errorCode = errorCode;
+  }
+
+  public ViewErrorCode getErrorCode() {
+    return errorCode;
+  }
+
+  @Override
+  public HttpStatus getHttpStatus() {
+    return errorCode.getHttpStatus();
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/exception/ViewErrorCode.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/exception/ViewErrorCode.java
@@ -1,0 +1,33 @@
+package com.linkedin.openhouse.tables.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Internal taxonomy of view failure modes. This enum is never serialized to the wire: it exists
+ * only to select the HTTP status of the response, and the error body shape stays unchanged.
+ *
+ * <p>The full set is declared up front, including codes M1 never emits, so later milestones (view
+ * admission, dependency analysis) add behavior without a breaking change to this enum.
+ */
+@AllArgsConstructor
+@Getter
+public enum ViewErrorCode {
+  NO_SUCH_VIEW(HttpStatus.NOT_FOUND),
+  VIEW_ALREADY_EXISTS(HttpStatus.CONFLICT),
+  NAME_ALREADY_EXISTS_AS_TABLE(HttpStatus.CONFLICT),
+  CONCURRENT_VIEW_MODIFICATION(HttpStatus.CONFLICT),
+  DATABASE_NOT_FOUND(HttpStatus.NOT_FOUND),
+  VIEWS_DISABLED(HttpStatus.NOT_FOUND),
+  INVALID_VIEW_DEFINITION(HttpStatus.BAD_REQUEST),
+  UNSUPPORTED_VIEW_DIALECT(HttpStatus.BAD_REQUEST),
+  UNSUPPORTED_VIEW_SCHEMA(HttpStatus.BAD_REQUEST),
+  VIEW_ADMISSION_FAILED(HttpStatus.UNPROCESSABLE_ENTITY),
+  REQUIRED_REPRESENTATION_MISSING(HttpStatus.UNPROCESSABLE_ENTITY),
+  DEPENDENCY_CYCLE(HttpStatus.UNPROCESSABLE_ENTITY),
+  MAX_VIEW_DEPTH_EXCEEDED(HttpStatus.UNPROCESSABLE_ENTITY),
+  ADMISSION_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE);
+
+  private final HttpStatus httpStatus;
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/exception/ViewErrorCode.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/exception/ViewErrorCode.java
@@ -8,8 +8,7 @@ import org.springframework.http.HttpStatus;
  * Internal taxonomy of view failure modes. This enum is never serialized to the wire: it exists
  * only to select the HTTP status of the response, and the error body shape stays unchanged.
  *
- * <p>The full set is declared up front, including codes M1 never emits, so later milestones (view
- * admission, dependency analysis) add behavior without a breaking change to this enum.
+ * <p>Admission and dependency-analysis codes are reserved for those capabilities.
  */
 @AllArgsConstructor
 @Getter

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/exception/ViewRequestValidationFailureException.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/exception/ViewRequestValidationFailureException.java
@@ -1,7 +1,7 @@
 package com.linkedin.openhouse.tables.exception;
 
 import java.util.List;
-import org.springframework.http.HttpStatus;
+import java.util.Objects;
 
 /**
  * Structural validation failure of a /v2 views request. Accumulated reasons are joined with {@code
@@ -9,24 +9,27 @@ import org.springframework.http.HttpStatus;
  * com.linkedin.openhouse.common.exception.RequestValidationFailureException} does for tables, so
  * the two APIs report multiple failures identically.
  *
- * <p>Only 400-mapped codes are accepted: a validation failure that is not a bad request would be a
- * programming error, not a client error.
+ * <p>Only 400-mapped codes are accepted, and that is expressed in the type: the constructors take a
+ * {@link ViewValidationErrorCode}, which can only name one of the three {@code BAD_REQUEST} codes.
+ * A validation failure that is not a bad request is therefore not expressible, rather than
+ * representable and rejected at runtime. {@link #getErrorCode()} still reports the corresponding
+ * {@link ViewErrorCode}, so status selection is unchanged.
  */
 public final class ViewRequestValidationFailureException extends ViewApiException {
 
-  public ViewRequestValidationFailureException(ViewErrorCode errorCode, List<String> reasons) {
-    super(requireBadRequest(errorCode), String.join("; ", reasons));
+  private static final String ERROR_CODE_REQUIRED =
+      "ViewRequestValidationFailureException requires a non-null ViewValidationErrorCode";
+
+  public ViewRequestValidationFailureException(
+      ViewValidationErrorCode errorCode, List<String> reasons) {
+    super(viewErrorCode(errorCode), String.join("; ", reasons));
   }
 
-  public ViewRequestValidationFailureException(ViewErrorCode errorCode, String message) {
-    super(requireBadRequest(errorCode), message);
+  public ViewRequestValidationFailureException(ViewValidationErrorCode errorCode, String message) {
+    super(viewErrorCode(errorCode), message);
   }
 
-  private static ViewErrorCode requireBadRequest(ViewErrorCode errorCode) {
-    if (errorCode == null || errorCode.getHttpStatus() != HttpStatus.BAD_REQUEST) {
-      throw new IllegalArgumentException(
-          "ViewRequestValidationFailureException requires a BAD_REQUEST view error code");
-    }
-    return errorCode;
+  private static ViewErrorCode viewErrorCode(ViewValidationErrorCode errorCode) {
+    return Objects.requireNonNull(errorCode, ERROR_CODE_REQUIRED).getViewErrorCode();
   }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/exception/ViewRequestValidationFailureException.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/exception/ViewRequestValidationFailureException.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Structural validation failure of a /v2 views request. Accumulated reasons are joined with {@code
+ * Structural validation failure of a /v1 views request. Accumulated reasons are joined with {@code
  * "; "} exactly like {@link
  * com.linkedin.openhouse.common.exception.RequestValidationFailureException} does for tables, so
  * the two APIs report multiple failures identically.

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/exception/ViewRequestValidationFailureException.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/exception/ViewRequestValidationFailureException.java
@@ -1,0 +1,32 @@
+package com.linkedin.openhouse.tables.exception;
+
+import java.util.List;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Structural validation failure of a /v2 views request. Accumulated reasons are joined with {@code
+ * "; "} exactly like {@link
+ * com.linkedin.openhouse.common.exception.RequestValidationFailureException} does for tables, so
+ * the two APIs report multiple failures identically.
+ *
+ * <p>Only 400-mapped codes are accepted: a validation failure that is not a bad request would be a
+ * programming error, not a client error.
+ */
+public final class ViewRequestValidationFailureException extends ViewApiException {
+
+  public ViewRequestValidationFailureException(ViewErrorCode errorCode, List<String> reasons) {
+    super(requireBadRequest(errorCode), String.join("; ", reasons));
+  }
+
+  public ViewRequestValidationFailureException(ViewErrorCode errorCode, String message) {
+    super(requireBadRequest(errorCode), message);
+  }
+
+  private static ViewErrorCode requireBadRequest(ViewErrorCode errorCode) {
+    if (errorCode == null || errorCode.getHttpStatus() != HttpStatus.BAD_REQUEST) {
+      throw new IllegalArgumentException(
+          "ViewRequestValidationFailureException requires a BAD_REQUEST view error code");
+    }
+    return errorCode;
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/exception/ViewValidationErrorCode.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/exception/ViewValidationErrorCode.java
@@ -1,0 +1,28 @@
+package com.linkedin.openhouse.tables.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * The subset of {@link ViewErrorCode} a structural validation failure is allowed to carry: exactly
+ * the three codes that map to {@link org.springframework.http.HttpStatus#BAD_REQUEST}.
+ *
+ * <p>This exists so {@link ViewRequestValidationFailureException} can take a type that cannot hold
+ * a non-400 code, rather than accepting the full taxonomy and rejecting the illegal ones at
+ * runtime. A validation failure carrying, say, {@code NO_SUCH_VIEW} is a programming error, and the
+ * compiler is a better place to catch it than a constructor guard.
+ *
+ * <p>{@link ViewErrorCode} keeps all of its values and its status mapping: this enum narrows what a
+ * validator may throw, it does not narrow the taxonomy itself. Every constant here must name a
+ * {@code ViewErrorCode} whose status is {@code BAD_REQUEST}, which {@code ViewApiExceptionTest}
+ * asserts.
+ */
+@AllArgsConstructor
+@Getter
+public enum ViewValidationErrorCode {
+  INVALID_VIEW_DEFINITION(ViewErrorCode.INVALID_VIEW_DEFINITION),
+  UNSUPPORTED_VIEW_DIALECT(ViewErrorCode.UNSUPPORTED_VIEW_DIALECT),
+  UNSUPPORTED_VIEW_SCHEMA(ViewErrorCode.UNSUPPORTED_VIEW_SCHEMA);
+
+  private final ViewErrorCode viewErrorCode;
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/model/ViewDto.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/model/ViewDto.java
@@ -1,0 +1,67 @@
+package com.linkedin.openhouse.tables.model;
+
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.ViewRepresentation;
+import java.util.List;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Internal representation of a view as it moves between the API handler and the view service.
+ *
+ * <p>Deliberately <b>not</b> a JPA entity: it carries no {@code @Entity}, no {@code @IdClass} and
+ * no primary-key companion class, because view persistence does not exist yet and M2 must not
+ * retrofit this DTO as a separate persisted namespace. It likewise carries no UUID and no {@code
+ * TableType} — views are not a table variant.
+ *
+ * <p>Fields split into two groups. The pointer group ({@code viewUri}, {@code metadataLocation},
+ * {@code viewVersion}, {@code creationTime}, {@code lastModifiedTime}, {@code viewCreator}) is what
+ * a read returns. The definition group ({@code schema}, {@code representations}, {@code
+ * sourceDialect}, {@code defaultCatalog}, {@code defaultNamespace}, {@code viewProperties}) is
+ * write-only input and never appears in a response.
+ */
+@Builder(toBuilder = true)
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ViewDto {
+
+  private String viewId;
+
+  private String databaseId;
+
+  private String clusterId;
+
+  private String viewUri;
+
+  private String metadataLocation;
+
+  /**
+   * On a read this is the view's current version pointer. On a write it carries the caller's
+   * supplied {@code baseViewVersion} so the service can compare it later.
+   */
+  private String viewVersion;
+
+  private String viewCreator;
+
+  private long creationTime;
+
+  private long lastModifiedTime;
+
+  private String schema;
+
+  private List<ViewRepresentation> representations;
+
+  private String sourceDialect;
+
+  private String defaultCatalog;
+
+  private List<String> defaultNamespace;
+
+  private Map<String, String> viewProperties;
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/model/ViewDto.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/model/ViewDto.java
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
  * {@code viewVersion}, {@code creationTime}, {@code lastModifiedTime}, {@code viewCreator}) is what
  * a read returns. The definition group ({@code schema}, {@code representations}, {@code
  * sourceDialect}, {@code defaultCatalog}, {@code defaultNamespace}, {@code viewProperties}) is
- * write-only input and never appears in a response.
+ * write-only input today and is not carried into any response this milestone returns.
  */
 @Builder(toBuilder = true)
 @Getter

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/model/ViewDto.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/model/ViewDto.java
@@ -13,16 +13,10 @@ import lombok.NoArgsConstructor;
 /**
  * Internal representation of a view as it moves between the API handler and the view service.
  *
- * <p>Deliberately <b>not</b> a JPA entity: it carries no {@code @Entity}, no {@code @IdClass} and
- * no primary-key companion class, because view persistence does not exist yet and M2 must not
- * retrofit this DTO as a separate persisted namespace. It likewise carries no UUID and no {@code
- * TableType} — views are not a table variant.
+ * <p>This DTO is not a persistence entity. Views are not a {@code TableType} variant.
  *
- * <p>Fields split into two groups. The pointer group ({@code viewUri}, {@code metadataLocation},
- * {@code viewVersion}, {@code creationTime}, {@code lastModifiedTime}, {@code viewCreator}) is what
- * a read returns. The definition group ({@code schema}, {@code representations}, {@code
- * sourceDialect}, {@code defaultCatalog}, {@code defaultNamespace}, {@code viewProperties}) is
- * write-only input today and is not carried into any response this milestone returns.
+ * <p>Pointer fields populate the read response. Definition fields are write inputs and are omitted
+ * from the pointer-only response.
  */
 @Builder(toBuilder = true)
 @Getter
@@ -43,7 +37,7 @@ public class ViewDto {
 
   /**
    * On a read this is the view's current version pointer. On a write it carries the caller's
-   * supplied {@code baseMetadataLocation} so the service can compare it later.
+   * supplied {@code baseMetadataLocation} for the service's concurrency check.
    */
   private String viewVersion;
 

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/model/ViewDto.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/model/ViewDto.java
@@ -43,7 +43,7 @@ public class ViewDto {
 
   /**
    * On a read this is the view's current version pointer. On a write it carries the caller's
-   * supplied {@code baseViewVersion} so the service can compare it later.
+   * supplied {@code baseMetadataLocation} so the service can compare it later.
    */
   private String viewVersion;
 

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/ViewsDisabledService.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/ViewsDisabledService.java
@@ -1,0 +1,57 @@
+package com.linkedin.openhouse.tables.services;
+
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateViewRequestBody;
+import com.linkedin.openhouse.tables.exception.ViewApiException;
+import com.linkedin.openhouse.tables.exception.ViewErrorCode;
+import com.linkedin.openhouse.tables.model.ViewDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.util.Pair;
+import org.springframework.stereotype.Component;
+
+/**
+ * The only {@link ViewsService} bean today. View business logic is intentionally out of scope for
+ * this API-only increment, so every operation reports that views are disabled.
+ *
+ * <p>It throws a {@link ViewApiException} carrying {@link ViewErrorCode#VIEWS_DISABLED} rather than
+ * an {@code UnsupportedOperationException}: the finalized design specifies 404 {@code
+ * VIEWS_DISABLED} for a database without views enabled, and an unchecked non-coded exception would
+ * instead surface as a generic 500 with a stack trace. A structurally valid view request therefore
+ * gets the designed disabled response, not an error probe.
+ *
+ * <p>The later real service replaces this bean and implements the per-database gate.
+ */
+@Component
+public class ViewsDisabledService implements ViewsService {
+
+  /**
+   * Fixed and redacted. The message is copied into the error body and into service audit events, so
+   * it must never echo request content.
+   */
+  static final String VIEWS_DISABLED_MESSAGE = "Views are disabled";
+
+  @Override
+  public ViewDto getView(String databaseId, String viewId, String actingPrincipal) {
+    throw viewsDisabled();
+  }
+
+  @Override
+  public Page<ViewDto> getAllViews(
+      String databaseId, int page, int size, String sortBy, String actingPrincipal) {
+    throw viewsDisabled();
+  }
+
+  @Override
+  public Pair<ViewDto, Boolean> putView(
+      CreateUpdateViewRequestBody requestBody, String actingPrincipal, boolean failOnExist) {
+    throw viewsDisabled();
+  }
+
+  @Override
+  public void deleteView(String databaseId, String viewId, String actingPrincipal) {
+    throw viewsDisabled();
+  }
+
+  private ViewApiException viewsDisabled() {
+    return new ViewApiException(ViewErrorCode.VIEWS_DISABLED, VIEWS_DISABLED_MESSAGE);
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/ViewsDisabledService.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/ViewsDisabledService.java
@@ -9,16 +9,8 @@ import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Component;
 
 /**
- * The only {@link ViewsService} bean today. View business logic is intentionally out of scope for
- * this API-only increment, so every operation reports that views are disabled.
- *
- * <p>It throws a {@link ViewApiException} carrying {@link ViewErrorCode#VIEWS_DISABLED} rather than
- * an {@code UnsupportedOperationException}: the finalized design specifies 404 {@code
- * VIEWS_DISABLED} for a database without views enabled, and an unchecked non-coded exception would
- * instead surface as a generic 500 with a stack trace. A structurally valid view request therefore
- * gets the designed disabled response, not an error probe.
- *
- * <p>The later real service replaces this bean and implements the per-database gate.
+ * Disabled {@link ViewsService} implementation. Every operation reports {@link
+ * ViewErrorCode#VIEWS_DISABLED}, producing HTTP 404 without reading or writing view state.
  */
 @Component
 public class ViewsDisabledService implements ViewsService {

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/ViewsService.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/ViewsService.java
@@ -1,0 +1,55 @@
+package com.linkedin.openhouse.tables.services;
+
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateViewRequestBody;
+import com.linkedin.openhouse.tables.model.ViewDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.util.Pair;
+
+/** Service interface backing the /v2 views endpoints. */
+public interface ViewsService {
+
+  /**
+   * Given a databaseId and viewId, prepare a {@link ViewDto} if actingPrincipal has the right
+   * privilege.
+   *
+   * @param databaseId database identifier
+   * @param viewId view identifier
+   * @param actingPrincipal authenticated user
+   * @return the view pointer
+   */
+  ViewDto getView(String databaseId, String viewId, String actingPrincipal);
+
+  /**
+   * Given a databaseId, prepare a page of identifier-only {@link ViewDto}s.
+   *
+   * @param databaseId database identifier
+   * @param page zero-based page index
+   * @param size page size
+   * @param sortBy optional single sort field
+   * @param actingPrincipal authenticated user
+   * @return a page of identifier-only dtos
+   */
+  Page<ViewDto> getAllViews(
+      String databaseId, int page, int size, String sortBy, String actingPrincipal);
+
+  /**
+   * Create or replace a view.
+   *
+   * @param requestBody the create/update request
+   * @param actingPrincipal authenticated user performing the write
+   * @param failOnExist true for POST create, false for PUT create-or-replace
+   * @return a pair whose first element is the saved view and whose second element is true iff the
+   *     call created the view rather than replacing it
+   */
+  Pair<ViewDto, Boolean> putView(
+      CreateUpdateViewRequestBody requestBody, String actingPrincipal, boolean failOnExist);
+
+  /**
+   * Delete the view identified by databaseId and viewId if actingPrincipal has the right privilege.
+   *
+   * @param databaseId database identifier
+   * @param viewId view identifier
+   * @param actingPrincipal authenticated user
+   */
+  void deleteView(String databaseId, String viewId, String actingPrincipal);
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/ViewsService.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/ViewsService.java
@@ -5,7 +5,7 @@ import com.linkedin.openhouse.tables.model.ViewDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.util.Pair;
 
-/** Service interface backing the /v2 views endpoints. */
+/** Service interface backing the /v1 views endpoints. */
 public interface ViewsService {
 
   /**

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/api/spec/ViewApiContractTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/api/spec/ViewApiContractTest.java
@@ -1,0 +1,466 @@
+package com.linkedin.openhouse.tables.api.spec;
+
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.INITIAL_TABLE_VERSION;
+
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateViewRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.ViewRepresentation;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllViewsResponseBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetViewResponseBody;
+import com.linkedin.openhouse.tables.exception.ViewErrorCode;
+import com.linkedin.openhouse.tables.model.ViewModelConstants;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Freezes the M1 wire surface of {@code /v2/databases/{databaseId}/views}.
+ *
+ * <p>This test exists to satisfy the BDP-108397 acceptance criterion: "A contract test pins the M1
+ * wire surface, so adding the admission service, the polymorphic lookup or /versions later changes
+ * no field this ships." Every assertion is an exact set equality, so the test fails when a field is
+ * added as well as when one is removed.
+ *
+ * <p>It deliberately runs as a plain JUnit 5 test with reflection and a bare Jackson {@link
+ * ObjectMapper}: no Spring context is loaded, so the contract stays pinned even if application
+ * wiring changes.
+ */
+public class ViewApiContractTest {
+
+  /**
+   * Bare mapper with default configuration. Assertions run on the Jackson path because Jackson is
+   * what actually serializes responses over the wire; Gson {@code toJson()} on these models is a
+   * convenience helper only.
+   *
+   * <p>TODO: this is a bare mapper, not the Spring MVC message converter. {@code
+   * TablesMvcConfigurer} customizes no converters today, so the two are equivalent, but a
+   * MockMvc-path serialization assertion belongs in the views controller-test slice to keep that
+   * equivalence honest.
+   */
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Test
+  public void testCreateUpdateViewRequestBodyFieldsAreFrozen() {
+    Set<String> expected =
+        setOf(
+            "viewId",
+            "databaseId",
+            "clusterId",
+            "schema",
+            "representations",
+            "sourceDialect",
+            "defaultCatalog",
+            "defaultNamespace",
+            "viewProperties",
+            "baseViewVersion");
+
+    Assertions.assertEquals(
+        expected,
+        contractFieldNames(CreateUpdateViewRequestBody.class),
+        "CreateUpdateViewRequestBody is a frozen M1 request contract; adding or removing a field is"
+            + " a wire-visible change that needs an explicit contract review.");
+
+    Assertions.assertEquals(
+        expected,
+        jacksonPropertyNames(CreateUpdateViewRequestBody.class),
+        "The Jackson-visible property set is the true wire surface. It must not drift from the"
+            + " declared fields, which a computed or inherited getter would silently do.");
+  }
+
+  @Test
+  public void testViewRepresentationFieldsAreFrozen() {
+    Set<String> expected = setOf("type", "sql", "dialect");
+
+    Assertions.assertEquals(
+        expected,
+        contractFieldNames(ViewRepresentation.class),
+        "ViewRepresentation is a frozen M1 request component.");
+
+    Assertions.assertEquals(
+        expected,
+        jacksonPropertyNames(ViewRepresentation.class),
+        "The Jackson-visible property set is the true wire surface for the nested component.");
+  }
+
+  @Test
+  public void testGetViewResponseBodyFieldsAreFrozen() {
+    Set<String> expected =
+        setOf(
+            "viewId",
+            "databaseId",
+            "clusterId",
+            "viewUri",
+            "metadataLocation",
+            "viewVersion",
+            "creationTime");
+
+    Assertions.assertEquals(
+        expected,
+        contractFieldNames(GetViewResponseBody.class),
+        "GetViewResponseBody is pointer-only. SQL, schema, representations, history, UUID,"
+            + " properties and resolution context must stay in the metadata file.");
+
+    Assertions.assertEquals(
+        expected,
+        jacksonPropertyNames(GetViewResponseBody.class),
+        "A getter-only property would leak onto the wire without adding a declared field, so the"
+            + " Jackson property set is pinned as well.");
+  }
+
+  @Test
+  public void testGetAllViewsResponseBodyFieldsAreFrozen() {
+    Assertions.assertEquals(
+        setOf("pageResults"),
+        contractFieldNames(GetAllViewsResponseBody.class),
+        "GetAllViewsResponseBody is paginated from the first release; there is deliberately no"
+            + " unpaginated legacy 'results' field.");
+  }
+
+  @Test
+  public void testFullyPopulatedRequestSerializesExactKeys() {
+    JsonNode json = MAPPER.valueToTree(ViewModelConstants.fullyPopulatedRequest());
+
+    Assertions.assertEquals(
+        setOf(
+            "viewId",
+            "databaseId",
+            "clusterId",
+            "schema",
+            "representations",
+            "sourceDialect",
+            "defaultCatalog",
+            "defaultNamespace",
+            "viewProperties",
+            "baseViewVersion"),
+        keysOf(json));
+
+    Assertions.assertEquals(ViewModelConstants.VIEW_ID, json.get("viewId").asText());
+    Assertions.assertEquals(ViewModelConstants.DATABASE_ID, json.get("databaseId").asText());
+    Assertions.assertEquals(ViewModelConstants.CLUSTER_ID, json.get("clusterId").asText());
+    Assertions.assertEquals(ViewModelConstants.SOURCE_DIALECT, json.get("sourceDialect").asText());
+    Assertions.assertEquals(
+        ViewModelConstants.METADATA_LOCATION, json.get("baseViewVersion").asText());
+
+    Assertions.assertTrue(json.get("representations").isArray());
+    Assertions.assertEquals(1, json.get("representations").size());
+    JsonNode representation = json.get("representations").get(0);
+    Assertions.assertEquals(setOf("type", "sql", "dialect"), keysOf(representation));
+    Assertions.assertEquals(
+        ViewModelConstants.SQL_REPRESENTATION_TYPE, representation.get("type").asText());
+    Assertions.assertEquals(ViewModelConstants.VIEW_SQL, representation.get("sql").asText());
+    Assertions.assertEquals(
+        ViewModelConstants.SOURCE_DIALECT, representation.get("dialect").asText());
+
+    Assertions.assertTrue(json.get("defaultNamespace").isArray());
+    Assertions.assertEquals(
+        ViewModelConstants.DATABASE_ID, json.get("defaultNamespace").get(0).asText());
+    Assertions.assertEquals(
+        setOf("owner"), keysOf(json.get("viewProperties")), "viewProperties is a free-form map");
+  }
+
+  @Test
+  public void testCreateRequestOmitsNullBaseViewVersion() {
+    CreateUpdateViewRequestBody request = ViewModelConstants.createRequestWithoutBaseVersion();
+    Assertions.assertNull(request.getBaseViewVersion());
+
+    JsonNode json = MAPPER.valueToTree(request);
+
+    Assertions.assertFalse(
+        json.has("baseViewVersion"),
+        "An omitted baseViewVersion must be absent from the payload, not present as JSON null,"
+            + " so the server can distinguish 'not supplied' on create.");
+    Assertions.assertEquals(
+        setOf(
+            "viewId",
+            "databaseId",
+            "clusterId",
+            "schema",
+            "representations",
+            "sourceDialect",
+            "defaultCatalog",
+            "defaultNamespace",
+            "viewProperties"),
+        keysOf(json));
+
+    // The Gson helper on the model is configured to agree with @JsonInclude(NON_NULL): unlike
+    // CreateUpdateTableRequestBody, it does not call serializeNulls().
+    Assertions.assertFalse(
+        request.toJson().contains("baseViewVersion"),
+        "toJson() must not disagree with the Jackson wire representation.");
+  }
+
+  @Test
+  public void testCreateRequestSerializesInitialBaseViewVersion() {
+    CreateUpdateViewRequestBody request = ViewModelConstants.createRequestWithInitialBaseVersion();
+
+    JsonNode json = MAPPER.valueToTree(request);
+
+    Assertions.assertTrue(json.has("baseViewVersion"));
+    Assertions.assertEquals("INITIAL_VERSION", json.get("baseViewVersion").asText());
+    Assertions.assertEquals(
+        INITIAL_TABLE_VERSION,
+        json.get("baseViewVersion").asText(),
+        "The create token reuses the existing INITIAL_VERSION literal rather than minting a"
+            + " view-specific value.");
+  }
+
+  @Test
+  public void testPointerResponseSerializesExactKeysAndNoDefinition() {
+    // Uses distinct metadataLocation/viewVersion sentinels so a swap of the two Jackson property
+    // associations cannot pass. Production keeps them equal; see ViewModelConstants.
+    JsonNode json = MAPPER.valueToTree(ViewModelConstants.pointerResponseWithDistinctPointers());
+
+    Assertions.assertEquals(
+        setOf(
+            "viewId",
+            "databaseId",
+            "clusterId",
+            "viewUri",
+            "metadataLocation",
+            "viewVersion",
+            "creationTime"),
+        keysOf(json));
+
+    List<String> definitionFields =
+        Arrays.asList(
+            "sql",
+            "schema",
+            "representations",
+            "sourceDialect",
+            "defaultCatalog",
+            "defaultNamespace",
+            "viewProperties",
+            "viewUUID",
+            "history",
+            "versions",
+            "properties",
+            "tableType");
+    for (String forbidden : definitionFields) {
+      Assertions.assertFalse(
+          json.has(forbidden), "Pointer response leaked definition field '" + forbidden + "'.");
+    }
+
+    Assertions.assertEquals(ViewModelConstants.VIEW_URI, json.get("viewUri").asText());
+    Assertions.assertEquals(
+        ViewModelConstants.DISTINCT_METADATA_LOCATION, json.get("metadataLocation").asText());
+    Assertions.assertEquals(
+        ViewModelConstants.DISTINCT_VIEW_VERSION, json.get("viewVersion").asText());
+    Assertions.assertNotEquals(
+        json.get("metadataLocation").asText(),
+        json.get("viewVersion").asText(),
+        "The fixture must keep the two pointers distinct, otherwise this test cannot detect a"
+            + " swapped property association.");
+    Assertions.assertTrue(json.get("creationTime").isNumber());
+    Assertions.assertEquals(ViewModelConstants.CREATION_TIME, json.get("creationTime").asLong());
+  }
+
+  @Test
+  public void testSparseListResponseUsesGetViewResponseBodyElementsAndPageMetadata() {
+    GetAllViewsResponseBody listResponse = ViewModelConstants.listResponse();
+
+    Assertions.assertTrue(
+        listResponse.getPageResults().getContent().stream()
+            .allMatch(element -> element instanceof GetViewResponseBody),
+        "List elements are the full response type populated sparsely, not a separate identifier"
+            + " response type.");
+
+    JsonNode json = MAPPER.valueToTree(listResponse);
+    Assertions.assertEquals(setOf("pageResults"), keysOf(json));
+
+    JsonNode page = json.get("pageResults");
+
+    // Exact key-set equality, not has(): GetAllTablesResponseBody already ships a Spring Data Page
+    // on the wire today, so this documents the real shipped shape. A Spring Data upgrade that adds,
+    // removes or renames a page-level key is a client-visible wire change and must be reviewed
+    // here rather than silently absorbed.
+    Assertions.assertEquals(
+        setOf(
+            "content",
+            "pageable",
+            "totalPages",
+            "totalElements",
+            "last",
+            "sort",
+            "number",
+            "size",
+            "numberOfElements",
+            "first",
+            "empty"),
+        keysOf(page),
+        "The serialized Page shape is part of the view list contract.");
+
+    Assertions.assertEquals(1, page.get("totalPages").asInt());
+    Assertions.assertEquals(2L, page.get("totalElements").asLong());
+    Assertions.assertEquals(2, page.get("numberOfElements").asInt());
+    Assertions.assertEquals(0, page.get("number").asInt());
+    Assertions.assertEquals(50, page.get("size").asInt());
+    Assertions.assertTrue(page.get("first").asBoolean());
+    Assertions.assertTrue(page.get("last").asBoolean());
+    Assertions.assertFalse(page.get("empty").asBoolean());
+
+    Assertions.assertEquals(
+        setOf("empty", "sorted", "unsorted"),
+        keysOf(page.get("sort")),
+        "The nested sort descriptor is client-visible too.");
+    Assertions.assertTrue(page.get("sort").get("empty").asBoolean());
+    Assertions.assertFalse(page.get("sort").get("sorted").asBoolean());
+    Assertions.assertTrue(page.get("sort").get("unsorted").asBoolean());
+
+    JsonNode pageable = page.get("pageable");
+    Assertions.assertEquals(
+        setOf("sort", "offset", "pageNumber", "pageSize", "paged", "unpaged"),
+        keysOf(pageable),
+        "The nested pageable descriptor is client-visible too.");
+    Assertions.assertEquals(0L, pageable.get("offset").asLong());
+    Assertions.assertEquals(0, pageable.get("pageNumber").asInt());
+    Assertions.assertEquals(50, pageable.get("pageSize").asInt());
+    Assertions.assertTrue(pageable.get("paged").asBoolean());
+    Assertions.assertFalse(pageable.get("unpaged").asBoolean());
+    Assertions.assertEquals(setOf("empty", "sorted", "unsorted"), keysOf(pageable.get("sort")));
+
+    JsonNode content = page.get("content");
+    Assertions.assertEquals(2, content.size());
+    for (JsonNode element : content) {
+      Assertions.assertEquals(
+          setOf(
+              "viewId",
+              "databaseId",
+              "clusterId",
+              "viewUri",
+              "metadataLocation",
+              "viewVersion",
+              "creationTime"),
+          keysOf(element),
+          "List elements must expose exactly the pointer contract.");
+      Assertions.assertFalse(element.get("viewId").isNull());
+      Assertions.assertEquals(ViewModelConstants.DATABASE_ID, element.get("databaseId").asText());
+      List<String> unpopulatedPointerFields =
+          Arrays.asList("clusterId", "viewUri", "metadataLocation", "viewVersion");
+      for (String unpopulated : unpopulatedPointerFields) {
+        Assertions.assertTrue(
+            element.get(unpopulated).isNull(),
+            "List results are identifier-only, so '" + unpopulated + "' must stay unpopulated.");
+      }
+      Assertions.assertEquals(0L, element.get("creationTime").asLong());
+    }
+  }
+
+  @Test
+  public void testViewErrorCodeNamesAndStatusesAreFrozen() {
+    Map<ViewErrorCode, HttpStatus> expected = new EnumMap<>(ViewErrorCode.class);
+    expected.put(ViewErrorCode.NO_SUCH_VIEW, HttpStatus.NOT_FOUND);
+    expected.put(ViewErrorCode.VIEW_ALREADY_EXISTS, HttpStatus.CONFLICT);
+    expected.put(ViewErrorCode.NAME_ALREADY_EXISTS_AS_TABLE, HttpStatus.CONFLICT);
+    expected.put(ViewErrorCode.CONCURRENT_VIEW_MODIFICATION, HttpStatus.CONFLICT);
+    expected.put(ViewErrorCode.DATABASE_NOT_FOUND, HttpStatus.NOT_FOUND);
+    expected.put(ViewErrorCode.VIEWS_DISABLED, HttpStatus.NOT_FOUND);
+    expected.put(ViewErrorCode.INVALID_VIEW_DEFINITION, HttpStatus.BAD_REQUEST);
+    expected.put(ViewErrorCode.UNSUPPORTED_VIEW_DIALECT, HttpStatus.BAD_REQUEST);
+    expected.put(ViewErrorCode.UNSUPPORTED_VIEW_SCHEMA, HttpStatus.BAD_REQUEST);
+    expected.put(ViewErrorCode.VIEW_ADMISSION_FAILED, HttpStatus.UNPROCESSABLE_ENTITY);
+    expected.put(ViewErrorCode.REQUIRED_REPRESENTATION_MISSING, HttpStatus.UNPROCESSABLE_ENTITY);
+    expected.put(ViewErrorCode.DEPENDENCY_CYCLE, HttpStatus.UNPROCESSABLE_ENTITY);
+    expected.put(ViewErrorCode.MAX_VIEW_DEPTH_EXCEEDED, HttpStatus.UNPROCESSABLE_ENTITY);
+    expected.put(ViewErrorCode.ADMISSION_SERVICE_UNAVAILABLE, HttpStatus.SERVICE_UNAVAILABLE);
+
+    Assertions.assertEquals(
+        14, ViewErrorCode.values().length, "ViewErrorCode ships exactly 14 values.");
+
+    Assertions.assertEquals(
+        setOf(
+            "NO_SUCH_VIEW",
+            "VIEW_ALREADY_EXISTS",
+            "NAME_ALREADY_EXISTS_AS_TABLE",
+            "CONCURRENT_VIEW_MODIFICATION",
+            "DATABASE_NOT_FOUND",
+            "VIEWS_DISABLED",
+            "INVALID_VIEW_DEFINITION",
+            "UNSUPPORTED_VIEW_DIALECT",
+            "UNSUPPORTED_VIEW_SCHEMA",
+            "VIEW_ADMISSION_FAILED",
+            "REQUIRED_REPRESENTATION_MISSING",
+            "DEPENDENCY_CYCLE",
+            "MAX_VIEW_DEPTH_EXCEEDED",
+            "ADMISSION_SERVICE_UNAVAILABLE"),
+        Arrays.stream(ViewErrorCode.values())
+            .map(Enum::name)
+            .collect(Collectors.toCollection(LinkedHashSet::new)),
+        "Reserved codes ship now so later milestones add behavior without an enum change.");
+
+    Assertions.assertEquals(expected.size(), ViewErrorCode.values().length);
+    for (ViewErrorCode code : ViewErrorCode.values()) {
+      Assertions.assertEquals(
+          expected.get(code),
+          code.getHttpStatus(),
+          "ViewErrorCode." + code.name() + " must keep its HTTP status.");
+      Assertions.assertEquals(
+          expected.get(code).value(),
+          code.getHttpStatus().value(),
+          "ViewErrorCode." + code.name() + " must keep its numeric HTTP status.");
+    }
+
+    // The enum only selects an HTTP status; it is never serialized into the error body.
+    Assertions.assertEquals(
+        setOf("httpStatus"),
+        contractFieldNames(ViewErrorCode.class),
+        "ViewErrorCode carries only an HttpStatus. A wire-facing code field would change the"
+            + " unchanged error response contract.");
+  }
+
+  /**
+   * Declared instance fields that form the contract. Static fields (including the enum constants
+   * themselves and {@code $VALUES}), synthetic fields, and instrumentation artifacts such as
+   * JaCoCo's {@code $jacocoData} or Lombok-generated members are excluded so the assertion stays
+   * stable under coverage instrumentation.
+   */
+  private static Set<String> contractFieldNames(Class<?> type) {
+    return Arrays.stream(type.getDeclaredFields())
+        .filter(field -> !field.isSynthetic())
+        .filter(field -> !Modifier.isStatic(field.getModifiers()))
+        .map(Field::getName)
+        .filter(name -> !name.contains("$"))
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  /**
+   * Property names Jackson will actually serialize for the type. Unlike {@link
+   * #contractFieldNames}, this sees inherited and getter-only (computed) properties, so it pins the
+   * true wire surface rather than the declared source shape.
+   */
+  private static Set<String> jacksonPropertyNames(Class<?> type) {
+    BeanDescription description =
+        MAPPER.getSerializationConfig().introspect(MAPPER.getTypeFactory().constructType(type));
+    return description.findProperties().stream()
+        .map(BeanPropertyDefinition::getName)
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  private static Set<String> keysOf(JsonNode node) {
+    Set<String> keys = new LinkedHashSet<>();
+    Iterator<String> fieldNames = node.fieldNames();
+    while (fieldNames.hasNext()) {
+      keys.add(fieldNames.next());
+    }
+    return keys;
+  }
+
+  private static Set<String> setOf(String... values) {
+    List<String> asList = Arrays.asList(values);
+    Set<String> set = new LinkedHashSet<>(asList);
+    Assertions.assertEquals(asList.size(), set.size(), "Duplicate expectation in test fixture.");
+    return set;
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/api/spec/ViewApiContractTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/api/spec/ViewApiContractTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
 /**
- * Freezes the M1 wire surface of {@code /v2/databases/{databaseId}/views}.
+ * Freezes the M1 wire surface of {@code /v1/databases/{databaseId}/views}.
  *
  * <p>This test exists to satisfy the BDP-108397 acceptance criterion: "A contract test pins the M1
  * wire surface, so adding the admission service, the polymorphic lookup or /versions later changes

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/api/spec/ViewApiContractTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/api/spec/ViewApiContractTest.java
@@ -3,6 +3,7 @@ package com.linkedin.openhouse.tables.api.spec;
 import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.INITIAL_TABLE_VERSION;
 
 import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
@@ -65,7 +66,7 @@ public class ViewApiContractTest {
             "defaultCatalog",
             "defaultNamespace",
             "viewProperties",
-            "baseViewVersion");
+            "baseMetadataLocation");
 
     Assertions.assertEquals(
         expected,
@@ -144,7 +145,7 @@ public class ViewApiContractTest {
             "defaultCatalog",
             "defaultNamespace",
             "viewProperties",
-            "baseViewVersion"),
+            "baseMetadataLocation"),
         keysOf(json));
 
     Assertions.assertEquals(ViewModelConstants.VIEW_ID, json.get("viewId").asText());
@@ -152,7 +153,7 @@ public class ViewApiContractTest {
     Assertions.assertEquals(ViewModelConstants.CLUSTER_ID, json.get("clusterId").asText());
     Assertions.assertEquals(ViewModelConstants.SOURCE_DIALECT, json.get("sourceDialect").asText());
     Assertions.assertEquals(
-        ViewModelConstants.METADATA_LOCATION, json.get("baseViewVersion").asText());
+        ViewModelConstants.METADATA_LOCATION, json.get("baseMetadataLocation").asText());
 
     Assertions.assertTrue(json.get("representations").isArray());
     Assertions.assertEquals(1, json.get("representations").size());
@@ -172,15 +173,15 @@ public class ViewApiContractTest {
   }
 
   @Test
-  public void testCreateRequestOmitsNullBaseViewVersion() {
+  public void testCreateRequestOmitsNullBaseMetadataLocation() {
     CreateUpdateViewRequestBody request = ViewModelConstants.createRequestWithoutBaseVersion();
-    Assertions.assertNull(request.getBaseViewVersion());
+    Assertions.assertNull(request.getBaseMetadataLocation());
 
     JsonNode json = MAPPER.valueToTree(request);
 
     Assertions.assertFalse(
-        json.has("baseViewVersion"),
-        "An omitted baseViewVersion must be absent from the payload, not present as JSON null,"
+        json.has("baseMetadataLocation"),
+        "An omitted baseMetadataLocation must be absent from the payload, not present as JSON null,"
             + " so the server can distinguish 'not supplied' on create.");
     Assertions.assertEquals(
         setOf(
@@ -198,23 +199,131 @@ public class ViewApiContractTest {
     // The Gson helper on the model is configured to agree with @JsonInclude(NON_NULL): unlike
     // CreateUpdateTableRequestBody, it does not call serializeNulls().
     Assertions.assertFalse(
-        request.toJson().contains("baseViewVersion"),
+        request.toJson().contains("baseMetadataLocation"),
         "toJson() must not disagree with the Jackson wire representation.");
   }
 
   @Test
-  public void testCreateRequestSerializesInitialBaseViewVersion() {
+  public void testCreateRequestSerializesInitialBaseMetadataLocation() {
     CreateUpdateViewRequestBody request = ViewModelConstants.createRequestWithInitialBaseVersion();
 
     JsonNode json = MAPPER.valueToTree(request);
 
-    Assertions.assertTrue(json.has("baseViewVersion"));
-    Assertions.assertEquals("INITIAL_VERSION", json.get("baseViewVersion").asText());
+    Assertions.assertTrue(json.has("baseMetadataLocation"));
+    Assertions.assertEquals("INITIAL_VERSION", json.get("baseMetadataLocation").asText());
     Assertions.assertEquals(
         INITIAL_TABLE_VERSION,
-        json.get("baseViewVersion").asText(),
+        json.get("baseMetadataLocation").asText(),
         "The create token reuses the existing INITIAL_VERSION literal rather than minting a"
             + " view-specific value.");
+  }
+
+  /**
+   * Gson serializes declared fields rather than Jackson properties, so this pins that the Java
+   * field itself carries the wire name. A rename applied only as a Jackson annotation would leave
+   * the Gson helper — and with it the audited request payload — on the old key.
+   */
+  @Test
+  public void testGsonPayloadCarriesTheSameBaseMetadataLocationKey() {
+    CreateUpdateViewRequestBody request = ViewModelConstants.fullyPopulatedRequest();
+
+    JsonNode gsonPayload = Assertions.assertDoesNotThrow(() -> MAPPER.readTree(request.toJson()));
+
+    Assertions.assertTrue(
+        gsonPayload.has("baseMetadataLocation"),
+        "The Gson helper must emit the renamed field, which it only can once the declared field is"
+            + " renamed rather than annotated.");
+    Assertions.assertEquals(
+        ViewModelConstants.METADATA_LOCATION, gsonPayload.get("baseMetadataLocation").asText());
+    Assertions.assertFalse(
+        gsonPayload.has("baseViewVersion"),
+        "The field is renamed, not aliased, so the pre-rename key must not survive on the wire.");
+    Assertions.assertEquals(
+        keysOf(MAPPER.valueToTree(request)),
+        keysOf(gsonPayload),
+        "toJson() must not disagree with the Jackson wire representation.");
+  }
+
+  /**
+   * Deserialization is the direction a caller actually exercises, and it is the direction the
+   * serialization assertions above cannot cover. The bare mapper keeps its default {@code
+   * FAIL_ON_UNKNOWN_PROPERTIES}, so a key that does not bind fails loudly here rather than becoming
+   * a silent null.
+   */
+  @Test
+  public void testRequestBindsBaseMetadataLocationFromTheWireKey() {
+    String payload =
+        "{\"viewId\": \""
+            + ViewModelConstants.VIEW_ID
+            + "\", \"databaseId\": \""
+            + ViewModelConstants.DATABASE_ID
+            + "\", \"baseMetadataLocation\": \""
+            + ViewModelConstants.METADATA_LOCATION
+            + "\"}";
+
+    CreateUpdateViewRequestBody request =
+        Assertions.assertDoesNotThrow(
+            () -> MAPPER.readValue(payload, CreateUpdateViewRequestBody.class),
+            "baseMetadataLocation is the key a caller sends, so it must bind onto the request"
+                + " model.");
+
+    Assertions.assertEquals(
+        ViewModelConstants.VIEW_ID,
+        request.getViewId(),
+        "Precondition: the model binds from JSON at all.");
+    Assertions.assertEquals(
+        ViewModelConstants.METADATA_LOCATION, request.getBaseMetadataLocation());
+  }
+
+  /**
+   * The value is an opaque metadata pointer rather than a number, so the whole populated shape has
+   * to survive a round trip unchanged: no normalization, no coercion and no field dropped.
+   */
+  @Test
+  public void testFullyPopulatedRequestRoundTripsThroughJackson() {
+    CreateUpdateViewRequestBody request = ViewModelConstants.fullyPopulatedRequest();
+
+    JsonNode json = MAPPER.valueToTree(request);
+    Assertions.assertTrue(
+        json.has("baseMetadataLocation"),
+        "Precondition: the serialized form carries the wire key.");
+
+    CreateUpdateViewRequestBody roundTripped =
+        Assertions.assertDoesNotThrow(
+            () -> MAPPER.treeToValue(json, CreateUpdateViewRequestBody.class));
+
+    Assertions.assertEquals(
+        request, roundTripped, "Serializing and reading back must preserve every field.");
+  }
+
+  /**
+   * The rename ships without a compatibility alias, so the pre-rename key must leave the property
+   * unset rather than silently populating it. Read with unknown properties ignored, which is how
+   * the application's converter is configured; the shared bare mapper deliberately keeps its strict
+   * default and is left alone.
+   */
+  @Test
+  public void testLegacyBaseViewVersionKeyDoesNotPopulateBaseMetadataLocation() {
+    ObjectMapper lenientMapper =
+        new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    String payload =
+        "{\"viewId\": \""
+            + ViewModelConstants.VIEW_ID
+            + "\", \"baseViewVersion\": \""
+            + ViewModelConstants.METADATA_LOCATION
+            + "\"}";
+
+    CreateUpdateViewRequestBody request =
+        Assertions.assertDoesNotThrow(
+            () -> lenientMapper.readValue(payload, CreateUpdateViewRequestBody.class));
+
+    Assertions.assertEquals(
+        ViewModelConstants.VIEW_ID,
+        request.getViewId(),
+        "Precondition: the rest of a legacy payload still binds; only the renamed key is unknown.");
+    Assertions.assertNull(
+        request.getBaseMetadataLocation(),
+        "The old key is not an alias: a caller that has not migrated leaves the field unset.");
   }
 
   @Test

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/api/spec/ViewApiContractTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/api/spec/ViewApiContractTest.java
@@ -28,12 +28,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
 /**
- * Freezes the M1 wire surface of {@code /v1/databases/{databaseId}/views}.
- *
- * <p>This test exists to satisfy the BDP-108397 acceptance criterion: "A contract test pins the M1
- * wire surface, so adding the admission service, the polymorphic lookup or /versions later changes
- * no field this ships." Every assertion is an exact set equality, so the test fails when a field is
- * added as well as when one is removed.
+ * Pins the wire surface of {@code /v1/databases/{databaseId}/views}. Exact field-set assertions
+ * detect additions as well as removals.
  *
  * <p>It deliberately runs as a plain JUnit 5 test with reflection and a bare Jackson {@link
  * ObjectMapper}: no Spring context is loaded, so the contract stays pinned even if application
@@ -42,14 +38,8 @@ import org.springframework.http.HttpStatus;
 public class ViewApiContractTest {
 
   /**
-   * Bare mapper with default configuration. Assertions run on the Jackson path because Jackson is
-   * what actually serializes responses over the wire; Gson {@code toJson()} on these models is a
-   * convenience helper only.
-   *
-   * <p>TODO: this is a bare mapper, not the Spring MVC message converter. {@code
-   * TablesMvcConfigurer} customizes no converters today, so the two are equivalent, but a
-   * MockMvc-path serialization assertion belongs in the views controller-test slice to keep that
-   * equivalence honest.
+   * Default Jackson mapper for wire-shape assertions. Controller tests cover binding through the
+   * application's MVC converter separately.
    */
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -126,8 +116,7 @@ public class ViewApiContractTest {
     Assertions.assertEquals(
         setOf("pageResults"),
         contractFieldNames(GetAllViewsResponseBody.class),
-        "GetAllViewsResponseBody is paginated from the first release; there is deliberately no"
-            + " unpaginated legacy 'results' field.");
+        "GetAllViewsResponseBody contains only the paginated pageResults field.");
   }
 
   @Test
@@ -391,10 +380,7 @@ public class ViewApiContractTest {
 
     JsonNode page = json.get("pageResults");
 
-    // Exact key-set equality, not has(): GetAllTablesResponseBody already ships a Spring Data Page
-    // on the wire today, so this documents the real shipped shape. A Spring Data upgrade that adds,
-    // removes or renames a page-level key is a client-visible wire change and must be reviewed
-    // here rather than silently absorbed.
+    // Spring Data upgrades must not silently add, remove or rename fields in the wire contract.
     Assertions.assertEquals(
         setOf(
             "content",

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/api/validator/ViewSchemaParseBoundaryTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/api/validator/ViewSchemaParseBoundaryTest.java
@@ -1,0 +1,93 @@
+package com.linkedin.openhouse.tables.api.validator;
+
+import com.linkedin.openhouse.common.schema.IcebergSchemaHelper;
+import com.linkedin.openhouse.tables.model.ViewModelConstants;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Pins the exception taxonomy {@code OpenHouseViewsApiValidator#validateSchema} depends on.
+ *
+ * <p>That method catches {@link IllegalArgumentException} and {@link UncheckedIOException} rather
+ * than bare {@code Exception}, so a genuine parser defect propagates as a server fault instead of
+ * being reported to the caller as a bad request. The narrowing is only correct while those two
+ * types remain exactly what Iceberg raises for caller-supplied text, and that is a property of a
+ * third-party library which an upgrade can change silently.
+ *
+ * <p>Iceberg splits the failure in two, and both halves are reachable from a request body:
+ *
+ * <ul>
+ *   <li>Text that Jackson cannot parse as JSON at all fails inside {@code JsonUtil.parse}, which
+ *       wraps the {@code IOException} in an {@link UncheckedIOException}.
+ *   <li>Structurally valid JSON that is not an Iceberg schema fails Iceberg's own semantic checks
+ *       and surfaces as an {@link IllegalArgumentException}.
+ * </ul>
+ *
+ * <p>Catching only the second would let a merely malformed document escape and be reported as a
+ * 500. This test fails the moment that split moves.
+ *
+ * <p>The complementary assertion — that all of these inputs are reported to the caller as a 400
+ * carrying the same fixed, redacted schema message — lives in {@code
+ * ViewsValidatorTest#validateRejectsEverySchemaIcebergCannotParse}, which drives the same three
+ * fixtures through the validator itself.
+ */
+public class ViewSchemaParseBoundaryTest {
+
+  /**
+   * The types {@code validateSchema} catches. Any parse failure not assignable to one of these
+   * escapes the validator and becomes a 500.
+   */
+  private static final List<Class<? extends RuntimeException>> CAUGHT_BY_VALIDATOR =
+      Arrays.asList(IllegalArgumentException.class, UncheckedIOException.class);
+
+  private static Stream<Arguments> unparseableSchemas() {
+    return Stream.of(
+        Arguments.of(
+            "syntactically malformed JSON",
+            ViewModelConstants.MALFORMED_SCHEMA_LITERAL,
+            UncheckedIOException.class),
+        Arguments.of("text that is not JSON at all", "not json at all", UncheckedIOException.class),
+        Arguments.of(
+            "Spark StructType JSON",
+            ViewModelConstants.SPARK_STRUCT_TYPE_SCHEMA_LITERAL,
+            IllegalArgumentException.class),
+        Arguments.of(
+            "duplicate field ids",
+            ViewModelConstants.DUPLICATE_FIELD_ID_SCHEMA_LITERAL,
+            IllegalArgumentException.class));
+  }
+
+  @ParameterizedTest(name = "{0} is rejected as {2}")
+  @MethodSource("unparseableSchemas")
+  public void icebergRejectsEachUnparseableSchemaWithATypeTheValidatorCatches(
+      String description, String schema, Class<? extends RuntimeException> expectedType) {
+    RuntimeException thrown =
+        Assertions.assertThrows(
+            RuntimeException.class,
+            () -> IcebergSchemaHelper.getSchemaFromSchemaJson(schema),
+            description + " must not parse as an Iceberg schema.");
+
+    Assertions.assertEquals(
+        expectedType,
+        thrown.getClass(),
+        description
+            + " must keep failing as "
+            + expectedType.getSimpleName()
+            + ". If Iceberg changed this, the catch clause in OpenHouseViewsApiValidator"
+            + ".validateSchema has to change with it.");
+
+    Assertions.assertTrue(
+        CAUGHT_BY_VALIDATOR.stream().anyMatch(caught -> caught.isInstance(thrown)),
+        description
+            + " throws "
+            + thrown.getClass().getName()
+            + ", which OpenHouseViewsApiValidator.validateSchema does not catch, so a client"
+            + " sending it would receive a 500 instead of a 400.");
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/controller/ViewsControllerPrivilegeTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/controller/ViewsControllerPrivilegeTest.java
@@ -14,7 +14,7 @@ import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
- * Pins the privilege each /v2 views route is guarded by.
+ * Pins the privilege each /v1 views route is guarded by.
  *
  * <p>{@code @Secured} is enforced by a proxy at runtime, so a route that loses its annotation, or
  * has it silently retargeted at the wrong privilege, still compiles and still serves traffic. This

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/controller/ViewsControllerPrivilegeTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/controller/ViewsControllerPrivilegeTest.java
@@ -1,0 +1,86 @@
+package com.linkedin.openhouse.tables.controller;
+
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateViewRequestBody;
+import com.linkedin.openhouse.tables.authorization.Privileges;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * Pins the privilege each /v2 views route is guarded by.
+ *
+ * <p>{@code @Secured} is enforced by a proxy at runtime, so a route that loses its annotation, or
+ * has it silently retargeted at the wrong privilege, still compiles and still serves traffic. This
+ * test freezes the mapping so that drift is a build failure rather than an authorization hole.
+ *
+ * <p>Runs as a plain JUnit 5 reflection test: no Spring context is loaded, so the mapping stays
+ * pinned independently of how method security happens to be wired.
+ */
+public class ViewsControllerPrivilegeTest {
+
+  @Test
+  public void everyViewRouteDeclaresItsExpectedPrivilege() throws NoSuchMethodException {
+    Map<Method, String> expected = new LinkedHashMap<>();
+    expected.put(
+        ViewsController.class.getMethod("getView", String.class, String.class),
+        Privileges.Privilege.SELECT);
+    expected.put(
+        ViewsController.class.getMethod(
+            "getAllViews", String.class, int.class, int.class, String.class),
+        Privileges.Privilege.LIST_VIEW);
+    expected.put(
+        ViewsController.class.getMethod(
+            "createView", String.class, CreateUpdateViewRequestBody.class),
+        Privileges.Privilege.CREATE_VIEW);
+    expected.put(
+        ViewsController.class.getMethod(
+            "updateView", String.class, String.class, CreateUpdateViewRequestBody.class),
+        Privileges.Privilege.UPDATE_VIEW_METADATA);
+    expected.put(
+        ViewsController.class.getMethod("deleteView", String.class, String.class),
+        Privileges.Privilege.DELETE_VIEW);
+
+    for (Map.Entry<Method, String> route : expected.entrySet()) {
+      Secured secured = route.getKey().getAnnotation(Secured.class);
+      Assertions.assertNotNull(
+          secured,
+          "ViewsController." + route.getKey().getName() + " must stay guarded by @Secured.");
+      Assertions.assertArrayEquals(
+          new String[] {route.getValue()},
+          secured.value(),
+          "ViewsController."
+              + route.getKey().getName()
+              + " must require exactly the "
+              + route.getValue()
+              + " privilege.");
+    }
+
+    Assertions.assertEquals(
+        expected.keySet().stream().map(Method::getName).collect(Collectors.toSet()),
+        handlerMethodNames(),
+        "Every request-mapped method on ViewsController must have its privilege pinned above.");
+  }
+
+  /**
+   * Names of the methods Spring MVC would expose as routes. Derived from the mapping annotations
+   * rather than a hard-coded list, so adding a route without pinning its privilege fails here.
+   */
+  private static Set<String> handlerMethodNames() {
+    return Arrays.stream(ViewsController.class.getDeclaredMethods())
+        .filter(
+            method ->
+                Arrays.stream(method.getAnnotations())
+                    .anyMatch(
+                        annotation ->
+                            annotation.annotationType().isAnnotationPresent(RequestMapping.class)))
+        .map(Method::getName)
+        .collect(Collectors.toSet());
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/exception/ViewApiExceptionTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/exception/ViewApiExceptionTest.java
@@ -1,0 +1,116 @@
+package com.linkedin.openhouse.tables.exception;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Construction-time invariants of the views exception hierarchy.
+ *
+ * <p>Runs as a plain JUnit 5 test: these types hold no Spring wiring, and the point of the class is
+ * that the failures below happen at the throw site rather than anywhere a context could be
+ * involved.
+ */
+public class ViewApiExceptionTest {
+
+  /**
+   * {@link ViewApiException#getHttpStatus()} dereferences the code, and it is called by {@code
+   * OpenHouseExceptionHandler} while it is already building the response. A null code accepted at
+   * construction would therefore surface as a {@code NullPointerException} inside the handler and
+   * be reported as a generic 500, hiding both the real fault and the status the throw site
+   * intended.
+   */
+  @Test
+  public void constructionRejectsANullErrorCodeRatherThanFailingInsideTheHandler() {
+    NullPointerException fromMessageConstructor =
+        Assertions.assertThrows(
+            NullPointerException.class, () -> new ViewApiException(null, "any message"));
+    Assertions.assertTrue(
+        fromMessageConstructor.getMessage().contains("ViewErrorCode"),
+        "The failure must name the missing argument, not read as an anonymous NPE.");
+
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> new ViewApiException(null, "any message", new RuntimeException("cause")),
+        "The cause-carrying constructor must apply the same rule.");
+
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> new ViewRequestValidationFailureException(null, Collections.singletonList("reason")),
+        "The validation subclass must reject a null code at construction too.");
+
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> new ViewRequestValidationFailureException(null, "reason"));
+  }
+
+  /** A well-formed exception reports the code it was given and the status that code maps to. */
+  @Test
+  public void aWellFormedExceptionReportsItsCodeAndStatus() {
+    ViewApiException exception = new ViewApiException(ViewErrorCode.NO_SUCH_VIEW, "view not found");
+
+    Assertions.assertEquals(ViewErrorCode.NO_SUCH_VIEW, exception.getErrorCode());
+    Assertions.assertEquals(HttpStatus.NOT_FOUND, exception.getHttpStatus());
+    Assertions.assertEquals("view not found", exception.getMessage());
+  }
+
+  /**
+   * The reason {@link ViewValidationErrorCode} exists: a validation failure that is not a bad
+   * request must not be expressible. This freezes the mapping so a later code added to {@link
+   * ViewErrorCode} cannot drift into or out of the validation subset unnoticed.
+   */
+  @Test
+  public void everyValidationCodeMapsToABadRequestViewErrorCode() {
+    Set<String> expected =
+        setOf("INVALID_VIEW_DEFINITION", "UNSUPPORTED_VIEW_DIALECT", "UNSUPPORTED_VIEW_SCHEMA");
+
+    Assertions.assertEquals(
+        expected,
+        Arrays.stream(ViewValidationErrorCode.values())
+            .map(Enum::name)
+            .collect(Collectors.toCollection(LinkedHashSet::new)),
+        "ViewValidationErrorCode names exactly the 400-mapped codes.");
+
+    for (ViewValidationErrorCode code : ViewValidationErrorCode.values()) {
+      Assertions.assertEquals(
+          code.name(),
+          code.getViewErrorCode().name(),
+          "Each validation code must name the identically named ViewErrorCode.");
+      Assertions.assertEquals(
+          HttpStatus.BAD_REQUEST,
+          code.getViewErrorCode().getHttpStatus(),
+          "ViewValidationErrorCode." + code.name() + " must map to a BAD_REQUEST code.");
+    }
+
+    Assertions.assertEquals(
+        expected,
+        Arrays.stream(ViewErrorCode.values())
+            .filter(code -> code.getHttpStatus() == HttpStatus.BAD_REQUEST)
+            .map(Enum::name)
+            .collect(Collectors.toCollection(LinkedHashSet::new)),
+        "The validation subset must stay exhaustive: every BAD_REQUEST ViewErrorCode is"
+            + " expressible as a validation failure.");
+  }
+
+  /** Reasons are joined the way the tables API joins them, so both APIs read identically. */
+  @Test
+  public void accumulatedReasonsAreJoinedWithASemicolon() {
+    ViewRequestValidationFailureException exception =
+        new ViewRequestValidationFailureException(
+            ViewValidationErrorCode.UNSUPPORTED_VIEW_DIALECT,
+            Arrays.asList("first reason", "second reason"));
+
+    Assertions.assertEquals("first reason; second reason", exception.getMessage());
+    Assertions.assertEquals(ViewErrorCode.UNSUPPORTED_VIEW_DIALECT, exception.getErrorCode());
+    Assertions.assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
+  }
+
+  private static Set<String> setOf(String... values) {
+    return new LinkedHashSet<>(Arrays.asList(values));
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/MockViewsApiHandler.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/MockViewsApiHandler.java
@@ -1,0 +1,150 @@
+package com.linkedin.openhouse.tables.mock;
+
+import com.linkedin.openhouse.common.api.spec.ApiResponse;
+import com.linkedin.openhouse.tables.api.handler.ViewsApiHandler;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateViewRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllViewsResponseBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetViewResponseBody;
+import com.linkedin.openhouse.tables.exception.ViewApiException;
+import com.linkedin.openhouse.tables.exception.ViewErrorCode;
+import com.linkedin.openhouse.tables.model.ViewModelConstants;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.AuthorizationServiceException;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@code @Primary} stand-in for {@link ViewsApiHandler} used by the views controller tests,
+ * mirroring {@link MockTablesApiHandler}. It exists so the controller tests exercise routing,
+ * status codes and response serialization without depending on a view service that does not exist
+ * yet.
+ *
+ * <p><b>Error signal:</b> every route first runs the request's {@code databaseId} through a
+ * deterministic switch, mirroring {@link MockTablesApiHandler}'s {@code "d200"}/{@code "d404"}
+ * convention. {@link #databaseIdFor(ViewErrorCode)} yields the database id that makes a route throw
+ * a {@link ViewApiException} carrying that code, and two further ids cover the uncoded paths: an
+ * {@link AccessDeniedException} and a generic infrastructure {@link AuthorizationServiceException}.
+ * Any other database id, including the {@code "d200"} the tests use for success, responds normally.
+ *
+ * <p><b>PUT signal:</b> PUT has two success statuses and the handler picks between them from the
+ * service's created flag, which does not exist here. The mock therefore uses a deterministic,
+ * documented identifier signal instead: a PUT for {@link #PUT_CREATES_VIEW_ID} reports 201 CREATED
+ * and every other view id reports 200 OK. Keep this signal on the view id rather than the database
+ * id so a later negative-path slice is free to use the database id for error selection, matching
+ * how {@link MockTablesApiHandler} switches on {@code databaseId}.
+ */
+@Component
+@Primary
+public class MockViewsApiHandler implements ViewsApiHandler {
+
+  /** A PUT to this view id reports 201 CREATED; any other view id reports 200 OK. */
+  public static final String PUT_CREATES_VIEW_ID = "v201";
+
+  /**
+   * Fixed message carried by every thrown {@link ViewApiException}. Deliberately identical across
+   * codes: the controller contract is status plus message, and the code itself never reaches the
+   * wire, so tests must not be able to recover it from the body by accident.
+   */
+  public static final String VIEW_FAILURE_MESSAGE = "Mock view handler failure";
+
+  /** Fixed message for the access-denied path. */
+  public static final String ACCESS_DENIED_MESSAGE = "Mock view handler denied access";
+
+  /** Fixed message for the generic, uncoded infrastructure failure path. */
+  public static final String UNAVAILABLE_MESSAGE = "Mock view handler dependency unavailable";
+
+  /** Database id that makes any route throw {@link AccessDeniedException} (403). */
+  public static final String ACCESS_DENIED_DATABASE_ID = "d403";
+
+  /**
+   * Database id that makes any route throw {@link AuthorizationServiceException}, the generic
+   * uncoded infrastructure failure that the shared handler maps to 503.
+   */
+  public static final String UNAVAILABLE_DATABASE_ID = "d503";
+
+  private static final Map<String, ViewErrorCode> ERROR_CODE_BY_DATABASE_ID;
+
+  static {
+    Map<String, ViewErrorCode> byDatabaseId = new LinkedHashMap<>();
+    for (ViewErrorCode errorCode : ViewErrorCode.values()) {
+      byDatabaseId.put(databaseIdFor(errorCode), errorCode);
+    }
+    ERROR_CODE_BY_DATABASE_ID = Collections.unmodifiableMap(byDatabaseId);
+  }
+
+  /**
+   * @return the database id that makes every route throw a {@link ViewApiException} carrying {@code
+   *     errorCode}. Derived from the enum constant so a new code is covered automatically rather
+   *     than needing a hand-maintained switch arm.
+   */
+  public static String databaseIdFor(ViewErrorCode errorCode) {
+    return "derr_" + errorCode.name();
+  }
+
+  private static void throwIfErrorDatabaseId(String databaseId) {
+    if (ACCESS_DENIED_DATABASE_ID.equals(databaseId)) {
+      throw new AccessDeniedException(ACCESS_DENIED_MESSAGE);
+    }
+    if (UNAVAILABLE_DATABASE_ID.equals(databaseId)) {
+      throw new AuthorizationServiceException(UNAVAILABLE_MESSAGE);
+    }
+    ViewErrorCode errorCode = ERROR_CODE_BY_DATABASE_ID.get(databaseId);
+    if (errorCode != null) {
+      throw new ViewApiException(errorCode, VIEW_FAILURE_MESSAGE);
+    }
+  }
+
+  @Override
+  public ApiResponse<GetViewResponseBody> getView(
+      String databaseId, String viewId, String actingPrincipal) {
+    throwIfErrorDatabaseId(databaseId);
+    return ApiResponse.<GetViewResponseBody>builder()
+        .httpStatus(HttpStatus.OK)
+        .responseBody(ViewModelConstants.pointerResponse())
+        .build();
+  }
+
+  @Override
+  public ApiResponse<GetAllViewsResponseBody> getAllViews(
+      String databaseId, int page, int size, String sortBy, String actingPrincipal) {
+    throwIfErrorDatabaseId(databaseId);
+    return ApiResponse.<GetAllViewsResponseBody>builder()
+        .httpStatus(HttpStatus.OK)
+        .responseBody(ViewModelConstants.listResponse())
+        .build();
+  }
+
+  @Override
+  public ApiResponse<GetViewResponseBody> createView(
+      String databaseId, CreateUpdateViewRequestBody requestBody, String actingPrincipal) {
+    throwIfErrorDatabaseId(databaseId);
+    return ApiResponse.<GetViewResponseBody>builder()
+        .httpStatus(HttpStatus.CREATED)
+        .responseBody(ViewModelConstants.pointerResponse())
+        .build();
+  }
+
+  @Override
+  public ApiResponse<GetViewResponseBody> updateView(
+      String databaseId,
+      String viewId,
+      CreateUpdateViewRequestBody requestBody,
+      String actingPrincipal) {
+    throwIfErrorDatabaseId(databaseId);
+    HttpStatus httpStatus = PUT_CREATES_VIEW_ID.equals(viewId) ? HttpStatus.CREATED : HttpStatus.OK;
+    return ApiResponse.<GetViewResponseBody>builder()
+        .httpStatus(httpStatus)
+        .responseBody(ViewModelConstants.pointerResponse())
+        .build();
+  }
+
+  @Override
+  public ApiResponse<Void> deleteView(String databaseId, String viewId, String actingPrincipal) {
+    throwIfErrorDatabaseId(databaseId);
+    return ApiResponse.<Void>builder().httpStatus(HttpStatus.NO_CONTENT).build();
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/MockViewsApiHandler.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/MockViewsApiHandler.java
@@ -20,8 +20,7 @@ import org.springframework.stereotype.Component;
 /**
  * {@code @Primary} stand-in for {@link ViewsApiHandler} used by the views controller tests,
  * mirroring {@link MockTablesApiHandler}. It exists so the controller tests exercise routing,
- * status codes and response serialization without depending on a view service that does not exist
- * yet.
+ * status codes and response serialization independently of the view service.
  *
  * <p><b>Error signal:</b> every route first runs the request's {@code databaseId} through a
  * deterministic switch, mirroring {@link MockTablesApiHandler}'s {@code "d200"}/{@code "d404"}
@@ -33,9 +32,8 @@ import org.springframework.stereotype.Component;
  * <p><b>PUT signal:</b> PUT has two success statuses and the handler picks between them from the
  * service's created flag, which does not exist here. The mock therefore uses a deterministic,
  * documented identifier signal instead: a PUT for {@link #PUT_CREATES_VIEW_ID} reports 201 CREATED
- * and every other view id reports 200 OK. Keep this signal on the view id rather than the database
- * id so a later negative-path slice is free to use the database id for error selection, matching
- * how {@link MockTablesApiHandler} switches on {@code databaseId}.
+ * and every other view id reports 200 OK. Database ids select errors independently of this
+ * success-status signal.
  */
 @Component
 @Primary

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/api/OpenHouseViewsApiHandlerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/api/OpenHouseViewsApiHandlerTest.java
@@ -1,0 +1,208 @@
+package com.linkedin.openhouse.tables.mock.api;
+
+import static org.mockito.Mockito.when;
+
+import com.linkedin.openhouse.cluster.configs.ClusterProperties;
+import com.linkedin.openhouse.common.api.spec.ApiResponse;
+import com.linkedin.openhouse.tables.api.handler.impl.OpenHouseViewsApiHandler;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateViewRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllViewsResponseBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetViewResponseBody;
+import com.linkedin.openhouse.tables.api.validator.ViewsApiValidator;
+import com.linkedin.openhouse.tables.dto.mapper.ViewsMapper;
+import com.linkedin.openhouse.tables.model.ViewDto;
+import com.linkedin.openhouse.tables.model.ViewModelConstants;
+import com.linkedin.openhouse.tables.services.ViewsService;
+import java.util.Collections;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.util.Pair;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Plain-Mockito coverage of {@link OpenHouseViewsApiHandler}.
+ *
+ * <p>Intentionally no Spring context: {@code MockTablesApplication} does not component-scan {@code
+ * tables.api.handler.impl}, and the {@code @Primary} mock handler would shadow the real one anyway,
+ * so a Spring test could not obtain this bean.
+ */
+@ExtendWith(MockitoExtension.class)
+public class OpenHouseViewsApiHandlerTest {
+
+  private static final String SERVING_CLUSTER = "local-cluster";
+  private static final String ACTING_PRINCIPAL = "DUMMY_ANONYMOUS_USER";
+
+  @Mock private ViewsApiValidator viewsApiValidator;
+
+  @Mock private ViewsService viewsService;
+
+  @Mock private ViewsMapper viewsMapper;
+
+  @Mock private ClusterProperties clusterProperties;
+
+  @InjectMocks private OpenHouseViewsApiHandler handler;
+
+  private ViewDto viewDto;
+
+  private GetViewResponseBody responseBody;
+
+  @BeforeEach
+  public void setup() {
+    viewDto =
+        ViewDto.builder()
+            .viewId(ViewModelConstants.VIEW_ID)
+            .databaseId(ViewModelConstants.DATABASE_ID)
+            .build();
+    responseBody = ViewModelConstants.pointerResponse();
+  }
+
+  @Test
+  public void getViewValidatesBeforeCallingTheServiceAndReturns200() {
+    when(viewsService.getView(
+            ViewModelConstants.DATABASE_ID, ViewModelConstants.VIEW_ID, ACTING_PRINCIPAL))
+        .thenReturn(viewDto);
+    when(viewsMapper.toGetViewResponseBody(viewDto)).thenReturn(responseBody);
+
+    ApiResponse<GetViewResponseBody> apiResponse =
+        handler.getView(
+            ViewModelConstants.DATABASE_ID, ViewModelConstants.VIEW_ID, ACTING_PRINCIPAL);
+
+    InOrder inOrder = Mockito.inOrder(viewsApiValidator, viewsService);
+    inOrder
+        .verify(viewsApiValidator)
+        .validateGetView(ViewModelConstants.DATABASE_ID, ViewModelConstants.VIEW_ID);
+    inOrder
+        .verify(viewsService)
+        .getView(ViewModelConstants.DATABASE_ID, ViewModelConstants.VIEW_ID, ACTING_PRINCIPAL);
+
+    Assertions.assertEquals(HttpStatus.OK, apiResponse.getHttpStatus());
+    Assertions.assertSame(
+        responseBody,
+        apiResponse.getResponseBody(),
+        "The handler must forward the mapper's result untouched; it does no serialization or"
+            + " enrichment of its own.");
+  }
+
+  @Test
+  public void getAllViewsPassesThroughTheMappedPageAndReturns200() {
+    Page<ViewDto> servicePage =
+        new PageImpl<>(Collections.singletonList(viewDto), PageRequest.of(0, 50), 1);
+    Page<GetViewResponseBody> mappedPage = ViewModelConstants.sparseListPage();
+
+    when(viewsService.getAllViews(ViewModelConstants.DATABASE_ID, 0, 50, null, ACTING_PRINCIPAL))
+        .thenReturn(servicePage);
+    when(viewsMapper.toGetViewResponseBodyPage(servicePage)).thenReturn(mappedPage);
+
+    ApiResponse<GetAllViewsResponseBody> apiResponse =
+        handler.getAllViews(ViewModelConstants.DATABASE_ID, 0, 50, null, ACTING_PRINCIPAL);
+
+    InOrder inOrder = Mockito.inOrder(viewsApiValidator, viewsService);
+    inOrder
+        .verify(viewsApiValidator)
+        .validateGetAllViews(ViewModelConstants.DATABASE_ID, 0, 50, null);
+    inOrder
+        .verify(viewsService)
+        .getAllViews(ViewModelConstants.DATABASE_ID, 0, 50, null, ACTING_PRINCIPAL);
+
+    Assertions.assertEquals(HttpStatus.OK, apiResponse.getHttpStatus());
+    Assertions.assertSame(mappedPage, apiResponse.getResponseBody().getPageResults());
+  }
+
+  @Test
+  public void createViewValidatesAgainstTheServingClusterAndReturns201() {
+    CreateUpdateViewRequestBody requestBody = ViewModelConstants.createRequestWithoutBaseVersion();
+    when(clusterProperties.getClusterName()).thenReturn(SERVING_CLUSTER);
+    when(viewsService.putView(requestBody, ACTING_PRINCIPAL, true))
+        .thenReturn(Pair.of(viewDto, true));
+    when(viewsMapper.toGetViewResponseBody(viewDto)).thenReturn(responseBody);
+
+    ApiResponse<GetViewResponseBody> apiResponse =
+        handler.createView(ViewModelConstants.DATABASE_ID, requestBody, ACTING_PRINCIPAL);
+
+    InOrder inOrder = Mockito.inOrder(viewsApiValidator, viewsService);
+    inOrder
+        .verify(viewsApiValidator)
+        .validateCreateView(SERVING_CLUSTER, ViewModelConstants.DATABASE_ID, requestBody);
+    // failOnExist is true on POST: a POST must never silently replace an existing view.
+    inOrder.verify(viewsService).putView(requestBody, ACTING_PRINCIPAL, true);
+
+    Assertions.assertEquals(HttpStatus.CREATED, apiResponse.getHttpStatus());
+    Assertions.assertSame(responseBody, apiResponse.getResponseBody());
+  }
+
+  @Test
+  public void updateViewSelectsStatusFromTheServiceCreatedFlag() {
+    CreateUpdateViewRequestBody requestBody = ViewModelConstants.fullyPopulatedRequest();
+    when(clusterProperties.getClusterName()).thenReturn(SERVING_CLUSTER);
+    when(viewsMapper.toGetViewResponseBody(viewDto)).thenReturn(responseBody);
+
+    when(viewsService.putView(requestBody, ACTING_PRINCIPAL, false))
+        .thenReturn(Pair.of(viewDto, false));
+    Assertions.assertEquals(
+        HttpStatus.OK,
+        handler
+            .updateView(
+                ViewModelConstants.DATABASE_ID,
+                ViewModelConstants.VIEW_ID,
+                requestBody,
+                ACTING_PRINCIPAL)
+            .getHttpStatus(),
+        "A PUT that replaced an existing view reports 200.");
+
+    when(viewsService.putView(requestBody, ACTING_PRINCIPAL, false))
+        .thenReturn(Pair.of(viewDto, true));
+    Assertions.assertEquals(
+        HttpStatus.CREATED,
+        handler
+            .updateView(
+                ViewModelConstants.DATABASE_ID,
+                ViewModelConstants.VIEW_ID,
+                requestBody,
+                ACTING_PRINCIPAL)
+            .getHttpStatus(),
+        "A PUT that created the view reports 201.");
+
+    // Strict alternation proves the validator ran before the service on *each* invocation, not
+    // merely that both collaborators were touched. failOnExist is false on PUT: a PUT may create.
+    InOrder inOrder = Mockito.inOrder(viewsApiValidator, viewsService);
+    for (int invocation = 0; invocation < 2; invocation++) {
+      inOrder
+          .verify(viewsApiValidator)
+          .validateUpdateView(
+              SERVING_CLUSTER,
+              ViewModelConstants.DATABASE_ID,
+              ViewModelConstants.VIEW_ID,
+              requestBody);
+      inOrder.verify(viewsService).putView(requestBody, ACTING_PRINCIPAL, false);
+    }
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void deleteViewValidatesBeforeCallingTheServiceAndReturns204() {
+    ApiResponse<Void> apiResponse =
+        handler.deleteView(
+            ViewModelConstants.DATABASE_ID, ViewModelConstants.VIEW_ID, ACTING_PRINCIPAL);
+
+    InOrder inOrder = Mockito.inOrder(viewsApiValidator, viewsService);
+    inOrder
+        .verify(viewsApiValidator)
+        .validateDeleteView(ViewModelConstants.DATABASE_ID, ViewModelConstants.VIEW_ID);
+    inOrder
+        .verify(viewsService)
+        .deleteView(ViewModelConstants.DATABASE_ID, ViewModelConstants.VIEW_ID, ACTING_PRINCIPAL);
+
+    Assertions.assertEquals(HttpStatus.NO_CONTENT, apiResponse.getHttpStatus());
+    Assertions.assertNull(apiResponse.getResponseBody());
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/api/ViewsValidatorMultiDialectTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/api/ViewsValidatorMultiDialectTest.java
@@ -1,0 +1,151 @@
+package com.linkedin.openhouse.tables.mock.api;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.linkedin.openhouse.cluster.configs.ClusterProperties;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateViewRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.ViewRepresentation;
+import com.linkedin.openhouse.tables.api.validator.ViewsApiValidator;
+import com.linkedin.openhouse.tables.exception.ViewErrorCode;
+import com.linkedin.openhouse.tables.exception.ViewRequestValidationFailureException;
+import com.linkedin.openhouse.tables.model.ViewModelConstants;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * The half of the dialect rule that a single-dialect deployment cannot demonstrate: what a
+ * deployment that configures a second dialect actually accepts.
+ *
+ * <p>{@link ViewsValidatorTest} covers the default configuration, where {@code spark} is the only
+ * supported dialect. That default makes "supported" and "the only one" indistinguishable, so it
+ * cannot show that the rule is a membership test against configuration rather than a count of the
+ * list or a literal comparison against Spark. This class configures {@code spark,trino} and asserts
+ * the difference that makes: a two-representation request is accepted, and every rule that is not
+ * about the supported set still rejects what it did before.
+ */
+@SpringBootTest(properties = "cluster.tables.views.supported-dialects=spark,trino")
+public class ViewsValidatorMultiDialectTest {
+
+  private static final ViewRepresentation TRINO_REPRESENTATION =
+      ViewModelConstants.SPARK_REPRESENTATION.toBuilder().dialect("trino").build();
+
+  @Autowired private ViewsApiValidator viewsApiValidator;
+
+  @Autowired private ClusterProperties clusterProperties;
+
+  @Test
+  public void validateAcceptsOneRepresentationPerConfiguredDialect() {
+    assertDoesNotThrow(
+        createOf(
+            requestWith(
+                Arrays.asList(ViewModelConstants.SPARK_REPRESENTATION, TRINO_REPRESENTATION))),
+        "Both dialects are configured and neither is duplicated, so the request is unambiguous and"
+            + " must be accepted; the old rule rejected it purely for its length.");
+  }
+
+  /** The source may name either configured dialect, not just the one that happens to be first. */
+  @Test
+  public void validateAcceptsAConfiguredSourceDialectThatIsNotSpark() {
+    assertDoesNotThrow(
+        createOf(
+            requestWith(
+                    Arrays.asList(ViewModelConstants.SPARK_REPRESENTATION, TRINO_REPRESENTATION))
+                .toBuilder()
+                .sourceDialect("trino")
+                .build()),
+        "trino is configured and is supplied as a representation, so it is a legal source dialect.");
+
+    assertDoesNotThrow(
+        createOf(
+            requestWith(Arrays.asList(TRINO_REPRESENTATION))
+                .toBuilder()
+                .sourceDialect("trino")
+                .build()),
+        "A view defined only in trino is legal once trino is configured.");
+  }
+
+  /** Widening the set widens it by exactly what was configured, and by nothing else. */
+  @Test
+  public void validateStillRejectsADialectOutsideTheConfiguredSet() {
+    assertRejected(
+        createOf(
+            requestWith(
+                Arrays.asList(
+                    ViewModelConstants.SPARK_REPRESENTATION,
+                    ViewModelConstants.SPARK_REPRESENTATION
+                        .toBuilder()
+                        .dialect("presto")
+                        .build()))),
+        ViewErrorCode.UNSUPPORTED_VIEW_DIALECT,
+        "representations[1].dialect : must be one of the supported dialects: spark, trino");
+
+    assertRejected(
+        createOf(
+            requestWith(Arrays.asList(ViewModelConstants.SPARK_REPRESENTATION))
+                .toBuilder()
+                .sourceDialect("presto")
+                .build()),
+        ViewErrorCode.UNSUPPORTED_VIEW_DIALECT,
+        "sourceDialect : must be one of the supported dialects: spark, trino");
+  }
+
+  /**
+   * Uniqueness is what makes dropping the count rule safe, so it has to keep holding for a dialect
+   * that only a widened configuration can reach.
+   */
+  @Test
+  public void validateStillRejectsDuplicateDialectsCaseInsensitively() {
+    assertRejected(
+        createOf(
+            requestWith(
+                Arrays.asList(
+                    TRINO_REPRESENTATION,
+                    TRINO_REPRESENTATION.toBuilder().dialect("TRINO").build()))),
+        ViewErrorCode.UNSUPPORTED_VIEW_DIALECT,
+        "representations : dialects must be unique, duplicated: trino");
+  }
+
+  /** Configuring a dialect widens the supported set; it does not relax the exact-lowercase rule. */
+  @Test
+  public void validateStillRejectsAConfiguredDialectSuppliedInTheWrongCase() {
+    assertRejected(
+        createOf(
+            requestWith(
+                Arrays.asList(
+                    ViewModelConstants.SPARK_REPRESENTATION,
+                    TRINO_REPRESENTATION.toBuilder().dialect("Trino").build()))),
+        ViewErrorCode.UNSUPPORTED_VIEW_DIALECT,
+        "representations[1].dialect : must be one of the supported dialects: spark, trino");
+  }
+
+  private CreateUpdateViewRequestBody requestWith(List<ViewRepresentation> representations) {
+    return ViewModelConstants.createRequestWithoutBaseVersion()
+        .toBuilder()
+        .clusterId(clusterProperties.getClusterName())
+        .representations(representations)
+        .build();
+  }
+
+  private Executable createOf(CreateUpdateViewRequestBody requestBody) {
+    return () ->
+        viewsApiValidator.validateCreateView(
+            clusterProperties.getClusterName(), ViewModelConstants.DATABASE_ID, requestBody);
+  }
+
+  private void assertRejected(
+      Executable executable, ViewErrorCode expectedCode, String expectedMessage) {
+    ViewRequestValidationFailureException exception =
+        Assertions.assertThrows(ViewRequestValidationFailureException.class, executable);
+    Assertions.assertTrue(
+        exception.getMessage().contains(expectedMessage),
+        String.format(
+            "Expected the failure to report \"%s\" but it reported \"%s\"",
+            expectedMessage, exception.getMessage()));
+    Assertions.assertEquals(expectedCode, exception.getErrorCode());
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/api/ViewsValidatorTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/api/ViewsValidatorTest.java
@@ -135,6 +135,17 @@ public class ViewsValidatorTest {
       "schema : must be valid Iceberg schema JSON; Spark StructType JSON is not supported";
 
   /**
+   * The messages the default configuration produces. Written out rather than derived from the
+   * property, so a change to how the supported set is rendered has to be made deliberately here
+   * too: these strings are copied verbatim into the response body a caller reads.
+   */
+  private static final String UNSUPPORTED_REPRESENTATION_DIALECT =
+      "representations[0].dialect : must be one of the supported dialects: spark";
+
+  private static final String UNSUPPORTED_SOURCE_DIALECT =
+      "sourceDialect : must be one of the supported dialects: spark";
+
+  /**
    * Asserts the request is rejected, that the reported reason is exactly {@code expectedMessage},
    * and that the internal code is the expected one. The code is asserted everywhere because it is
    * never serialized: all three 400-mapped codes look identical to a client, so this test class is
@@ -399,19 +410,7 @@ public class ViewsValidatorTest {
   }
 
   @Test
-  public void validateRejectsRepresentationCountNullElementAndType() {
-    // A second representation necessarily also breaks a dialect rule, because spark is the only
-    // supported dialect and duplicates of it are rejected. The count message is what is asserted;
-    // the dialect code simply reflects that more specific coexisting failure.
-    assertRejected(
-        createOf(
-            createRequestWith(
-                Arrays.asList(
-                    ViewModelConstants.SPARK_REPRESENTATION,
-                    ViewModelConstants.SPARK_REPRESENTATION.toBuilder().dialect("trino").build()))),
-        ViewErrorCode.UNSUPPORTED_VIEW_DIALECT,
-        "representations : must contain exactly one representation");
-
+  public void validateRejectsANullRepresentationAndANonSqlType() {
     assertRejected(
         createOf(createRequestWith(Collections.singletonList((ViewRepresentation) null))),
         ViewErrorCode.INVALID_VIEW_DEFINITION,
@@ -425,26 +424,60 @@ public class ViewsValidatorTest {
         "representations[0].type : must be 'sql'");
   }
 
+  /**
+   * The supported set is configuration, and this deployment configures nothing, so the default
+   * applies. That default is exactly {@code spark}: a Spark view is accepted and a Trino one is
+   * rejected, which is the behaviour the count-and-literal rules this replaced used to produce.
+   */
   @Test
-  public void validateRejectsEveryDialectOtherThanExactlySpark() {
+  public void validateAcceptsTheDefaultConfiguredDialectAndRejectsEveryOther() {
+    assertDoesNotThrow(
+        createOf(validCreateRequest()),
+        "spark is the default supported dialect, so a single spark representation must be accepted.");
+
     assertRejected(
         createOf(
             createRequestWith(
                 ViewModelConstants.SPARK_REPRESENTATION.toBuilder().dialect("trino").build())),
         ViewErrorCode.UNSUPPORTED_VIEW_DIALECT,
-        "representations[0].dialect : only 'spark' is supported");
+        UNSUPPORTED_REPRESENTATION_DIALECT);
 
     assertRejected(
         createOf(
             createRequestWith(
                 ViewModelConstants.SPARK_REPRESENTATION.toBuilder().dialect("SPARK").build())),
         ViewErrorCode.UNSUPPORTED_VIEW_DIALECT,
-        "representations[0].dialect : only 'spark' is supported");
+        UNSUPPORTED_REPRESENTATION_DIALECT);
 
     assertRejected(
         createOf(validCreateRequest().toBuilder().sourceDialect("trino").build()),
         ViewErrorCode.UNSUPPORTED_VIEW_DIALECT,
-        "sourceDialect : only 'spark' is supported");
+        UNSUPPORTED_SOURCE_DIALECT);
+  }
+
+  /**
+   * Two representations are structurally fine; two representations the deployment cannot both serve
+   * are not. With only spark configured, the second one is rejected on its own dialect rather than
+   * on a count of the list.
+   */
+  @Test
+  public void validateRejectsASecondRepresentationOnlyForItsUnsupportedDialect() {
+    ViewRequestValidationFailureException exception =
+        assertRejected(
+            createOf(
+                createRequestWith(
+                    Arrays.asList(
+                        ViewModelConstants.SPARK_REPRESENTATION,
+                        ViewModelConstants.SPARK_REPRESENTATION
+                            .toBuilder()
+                            .dialect("trino")
+                            .build()))),
+            ViewErrorCode.UNSUPPORTED_VIEW_DIALECT,
+            "representations[1].dialect : must be one of the supported dialects: spark");
+
+    Assertions.assertFalse(
+        exception.getMessage().contains("representations[0]"),
+        "The supported representation must not be implicated: only the unsupported one is at fault.");
   }
 
   /**

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/api/ViewsValidatorTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/api/ViewsValidatorTest.java
@@ -69,7 +69,7 @@ public class ViewsValidatorTest {
                 clusterProperties.getClusterName(),
                 ViewModelConstants.DATABASE_ID,
                 servingCluster(ViewModelConstants.createRequestWithInitialBaseVersion())),
-        "The Iceberg client always sends "
+        "The Iceberg client sends "
             + INITIAL_TABLE_VERSION
             + " on create, so that form must be accepted too.");
   }
@@ -315,7 +315,7 @@ public class ViewsValidatorTest {
         createOf(
             validCreateRequest()
                 .toBuilder()
-                .schema(ViewModelConstants.schemaOfExactUtf8Size(MAX_VIEW_SCHEMA_BYTES))
+                .schema(ViewModelConstants.schemaAtMaxUtf8Size())
                 .build()),
         "The limit is inclusive: a schema of exactly the maximum size must be accepted.");
 
@@ -323,7 +323,7 @@ public class ViewsValidatorTest {
         createOf(
             validCreateRequest()
                 .toBuilder()
-                .schema(ViewModelConstants.schemaOfExactUtf8Size(MAX_VIEW_SCHEMA_BYTES + 1))
+                .schema(ViewModelConstants.schemaOneByteOverMaxUtf8Size())
                 .build()),
         ViewErrorCode.UNSUPPORTED_VIEW_SCHEMA,
         String.format("schema : exceeds maximum UTF-8 size of %d bytes", MAX_VIEW_SCHEMA_BYTES));
@@ -333,16 +333,13 @@ public class ViewsValidatorTest {
   public void validateEnforcesTheSqlUtf8ByteBoundary() {
     assertDoesNotThrow(
         createOf(
-            createRequestWith(
-                sparkRepresentationWithSql(
-                    ViewModelConstants.sqlOfExactUtf8Size(MAX_VIEW_SQL_BYTES)))),
+            createRequestWith(sparkRepresentationWithSql(ViewModelConstants.sqlAtMaxUtf8Size()))),
         "The limit is inclusive: SQL of exactly the maximum size must be accepted.");
 
     assertRejected(
         createOf(
             createRequestWith(
-                sparkRepresentationWithSql(
-                    ViewModelConstants.sqlOfExactUtf8Size(MAX_VIEW_SQL_BYTES + 1)))),
+                sparkRepresentationWithSql(ViewModelConstants.sqlOneByteOverMaxUtf8Size()))),
         ViewErrorCode.INVALID_VIEW_DEFINITION,
         String.format(
             "representations[0].sql : exceeds maximum UTF-8 size of %d bytes", MAX_VIEW_SQL_BYTES));

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/api/ViewsValidatorTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/api/ViewsValidatorTest.java
@@ -1,0 +1,696 @@
+package com.linkedin.openhouse.tables.mock.api;
+
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.INITIAL_TABLE_VERSION;
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.MAX_VIEW_IDENTIFIER_LENGTH;
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.MAX_VIEW_SCHEMA_BYTES;
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.MAX_VIEW_SQL_BYTES;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.linkedin.openhouse.cluster.configs.ClusterProperties;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateViewRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.ViewRepresentation;
+import com.linkedin.openhouse.tables.api.validator.ViewsApiValidator;
+import com.linkedin.openhouse.tables.exception.ViewErrorCode;
+import com.linkedin.openhouse.tables.exception.ViewRequestValidationFailureException;
+import com.linkedin.openhouse.tables.model.ViewModelConstants;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * Coverage of {@link ViewsApiValidator}: the requests it must accept, and every structural rule it
+ * must reject.
+ *
+ * <p>Rejections are asserted on <b>both</b> the exact message and the internal {@link
+ * ViewErrorCode}. The code never reaches the wire, so this test is the only place its selection is
+ * observable, and all three 400-mapped codes are otherwise indistinguishable from a client's point
+ * of view.
+ *
+ * <p>Nothing here parses or interprets SQL: SQL is opaque to the server and the only rule applied
+ * to it is a size ceiling.
+ */
+@SpringBootTest
+public class ViewsValidatorTest {
+
+  @Autowired private ViewsApiValidator viewsApiValidator;
+
+  @Autowired private ClusterProperties clusterProperties;
+
+  /**
+   * {@link ViewModelConstants} fixes a literal cluster id so the contract test stays byte-stable,
+   * but the validator compares against the cluster this server is actually serving. Rebind it here.
+   */
+  private CreateUpdateViewRequestBody servingCluster(CreateUpdateViewRequestBody requestBody) {
+    return requestBody.toBuilder().clusterId(clusterProperties.getClusterName()).build();
+  }
+
+  @Test
+  public void validateCreateViewAcceptsBothLegalPostTokenForms() {
+    assertDoesNotThrow(
+        () ->
+            viewsApiValidator.validateCreateView(
+                clusterProperties.getClusterName(),
+                ViewModelConstants.DATABASE_ID,
+                servingCluster(ViewModelConstants.createRequestWithoutBaseVersion())),
+        "A POST that omits baseViewVersion entirely is the plain create shape and must be accepted.");
+
+    assertDoesNotThrow(
+        () ->
+            viewsApiValidator.validateCreateView(
+                clusterProperties.getClusterName(),
+                ViewModelConstants.DATABASE_ID,
+                servingCluster(ViewModelConstants.createRequestWithInitialBaseVersion())),
+        "The Iceberg client always sends "
+            + INITIAL_TABLE_VERSION
+            + " on create, so that form must be accepted too.");
+  }
+
+  @Test
+  public void validateUpdateViewAcceptsAnOpaqueBaseVersionToken() {
+    CreateUpdateViewRequestBody request =
+        servingCluster(ViewModelConstants.fullyPopulatedRequest())
+            .toBuilder()
+            // Deliberately not a metadata path: PUT treats the token as fully opaque.
+            .baseViewVersion("an-entirely-opaque-token")
+            .build();
+
+    assertDoesNotThrow(
+        () ->
+            viewsApiValidator.validateUpdateView(
+                clusterProperties.getClusterName(),
+                ViewModelConstants.DATABASE_ID,
+                ViewModelConstants.VIEW_ID,
+                request));
+  }
+
+  @Test
+  public void validateIdentifierAndPagingRoutesAcceptValidInput() {
+    assertDoesNotThrow(
+        () ->
+            viewsApiValidator.validateGetView(
+                ViewModelConstants.DATABASE_ID, ViewModelConstants.VIEW_ID));
+
+    assertDoesNotThrow(
+        () ->
+            viewsApiValidator.validateDeleteView(
+                ViewModelConstants.DATABASE_ID, ViewModelConstants.VIEW_ID));
+
+    assertDoesNotThrow(
+        () -> viewsApiValidator.validateGetAllViews(ViewModelConstants.DATABASE_ID, 0, 50, null),
+        "The controller's default paging values must pass unchanged.");
+
+    assertDoesNotThrow(
+        () ->
+            viewsApiValidator.validateGetAllViews(
+                ViewModelConstants.DATABASE_ID, 3, 10000, "viewId"),
+        "A single sort field and a large page size are both legal: view paging deliberately has no"
+            + " upper size cap, matching the shared table paging rules.");
+  }
+
+  @Test
+  public void validateGetViewAcceptsMaximumLengthIdentifiers() {
+    String maxLengthId = String.join("", Collections.nCopies(MAX_VIEW_IDENTIFIER_LENGTH, "a"));
+    Assertions.assertEquals(MAX_VIEW_IDENTIFIER_LENGTH, maxLengthId.length());
+
+    assertDoesNotThrow(
+        () -> viewsApiValidator.validateGetView(maxLengthId, maxLengthId),
+        "The identifier length limit is inclusive, so an identifier of exactly"
+            + " MAX_VIEW_IDENTIFIER_LENGTH characters must still be accepted.");
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Negative paths
+  // ---------------------------------------------------------------------------------------------
+
+  private static final String SCHEMA_PARSE_MESSAGE =
+      "schema : must be valid Iceberg schema JSON; Spark StructType JSON is not supported";
+
+  /**
+   * Asserts the request is rejected, that the reported reason is exactly {@code expectedMessage},
+   * and that the internal code is the expected one. The code is asserted everywhere because it is
+   * never serialized: all three 400-mapped codes look identical to a client, so this test class is
+   * the only place their selection is observable.
+   */
+  private ViewRequestValidationFailureException assertRejected(
+      Executable executable, ViewErrorCode expectedCode, String expectedMessage) {
+    ViewRequestValidationFailureException exception =
+        Assertions.assertThrows(ViewRequestValidationFailureException.class, executable);
+    Assertions.assertTrue(
+        exception.getMessage().contains(expectedMessage),
+        String.format(
+            "Expected the failure to report \"%s\" but it reported \"%s\"",
+            expectedMessage, exception.getMessage()));
+    Assertions.assertEquals(
+        expectedCode,
+        exception.getErrorCode(),
+        "The internal code must be the most specific one the accumulated failures warrant.");
+    return exception;
+  }
+
+  /** A request that a POST would accept unchanged: serving cluster, no base version. */
+  private CreateUpdateViewRequestBody validCreateRequest() {
+    return servingCluster(ViewModelConstants.createRequestWithoutBaseVersion());
+  }
+
+  /** A request that a PUT would accept unchanged: serving cluster, replace token present. */
+  private CreateUpdateViewRequestBody validUpdateRequest() {
+    return servingCluster(ViewModelConstants.fullyPopulatedRequest());
+  }
+
+  private CreateUpdateViewRequestBody createRequestWith(List<ViewRepresentation> representations) {
+    return validCreateRequest().toBuilder().representations(representations).build();
+  }
+
+  private CreateUpdateViewRequestBody createRequestWith(ViewRepresentation representation) {
+    return createRequestWith(Collections.singletonList(representation));
+  }
+
+  private static ViewRepresentation sparkRepresentationWithSql(String sql) {
+    return ViewModelConstants.SPARK_REPRESENTATION.toBuilder().sql(sql).build();
+  }
+
+  private Executable createOf(CreateUpdateViewRequestBody requestBody) {
+    return () ->
+        viewsApiValidator.validateCreateView(
+            clusterProperties.getClusterName(), ViewModelConstants.DATABASE_ID, requestBody);
+  }
+
+  private Executable updateOf(CreateUpdateViewRequestBody requestBody) {
+    return () ->
+        viewsApiValidator.validateUpdateView(
+            clusterProperties.getClusterName(),
+            ViewModelConstants.DATABASE_ID,
+            ViewModelConstants.VIEW_ID,
+            requestBody);
+  }
+
+  @Test
+  public void validateRejectsIdentifierMismatchesAgainstPathAndCluster() {
+    assertRejected(
+        createOf(validCreateRequest().toBuilder().databaseId("another_database").build()),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        String.format(
+            "databaseId : provided %s, doesn't match with the RequestBody another_database",
+            ViewModelConstants.DATABASE_ID));
+
+    assertRejected(
+        updateOf(validUpdateRequest().toBuilder().viewId("another_view").build()),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        String.format(
+            "viewId : provided %s, doesn't match with the RequestBody another_view",
+            ViewModelConstants.VIEW_ID));
+
+    assertRejected(
+        createOf(validCreateRequest().toBuilder().clusterId("not-the-serving-cluster").build()),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        String.format(
+            "clusterId : provided not-the-serving-cluster, doesn't match with the server cluster %s",
+            clusterProperties.getClusterName()));
+  }
+
+  @Test
+  public void validateRejectsMissingRequiredBodyFields() {
+    assertRejected(
+        createOf(validCreateRequest().toBuilder().schema(null).build()),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "CreateUpdateViewRequestBody.schema : schema cannot be empty");
+
+    assertRejected(
+        createOf(validCreateRequest().toBuilder().sourceDialect(null).build()),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "CreateUpdateViewRequestBody.sourceDialect : sourceDialect cannot be empty");
+
+    assertRejected(
+        createOf(createRequestWith(Collections.<ViewRepresentation>emptyList())),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "CreateUpdateViewRequestBody.representations : representations cannot be empty");
+  }
+
+  @Test
+  public void validateGetViewRejectsEmptyAndMalformedIdentifiers() {
+    assertRejected(
+        () -> viewsApiValidator.validateGetView("", ViewModelConstants.VIEW_ID),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "databaseId : Cannot be empty");
+
+    assertRejected(
+        () -> viewsApiValidator.validateGetView(ViewModelConstants.DATABASE_ID, "bad view!"),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "viewId : provided bad view!, Only alphanumerics and underscore supported");
+
+    assertRejected(
+        () -> viewsApiValidator.validateDeleteView(ViewModelConstants.DATABASE_ID, ""),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "viewId : Cannot be empty");
+  }
+
+  /**
+   * <b>Known deviation from the table convention.</b> {@code OpenHouseTablesApiValidator} checks
+   * only emptiness and the character regex on path identifiers, so this length rule is new
+   * behaviour rather than a copy of the table rule. It is here because an over-long identifier
+   * would otherwise pass validation and come back as a misleading 404 rather than a 400 naming the
+   * actual problem. If the table convention is preferred, removing this rule and this test is the
+   * whole change.
+   */
+  @Test
+  public void validateGetViewRejectsOverLongIdentifiersUnlikeTheTableValidator() {
+    String tooLong = String.join("", Collections.nCopies(MAX_VIEW_IDENTIFIER_LENGTH + 1, "a"));
+
+    ViewRequestValidationFailureException exception =
+        assertRejected(
+            () -> viewsApiValidator.validateGetView(ViewModelConstants.DATABASE_ID, tooLong),
+            ViewErrorCode.INVALID_VIEW_DEFINITION,
+            String.format(
+                "viewId : exceeds the maximum length of %d characters",
+                MAX_VIEW_IDENTIFIER_LENGTH));
+
+    Assertions.assertFalse(
+        exception.getMessage().contains(tooLong),
+        "An over-long identifier is by definition large and the message is copied into the error"
+            + " body and into audit events, so it must not be echoed back.");
+  }
+
+  /**
+   * Malformed JSON, the Spark {@code StructType} shape an engine might send by mistake, and a
+   * schema with duplicate field ids all fail inside Iceberg's parser and must collapse to the same
+   * fixed message. The duplicate-id case is why the validator deliberately has no duplicate-id
+   * check of its own.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {"malformed", "sparkStructType", "duplicateFieldIds"})
+  public void validateRejectsEverySchemaIcebergCannotParse(String variant) {
+    String schema;
+    if ("malformed".equals(variant)) {
+      schema = ViewModelConstants.MALFORMED_SCHEMA_LITERAL;
+    } else if ("sparkStructType".equals(variant)) {
+      schema = ViewModelConstants.SPARK_STRUCT_TYPE_SCHEMA_LITERAL;
+    } else {
+      schema = ViewModelConstants.DUPLICATE_FIELD_ID_SCHEMA_LITERAL;
+    }
+
+    ViewRequestValidationFailureException exception =
+        assertRejected(
+            createOf(validCreateRequest().toBuilder().schema(schema).build()),
+            ViewErrorCode.UNSUPPORTED_VIEW_SCHEMA,
+            SCHEMA_PARSE_MESSAGE);
+
+    Assertions.assertFalse(
+        exception.getMessage().contains("fields"),
+        "Iceberg's own parse message can echo the submitted schema, so the validator must replace"
+            + " it with a fixed one rather than wrap it.");
+  }
+
+  @Test
+  public void validateEnforcesTheSchemaUtf8ByteBoundary() {
+    assertDoesNotThrow(
+        createOf(
+            validCreateRequest()
+                .toBuilder()
+                .schema(ViewModelConstants.schemaOfExactUtf8Size(MAX_VIEW_SCHEMA_BYTES))
+                .build()),
+        "The limit is inclusive: a schema of exactly the maximum size must be accepted.");
+
+    assertRejected(
+        createOf(
+            validCreateRequest()
+                .toBuilder()
+                .schema(ViewModelConstants.schemaOfExactUtf8Size(MAX_VIEW_SCHEMA_BYTES + 1))
+                .build()),
+        ViewErrorCode.UNSUPPORTED_VIEW_SCHEMA,
+        String.format("schema : exceeds maximum UTF-8 size of %d bytes", MAX_VIEW_SCHEMA_BYTES));
+  }
+
+  @Test
+  public void validateEnforcesTheSqlUtf8ByteBoundary() {
+    assertDoesNotThrow(
+        createOf(
+            createRequestWith(
+                sparkRepresentationWithSql(
+                    ViewModelConstants.sqlOfExactUtf8Size(MAX_VIEW_SQL_BYTES)))),
+        "The limit is inclusive: SQL of exactly the maximum size must be accepted.");
+
+    assertRejected(
+        createOf(
+            createRequestWith(
+                sparkRepresentationWithSql(
+                    ViewModelConstants.sqlOfExactUtf8Size(MAX_VIEW_SQL_BYTES + 1)))),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        String.format(
+            "representations[0].sql : exceeds maximum UTF-8 size of %d bytes", MAX_VIEW_SQL_BYTES));
+  }
+
+  /**
+   * The reason the size rules are hand-written instead of declared with {@code @Size}: a bean
+   * constraint counts UTF-16 characters, so this payload — under the limit in characters, and at
+   * roughly twice the limit in bytes — would have been accepted.
+   */
+  @Test
+  public void validateCountsSqlInUtf8BytesNotCharacters() {
+    String multiByteSql = ViewModelConstants.multiByteSql(MAX_VIEW_SQL_BYTES - 1);
+
+    Assertions.assertTrue(
+        multiByteSql.length() <= MAX_VIEW_SQL_BYTES,
+        "Precondition: the fixture must be within the limit when counted as characters.");
+
+    assertRejected(
+        createOf(createRequestWith(sparkRepresentationWithSql(multiByteSql))),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        String.format(
+            "representations[0].sql : exceeds maximum UTF-8 size of %d bytes", MAX_VIEW_SQL_BYTES));
+  }
+
+  /**
+   * The redaction invariant. Exception messages are copied verbatim into the error response body
+   * and into service audit events, so a rejection must never carry back the payload that caused it.
+   */
+  @Test
+  public void rejectionMessagesNeverEchoSqlSchemaOrVersionToken() {
+    String secretSql =
+        "SELECT secret_column FROM secret_database.secret_table "
+            + ViewModelConstants.multiByteSql(MAX_VIEW_SQL_BYTES);
+    String secretToken = "file:/secret/metadata/00000-secret.metadata.json";
+
+    CreateUpdateViewRequestBody requestBody =
+        createRequestWith(sparkRepresentationWithSql(secretSql))
+            .toBuilder()
+            .schema(ViewModelConstants.SPARK_STRUCT_TYPE_SCHEMA_LITERAL)
+            .baseViewVersion(secretToken)
+            .build();
+
+    ViewRequestValidationFailureException exception =
+        Assertions.assertThrows(ViewRequestValidationFailureException.class, updateOf(requestBody));
+
+    Assertions.assertTrue(
+        exception.getMessage().contains("exceeds maximum UTF-8 size"),
+        "Precondition: this request must actually be rejected for its oversized SQL.");
+    Assertions.assertFalse(
+        exception.getMessage().contains("secret_column"), "SQL text must not reach the message.");
+    Assertions.assertFalse(
+        exception.getMessage().contains("nullable"), "Schema text must not reach the message.");
+    Assertions.assertFalse(
+        exception.getMessage().contains(secretToken),
+        "The base version token must not reach the message.");
+  }
+
+  @Test
+  public void validateRejectsRepresentationCountNullElementAndType() {
+    // A second representation necessarily also breaks a dialect rule, because spark is the only
+    // supported dialect and duplicates of it are rejected. The count message is what is asserted;
+    // the dialect code simply reflects that more specific coexisting failure.
+    assertRejected(
+        createOf(
+            createRequestWith(
+                Arrays.asList(
+                    ViewModelConstants.SPARK_REPRESENTATION,
+                    ViewModelConstants.SPARK_REPRESENTATION.toBuilder().dialect("trino").build()))),
+        ViewErrorCode.UNSUPPORTED_VIEW_DIALECT,
+        "representations : must contain exactly one representation");
+
+    assertRejected(
+        createOf(createRequestWith(Collections.singletonList((ViewRepresentation) null))),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "representations[0] : cannot be null");
+
+    assertRejected(
+        createOf(
+            createRequestWith(
+                ViewModelConstants.SPARK_REPRESENTATION.toBuilder().type("SQL").build())),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "representations[0].type : must be 'sql'");
+  }
+
+  @Test
+  public void validateRejectsEveryDialectOtherThanExactlySpark() {
+    assertRejected(
+        createOf(
+            createRequestWith(
+                ViewModelConstants.SPARK_REPRESENTATION.toBuilder().dialect("trino").build())),
+        ViewErrorCode.UNSUPPORTED_VIEW_DIALECT,
+        "representations[0].dialect : only 'spark' is supported");
+
+    assertRejected(
+        createOf(
+            createRequestWith(
+                ViewModelConstants.SPARK_REPRESENTATION.toBuilder().dialect("SPARK").build())),
+        ViewErrorCode.UNSUPPORTED_VIEW_DIALECT,
+        "representations[0].dialect : only 'spark' is supported");
+
+    assertRejected(
+        createOf(validCreateRequest().toBuilder().sourceDialect("trino").build()),
+        ViewErrorCode.UNSUPPORTED_VIEW_DIALECT,
+        "sourceDialect : only 'spark' is supported");
+  }
+
+  /**
+   * A source dialect naming no supplied representation leaves the view with no definition to read,
+   * which is a different failure from an unsupported dialect and gets its own message.
+   */
+  @Test
+  public void validateRejectsASourceDialectThatNamesNoSuppliedRepresentation() {
+    assertRejected(
+        createOf(
+            createRequestWith(
+                ViewModelConstants.SPARK_REPRESENTATION.toBuilder().dialect(null).build())),
+        ViewErrorCode.UNSUPPORTED_VIEW_DIALECT,
+        "sourceDialect : does not name a supplied representation");
+  }
+
+  /** Two representations claiming the same engine are ambiguous, whatever their casing. */
+  @Test
+  public void validateRejectsDuplicateDialectsCaseInsensitively() {
+    assertRejected(
+        createOf(
+            createRequestWith(
+                Arrays.asList(
+                    ViewModelConstants.SPARK_REPRESENTATION,
+                    ViewModelConstants.SPARK_REPRESENTATION.toBuilder().dialect("SPARK").build()))),
+        ViewErrorCode.UNSUPPORTED_VIEW_DIALECT,
+        "representations : dialects must be unique, duplicated: spark");
+  }
+
+  @Test
+  public void validateRejectsBlankAndOverLongDefaultCatalog() {
+    assertRejected(
+        createOf(validCreateRequest().toBuilder().defaultCatalog("   ").build()),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "defaultCatalog : cannot be blank when provided");
+
+    assertRejected(
+        createOf(
+            validCreateRequest()
+                .toBuilder()
+                .defaultCatalog(
+                    String.join("", Collections.nCopies(MAX_VIEW_IDENTIFIER_LENGTH + 1, "c")))
+                .build()),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        String.format(
+            "defaultCatalog : exceeds the maximum length of %d characters",
+            MAX_VIEW_IDENTIFIER_LENGTH));
+
+    assertDoesNotThrow(
+        createOf(validCreateRequest().toBuilder().defaultCatalog(null).build()),
+        "The catalog is optional: omitting it entirely stays legal.");
+  }
+
+  @Test
+  public void validateRejectsEmptyAndMalformedDefaultNamespaceSegments() {
+    assertRejected(
+        createOf(
+            validCreateRequest()
+                .toBuilder()
+                .defaultNamespace(Collections.<String>emptyList())
+                .build()),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "defaultNamespace : cannot be empty when provided");
+
+    assertRejected(
+        createOf(
+            validCreateRequest()
+                .toBuilder()
+                .defaultNamespace(Collections.singletonList((String) null))
+                .build()),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "defaultNamespace[0] : cannot be blank");
+
+    assertRejected(
+        createOf(
+            validCreateRequest()
+                .toBuilder()
+                .defaultNamespace(Arrays.asList(ViewModelConstants.DATABASE_ID, "  "))
+                .build()),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "defaultNamespace[1] : cannot be blank");
+
+    assertRejected(
+        createOf(
+            validCreateRequest()
+                .toBuilder()
+                .defaultNamespace(Collections.singletonList("not a namespace!"))
+                .build()),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "defaultNamespace[0] : Only alphanumerics and underscore supported");
+
+    assertRejected(
+        createOf(
+            validCreateRequest()
+                .toBuilder()
+                .defaultNamespace(
+                    Collections.singletonList(
+                        String.join("", Collections.nCopies(MAX_VIEW_IDENTIFIER_LENGTH + 1, "n"))))
+                .build()),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        String.format(
+            "defaultNamespace[0] : exceeds the maximum length of %d characters",
+            MAX_VIEW_IDENTIFIER_LENGTH));
+  }
+
+  @Test
+  public void validateRejectsBlankPropertyKeysAndNullPropertyValues() {
+    Map<String, String> blankKey = new LinkedHashMap<>();
+    blankKey.put("  ", "value");
+    assertRejected(
+        createOf(validCreateRequest().toBuilder().viewProperties(blankKey).build()),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "viewProperties : property keys cannot be blank");
+
+    Map<String, String> nullValues = new LinkedHashMap<>();
+    nullValues.put("owner", null);
+    nullValues.put("team", null);
+    assertRejected(
+        createOf(validCreateRequest().toBuilder().viewProperties(nullValues).build()),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "viewProperties : property values cannot be null, keys: owner, team");
+  }
+
+  /**
+   * Reserved-key detection reuses the internal catalog's case-sensitive {@code openhouse.}
+   * predicate verbatim. The final assertion is the point of the test: because that predicate is
+   * case-sensitive and {@code policies} is matched exactly, a user property such as {@code
+   * OpenHouse.myTeam} is <b>not</b> reserved and must keep working.
+   */
+  @Test
+  public void validateRejectsReservedPropertyKeysCaseSensitively() {
+    Map<String, String> openhousePrefixed = new LinkedHashMap<>();
+    openhousePrefixed.put("openhouse.tableId", "hijacked");
+    assertRejected(
+        createOf(validCreateRequest().toBuilder().viewProperties(openhousePrefixed).build()),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "viewProperties : reserved keys are not allowed: openhouse.tableId");
+
+    Map<String, String> policies = new LinkedHashMap<>();
+    policies.put("policies", "hijacked");
+    assertRejected(
+        createOf(validCreateRequest().toBuilder().viewProperties(policies).build()),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "viewProperties : reserved keys are not allowed: policies");
+
+    Map<String, String> userOwned = new LinkedHashMap<>();
+    userOwned.put("OpenHouse.myTeam", "grid");
+    userOwned.put("policies_owner", "grid");
+    assertDoesNotThrow(
+        createOf(validCreateRequest().toBuilder().viewProperties(userOwned).build()),
+        "Neither of these user-owned keys is reserved: the openhouse. predicate is case-sensitive"
+            + " and policies is matched exactly.");
+  }
+
+  @Test
+  public void validateRejectsIllegalBaseVersionTokensPerVerb() {
+    assertRejected(
+        createOf(validCreateRequest().toBuilder().baseViewVersion("some-other-token").build()),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "baseViewVersion : must be omitted or " + INITIAL_TABLE_VERSION + " on POST create");
+
+    assertRejected(
+        updateOf(validUpdateRequest().toBuilder().baseViewVersion(null).build()),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "baseViewVersion : is required and cannot be blank on PUT");
+
+    assertRejected(
+        updateOf(validUpdateRequest().toBuilder().baseViewVersion("   ").build()),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "baseViewVersion : is required and cannot be blank on PUT");
+  }
+
+  @Test
+  public void validateGetAllViewsRejectsInvalidPagingAndCompositeSort() {
+    assertRejected(
+        () -> viewsApiValidator.validateGetAllViews(ViewModelConstants.DATABASE_ID, -1, 50, null),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "page : provided -1, cannot be negative");
+
+    assertRejected(
+        () -> viewsApiValidator.validateGetAllViews(ViewModelConstants.DATABASE_ID, 0, 0, null),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "size : provided 0, must be greater than 0");
+
+    assertRejected(
+        () ->
+            viewsApiValidator.validateGetAllViews(
+                ViewModelConstants.DATABASE_ID, 0, 50, "viewId,databaseId"),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "sortBy : provided viewId,databaseId, does not support multiple sort fields or directions");
+  }
+
+  /** Failures accumulate, so a client sees every structural problem in one response. */
+  @Test
+  public void validateReportsEveryFailureRatherThanStoppingAtTheFirst() {
+    CreateUpdateViewRequestBody requestBody =
+        validCreateRequest()
+            .toBuilder()
+            .databaseId("another_database")
+            .defaultCatalog("   ")
+            .baseViewVersion("not-the-initial-token")
+            .build();
+
+    ViewRequestValidationFailureException exception =
+        Assertions.assertThrows(ViewRequestValidationFailureException.class, createOf(requestBody));
+
+    Assertions.assertTrue(exception.getMessage().contains("databaseId : provided"));
+    Assertions.assertTrue(
+        exception.getMessage().contains("defaultCatalog : cannot be blank when provided"));
+    Assertions.assertTrue(exception.getMessage().contains("baseViewVersion : must be omitted"));
+    Assertions.assertTrue(
+        exception.getMessage().contains("; "),
+        "Reasons are joined with \"; \", matching how the table API reports multiple failures.");
+  }
+
+  /**
+   * When a request breaks several rules at once the thrown code is the most specific one: schema
+   * beats dialect, and dialect beats the generic definition code. All three map to 400, so this
+   * ordering is invisible on the wire and only assertable here.
+   */
+  @Test
+  public void errorCodePrecedenceIsSchemaThenDialectThenGeneric() {
+    CreateUpdateViewRequestBody allThree =
+        createRequestWith(
+                ViewModelConstants.SPARK_REPRESENTATION.toBuilder().dialect("trino").build())
+            .toBuilder()
+            .schema(ViewModelConstants.MALFORMED_SCHEMA_LITERAL)
+            .defaultCatalog("   ")
+            .build();
+    assertRejected(createOf(allThree), ViewErrorCode.UNSUPPORTED_VIEW_SCHEMA, SCHEMA_PARSE_MESSAGE);
+
+    CreateUpdateViewRequestBody dialectAndGeneric =
+        allThree.toBuilder().schema(ViewModelConstants.VIEW_SCHEMA_LITERAL).build();
+    assertRejected(
+        createOf(dialectAndGeneric),
+        ViewErrorCode.UNSUPPORTED_VIEW_DIALECT,
+        "defaultCatalog : cannot be blank when provided");
+
+    CreateUpdateViewRequestBody genericOnly =
+        validCreateRequest().toBuilder().defaultCatalog("   ").build();
+    assertRejected(
+        createOf(genericOnly),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "defaultCatalog : cannot be blank when provided");
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/api/ViewsValidatorTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/api/ViewsValidatorTest.java
@@ -61,7 +61,8 @@ public class ViewsValidatorTest {
                 clusterProperties.getClusterName(),
                 ViewModelConstants.DATABASE_ID,
                 servingCluster(ViewModelConstants.createRequestWithoutBaseVersion())),
-        "A POST that omits baseViewVersion entirely is the plain create shape and must be accepted.");
+        "A POST that omits baseMetadataLocation entirely is the plain create shape and must be"
+            + " accepted.");
 
     assertDoesNotThrow(
         () ->
@@ -80,7 +81,7 @@ public class ViewsValidatorTest {
         servingCluster(ViewModelConstants.fullyPopulatedRequest())
             .toBuilder()
             // Deliberately not a metadata path: PUT treats the token as fully opaque.
-            .baseViewVersion("an-entirely-opaque-token")
+            .baseMetadataLocation("an-entirely-opaque-token")
             .build();
 
     assertDoesNotThrow(
@@ -90,6 +91,28 @@ public class ViewsValidatorTest {
                 ViewModelConstants.DATABASE_ID,
                 ViewModelConstants.VIEW_ID,
                 request));
+  }
+
+  /**
+   * The token is the metadata pointer the replace is based upon, not a number and not a path the
+   * server parses: PUT applies no scheme, suffix, numeric or trimming rule, so every nonblank form
+   * is accepted. That is the semantic the field name describes, so it is pinned here rather than
+   * left implied by a single opaque example.
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        INITIAL_TABLE_VERSION,
+        "42",
+        "  file:/tmp/openhouse/my_database/my_view/metadata/00000-fixed.metadata.json  ",
+        "s3://bucket/openhouse/my_database/my_view/metadata/00001-abc.metadata.json",
+        "not a path at all"
+      })
+  public void validateUpdateViewAcceptsEveryNonBlankBaseVersionForm(String token) {
+    assertDoesNotThrow(
+        updateOf(validUpdateRequest().toBuilder().baseMetadataLocation(token).build()),
+        "PUT treats the token as opaque, so a padded, numeric or non-path form must be accepted"
+            + " exactly as a metadata path is.");
   }
 
   @Test
@@ -391,7 +414,7 @@ public class ViewsValidatorTest {
         createRequestWith(sparkRepresentationWithSql(secretSql))
             .toBuilder()
             .schema(ViewModelConstants.SPARK_STRUCT_TYPE_SCHEMA_LITERAL)
-            .baseViewVersion(secretToken)
+            .baseMetadataLocation(secretToken)
             .build();
 
     ViewRequestValidationFailureException exception =
@@ -635,19 +658,36 @@ public class ViewsValidatorTest {
   @Test
   public void validateRejectsIllegalBaseVersionTokensPerVerb() {
     assertRejected(
-        createOf(validCreateRequest().toBuilder().baseViewVersion("some-other-token").build()),
+        createOf(validCreateRequest().toBuilder().baseMetadataLocation("some-other-token").build()),
         ViewErrorCode.INVALID_VIEW_DEFINITION,
-        "baseViewVersion : must be omitted or " + INITIAL_TABLE_VERSION + " on POST create");
+        "baseMetadataLocation : must be omitted or " + INITIAL_TABLE_VERSION + " on POST create");
+
+    // Supplied-but-empty and supplied-but-blank are values, not absences: POST distinguishes only
+    // "supplied" from "omitted", so neither collapses to the accepted omitted form.
+    assertRejected(
+        createOf(validCreateRequest().toBuilder().baseMetadataLocation("").build()),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "baseMetadataLocation : must be omitted or " + INITIAL_TABLE_VERSION + " on POST create");
 
     assertRejected(
-        updateOf(validUpdateRequest().toBuilder().baseViewVersion(null).build()),
+        createOf(validCreateRequest().toBuilder().baseMetadataLocation("   ").build()),
         ViewErrorCode.INVALID_VIEW_DEFINITION,
-        "baseViewVersion : is required and cannot be blank on PUT");
+        "baseMetadataLocation : must be omitted or " + INITIAL_TABLE_VERSION + " on POST create");
 
     assertRejected(
-        updateOf(validUpdateRequest().toBuilder().baseViewVersion("   ").build()),
+        updateOf(validUpdateRequest().toBuilder().baseMetadataLocation(null).build()),
         ViewErrorCode.INVALID_VIEW_DEFINITION,
-        "baseViewVersion : is required and cannot be blank on PUT");
+        "baseMetadataLocation : is required and cannot be blank on PUT");
+
+    assertRejected(
+        updateOf(validUpdateRequest().toBuilder().baseMetadataLocation("").build()),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "baseMetadataLocation : is required and cannot be blank on PUT");
+
+    assertRejected(
+        updateOf(validUpdateRequest().toBuilder().baseMetadataLocation("   ").build()),
+        ViewErrorCode.INVALID_VIEW_DEFINITION,
+        "baseMetadataLocation : is required and cannot be blank on PUT");
   }
 
   @Test
@@ -678,7 +718,7 @@ public class ViewsValidatorTest {
             .toBuilder()
             .databaseId("another_database")
             .defaultCatalog("   ")
-            .baseViewVersion("not-the-initial-token")
+            .baseMetadataLocation("not-the-initial-token")
             .build();
 
     ViewRequestValidationFailureException exception =
@@ -687,7 +727,12 @@ public class ViewsValidatorTest {
     Assertions.assertTrue(exception.getMessage().contains("databaseId : provided"));
     Assertions.assertTrue(
         exception.getMessage().contains("defaultCatalog : cannot be blank when provided"));
-    Assertions.assertTrue(exception.getMessage().contains("baseViewVersion : must be omitted"));
+    Assertions.assertTrue(
+        exception.getMessage().contains("baseMetadataLocation : must be omitted"));
+    Assertions.assertFalse(
+        exception.getMessage().contains("not-the-initial-token"),
+        "The rejected token is caller-supplied and the message is copied verbatim into the error"
+            + " body, so the POST rule must not echo it back either.");
     Assertions.assertTrue(
         exception.getMessage().contains("; "),
         "Reasons are joined with \"; \", matching how the table API reports multiple failures.");

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/ViewRequestPayloadRedactorTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/ViewRequestPayloadRedactorTest.java
@@ -33,9 +33,9 @@ public class ViewRequestPayloadRedactorTest {
   @ParameterizedTest
   @ValueSource(
       strings = {
-        "/v2/databases/my_database/views",
-        "/v2/databases/my_database/views/my_view",
-        "/v2/databases/d200/views"
+        "/v1/databases/my_database/views",
+        "/v1/databases/my_database/views/my_view",
+        "/v1/databases/d200/views"
       })
   public void appliesToTheViewRoutes(String uri) {
     Assertions.assertTrue(redactor.appliesTo(requestFor(uri)));
@@ -43,7 +43,9 @@ public class ViewRequestPayloadRedactorTest {
 
   /**
    * The scoping that protects the existing resources. A table create carries a {@code schema} too,
-   * so the redactor must decline every route but views.
+   * so the redactor must decline every route but views. The {@code /v2} entries pin that the scope
+   * moved off the prefix views were briefly drafted against, and that the live {@code /v2} table
+   * search route is untouched.
    */
   @ParameterizedTest
   @ValueSource(
@@ -52,9 +54,11 @@ public class ViewRequestPayloadRedactorTest {
         "/v1/databases/my_database/tables/my_table",
         "/v1/databases",
         "/v1/databases/my_database/tables/my_table/aclPolicies",
-        "/v2/databases/my_database/views/my_view/extra",
-        "/v2/databases/views",
-        "/v2/databases/my_database/tables"
+        "/v1/databases/my_database/views/my_view/extra",
+        "/v1/databases/views",
+        "/v2/databases/my_database/tables/search",
+        "/v2/databases/my_database/views",
+        "/v2/databases/my_database/views/my_view"
       })
   public void declinesEveryOtherRoute(String uri) {
     Assertions.assertFalse(redactor.appliesTo(requestFor(uri)));

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/ViewRequestPayloadRedactorTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/ViewRequestPayloadRedactorTest.java
@@ -1,0 +1,163 @@
+package com.linkedin.openhouse.tables.mock.audit;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import com.linkedin.openhouse.common.audit.ServiceAuditPayloadRedactor;
+import com.linkedin.openhouse.tables.audit.ViewRequestPayloadRedactor;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * Unit coverage of {@link ViewRequestPayloadRedactor}. The controller-level proof that the redactor
+ * is actually wired into {@link com.linkedin.openhouse.common.audit.ServiceAuditAspect} lives in
+ * {@code ViewsControllerTest}; this pins the route scoping and the shape of the rewrite, including
+ * the payload shapes a caller can send that are not a well-formed view request.
+ */
+public class ViewRequestPayloadRedactorTest {
+
+  private final ViewRequestPayloadRedactor redactor = new ViewRequestPayloadRedactor();
+
+  private static MockHttpServletRequest requestFor(String uri) {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI(uri);
+    return request;
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "/v2/databases/my_database/views",
+        "/v2/databases/my_database/views/my_view",
+        "/v2/databases/d200/views"
+      })
+  public void appliesToTheViewRoutes(String uri) {
+    Assertions.assertTrue(redactor.appliesTo(requestFor(uri)));
+  }
+
+  /**
+   * The scoping that protects the existing resources. A table create carries a {@code schema} too,
+   * so the redactor must decline every route but views.
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "/v1/databases/my_database/tables",
+        "/v1/databases/my_database/tables/my_table",
+        "/v1/databases",
+        "/v1/databases/my_database/tables/my_table/aclPolicies",
+        "/v2/databases/my_database/views/my_view/extra",
+        "/v2/databases/views",
+        "/v2/databases/my_database/tables"
+      })
+  public void declinesEveryOtherRoute(String uri) {
+    Assertions.assertFalse(redactor.appliesTo(requestFor(uri)));
+  }
+
+  @Test
+  public void redactsSchemaAndEverySqlRepresentation() {
+    JsonElement payload =
+        JsonParser.parseString(
+            "{\"viewId\": \"my_view\", \"databaseId\": \"my_database\","
+                + " \"schema\": \"secret schema\","
+                + " \"representations\": ["
+                + "{\"type\": \"sql\", \"sql\": \"secret sql one\", \"dialect\": \"spark\"},"
+                + "{\"type\": \"sql\", \"sql\": \"secret sql two\", \"dialect\": \"trino\"}],"
+                + " \"sourceDialect\": \"spark\"}");
+
+    JsonObject redacted = redactor.redact(payload).getAsJsonObject();
+
+    Assertions.assertEquals(
+        ServiceAuditPayloadRedactor.REDACTED_VALUE, redacted.get("schema").getAsString());
+    JsonArray representations = redacted.getAsJsonArray("representations");
+    for (JsonElement representation : representations) {
+      Assertions.assertEquals(
+          ServiceAuditPayloadRedactor.REDACTED_VALUE,
+          representation.getAsJsonObject().get("sql").getAsString(),
+          "Every representation is redacted, not only the first.");
+    }
+    Assertions.assertFalse(redacted.toString().contains("secret"));
+
+    // Identifiers and dialect metadata survive.
+    Assertions.assertEquals("my_view", redacted.get("viewId").getAsString());
+    Assertions.assertEquals("my_database", redacted.get("databaseId").getAsString());
+    Assertions.assertEquals("spark", redacted.get("sourceDialect").getAsString());
+    Assertions.assertEquals(
+        "trino", representations.get(1).getAsJsonObject().get("dialect").getAsString());
+  }
+
+  @Test
+  public void leavesTheArgumentUntouched() {
+    JsonElement payload =
+        JsonParser.parseString(
+            "{\"schema\": \"secret schema\","
+                + " \"representations\": [{\"type\": \"sql\", \"sql\": \"secret sql\"}]}");
+    String before = payload.toString();
+
+    redactor.redact(payload);
+
+    Assertions.assertEquals(
+        before,
+        payload.toString(),
+        "Redacting must return a copy so one redactor cannot observe another's rewrite.");
+  }
+
+  /**
+   * A request whose body is absent, malformed or simply not shaped like a view request still
+   * reaches the redactor, because the aspect audits whatever the caller sent.
+   */
+  @Test
+  public void toleratesPayloadsThatCarryNoViewDefinition() {
+    Assertions.assertNull(redactor.redact(null));
+    Assertions.assertEquals(JsonNull.INSTANCE, redactor.redact(JsonNull.INSTANCE));
+    Assertions.assertEquals(
+        new JsonPrimitive("not an object"), redactor.redact(new JsonPrimitive("not an object")));
+    Assertions.assertEquals(new JsonArray(), redactor.redact(new JsonArray()));
+
+    JsonObject withoutDefinition = new JsonObject();
+    withoutDefinition.addProperty("viewId", "my_view");
+    Assertions.assertEquals(
+        withoutDefinition,
+        redactor.redact(withoutDefinition),
+        "An object carrying neither field is returned as an equal copy.");
+  }
+
+  /**
+   * {@code representations} is caller-supplied JSON, so it can be any element. Redaction must skip
+   * what it cannot interpret rather than fail and lose the whole payload to the aspect's
+   * fail-closed handler.
+   */
+  @Test
+  public void skipsRepresentationsThatAreNotSqlObjects() {
+    JsonElement payload =
+        JsonParser.parseString(
+            "{\"schema\": \"secret schema\","
+                + " \"representations\": [\"not an object\", {\"type\": \"sql\"}, null]}");
+
+    JsonObject redacted = redactor.redact(payload).getAsJsonObject();
+
+    Assertions.assertEquals(
+        ServiceAuditPayloadRedactor.REDACTED_VALUE, redacted.get("schema").getAsString());
+    Assertions.assertEquals(3, redacted.getAsJsonArray("representations").size());
+  }
+
+  @Test
+  public void redactsAnObjectRepresentationsFieldThatIsNotAnArray() {
+    JsonElement payload =
+        JsonParser.parseString(
+            "{\"schema\": \"secret schema\", \"representations\": \"nonsense\"}");
+
+    JsonObject redacted = redactor.redact(payload).getAsJsonObject();
+
+    Assertions.assertEquals(
+        ServiceAuditPayloadRedactor.REDACTED_VALUE,
+        redacted.get("schema").getAsString(),
+        "A malformed representations field must not stop the schema from being redacted.");
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/ViewRequestPayloadRedactorTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/audit/ViewRequestPayloadRedactorTest.java
@@ -42,10 +42,8 @@ public class ViewRequestPayloadRedactorTest {
   }
 
   /**
-   * The scoping that protects the existing resources. A table create carries a {@code schema} too,
-   * so the redactor must decline every route but views. The {@code /v2} entries pin that the scope
-   * moved off the prefix views were briefly drafted against, and that the live {@code /v2} table
-   * search route is untouched.
+   * A table create carries a {@code schema} too, so the redactor must match only the declared
+   * {@code /v1} view routes and leave other resources and prefixes untouched.
    */
   @ParameterizedTest
   @ValueSource(

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/controller/TablesControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/controller/TablesControllerTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.openhouse.tables.mock.controller;
 
 import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.INITIAL_TABLE_VERSION;
+import static com.linkedin.openhouse.common.audit.ServiceAuditPayloadRedactor.REDACTED_VALUE;
 import static com.linkedin.openhouse.tables.e2e.h2.ValidationUtilities.CURRENT_MAJOR_VERSION_PREFIX;
 import static com.linkedin.openhouse.tables.model.ServiceAuditModelConstants.EXCLUDE_FIELDS;
 import static com.linkedin.openhouse.tables.model.ServiceAuditModelConstants.SERVICE_AUDIT_EVENT_CREATE_TABLE_FAILED;
@@ -54,6 +55,16 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 @SpringBootTest
 @ContextConfiguration(initializers = AuthorizationPropertiesInitializer.class)
 public class TablesControllerTest {
+
+  /**
+   * A table schema carrying a marker that appears nowhere else, so {@link
+   * #tableCreateAuditPayloadStillCarriesItsSchemaUnredacted()} fails loudly if the value is ever
+   * scrubbed rather than passing on a coincidence.
+   */
+  private static final String TABLE_SCHEMA_WITH_MARKER =
+      "{\"type\": \"struct\", \"schema-id\": 0, \"fields\": ["
+          + "{\"id\": 1, \"required\": true, \"name\": \"table_schema_marker_column\","
+          + " \"type\": \"string\"}]}";
 
   private MockMvc mvc;
 
@@ -178,6 +189,41 @@ public class TablesControllerTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + jwtAccessToken))
         .andExpect(status().isNotFound());
+  }
+
+  /**
+   * Regression pin for {@link com.linkedin.openhouse.tables.audit.ViewRequestPayloadRedactor}.
+   * {@code CreateUpdateTableRequestBody} also carries a {@code schema}, so a redactor keyed on the
+   * field name alone would silently start scrubbing table audit events, which is not what the views
+   * change is allowed to do. The view redactor is scoped by request URI instead, and this asserts
+   * that a v1 table create still audits its schema verbatim.
+   */
+  @Test
+  public void tableCreateAuditPayloadStillCarriesItsSchemaUnredacted() throws Exception {
+    CreateUpdateTableRequestBody requestBody =
+        RequestConstants.TEST_CREATE_TABLE_REQUEST_BODY
+            .toBuilder()
+            .schema(TABLE_SCHEMA_WITH_MARKER)
+            .build();
+
+    mvc.perform(
+        MockMvcRequestBuilders.post(CURRENT_MAJOR_VERSION_PREFIX + "/databases/d200/tables")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody.toJson())
+            .accept(MediaType.APPLICATION_JSON)
+            .header("Authorization", "Bearer " + jwtAccessToken));
+
+    Mockito.verify(serviceAuditHandler, Mockito.atLeastOnce()).audit(argCaptor.capture());
+    ServiceAuditEvent actualEvent = argCaptor.getValue();
+    JsonObject payload = actualEvent.getRequestPayload().getAsJsonObject();
+
+    Assertions.assertEquals(
+        TABLE_SCHEMA_WITH_MARKER,
+        payload.get("schema").getAsString(),
+        "A table create must audit its schema exactly as it was sent.");
+    Assertions.assertFalse(
+        actualEvent.getRequestPayload().toString().contains(REDACTED_VALUE),
+        "Nothing in a table request payload may be redacted by the views change.");
   }
 
   @Test

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/controller/TablesControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/controller/TablesControllerTest.java
@@ -33,6 +33,7 @@ import java.util.*;
 import javax.servlet.Filter;
 import javax.servlet.http.HttpServletRequest;
 import org.codehaus.jettison.json.JSONException;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -140,21 +141,23 @@ public class TablesControllerTest {
   }
 
   /**
-   * Adding {@link ViewsController} must not change how a v1 table request is routed. Both
-   * controllers are registered in one dispatcher here, which is the only arrangement in which the
-   * new mappings could shadow or collide with the existing ones, and each assertion checks the
-   * response body, so it fails if a request reaches the wrong handler rather than merely returning
-   * a plausible status.
+   * Adding {@link ViewsController} must not change how a v1 table request is routed. Views now
+   * mount under the same {@code /v1/databases/{databaseId}/} prefix as tables and are told apart
+   * only by the {@code tables} vs {@code views} path segment, so this is the assertion that pins
+   * that disambiguation. Both controllers are registered in one dispatcher here, which is the only
+   * arrangement in which the new mappings could shadow or collide with the existing ones, and each
+   * assertion checks the response body, so it fails if a request reaches the wrong handler rather
+   * than merely returning a plausible status.
    *
    * <p>This <b>partially</b> satisfies the acceptance criterion. It proves the v1 table route is
-   * unchanged and that views answer only under /v2. It cannot prove the other half, that a real
-   * view's name returns 404 from the table route, because no view is persisted in this PR and the
-   * server has no way to tell a view's name from a missing table until the M2 {@code entityType}
-   * discriminator and the table-only read filter land. A test claiming that today would pass for
-   * the wrong reason.
+   * unchanged and that the sibling v1 views route reaches the views handler. It cannot prove the
+   * other half, that a real view's name returns 404 from the table route, because no view is
+   * persisted in this PR and the server has no way to tell a view's name from a missing table until
+   * the M2 {@code entityType} discriminator and the table-only read filter land. A test claiming
+   * that today would pass for the wrong reason.
    */
   @Test
-  public void addingViewsLeavesV1TableRoutingUnchanged() throws Exception {
+  public void v1TableAndViewRoutesResolveToTheirOwnHandlers() throws Exception {
     MockMvc mvcWithBothControllers =
         MockMvcBuilders.standaloneSetup(tablesController, viewsController)
             .setControllerAdvice(openHouseExceptionHandler)
@@ -172,14 +175,35 @@ public class TablesControllerTest {
         .andExpect(status().isOk())
         .andExpect(content().json(RequestConstants.TEST_GET_TABLE_RESPONSE_BODY.toJson()));
 
-    // The same name under /v2 reaches the views handler instead.
+    // A table literally named "views" is still a table: the views mapping must not capture it from
+    // the tableId position under the shared prefix.
     mvcWithBothControllers
         .perform(
-            MockMvcRequestBuilders.get("/v2/databases/d200/views/my_view")
+            MockMvcRequestBuilders.get(
+                    CURRENT_MAJOR_VERSION_PREFIX + "/databases/d200/tables/views")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwtAccessToken))
+        .andExpect(status().isOk())
+        .andExpect(content().json(RequestConstants.TEST_GET_TABLE_RESPONSE_BODY.toJson()));
+
+    // The same name under the sibling views segment reaches the views handler instead.
+    mvcWithBothControllers
+        .perform(
+            MockMvcRequestBuilders.get(
+                    CURRENT_MAJOR_VERSION_PREFIX + "/databases/d200/views/my_view")
                 .accept(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + jwtAccessToken))
         .andExpect(status().isOk())
         .andExpect(content().json(ViewModelConstants.pointerResponse().toJson()));
+
+    // The views collection route is likewise the views handler's, not the tables handler's.
+    mvcWithBothControllers
+        .perform(
+            MockMvcRequestBuilders.get(CURRENT_MAJOR_VERSION_PREFIX + "/databases/d200/views")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwtAccessToken))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.pageResults.content[0].viewId", Matchers.is("my_view")));
 
     // The v1 table route is otherwise unchanged, including its not-found behaviour.
     mvcWithBothControllers

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/controller/TablesControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/controller/TablesControllerTest.java
@@ -21,9 +21,11 @@ import com.linkedin.openhouse.common.security.DummyTokenInterceptor;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetTableResponseBody;
 import com.linkedin.openhouse.tables.controller.TablesController;
+import com.linkedin.openhouse.tables.controller.ViewsController;
 import com.linkedin.openhouse.tables.e2e.h2.ValidationUtilities;
 import com.linkedin.openhouse.tables.mock.RequestConstants;
 import com.linkedin.openhouse.tables.mock.properties.AuthorizationPropertiesInitializer;
+import com.linkedin.openhouse.tables.model.ViewModelConstants;
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.*;
@@ -62,6 +64,8 @@ public class TablesControllerTest {
   private String invalidAccessToken;
 
   @Autowired private TablesController tablesController;
+
+  @Autowired private ViewsController viewsController;
 
   @Autowired private OpenHouseExceptionHandler openHouseExceptionHandler;
 
@@ -119,6 +123,58 @@ public class TablesControllerTest {
   public void findTableById4xx() throws Exception {
     mvc.perform(
             MockMvcRequestBuilders.get(CURRENT_MAJOR_VERSION_PREFIX + "/databases/d404/tables/t1")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwtAccessToken))
+        .andExpect(status().isNotFound());
+  }
+
+  /**
+   * Adding {@link ViewsController} must not change how a v1 table request is routed. Both
+   * controllers are registered in one dispatcher here, which is the only arrangement in which the
+   * new mappings could shadow or collide with the existing ones, and each assertion checks the
+   * response body, so it fails if a request reaches the wrong handler rather than merely returning
+   * a plausible status.
+   *
+   * <p>This <b>partially</b> satisfies the acceptance criterion. It proves the v1 table route is
+   * unchanged and that views answer only under /v2. It cannot prove the other half, that a real
+   * view's name returns 404 from the table route, because no view is persisted in this PR and the
+   * server has no way to tell a view's name from a missing table until the M2 {@code entityType}
+   * discriminator and the table-only read filter land. A test claiming that today would pass for
+   * the wrong reason.
+   */
+  @Test
+  public void addingViewsLeavesV1TableRoutingUnchanged() throws Exception {
+    MockMvc mvcWithBothControllers =
+        MockMvcBuilders.standaloneSetup(tablesController, viewsController)
+            .setControllerAdvice(openHouseExceptionHandler)
+            .addInterceptors(new DummyTokenInterceptor())
+            .addFilter(new CachingRequestBodyFilter())
+            .build();
+
+    // A view-like name on the v1 table route still reaches the tables handler.
+    mvcWithBothControllers
+        .perform(
+            MockMvcRequestBuilders.get(
+                    CURRENT_MAJOR_VERSION_PREFIX + "/databases/d200/tables/my_view")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwtAccessToken))
+        .andExpect(status().isOk())
+        .andExpect(content().json(RequestConstants.TEST_GET_TABLE_RESPONSE_BODY.toJson()));
+
+    // The same name under /v2 reaches the views handler instead.
+    mvcWithBothControllers
+        .perform(
+            MockMvcRequestBuilders.get("/v2/databases/d200/views/my_view")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwtAccessToken))
+        .andExpect(status().isOk())
+        .andExpect(content().json(ViewModelConstants.pointerResponse().toJson()));
+
+    // The v1 table route is otherwise unchanged, including its not-found behaviour.
+    mvcWithBothControllers
+        .perform(
+            MockMvcRequestBuilders.get(
+                    CURRENT_MAJOR_VERSION_PREFIX + "/databases/d404/tables/my_view")
                 .accept(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + jwtAccessToken))
         .andExpect(status().isNotFound());

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/controller/ViewsControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/controller/ViewsControllerTest.java
@@ -4,11 +4,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.linkedin.openhouse.common.audit.AuditHandler;
 import com.linkedin.openhouse.common.audit.CachingRequestBodyFilter;
+import com.linkedin.openhouse.common.audit.ServiceAuditPayloadRedactor;
 import com.linkedin.openhouse.common.audit.model.ServiceAuditEvent;
 import com.linkedin.openhouse.common.exception.handler.OpenHouseExceptionHandler;
 import com.linkedin.openhouse.common.security.DummyTokenInterceptor;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateViewRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.ViewRepresentation;
+import com.linkedin.openhouse.tables.audit.ViewRequestPayloadRedactor;
 import com.linkedin.openhouse.tables.controller.ViewsController;
 import com.linkedin.openhouse.tables.exception.ViewErrorCode;
 import com.linkedin.openhouse.tables.mock.MockViewsApiHandler;
@@ -19,6 +26,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.text.ParseException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -32,6 +40,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -83,6 +94,8 @@ public class ViewsControllerTest {
   @Autowired private OpenHouseExceptionHandler openHouseExceptionHandler;
 
   @MockBean private AuditHandler<ServiceAuditEvent> serviceAuditHandler;
+
+  @Captor private ArgumentCaptor<ServiceAuditEvent> argCaptor;
 
   @BeforeEach
   public void setup() throws IOException, JSONException, ParseException {
@@ -198,6 +211,163 @@ public class ViewsControllerTest {
                 .header("Authorization", "Bearer " + jwtAccessToken))
         .andExpect(status().isNoContent())
         .andExpect(content().string(""));
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Service audit redaction
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * {@link com.linkedin.openhouse.common.audit.ServiceAuditAspect} records the complete cached
+   * request body for every controller call, so the create and replace routes would otherwise write
+   * the caller's SQL text and schema document into a service audit event. {@link
+   * ViewRequestPayloadRedactor} replaces those values before the event is built; these tests pin
+   * that, on the success path and on a failure path, and pin that nothing else in the payload is
+   * disturbed.
+   *
+   * <p>The fixtures carry marker identifiers that appear nowhere else, so the "absent" assertions
+   * fail loudly if the redaction is removed rather than passing on a coincidence.
+   */
+  private static final String SECRET_SQL_MARKER = "secret_sql_marker_column";
+
+  private static final String SECRET_SCHEMA_MARKER = "secret_schema_marker_column";
+
+  private static final String SECRET_SQL =
+      "SELECT " + SECRET_SQL_MARKER + " FROM my_database.my_table";
+
+  private static final String SECRET_SCHEMA =
+      "{\"type\": \"struct\", \"schema-id\": 0, \"fields\": ["
+          + "{\"id\": 1, \"required\": true, \"name\": \""
+          + SECRET_SCHEMA_MARKER
+          + "\", \"type\": \"string\"}]}";
+
+  private static CreateUpdateViewRequestBody requestCarryingSecretDefinition() {
+    return ViewModelConstants.fullyPopulatedRequest()
+        .toBuilder()
+        .schema(SECRET_SCHEMA)
+        .representations(
+            Collections.singletonList(
+                ViewRepresentation.builder()
+                    .type(ViewModelConstants.SQL_REPRESENTATION_TYPE)
+                    .sql(SECRET_SQL)
+                    .dialect(ViewModelConstants.SOURCE_DIALECT)
+                    .build()))
+        .build();
+  }
+
+  @Test
+  public void serviceAuditOnViewCreateRedactsSchemaAndSql() throws Exception {
+    mvc.perform(
+        MockMvcRequestBuilders.post(VIEWS_PATH)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestCarryingSecretDefinition().toJson())
+            .accept(MediaType.APPLICATION_JSON)
+            .header("Authorization", "Bearer " + jwtAccessToken));
+
+    ServiceAuditEvent event = capturedAuditEvent();
+    Assertions.assertEquals(201, event.getStatusCode(), "Precondition: the create must succeed.");
+    assertViewDefinitionRedacted(event);
+  }
+
+  @Test
+  public void serviceAuditOnViewReplaceRedactsSchemaAndSql() throws Exception {
+    mvc.perform(
+        MockMvcRequestBuilders.put(VIEWS_PATH + "/my_view")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestCarryingSecretDefinition().toJson())
+            .accept(MediaType.APPLICATION_JSON)
+            .header("Authorization", "Bearer " + jwtAccessToken));
+
+    ServiceAuditEvent event = capturedAuditEvent();
+    Assertions.assertEquals(200, event.getStatusCode(), "Precondition: the replace must succeed.");
+    assertViewDefinitionRedacted(event);
+  }
+
+  /**
+   * The failure path is the one the reviewer called out: the audit event is emitted from the shared
+   * exception handler, after the request body has already been cached, so a rejected request writes
+   * its payload just as an accepted one does.
+   */
+  @Test
+  public void serviceAuditOnFailedViewCreateRedactsSchemaAndSql() throws Exception {
+    String failingDatabaseId = MockViewsApiHandler.databaseIdFor(ViewErrorCode.VIEWS_DISABLED);
+
+    mvc.perform(
+        MockMvcRequestBuilders.post(viewsPath(failingDatabaseId))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestCarryingSecretDefinition().toJson())
+            .accept(MediaType.APPLICATION_JSON)
+            .header("Authorization", "Bearer " + jwtAccessToken));
+
+    ServiceAuditEvent event = capturedAuditEvent();
+    Assertions.assertEquals(
+        404, event.getStatusCode(), "Precondition: the create must actually be rejected.");
+    assertViewDefinitionRedacted(event);
+  }
+
+  private ServiceAuditEvent capturedAuditEvent() {
+    Mockito.verify(serviceAuditHandler, Mockito.atLeastOnce()).audit(argCaptor.capture());
+    return argCaptor.getValue();
+  }
+
+  private void assertViewDefinitionRedacted(ServiceAuditEvent event) {
+    JsonElement payload = event.getRequestPayload();
+    Assertions.assertNotNull(payload, "The audit event must still carry a request payload.");
+    Assertions.assertTrue(payload.isJsonObject(), "The view request payload is a JSON object.");
+    JsonObject payloadObject = payload.getAsJsonObject();
+
+    Assertions.assertTrue(
+        payloadObject.has("schema"),
+        "The key must survive redaction so an auditor can see the field was sent.");
+    Assertions.assertEquals(
+        ServiceAuditPayloadRedactor.REDACTED_VALUE,
+        payloadObject.get("schema").getAsString(),
+        "The schema document must not reach the audit event.");
+
+    JsonArray representations = payloadObject.getAsJsonArray("representations");
+    Assertions.assertNotNull(representations, "The representations array must survive redaction.");
+    Assertions.assertEquals(1, representations.size());
+    for (JsonElement representation : representations) {
+      JsonObject representationObject = representation.getAsJsonObject();
+      Assertions.assertEquals(
+          ServiceAuditPayloadRedactor.REDACTED_VALUE,
+          representationObject.get("sql").getAsString(),
+          "The SQL text must not reach the audit event.");
+      // Everything else on the representation is metadata, not caller content.
+      Assertions.assertEquals(
+          ViewModelConstants.SQL_REPRESENTATION_TYPE,
+          representationObject.get("type").getAsString());
+      Assertions.assertEquals(
+          ViewModelConstants.SOURCE_DIALECT, representationObject.get("dialect").getAsString());
+    }
+
+    String serializedPayload = payload.toString();
+    Assertions.assertFalse(
+        serializedPayload.contains(SECRET_SQL_MARKER),
+        "No fragment of the submitted SQL may appear anywhere in the audited payload.");
+    Assertions.assertFalse(
+        serializedPayload.contains(SECRET_SCHEMA_MARKER),
+        "No fragment of the submitted schema may appear anywhere in the audited payload.");
+
+    // The identifying and routing fields are what makes the audit event useful; leave them alone.
+    Assertions.assertEquals(ViewModelConstants.VIEW_ID, payloadObject.get("viewId").getAsString());
+    Assertions.assertEquals(
+        ViewModelConstants.DATABASE_ID, payloadObject.get("databaseId").getAsString());
+    Assertions.assertEquals(
+        ViewModelConstants.CLUSTER_ID, payloadObject.get("clusterId").getAsString());
+    Assertions.assertEquals(
+        ViewModelConstants.SOURCE_DIALECT, payloadObject.get("sourceDialect").getAsString());
+    Assertions.assertEquals(
+        ViewModelConstants.DEFAULT_CATALOG, payloadObject.get("defaultCatalog").getAsString());
+    Assertions.assertEquals(
+        ViewModelConstants.METADATA_LOCATION, payloadObject.get("baseViewVersion").getAsString());
+    Assertions.assertEquals(
+        ViewModelConstants.DATABASE_ID,
+        payloadObject.getAsJsonArray("defaultNamespace").get(0).getAsString());
+    Assertions.assertEquals(
+        "openhouse",
+        payloadObject.getAsJsonObject("viewProperties").get("owner").getAsString(),
+        "View properties are caller metadata, not view definition, and stay auditable.");
   }
 
   // ---------------------------------------------------------------------------------------------

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/controller/ViewsControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/controller/ViewsControllerTest.java
@@ -1,0 +1,441 @@
+package com.linkedin.openhouse.tables.mock.controller;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.linkedin.openhouse.common.audit.AuditHandler;
+import com.linkedin.openhouse.common.audit.CachingRequestBodyFilter;
+import com.linkedin.openhouse.common.audit.model.ServiceAuditEvent;
+import com.linkedin.openhouse.common.exception.handler.OpenHouseExceptionHandler;
+import com.linkedin.openhouse.common.security.DummyTokenInterceptor;
+import com.linkedin.openhouse.tables.controller.ViewsController;
+import com.linkedin.openhouse.tables.exception.ViewErrorCode;
+import com.linkedin.openhouse.tables.mock.MockViewsApiHandler;
+import com.linkedin.openhouse.tables.mock.properties.AuthorizationPropertiesInitializer;
+import com.linkedin.openhouse.tables.model.ViewModelConstants;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.text.ParseException;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.codehaus.jettison.json.JSONException;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+/**
+ * MockMvc coverage of the five /v2 view routes: success statuses plus every failure status the
+ * routes can report.
+ *
+ * <p>Error statuses are driven through {@link MockViewsApiHandler}'s database-id switch, so this
+ * class exercises controller wiring and the shared exception handler rather than validation. The
+ * validator's own rejections are covered by {@code ViewsValidatorTest}.
+ *
+ * <p><b>No test here asserts an error code in the response JSON.</b> View error codes are internal
+ * status selectors: they choose the HTTP status and are never serialized. The assertions are
+ * therefore status plus the fixed message, and one explicit assertion that no code field leaked.
+ *
+ * <p>Paths are written as literal {@code /v2} strings rather than reusing {@code
+ * ValidationUtilities.CURRENT_MAJOR_VERSION_PREFIX}, which is {@code /v1} and describes the table
+ * routes. Hard-coding {@code /v2} here is what pins views to their own major version.
+ */
+@SpringBootTest
+@ContextConfiguration(initializers = AuthorizationPropertiesInitializer.class)
+public class ViewsControllerTest {
+
+  private static final String VIEWS_PATH = "/v2/databases/d200/views";
+
+  private MockMvc mvc;
+
+  /**
+   * A second MockMvc that raises {@link org.springframework.web.servlet.NoHandlerFoundException}
+   * for an unmapped path instead of letting the container answer a bare 404. That routes the
+   * failure through {@link OpenHouseExceptionHandler#handleNoHandlerFoundException}, which is the
+   * behaviour the deployed application has, and it lets the unresolved-route test assert the real
+   * "cannot be resolved" response rather than a status that a missing controller would also
+   * produce.
+   */
+  private MockMvc mvcThrowingOnUnmappedPath;
+
+  private String jwtAccessToken;
+
+  @Autowired private ViewsController viewsController;
+
+  @Autowired private OpenHouseExceptionHandler openHouseExceptionHandler;
+
+  @MockBean private AuditHandler<ServiceAuditEvent> serviceAuditHandler;
+
+  @BeforeEach
+  public void setup() throws IOException, JSONException, ParseException {
+    mvc =
+        MockMvcBuilders.standaloneSetup(viewsController)
+            .setControllerAdvice(openHouseExceptionHandler)
+            .addInterceptors(new DummyTokenInterceptor())
+            .addFilter(new CachingRequestBodyFilter())
+            .build();
+
+    mvcThrowingOnUnmappedPath =
+        MockMvcBuilders.standaloneSetup(viewsController)
+            .setControllerAdvice(openHouseExceptionHandler)
+            .addInterceptors(new DummyTokenInterceptor())
+            .addFilter(new CachingRequestBodyFilter())
+            .addDispatcherServletCustomizer(
+                dispatcherServlet -> dispatcherServlet.setThrowExceptionIfNoHandlerFound(true))
+            .build();
+
+    DummyTokenInterceptor.DummySecurityJWT dummySecurityJWT =
+        new DummyTokenInterceptor.DummySecurityJWT("DUMMY_ANONYMOUS_USER");
+    jwtAccessToken = dummySecurityJWT.buildNoopJWT();
+  }
+
+  @Test
+  public void getViewReturns200WithPointerBody() throws Exception {
+    mvc.perform(
+            MockMvcRequestBuilders.get(VIEWS_PATH + "/my_view")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwtAccessToken))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(ViewModelConstants.pointerResponse().toJson()));
+  }
+
+  @Test
+  public void createViewReturns201WithPointerBody() throws Exception {
+    mvc.perform(
+            MockMvcRequestBuilders.post(VIEWS_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(ViewModelConstants.createRequestWithoutBaseVersion().toJson())
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwtAccessToken))
+        .andExpect(status().isCreated())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(ViewModelConstants.pointerResponse().toJson()));
+  }
+
+  @Test
+  public void updateViewReplacingExistingViewReturns200() throws Exception {
+    mvc.perform(
+            MockMvcRequestBuilders.put(VIEWS_PATH + "/my_view")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(ViewModelConstants.fullyPopulatedRequest().toJson())
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwtAccessToken))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(ViewModelConstants.pointerResponse().toJson()));
+  }
+
+  @Test
+  public void updateViewCreatingNewViewReturns201() throws Exception {
+    mvc.perform(
+            MockMvcRequestBuilders.put(VIEWS_PATH + "/" + MockViewsApiHandler.PUT_CREATES_VIEW_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    ViewModelConstants.fullyPopulatedRequest()
+                        .toBuilder()
+                        .viewId(MockViewsApiHandler.PUT_CREATES_VIEW_ID)
+                        .build()
+                        .toJson())
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwtAccessToken))
+        .andExpect(status().isCreated())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(ViewModelConstants.pointerResponse().toJson()));
+  }
+
+  /**
+   * The list body is asserted with JSON paths rather than a whole-document comparison: the Gson
+   * {@code toJson()} helper on {@link
+   * com.linkedin.openhouse.tables.api.spec.v0.response.GetAllViewsResponseBody} serializes the
+   * Spring {@code PageImpl} by its internal fields, whereas the response goes out through Jackson
+   * and its getters. Only the Jackson shape is the wire contract, so it is what this asserts.
+   */
+  @Test
+  public void getAllViewsReturns200WithSparsePaginatedBody() throws Exception {
+    mvc.perform(
+            MockMvcRequestBuilders.get(VIEWS_PATH)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwtAccessToken))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.pageResults.content", Matchers.hasSize(2)))
+        .andExpect(jsonPath("$.pageResults.content[0].viewId", Matchers.is("my_view")))
+        .andExpect(
+            jsonPath(
+                "$.pageResults.content[0].databaseId", Matchers.is(ViewModelConstants.DATABASE_ID)))
+        .andExpect(jsonPath("$.pageResults.content[1].viewId", Matchers.is("my_other_view")))
+        // Sparse by design: list elements populate identifiers only.
+        .andExpect(jsonPath("$.pageResults.content[0].metadataLocation").doesNotExist())
+        .andExpect(jsonPath("$.pageResults.totalElements", Matchers.is(2)))
+        .andExpect(jsonPath("$.pageResults.size", Matchers.is(50)))
+        .andExpect(jsonPath("$.pageResults.number", Matchers.is(0)));
+  }
+
+  @Test
+  public void deleteViewReturns204WithNoBody() throws Exception {
+    mvc.perform(
+            MockMvcRequestBuilders.delete(VIEWS_PATH + "/my_view")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwtAccessToken))
+        .andExpect(status().isNoContent())
+        .andExpect(content().string(""));
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Negative paths
+  // ---------------------------------------------------------------------------------------------
+
+  /** Builds a request against one of the five routes for a given database id. */
+  @FunctionalInterface
+  interface ViewRoute {
+    MockHttpServletRequestBuilder request(String databaseId);
+  }
+
+  private static String viewsPath(String databaseId) {
+    return "/v2/databases/" + databaseId + "/views";
+  }
+
+  /** All five routes, so a route cannot quietly skip authentication or exception handling. */
+  private static Stream<Arguments> allRoutes() {
+    return Stream.of(
+        Arguments.of(
+            "GET view",
+            (ViewRoute)
+                databaseId ->
+                    MockMvcRequestBuilders.get(viewsPath(databaseId) + "/my_view")
+                        .accept(MediaType.APPLICATION_JSON)),
+        Arguments.of(
+            "GET views",
+            (ViewRoute)
+                databaseId ->
+                    MockMvcRequestBuilders.get(viewsPath(databaseId))
+                        .accept(MediaType.APPLICATION_JSON)),
+        Arguments.of(
+            "POST view",
+            (ViewRoute)
+                databaseId ->
+                    MockMvcRequestBuilders.post(viewsPath(databaseId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(ViewModelConstants.createRequestWithoutBaseVersion().toJson())
+                        .accept(MediaType.APPLICATION_JSON)),
+        Arguments.of(
+            "PUT view",
+            (ViewRoute)
+                databaseId ->
+                    MockMvcRequestBuilders.put(viewsPath(databaseId) + "/my_view")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(ViewModelConstants.fullyPopulatedRequest().toJson())
+                        .accept(MediaType.APPLICATION_JSON)),
+        Arguments.of(
+            "DELETE view",
+            (ViewRoute)
+                databaseId ->
+                    MockMvcRequestBuilders.delete(viewsPath(databaseId) + "/my_view")
+                        .accept(MediaType.APPLICATION_JSON)));
+  }
+
+  /**
+   * Every internal code selects its declared status and leaves the fixed message untouched. The
+   * code itself is deliberately absent from the body: the last assertion is the guard that keeps it
+   * that way, because adding a code field would otherwise be an invisible wire change.
+   */
+  @ParameterizedTest(name = "{0}")
+  @EnumSource(ViewErrorCode.class)
+  public void everyInternalErrorCodeSelectsItsStatusAndKeepsTheMessageFixed(ViewErrorCode errorCode)
+      throws Exception {
+    mvc.perform(
+            MockMvcRequestBuilders.get(
+                    viewsPath(MockViewsApiHandler.databaseIdFor(errorCode)) + "/my_view")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwtAccessToken))
+        .andExpect(status().is(errorCode.getHttpStatus().value()))
+        .andExpect(jsonPath("$.message", Matchers.is(MockViewsApiHandler.VIEW_FAILURE_MESSAGE)))
+        .andExpect(jsonPath("$.status", Matchers.is(errorCode.getHttpStatus().name())))
+        .andExpect(jsonPath("$.errorCode").doesNotExist());
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("allRoutes")
+  public void everyRouteRejectsAMissingBearerTokenWith401(String routeName, ViewRoute route)
+      throws Exception {
+    mvc.perform(route.request("d200")).andExpect(status().isUnauthorized());
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("allRoutes")
+  public void everyRouteRejectsAMalformedBearerTokenWith401(String routeName, ViewRoute route)
+      throws Exception {
+    mvc.perform(route.request("d200").header("Authorization", "Bearer not-a-real-jwt"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  /**
+   * Exercises exception mapping only. {@code AuthorizationInterceptor.check()} unconditionally
+   * returns an allow decision today, so nothing in this PR can deny a request on privilege grounds;
+   * what this pins is that when the handler layer eventually does deny one, the shared handler
+   * turns it into a 403 rather than a 500.
+   */
+  @Test
+  public void accessDeniedFromTheHandlerIsMappedTo403WithoutPrivilegeEnforcement()
+      throws Exception {
+    mvc.perform(
+            MockMvcRequestBuilders.get(
+                    viewsPath(MockViewsApiHandler.ACCESS_DENIED_DATABASE_ID) + "/my_view")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwtAccessToken))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.message", Matchers.is(MockViewsApiHandler.ACCESS_DENIED_MESSAGE)));
+  }
+
+  /** An uncoded infrastructure failure still lands on 503 rather than falling through to 500. */
+  @Test
+  public void genericInfrastructureFailureIsMappedTo503() throws Exception {
+    mvc.perform(
+            MockMvcRequestBuilders.get(
+                    viewsPath(MockViewsApiHandler.UNAVAILABLE_DATABASE_ID) + "/my_view")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwtAccessToken))
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(jsonPath("$.message", Matchers.is(MockViewsApiHandler.UNAVAILABLE_MESSAGE)))
+        .andExpect(jsonPath("$.errorCode").doesNotExist());
+  }
+
+  /**
+   * Malformed JSON fails during message conversion, before any view code runs, so it must stay on
+   * the shared Jackson path and carry no view vocabulary at all.
+   */
+  @Test
+  public void malformedJsonBodyIsRejectedByTheSharedHandlerWith400() throws Exception {
+    mvc.perform(
+            MockMvcRequestBuilders.post(VIEWS_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"viewId\": ")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwtAccessToken))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message", Matchers.startsWith("Unacceptable JSON")))
+        .andExpect(jsonPath("$.errorCode").doesNotExist());
+  }
+
+  /**
+   * Views are a new resource mounted under {@code /v2}; the same path under {@code /v1} must not
+   * resolve. {@link ViewsController} is the only class that could ever map a {@code /v1} view path,
+   * so this fails exactly when someone adds one.
+   */
+  @Test
+  public void theSamePathUnderV1DoesNotResolve() throws Exception {
+    mvcThrowingOnUnmappedPath
+        .perform(
+            MockMvcRequestBuilders.get("/v1/databases/d200/views/my_view")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwtAccessToken))
+        .andExpect(jsonPath("$.message", Matchers.containsString("cannot be resolved by server")))
+        // Proves the request never reached the handler, which would have answered 200 with a
+        // pointer body.
+        .andExpect(jsonPath("$.viewId").doesNotExist());
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Published contract: declared response codes
+  // ---------------------------------------------------------------------------------------------
+
+  /**
+   * The status set each operation publishes, taken from the status matrix. {@code
+   * client/tableclient} is generated from the OpenAPI document these annotations produce, so a
+   * status the routes can return but do not declare is invisible to every generated client.
+   */
+  private static Stream<Arguments> declaredResponseCodes() {
+    return Stream.of(
+        Arguments.of("getView", codes("200", "400", "401", "403", "404", "503")),
+        Arguments.of("getAllViews", codes("200", "400", "401", "403", "404", "503")),
+        Arguments.of("createView", codes("201", "400", "401", "403", "404", "409", "422", "503")),
+        Arguments.of(
+            "updateView", codes("200", "201", "400", "401", "403", "404", "409", "422", "503")),
+        Arguments.of("deleteView", codes("204", "400", "401", "403", "404", "503")));
+  }
+
+  private static Set<String> codes(String... responseCodes) {
+    return new TreeSet<>(Arrays.asList(responseCodes));
+  }
+
+  private static Set<String> declaredResponseCodesOf(String methodName) {
+    Method method =
+        Arrays.stream(ViewsController.class.getDeclaredMethods())
+            .filter(candidate -> candidate.getName().equals(methodName))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new AssertionError(
+                        "ViewsController has no method named " + methodName + " any more"));
+
+    ApiResponses apiResponses = method.getAnnotation(ApiResponses.class);
+    Assertions.assertNotNull(
+        apiResponses, methodName + " must declare its responses for the generated spec");
+
+    return Arrays.stream(apiResponses.value())
+        .map(io.swagger.v3.oas.annotations.responses.ApiResponse::responseCode)
+        .collect(Collectors.toCollection(TreeSet::new));
+  }
+
+  /**
+   * Pins the exact published status set per operation.
+   *
+   * <p>Asserted off the annotations rather than off a generated document on purpose: booting the
+   * app to produce the spec needs a free port, and the default spec-generation port is occupied by
+   * an unrelated stale service in some environments, which silently yields a views-free document.
+   * The annotations are the sole input to that document, so pinning them pins the contract without
+   * that failure mode.
+   */
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("declaredResponseCodes")
+  public void eachOperationPublishesExactlyTheStatusesItCanReturn(
+      String methodName, Set<String> expectedCodes) {
+    Assertions.assertEquals(
+        expectedCodes,
+        declaredResponseCodesOf(methodName),
+        "The published status set for "
+            + methodName
+            + " drifted from the statuses the route can actually return. Every status asserted by"
+            + " the error-code, 401, 403 and 503 tests in this class must also be declared here,"
+            + " because the generated client is built from these annotations.");
+  }
+
+  /**
+   * Ties the internal taxonomy to the published contract: a write route can surface any {@link
+   * ViewErrorCode}, so every status those codes map to must be declared on POST and PUT. Adding a
+   * code with a new status now fails here instead of silently producing an undeclared response.
+   */
+  @Test
+  public void everyInternalErrorCodeStatusIsPublishedOnTheWriteRoutes() {
+    Set<String> codeStatuses =
+        Arrays.stream(ViewErrorCode.values())
+            .map(errorCode -> String.valueOf(errorCode.getHttpStatus().value()))
+            .collect(Collectors.toCollection(TreeSet::new));
+
+    Assertions.assertTrue(
+        declaredResponseCodesOf("createView").containsAll(codeStatuses),
+        "POST does not publish every status its internal codes can select: " + codeStatuses);
+    Assertions.assertTrue(
+        declaredResponseCodesOf("updateView").containsAll(codeStatuses),
+        "PUT does not publish every status its internal codes can select: " + codeStatuses);
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/controller/ViewsControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/controller/ViewsControllerTest.java
@@ -54,7 +54,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 /**
- * MockMvc coverage of the five /v2 view routes: success statuses plus every failure status the
+ * MockMvc coverage of the five /v1 view routes: success statuses plus every failure status the
  * routes can report.
  *
  * <p>Error statuses are driven through {@link MockViewsApiHandler}'s database-id switch, so this
@@ -65,15 +65,16 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
  * status selectors: they choose the HTTP status and are never serialized. The assertions are
  * therefore status plus the fixed message, and one explicit assertion that no code field leaked.
  *
- * <p>Paths are written as literal {@code /v2} strings rather than reusing {@code
- * ValidationUtilities.CURRENT_MAJOR_VERSION_PREFIX}, which is {@code /v1} and describes the table
- * routes. Hard-coding {@code /v2} here is what pins views to their own major version.
+ * <p>Paths are written as literal {@code /v1} strings rather than reusing {@code
+ * ValidationUtilities.CURRENT_MAJOR_VERSION_PREFIX}. Views share the prefix with tables but are a
+ * separate resource, so spelling the routes out here keeps this class asserting the exact URIs the
+ * controller publishes rather than whatever that constant later becomes.
  */
 @SpringBootTest
 @ContextConfiguration(initializers = AuthorizationPropertiesInitializer.class)
 public class ViewsControllerTest {
 
-  private static final String VIEWS_PATH = "/v2/databases/d200/views";
+  private static final String VIEWS_PATH = "/v1/databases/d200/views";
 
   private MockMvc mvc;
 
@@ -381,7 +382,7 @@ public class ViewsControllerTest {
   }
 
   private static String viewsPath(String databaseId) {
-    return "/v2/databases/" + databaseId + "/views";
+    return "/v1/databases/" + databaseId + "/views";
   }
 
   /** All five routes, so a route cannot quietly skip authentication or exception handling. */
@@ -507,15 +508,16 @@ public class ViewsControllerTest {
   }
 
   /**
-   * Views are a new resource mounted under {@code /v2}; the same path under {@code /v1} must not
-   * resolve. {@link ViewsController} is the only class that could ever map a {@code /v1} view path,
-   * so this fails exactly when someone adds one.
+   * Views mount under {@code /v1} alongside every other OpenHouse resource; the {@code /v2} prefix
+   * they were briefly drafted against must not resolve. {@link ViewsController} is the only class
+   * that could ever map a {@code /v2} view path, so this fails exactly when a stale mapping is left
+   * behind or reintroduced.
    */
   @Test
-  public void theSamePathUnderV1DoesNotResolve() throws Exception {
+  public void theSamePathUnderV2DoesNotResolve() throws Exception {
     mvcThrowingOnUnmappedPath
         .perform(
-            MockMvcRequestBuilders.get("/v1/databases/d200/views/my_view")
+            MockMvcRequestBuilders.get("/v2/databases/d200/views/my_view")
                 .accept(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + jwtAccessToken))
         .andExpect(jsonPath("$.message", Matchers.containsString("cannot be resolved by server")))

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/controller/ViewsControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/controller/ViewsControllerTest.java
@@ -46,6 +46,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -96,6 +97,13 @@ public class ViewsControllerTest {
 
   @MockBean private AuditHandler<ServiceAuditEvent> serviceAuditHandler;
 
+  /**
+   * Spy rather than mock: every other test in this class depends on the real {@link
+   * MockViewsApiHandler} behaviour, and a spy leaves it intact while making the arguments the
+   * controller passed on observable.
+   */
+  @SpyBean private MockViewsApiHandler viewsApiHandler;
+
   @Captor private ArgumentCaptor<ServiceAuditEvent> argCaptor;
 
   @BeforeEach
@@ -143,6 +151,51 @@ public class ViewsControllerTest {
         .andExpect(status().isCreated())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(content().json(ViewModelConstants.pointerResponse().toJson()));
+  }
+
+  /**
+   * Binding proof, not routing proof: {@link MockViewsApiHandler} answers 201 whatever the body
+   * held, so a green status says nothing about whether the wire key reached the model. The request
+   * the controller actually passed on is captured and asserted instead.
+   *
+   * <p>The body is a literal rather than a serialized fixture so it pins the key a caller sends
+   * rather than whatever the fixture happens to emit. Message conversion is per type, not per
+   * route, so POST covers the replace route too.
+   */
+  @Test
+  public void createViewBindsTheBaseMetadataLocationKeyOntoTheRequestBody() throws Exception {
+    String requestBody =
+        "{\"viewId\": \""
+            + ViewModelConstants.VIEW_ID
+            + "\", \"databaseId\": \""
+            + ViewModelConstants.DATABASE_ID
+            + "\", \"baseMetadataLocation\": \""
+            + ViewModelConstants.METADATA_LOCATION
+            + "\"}";
+
+    mvc.perform(
+            MockMvcRequestBuilders.post(VIEWS_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody)
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + jwtAccessToken))
+        .andExpect(status().isCreated());
+
+    ArgumentCaptor<CreateUpdateViewRequestBody> boundRequest =
+        ArgumentCaptor.forClass(CreateUpdateViewRequestBody.class);
+    Mockito.verify(viewsApiHandler)
+        .createView(Mockito.anyString(), boundRequest.capture(), Mockito.any());
+
+    CreateUpdateViewRequestBody captured = boundRequest.getValue();
+    Assertions.assertEquals(
+        ViewModelConstants.VIEW_ID,
+        captured.getViewId(),
+        "Precondition: the body binds onto the request model at all.");
+    Assertions.assertEquals(
+        ViewModelConstants.METADATA_LOCATION,
+        captured.getBaseMetadataLocation(),
+        "The wire key must populate the request property. The application's converter ignores an"
+            + " unknown property, so a stale key binds to null rather than failing the request.");
   }
 
   @Test
@@ -360,8 +413,12 @@ public class ViewsControllerTest {
         ViewModelConstants.SOURCE_DIALECT, payloadObject.get("sourceDialect").getAsString());
     Assertions.assertEquals(
         ViewModelConstants.DEFAULT_CATALOG, payloadObject.get("defaultCatalog").getAsString());
+    Assertions.assertTrue(
+        payloadObject.has("baseMetadataLocation"),
+        "The audited payload is the raw body the caller sent, so it carries the wire key.");
     Assertions.assertEquals(
-        ViewModelConstants.METADATA_LOCATION, payloadObject.get("baseViewVersion").getAsString());
+        ViewModelConstants.METADATA_LOCATION,
+        payloadObject.get("baseMetadataLocation").getAsString());
     Assertions.assertEquals(
         ViewModelConstants.DATABASE_ID,
         payloadObject.getAsJsonArray("defaultNamespace").get(0).getAsString());

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/controller/ViewsControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/controller/ViewsControllerTest.java
@@ -55,8 +55,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 /**
- * MockMvc coverage of the five /v1 view routes: success statuses plus every failure status the
- * routes can report.
+ * MockMvc coverage of the five /v1 view routes and their service-generated responses, plus
+ * annotation checks for the endpoint's published status codes.
  *
  * <p>Error statuses are driven through {@link MockViewsApiHandler}'s database-id switch, so this
  * class exercises controller wiring and the shared exception handler rather than validation. The
@@ -517,10 +517,8 @@ public class ViewsControllerTest {
   }
 
   /**
-   * Exercises exception mapping only. {@code AuthorizationInterceptor.check()} unconditionally
-   * returns an allow decision today, so nothing in this PR can deny a request on privilege grounds;
-   * what this pins is that when the handler layer eventually does deny one, the shared handler
-   * turns it into a 403 rather than a 500.
+   * Exercises exception mapping: an access denial from the handler becomes HTTP 403 independently
+   * of the authorization policy used by the request interceptors.
    */
   @Test
   public void accessDeniedFromTheHandlerIsMappedTo403WithoutPrivilegeEnforcement()
@@ -565,10 +563,8 @@ public class ViewsControllerTest {
   }
 
   /**
-   * Views mount under {@code /v1} alongside every other OpenHouse resource; the {@code /v2} prefix
-   * they were briefly drafted against must not resolve. {@link ViewsController} is the only class
-   * that could ever map a {@code /v2} view path, so this fails exactly when a stale mapping is left
-   * behind or reintroduced.
+   * View routes are mounted under {@code /v1}; the same resource path under {@code /v2} must not
+   * reach the view handler.
    */
   @Test
   public void theSamePathUnderV2DoesNotResolve() throws Exception {
@@ -588,18 +584,24 @@ public class ViewsControllerTest {
   // ---------------------------------------------------------------------------------------------
 
   /**
-   * The status set each operation publishes, taken from the status matrix. {@code
-   * client/tableclient} is generated from the OpenAPI document these annotations produce, so a
-   * status the routes can return but do not declare is invisible to every generated client.
+   * The published status set includes service failures and gateway-originated 502/504 responses.
    */
   private static Stream<Arguments> declaredResponseCodes() {
     return Stream.of(
-        Arguments.of("getView", codes("200", "400", "401", "403", "404", "503")),
-        Arguments.of("getAllViews", codes("200", "400", "401", "403", "404", "503")),
-        Arguments.of("createView", codes("201", "400", "401", "403", "404", "409", "422", "503")),
         Arguments.of(
-            "updateView", codes("200", "201", "400", "401", "403", "404", "409", "422", "503")),
-        Arguments.of("deleteView", codes("204", "400", "401", "403", "404", "503")));
+            "getView", codes("200", "400", "401", "403", "404", "500", "502", "503", "504")),
+        Arguments.of(
+            "getAllViews", codes("200", "400", "401", "403", "404", "500", "502", "503", "504")),
+        Arguments.of(
+            "createView",
+            codes("201", "400", "401", "403", "404", "409", "422", "500", "502", "503", "504")),
+        Arguments.of(
+            "updateView",
+            codes(
+                "200", "201", "400", "401", "403", "404", "409", "422", "500", "502", "503",
+                "504")),
+        Arguments.of(
+            "deleteView", codes("204", "400", "401", "403", "404", "500", "502", "503", "504")));
   }
 
   private static Set<String> codes(String... responseCodes) {
@@ -626,13 +628,7 @@ public class ViewsControllerTest {
   }
 
   /**
-   * Pins the exact published status set per operation.
-   *
-   * <p>Asserted off the annotations rather than off a generated document on purpose: booting the
-   * app to produce the spec needs a free port, and the default spec-generation port is occupied by
-   * an unrelated stale service in some environments, which silently yields a views-free document.
-   * The annotations are the sole input to that document, so pinning them pins the contract without
-   * that failure mode.
+   * Pins the status annotations used to generate the OpenAPI document without starting a server.
    */
   @ParameterizedTest(name = "{0}")
   @MethodSource("declaredResponseCodes")
@@ -643,9 +639,7 @@ public class ViewsControllerTest {
         declaredResponseCodesOf(methodName),
         "The published status set for "
             + methodName
-            + " drifted from the statuses the route can actually return. Every status asserted by"
-            + " the error-code, 401, 403 and 503 tests in this class must also be declared here,"
-            + " because the generated client is built from these annotations.");
+            + " must include the documented service and gateway outcomes.");
   }
 
   /**

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/mapper/ViewsMapperTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/mapper/ViewsMapperTest.java
@@ -1,0 +1,105 @@
+package com.linkedin.openhouse.tables.mock.mapper;
+
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateViewRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetViewResponseBody;
+import com.linkedin.openhouse.tables.dto.mapper.ViewsMapper;
+import com.linkedin.openhouse.tables.model.ViewDto;
+import com.linkedin.openhouse.tables.model.ViewModelConstants;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+/** Golden-path mapping coverage for {@link ViewsMapper}. */
+@SpringBootTest
+public class ViewsMapperTest {
+
+  @Autowired private ViewsMapper viewsMapper;
+
+  @Test
+  public void testRequestMapsToViewDtoStoringBaseVersionAsViewVersion() {
+    CreateUpdateViewRequestBody requestBody = ViewModelConstants.fullyPopulatedRequest();
+
+    ViewDto viewDto = viewsMapper.toViewDto(requestBody);
+
+    Assertions.assertEquals(requestBody.getViewId(), viewDto.getViewId());
+    Assertions.assertEquals(requestBody.getDatabaseId(), viewDto.getDatabaseId());
+    Assertions.assertEquals(requestBody.getClusterId(), viewDto.getClusterId());
+    Assertions.assertEquals(requestBody.getSchema(), viewDto.getSchema());
+    Assertions.assertEquals(requestBody.getRepresentations(), viewDto.getRepresentations());
+    Assertions.assertEquals(requestBody.getSourceDialect(), viewDto.getSourceDialect());
+    Assertions.assertEquals(requestBody.getDefaultCatalog(), viewDto.getDefaultCatalog());
+    Assertions.assertEquals(requestBody.getDefaultNamespace(), viewDto.getDefaultNamespace());
+    Assertions.assertEquals(requestBody.getViewProperties(), viewDto.getViewProperties());
+    Assertions.assertEquals(
+        requestBody.getBaseViewVersion(),
+        viewDto.getViewVersion(),
+        "The caller's base version is stored as viewVersion so the service can compare it against"
+            + " the current pointer, mirroring how baseTableVersion maps to tableVersion.");
+
+    // Pointer fields are server-owned and must not be populated from a request.
+    Assertions.assertNull(viewDto.getViewUri());
+    Assertions.assertNull(viewDto.getMetadataLocation());
+    Assertions.assertNull(viewDto.getViewCreator());
+    Assertions.assertEquals(0L, viewDto.getCreationTime());
+    Assertions.assertEquals(0L, viewDto.getLastModifiedTime());
+  }
+
+  /**
+   * Uses distinct sentinels for {@code metadataLocation} and {@code viewVersion}. In production the
+   * two hold the same value, which would let a swapped mapping pass unnoticed.
+   */
+  @Test
+  public void testViewDtoMapsToPointerResponseBody() {
+    ViewDto viewDto =
+        ViewDto.builder()
+            .viewId(ViewModelConstants.VIEW_ID)
+            .databaseId(ViewModelConstants.DATABASE_ID)
+            .clusterId(ViewModelConstants.CLUSTER_ID)
+            .viewUri(ViewModelConstants.VIEW_URI)
+            .metadataLocation(ViewModelConstants.DISTINCT_METADATA_LOCATION)
+            .viewVersion(ViewModelConstants.DISTINCT_VIEW_VERSION)
+            .creationTime(ViewModelConstants.CREATION_TIME)
+            // Definition fields have no counterpart on the pointer-only read contract.
+            .schema(ViewModelConstants.VIEW_SCHEMA_LITERAL)
+            .sourceDialect(ViewModelConstants.SOURCE_DIALECT)
+            .build();
+
+    GetViewResponseBody responseBody = viewsMapper.toGetViewResponseBody(viewDto);
+
+    Assertions.assertEquals(ViewModelConstants.pointerResponseWithDistinctPointers(), responseBody);
+    Assertions.assertEquals(
+        ViewModelConstants.DISTINCT_METADATA_LOCATION, responseBody.getMetadataLocation());
+    Assertions.assertEquals(
+        ViewModelConstants.DISTINCT_VIEW_VERSION, responseBody.getViewVersion());
+  }
+
+  @Test
+  public void testViewDtoPageMapsToSparseResponsePagePreservingMetadata() {
+    List<ViewDto> content =
+        Arrays.asList(
+            ViewDto.builder().viewId("my_view").databaseId(ViewModelConstants.DATABASE_ID).build(),
+            ViewDto.builder()
+                .viewId("my_other_view")
+                .databaseId(ViewModelConstants.DATABASE_ID)
+                .build());
+    Page<ViewDto> dtoPage = new PageImpl<>(content, PageRequest.of(1, 2), 7);
+
+    Page<GetViewResponseBody> responsePage = viewsMapper.toGetViewResponseBodyPage(dtoPage);
+
+    Assertions.assertEquals(
+        ViewModelConstants.sparseListPage().getContent(), responsePage.getContent());
+    Assertions.assertEquals(1, responsePage.getNumber());
+    Assertions.assertEquals(2, responsePage.getSize());
+    Assertions.assertEquals(7, responsePage.getTotalElements());
+    Assertions.assertEquals(4, responsePage.getTotalPages());
+    Assertions.assertNull(
+        responsePage.getContent().get(0).getMetadataLocation(),
+        "List elements stay sparse: only identifiers are populated.");
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/mapper/ViewsMapperTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/mapper/ViewsMapperTest.java
@@ -37,7 +37,7 @@ public class ViewsMapperTest {
     Assertions.assertEquals(requestBody.getDefaultNamespace(), viewDto.getDefaultNamespace());
     Assertions.assertEquals(requestBody.getViewProperties(), viewDto.getViewProperties());
     Assertions.assertEquals(
-        requestBody.getBaseViewVersion(),
+        requestBody.getBaseMetadataLocation(),
         viewDto.getViewVersion(),
         "The caller's base version is stored as viewVersion so the service can compare it against"
             + " the current pointer, mirroring how baseTableVersion maps to tableVersion.");

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/service/ViewsDisabledServiceTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/service/ViewsDisabledServiceTest.java
@@ -1,0 +1,89 @@
+package com.linkedin.openhouse.tables.mock.service;
+
+import com.linkedin.openhouse.tables.exception.ViewApiException;
+import com.linkedin.openhouse.tables.exception.ViewErrorCode;
+import com.linkedin.openhouse.tables.model.ViewModelConstants;
+import com.linkedin.openhouse.tables.services.ViewsDisabledService;
+import com.linkedin.openhouse.tables.services.ViewsService;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Freezes the only behaviour the stub service has: every operation reports that views are disabled.
+ *
+ * <p>Plain instantiation rather than a Spring context: the bean has no collaborators, so a context
+ * would only slow the test down without exercising anything extra.
+ */
+public class ViewsDisabledServiceTest {
+
+  /**
+   * Deliberately duplicated rather than referenced from the production constant, which is
+   * package-private. Restating the literal is the point: this is the frozen, redacted message that
+   * reaches the error body and the service audit event, so a change to it must break a test.
+   */
+  private static final String EXPECTED_MESSAGE = "Views are disabled";
+
+  private static final String ACTING_PRINCIPAL = "DUMMY_ANONYMOUS_USER";
+
+  /** One entry per {@link ViewsService} method, so a new method cannot silently skip the gate. */
+  private static Stream<Arguments> allServiceOperations() {
+    return Stream.of(
+        Arguments.of(
+            "getView",
+            (ServiceOperation)
+                service ->
+                    service.getView(
+                        ViewModelConstants.DATABASE_ID,
+                        ViewModelConstants.VIEW_ID,
+                        ACTING_PRINCIPAL)),
+        Arguments.of(
+            "getAllViews",
+            (ServiceOperation)
+                service ->
+                    service.getAllViews(
+                        ViewModelConstants.DATABASE_ID, 0, 50, null, ACTING_PRINCIPAL)),
+        Arguments.of(
+            "putView",
+            (ServiceOperation)
+                service ->
+                    service.putView(
+                        ViewModelConstants.createRequestWithoutBaseVersion(),
+                        ACTING_PRINCIPAL,
+                        true)),
+        Arguments.of(
+            "deleteView",
+            (ServiceOperation)
+                service ->
+                    service.deleteView(
+                        ViewModelConstants.DATABASE_ID,
+                        ViewModelConstants.VIEW_ID,
+                        ACTING_PRINCIPAL)));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("allServiceOperations")
+  public void everyOperationReportsViewsDisabled(String operationName, ServiceOperation operation) {
+    ViewsDisabledService service = new ViewsDisabledService();
+
+    ViewApiException exception =
+        Assertions.assertThrows(ViewApiException.class, () -> operation.run(service));
+
+    Assertions.assertEquals(
+        ViewErrorCode.VIEWS_DISABLED,
+        exception.getErrorCode(),
+        "The stub must report the designed disabled code, not a generic failure: an uncoded"
+            + " unchecked exception would surface as a 500 with a stack trace instead.");
+    Assertions.assertEquals(HttpStatus.NOT_FOUND, exception.getHttpStatus());
+    Assertions.assertEquals(EXPECTED_MESSAGE, exception.getMessage());
+  }
+
+  /** Invokes one {@link ViewsService} method; needed because the four have different shapes. */
+  @FunctionalInterface
+  interface ServiceOperation {
+    void run(ViewsService service);
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/model/ViewModelConstants.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/model/ViewModelConstants.java
@@ -19,7 +19,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 
 /**
- * Deterministic fixtures for the /v2 views wire surface. Everything here is a fixed literal: no
+ * Deterministic fixtures for the /v1 views wire surface. Everything here is a fixed literal: no
  * random identifiers, no {@code UUID.randomUUID()} and no {@code System.currentTimeMillis()}, so
  * contract assertions stay byte-stable across runs.
  */

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/model/ViewModelConstants.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/model/ViewModelConstants.java
@@ -1,7 +1,10 @@
 package com.linkedin.openhouse.tables.model;
 
 import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.INITIAL_TABLE_VERSION;
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.MAX_VIEW_SCHEMA_BYTES;
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.MAX_VIEW_SQL_BYTES;
 
+import com.linkedin.openhouse.common.api.validator.ValidatorConstants;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateViewRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.ViewRepresentation;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllViewsResponseBody;
@@ -137,7 +140,12 @@ public final class ViewModelConstants {
   // Negative-path fixtures
   // -----------------------------------------------------------------------------------------
 
-  /** Not JSON at all. */
+  /**
+   * Truncated JSON: Jackson cannot parse it at all, so Iceberg fails inside {@code JsonUtil.parse}
+   * and reports it as an {@code UncheckedIOException} rather than the {@code
+   * IllegalArgumentException} it raises for a document that parses but is not an Iceberg schema.
+   * {@code ViewSchemaParseBoundaryTest} pins that split, which is why the validator catches both.
+   */
   public static final String MALFORMED_SCHEMA_LITERAL = "{\"type\": \"struct\", \"fields\": [";
 
   /**
@@ -159,25 +167,42 @@ public final class ViewModelConstants {
           + "{\"id\": 1, \"required\": true, \"name\": \"name\", \"type\": \"string\"}]}";
 
   /**
-   * A valid Iceberg schema padded with insignificant JSON whitespace to exactly {@code totalBytes}
-   * UTF-8 bytes, so a size boundary can be probed without also changing whether it parses.
+   * A valid Iceberg schema of exactly {@link ValidatorConstants#MAX_VIEW_SCHEMA_BYTES} UTF-8 bytes,
+   * padded with insignificant JSON whitespace so the size boundary can be probed without also
+   * changing whether the document parses.
+   *
+   * <p>The boundary fixtures are exposed as no-argument methods rather than one helper taking a
+   * requested size. The size is derived from the limit the validator enforces, so there is no
+   * argument a caller could get wrong and therefore no precondition to enforce and no failure to
+   * report.
    */
-  public static String schemaOfExactUtf8Size(int totalBytes) {
-    int padding = totalBytes - VIEW_SCHEMA_LITERAL.length();
-    if (padding < 0) {
-      throw new IllegalArgumentException(
-          "Requested schema size is smaller than the base schema literal");
-    }
-    return "{" + spaces(padding) + VIEW_SCHEMA_LITERAL.substring(1);
+  public static String schemaAtMaxUtf8Size() {
+    return schemaPaddedTo(MAX_VIEW_SCHEMA_BYTES);
   }
 
-  /** Opaque SQL padded to exactly {@code totalBytes} UTF-8 bytes. */
-  public static String sqlOfExactUtf8Size(int totalBytes) {
-    int padding = totalBytes - VIEW_SQL.length();
-    if (padding < 0) {
-      throw new IllegalArgumentException("Requested SQL size is smaller than the base SQL literal");
-    }
-    return VIEW_SQL + spaces(padding);
+  /** The same valid Iceberg schema, one UTF-8 byte past the limit. */
+  public static String schemaOneByteOverMaxUtf8Size() {
+    return schemaPaddedTo(MAX_VIEW_SCHEMA_BYTES + 1);
+  }
+
+  /** Opaque SQL of exactly {@link ValidatorConstants#MAX_VIEW_SQL_BYTES} UTF-8 bytes. */
+  public static String sqlAtMaxUtf8Size() {
+    return sqlPaddedTo(MAX_VIEW_SQL_BYTES);
+  }
+
+  /** The same opaque SQL, one UTF-8 byte past the limit. */
+  public static String sqlOneByteOverMaxUtf8Size() {
+    return sqlPaddedTo(MAX_VIEW_SQL_BYTES + 1);
+  }
+
+  private static String schemaPaddedTo(int totalBytes) {
+    return "{"
+        + spaces(totalBytes - VIEW_SCHEMA_LITERAL.length())
+        + VIEW_SCHEMA_LITERAL.substring(1);
+  }
+
+  private static String sqlPaddedTo(int totalBytes) {
+    return VIEW_SQL + spaces(totalBytes - VIEW_SQL.length());
   }
 
   /**

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/model/ViewModelConstants.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/model/ViewModelConstants.java
@@ -1,0 +1,212 @@
+package com.linkedin.openhouse.tables.model;
+
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.INITIAL_TABLE_VERSION;
+
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateViewRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.ViewRepresentation;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllViewsResponseBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetViewResponseBody;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+/**
+ * Deterministic fixtures for the /v2 views wire surface. Everything here is a fixed literal: no
+ * random identifiers, no {@code UUID.randomUUID()} and no {@code System.currentTimeMillis()}, so
+ * contract assertions stay byte-stable across runs.
+ */
+public final class ViewModelConstants {
+
+  private ViewModelConstants() {}
+
+  public static final String VIEW_ID = "my_view";
+  public static final String DATABASE_ID = "my_database";
+  public static final String CLUSTER_ID = "my-cluster";
+  public static final String VIEW_URI = "my-cluster.my_database.my_view";
+  public static final String METADATA_LOCATION =
+      "file:/tmp/openhouse/my_database/my_view/metadata/00000-fixed.metadata.json";
+  public static final String VIEW_VERSION =
+      "file:/tmp/openhouse/my_database/my_view/metadata/00000-fixed.metadata.json";
+  public static final long CREATION_TIME = 1651002318265L;
+
+  /**
+   * Distinct sentinels for {@code metadataLocation} and {@code viewVersion}. In production the two
+   * are equal (design doc §5: viewVersion is the current metadataLocation), which is what the
+   * general fixtures model. That equality would, however, let a serialization bug swap the two
+   * Jackson property associations undetected, so this pair deliberately breaks it for the
+   * serialization-freeze test and pins each field independently.
+   */
+  public static final String DISTINCT_METADATA_LOCATION =
+      "file:/tmp/openhouse/my_database/my_view/metadata/sentinel-metadata-location.metadata.json";
+
+  public static final String DISTINCT_VIEW_VERSION =
+      "file:/tmp/openhouse/my_database/my_view/metadata/sentinel-view-version.metadata.json";
+
+  public static final String SOURCE_DIALECT = "spark";
+  public static final String SQL_REPRESENTATION_TYPE = "sql";
+  public static final String VIEW_SQL = "SELECT id, name FROM my_database.my_table";
+  public static final String DEFAULT_CATALOG = "openhouse";
+
+  /** Iceberg schema JSON with unique, explicit field ids. */
+  public static final String VIEW_SCHEMA_LITERAL =
+      "{\"type\": \"struct\", \"schema-id\": 0, \"fields\": ["
+          + "{\"id\": 1, \"required\": true, \"name\": \"id\", \"type\": \"string\"}, "
+          + "{\"id\": 2, \"required\": true, \"name\": \"name\", \"type\": \"string\"}]}";
+
+  public static final ViewRepresentation SPARK_REPRESENTATION =
+      ViewRepresentation.builder()
+          .type(SQL_REPRESENTATION_TYPE)
+          .sql(VIEW_SQL)
+          .dialect(SOURCE_DIALECT)
+          .build();
+
+  public static final List<String> DEFAULT_NAMESPACE =
+      Collections.unmodifiableList(Collections.singletonList(DATABASE_ID));
+
+  public static final Map<String, String> VIEW_PROPERTIES;
+
+  static {
+    Map<String, String> properties = new LinkedHashMap<>();
+    properties.put("owner", "openhouse");
+    VIEW_PROPERTIES = Collections.unmodifiableMap(properties);
+  }
+
+  /** Every field populated, including both nullable optional fields and a replace token. */
+  public static CreateUpdateViewRequestBody fullyPopulatedRequest() {
+    return baseRequestBuilder().baseViewVersion(METADATA_LOCATION).build();
+  }
+
+  /** POST create shape where the caller omits the base version entirely. */
+  public static CreateUpdateViewRequestBody createRequestWithoutBaseVersion() {
+    return baseRequestBuilder().build();
+  }
+
+  /** POST create shape where the caller sends the table-style initial version token. */
+  public static CreateUpdateViewRequestBody createRequestWithInitialBaseVersion() {
+    return baseRequestBuilder().baseViewVersion(INITIAL_TABLE_VERSION).build();
+  }
+
+  /** Fully populated pointer response for an item GET. */
+  public static GetViewResponseBody pointerResponse() {
+    return GetViewResponseBody.builder()
+        .viewId(VIEW_ID)
+        .databaseId(DATABASE_ID)
+        .clusterId(CLUSTER_ID)
+        .viewUri(VIEW_URI)
+        .metadataLocation(METADATA_LOCATION)
+        .viewVersion(VIEW_VERSION)
+        .creationTime(CREATION_TIME)
+        .build();
+  }
+
+  /** Sparse list element: identifiers only, as the list path populates nothing else. */
+  public static GetViewResponseBody sparseListElement(String viewId) {
+    return GetViewResponseBody.builder().viewId(viewId).databaseId(DATABASE_ID).build();
+  }
+
+  /**
+   * Pointer response whose {@code metadataLocation} and {@code viewVersion} carry distinct
+   * sentinels rather than the production-equal value, so a serialization freeze can pin the two
+   * fields independently. Use {@link #pointerResponse()} wherever production equality matters.
+   */
+  public static GetViewResponseBody pointerResponseWithDistinctPointers() {
+    return pointerResponse()
+        .toBuilder()
+        .metadataLocation(DISTINCT_METADATA_LOCATION)
+        .viewVersion(DISTINCT_VIEW_VERSION)
+        .build();
+  }
+
+  /** Deterministic single page of sparse identifier-only elements. */
+  public static Page<GetViewResponseBody> sparseListPage() {
+    List<GetViewResponseBody> content =
+        Arrays.asList(sparseListElement("my_view"), sparseListElement("my_other_view"));
+    return new PageImpl<>(content, PageRequest.of(0, 50), content.size());
+  }
+
+  public static GetAllViewsResponseBody listResponse() {
+    return GetAllViewsResponseBody.builder().pageResults(sparseListPage()).build();
+  }
+
+  // -----------------------------------------------------------------------------------------
+  // Negative-path fixtures
+  // -----------------------------------------------------------------------------------------
+
+  /** Not JSON at all. */
+  public static final String MALFORMED_SCHEMA_LITERAL = "{\"type\": \"struct\", \"fields\": [";
+
+  /**
+   * The Spark {@code StructType} JSON an engine may reach for by mistake: structurally similar, but
+   * its fields carry {@code nullable}/{@code metadata} instead of the field ids Iceberg requires.
+   */
+  public static final String SPARK_STRUCT_TYPE_SCHEMA_LITERAL =
+      "{\"type\": \"struct\", \"fields\": ["
+          + "{\"name\": \"id\", \"type\": \"string\", \"nullable\": true, \"metadata\": {}}, "
+          + "{\"name\": \"name\", \"type\": \"string\", \"nullable\": true, \"metadata\": {}}]}";
+
+  /**
+   * Two fields sharing field id 1. Iceberg's own parser rejects this while building the schema, so
+   * the validator deliberately has no duplicate-id check of its own.
+   */
+  public static final String DUPLICATE_FIELD_ID_SCHEMA_LITERAL =
+      "{\"type\": \"struct\", \"schema-id\": 0, \"fields\": ["
+          + "{\"id\": 1, \"required\": true, \"name\": \"id\", \"type\": \"string\"}, "
+          + "{\"id\": 1, \"required\": true, \"name\": \"name\", \"type\": \"string\"}]}";
+
+  /**
+   * A valid Iceberg schema padded with insignificant JSON whitespace to exactly {@code totalBytes}
+   * UTF-8 bytes, so a size boundary can be probed without also changing whether it parses.
+   */
+  public static String schemaOfExactUtf8Size(int totalBytes) {
+    int padding = totalBytes - VIEW_SCHEMA_LITERAL.length();
+    if (padding < 0) {
+      throw new IllegalArgumentException(
+          "Requested schema size is smaller than the base schema literal");
+    }
+    return "{" + spaces(padding) + VIEW_SCHEMA_LITERAL.substring(1);
+  }
+
+  /** Opaque SQL padded to exactly {@code totalBytes} UTF-8 bytes. */
+  public static String sqlOfExactUtf8Size(int totalBytes) {
+    int padding = totalBytes - VIEW_SQL.length();
+    if (padding < 0) {
+      throw new IllegalArgumentException("Requested SQL size is smaller than the base SQL literal");
+    }
+    return VIEW_SQL + spaces(padding);
+  }
+
+  /**
+   * SQL built entirely from a two-byte character, so its character count and its UTF-8 byte count
+   * differ by a factor of two. Used to prove the size rules count bytes.
+   */
+  public static String multiByteSql(int characterCount) {
+    char[] characters = new char[characterCount];
+    Arrays.fill(characters, 'é');
+    return new String(characters);
+  }
+
+  private static String spaces(int count) {
+    char[] characters = new char[count];
+    Arrays.fill(characters, ' ');
+    return new String(characters);
+  }
+
+  private static CreateUpdateViewRequestBody.CreateUpdateViewRequestBodyBuilder
+      baseRequestBuilder() {
+    return CreateUpdateViewRequestBody.builder()
+        .viewId(VIEW_ID)
+        .databaseId(DATABASE_ID)
+        .clusterId(CLUSTER_ID)
+        .schema(VIEW_SCHEMA_LITERAL)
+        .representations(Collections.singletonList(SPARK_REPRESENTATION))
+        .sourceDialect(SOURCE_DIALECT)
+        .defaultCatalog(DEFAULT_CATALOG)
+        .defaultNamespace(DEFAULT_NAMESPACE)
+        .viewProperties(VIEW_PROPERTIES);
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/model/ViewModelConstants.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/model/ViewModelConstants.java
@@ -81,7 +81,7 @@ public final class ViewModelConstants {
 
   /** Every field populated, including both nullable optional fields and a replace token. */
   public static CreateUpdateViewRequestBody fullyPopulatedRequest() {
-    return baseRequestBuilder().baseViewVersion(METADATA_LOCATION).build();
+    return baseRequestBuilder().baseMetadataLocation(METADATA_LOCATION).build();
   }
 
   /** POST create shape where the caller omits the base version entirely. */
@@ -91,7 +91,7 @@ public final class ViewModelConstants {
 
   /** POST create shape where the caller sends the table-style initial version token. */
   public static CreateUpdateViewRequestBody createRequestWithInitialBaseVersion() {
-    return baseRequestBuilder().baseViewVersion(INITIAL_TABLE_VERSION).build();
+    return baseRequestBuilder().baseMetadataLocation(INITIAL_TABLE_VERSION).build();
   }
 
   /** Fully populated pointer response for an item GET. */


### PR DESCRIPTION
## Summary

Expand the `/v1/databases/{databaseId}/views` API: models, routes, handler, structural validation, continuation-token pagination, and view-definition audit redaction.

**Business logic remains stubbed.** `ViewsDisabledService` returns `404 VIEWS_DISABLED` for structurally valid requests. No catalog/repository behavior, HTS persistence, actual listing/token generation, admission, or real view authorization enforcement is implemented here. Existing table routes remain separate.

## API contract

- Five `/v1` routes: POST 201, GET item 200, PUT 200/201, GET list 200, DELETE 204. PUT's result flag means created, not successful.
- Create/update requests carry `viewId` and `databaseId`, Iceberg schema JSON, SQL representations, source dialect, resolution context, user properties, and `baseMetadataLocation`. That field is the expected metadata-file path, not a numeric Iceberg/JPA version. POST accepts omission/null or exact `INITIAL_VERSION`; PUT requires a nonblank opaque value.
- View requests omit `clusterId`; cluster identity is server-owned. Response `clusterId` and server-configured logging identity are retained.
- Pointer-only item responses contain `viewId`, `databaseId`, `clusterId`, `metadataLocation`, `viewVersion`, `viewCreator`, `lastModifiedTime`, and `creationTime`; the derived `viewUri` is omitted. SQL/schema/history remain in the metadata file.
- **List requests use optional `pageToken`, optional positive `size` (default 50), and optional `sortBy`.** Omit the token to start. Each continuation request can choose a different size; omission uses 50 again. The existing size range and sort validation are preserved, with no unlimited default or new size cap.
- **List responses contain required array `results` and optional `nextPageToken`.** Omission of the next token means completion, independently of result count. Empty or short pages may still have a token. Sparse item fields remain supported, including an unpopulated creator and zero timestamps. No Spring `Page`, page number, or total-count envelope is exposed for views.
- Any unsupported `page` query key, including a bare/empty key, returns a fixed 400 instead of being silently ignored. Tokens pass through the API/service seam without parsing, trimming, or double-decoding.

## Validation and errors

Structural validation covers identifier consistency, Iceberg schema parsing, unique configured dialects (default `spark`), matching source dialect, reserved-property rejection, and SQL/schema UTF-8 limits of 256 KiB / 512 KiB. Blank supplied page tokens, nonpositive sizes, and composite sort expressions are rejected. No SQL translation or engine validation is added.

A minimal `ViewListResult` carries ordered DTOs and the next token from the service to the existing mapper. Invalid server output fails as 500 rather than becoming a successful empty/terminal page. The common table/job/HTS pagination rules are unchanged.

The 14-value `ViewErrorCode` taxonomy selects HTTP status only; the shared error envelope is unchanged. The internal 503 code is named `VIEW_SERVICE_UNAVAILABLE`; `VIEW_ADMISSION_FAILED` remains reserved for admission rejection. Endpoint docs distinguish service failures from gateway 502/504 outcomes and warn against blindly retrying writes with unknown outcomes. Engine-to-API exception translation remains tracked in [BDP-108413](https://linkedin.atlassian.net/browse/BDP-108413?focusedCommentId=44320269).

## Testing Done

**Latest follow-up validation: 270 view tests and 24 table-controller tests passed**, with no failures, errors, or skips. Coverage includes service-owned creator/modification metadata, exact Jackson/Gson values and read-only declarations, sparse responses, ignored forged metadata, unchanged requests, and the renamed 503 code. Independent design, test, and final reviews passed.

Earlier validation: **331 targeted tests across 21 suites passed**, with no failures, errors, or skips. Coverage includes exact Jackson/Gson list envelopes, token omission and verbatim forwarding, first/continuation/terminal requests, empty/short/full pages, size changes, unsupported-parameter rejection, input and server-output failures, disabled-service behavior, authorization declarations, table-pagination regressions, cluster-free/forged requests, preserved response/logging identity, and failed-parse/redaction event retention. The pagination change followed independently reviewed design and tests-first implementation.

Tables Checkstyle and Spotless checks passed; existing warning-severity Checkstyle diagnostics remain. A freshly served `/v3/api-docs` document confirms only `pageToken`/`size`/`sortBy` query parameters, default size 50, required results array, and optional string next token. The view request schema has nine fields without `clusterId`; the view response has eight read-only fields without `viewUri`. Response `clusterId`, table request `clusterId`, and table response `tableUri` remain. The Java table client was regenerated and compiled successfully against that document; generated build artifacts are not committed.

## Scope notes

- Token format, validation of token context/expiry, ordering and concurrency consistency, actual database traversal, and automatic client pagination belong to the real service/client implementation. Successful walkthrough tests use a mocked service behind the real controller/handler/validator/mapper.
- Existing raw query-string auditing is unchanged, so page tokens can appear in audit URLs. No token confidentiality guarantee is introduced. Body redaction continues protecting view SQL/schema.
- `@Secured` declares view privileges; real view authorization, per-database gating, and namespace-collision behavior remain deferred.
- No changes to other resources' pagination, response-identity choices, or dialect-generation implementation.
