### PR TITLE
Add cluster.yaml support for write.orc.compression-codec

### DIFF
--- a/cluster/configs/src/main/java/com/linkedin/openhouse/cluster/configs/ClusterProperties.java
+++ b/cluster/configs/src/main/java/com/linkedin/openhouse/cluster/configs/ClusterProperties.java
@@ -40,6 +40,9 @@ public class ClusterProperties {
   @Value("${cluster.iceberg.write.format.default:orc}")
   private String clusterIcebergWriteFormatDefault;
 
+  @Value("${cluster.iceberg.write.orc.compression-codec:#{null}}")
+  private String clusterIcebergWriteOrcCompressionCodec;
+
   @Value("${cluster.iceberg.format-version:2}")
   private int clusterIcebergFormatVersion;
 

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -545,6 +545,15 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
           clusterProperties.getClusterIcebergWriteFormatDefault());
     }
 
+    // Only set cluster default for ORC_COMPRESSION if it is configured at the cluster level and the
+    // user hasn't provided a value.
+    String clusterOrcCompressionCodec =
+        clusterProperties.getClusterIcebergWriteOrcCompressionCodec();
+    if (clusterOrcCompressionCodec != null
+        && !propertiesMap.containsKey(TableProperties.ORC_COMPRESSION)) {
+      propertiesMap.put(TableProperties.ORC_COMPRESSION, clusterOrcCompressionCodec);
+    }
+
     // Populate server reserved properties
     Map<String, String> dtoMap = tableDto.convertToMap();
     for (String htsFieldName : HTS_FIELD_NAMES) {

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/properties/CustomClusterPropertiesTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/properties/CustomClusterPropertiesTest.java
@@ -34,6 +34,11 @@ public class CustomClusterPropertiesTest {
         Arrays.asList("trino", "spark"), clusterProperties.getAllowedClientNameValues());
   }
 
+  @Test
+  public void testClusterPropertiesIcebergOrcCompressionCodec() {
+    Assertions.assertEquals("zstd", clusterProperties.getClusterIcebergWriteOrcCompressionCodec());
+  }
+
   @AfterAll
   static void unsetSysProp() {
     System.clearProperty("OPENHOUSE_CLUSTER_CONFIG_PATH");

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/properties/DefaultClusterPropertiesTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/properties/DefaultClusterPropertiesTest.java
@@ -19,6 +19,11 @@ public class DefaultClusterPropertiesTest {
     Assertions.assertEquals("local-cluster", clusterProperties.getClusterName());
   }
 
+  @Test
+  public void testClusterPropertiesIcebergOrcCompressionCodecDefaultsToNull() {
+    Assertions.assertNull(clusterProperties.getClusterIcebergWriteOrcCompressionCodec());
+  }
+
   @AfterAll
   static void unsetSysProp() {
     System.clearProperty("OPENHOUSE_CLUSTER_CONFIG_PATH");

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImplTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImplTest.java
@@ -98,6 +98,44 @@ public class OpenHouseInternalRepositoryImplTest {
   }
 
   @Test
+  void testComputePropsForTableCreation_ClusterOrcCompressionCodec() {
+    when(clusterProperties.getClusterIcebergWriteOrcCompressionCodec()).thenReturn("zstd");
+
+    TableDto tableDto = createTableDto(new HashMap<>());
+    Map<String, String> actualProps =
+        openHouseInternalRepository.computePropsForTableCreation(tableDto);
+
+    Assertions.assertEquals("zstd", actualProps.get(TableProperties.ORC_COMPRESSION));
+  }
+
+  @Test
+  void testComputePropsForTableCreation_UserProvidedOrcCompressionCodecWins() {
+    // Cluster default is set but the user-provided value should take precedence.
+    when(clusterProperties.getClusterIcebergWriteOrcCompressionCodec()).thenReturn("zstd");
+
+    Map<String, String> userProps = new HashMap<>();
+    userProps.put(TableProperties.ORC_COMPRESSION, "snappy");
+    TableDto tableDto = createTableDto(userProps);
+
+    Map<String, String> actualProps =
+        openHouseInternalRepository.computePropsForTableCreation(tableDto);
+
+    Assertions.assertEquals("snappy", actualProps.get(TableProperties.ORC_COMPRESSION));
+  }
+
+  @Test
+  void testComputePropsForTableCreation_NoOrcCompressionCodecWhenClusterUnset() {
+    // When the cluster does not configure a codec, the property should not be set.
+    when(clusterProperties.getClusterIcebergWriteOrcCompressionCodec()).thenReturn(null);
+
+    TableDto tableDto = createTableDto(new HashMap<>());
+    Map<String, String> actualProps =
+        openHouseInternalRepository.computePropsForTableCreation(tableDto);
+
+    Assertions.assertFalse(actualProps.containsKey(TableProperties.ORC_COMPRESSION));
+  }
+
+  @Test
   void testComputePropsForTableCreation_tableLocation() {
     TableDto tableDto = createTableDto(new HashMap<>());
     tableDto = tableDto.toBuilder().tableLocation("file:///data/openhouse/db/table").build();

--- a/services/tables/src/test/resources/cluster-test-properties.yaml
+++ b/services/tables/src/test/resources/cluster-test-properties.yaml
@@ -20,6 +20,10 @@ cluster:
         storage-type: local
   housetables:
     base-uri: "http://localhost:8080"
+  iceberg:
+    write:
+      orc:
+        compression-codec: "zstd"
   tables:
     allowed-client-name-values: trino,spark
   security:


### PR DESCRIPTION
## Summary

Introduce a new cluster config key
`cluster.iceberg.write.orc.compression-codec` in ClusterProperties and apply it to new tables as the Iceberg `TableProperties.ORC_COMPRESSION` table property during table creation.

The cluster value is only applied when configured (defaults to null) and when the user has not explicitly provided the property, mirroring the existing `write.format.default` behavior.

Adds unit tests for the property-to-table mapping and YAML parsing coverage (custom value + null default).

## Changes

- [ ] Client-facing API Changes
- [x] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
