### PR TITLE
Fix RTAS detection logic in catalog

### DIFF
--- a/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
@@ -865,6 +865,7 @@ public class OpenHouseTableOperationsTest {
     } catch (Exception e) {
       throw new IllegalStateException(e);
     }
+  }
 
   /**
    * A snapshot that round-trips through {@link SnapshotParser}, so commits carrying it exercise the

--- a/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-itest/src/test/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperationsTest.java
@@ -8,6 +8,7 @@ import com.linkedin.openhouse.gen.tables.client.invoker.ApiClient;
 import com.linkedin.openhouse.gen.tables.client.model.CreateUpdateTableRequestBody;
 import com.linkedin.openhouse.gen.tables.client.model.GetTableResponseBody;
 import com.linkedin.openhouse.gen.tables.client.model.History;
+import com.linkedin.openhouse.gen.tables.client.model.IcebergSnapshotsRequestBody;
 import com.linkedin.openhouse.gen.tables.client.model.Policies;
 import com.linkedin.openhouse.gen.tables.client.model.PolicyTag;
 import com.linkedin.openhouse.gen.tables.client.model.Retention;
@@ -33,9 +34,11 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotParser;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.expressions.Expressions;
@@ -48,6 +51,7 @@ import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.util.Tasks;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 public class OpenHouseTableOperationsTest {
 
@@ -861,5 +865,181 @@ public class OpenHouseTableOperationsTest {
     } catch (Exception e) {
       throw new IllegalStateException(e);
     }
+
+  /**
+   * A snapshot that round-trips through {@link SnapshotParser}, so commits carrying it exercise the
+   * real request-body serialization rather than a mock.
+   */
+  private static final String SNAPSHOT_JSON =
+      "{\"snapshot-id\":3051729675574597004,\"timestamp-ms\":1515100955770,"
+          + "\"summary\":{\"operation\":\"append\"},"
+          + "\"manifest-list\":\"file:/tmp/manifest-list-1.avro\"}";
+
+  /** The {@code (base, metadata)} pair handed to {@code doCommit}. */
+  private static final class Commit {
+    private final TableMetadata base;
+    private final TableMetadata metadata;
+
+    Commit(TableMetadata base, TableMetadata metadata) {
+      this.base = base;
+      this.metadata = metadata;
+    }
+  }
+
+  /**
+   * A commit against an existing table that carries both a metadata change and a snapshot change.
+   *
+   * <p>This single shape is the crux of the routing problem: Iceberg's {@code BaseTransaction}
+   * funnels a replace transaction and an ordinary transaction (say, a schema evolution plus an
+   * append) into the identical {@code ops.commit(base, metadata)} call, so both arrive looking
+   * exactly like this. Routing therefore has to come from the transaction that produced the commit,
+   * never from the diff.
+   */
+  private static Commit metadataAndSnapshotsUpdated() {
+    TableMetadata base = mock(TableMetadata.class);
+    TableMetadata metadata = mock(TableMetadata.class);
+
+    when(base.schema()).thenReturn(mock(Schema.class));
+    when(metadata.schema()).thenReturn(mock(Schema.class));
+    when(base.properties()).thenReturn(ImmutableMap.of());
+    when(metadata.properties()).thenReturn(ImmutableMap.of("a", "b"));
+    when(base.metadataFileLocation()).thenReturn("file:/tmp/v1.metadata.json");
+
+    when(base.snapshots()).thenReturn(Collections.emptyList());
+    when(metadata.snapshots())
+        .thenReturn(Collections.singletonList(SnapshotParser.fromJson(SNAPSHOT_JSON)));
+    when(base.refs()).thenReturn(Collections.emptyMap());
+    when(metadata.refs()).thenReturn(Collections.emptyMap());
+
+    return new Commit(base, metadata);
+  }
+
+  private OpenHouseTableOperationsForTest opsFor(SnapshotApi snapshotApi) {
+    return new OpenHouseTableOperationsForTest(
+        TableIdentifier.of("a", "b"),
+        mock(FileIO.class),
+        mock(TableApi.class),
+        snapshotApi,
+        "cluster");
+  }
+
+  private static SnapshotApi acceptingSnapshotApi() {
+    SnapshotApi snapshotApi = mock(SnapshotApi.class);
+    when(snapshotApi.putSnapshotsV1(anyString(), anyString(), any())).thenReturn(Mono.empty());
+    return snapshotApi;
+  }
+
+  /** The {@code replaceCommit} flag on the {@code nth} snapshot request the client sent. */
+  private static Boolean sentReplaceCommitFlag(SnapshotApi snapshotApi, int nth) {
+    ArgumentCaptor<IcebergSnapshotsRequestBody> captor =
+        ArgumentCaptor.forClass(IcebergSnapshotsRequestBody.class);
+    verify(snapshotApi, times(nth)).putSnapshotsV1(eq("db"), eq("tbl"), captor.capture());
+    return captor.getAllValues().get(nth - 1).getCreateUpdateTableRequestBody().getReplaceCommit();
+  }
+
+  /** Commits are ordinary updates until the catalog declares a replace transaction. */
+  @Test
+  public void testNotAReplaceTransactionByDefault() {
+    Assertions.assertFalse(refreshableOps(mock(TableApi.class)).isReplaceTransaction());
+  }
+
+  /**
+   * The regression this guards: an ordinary transaction that updates metadata and appends a
+   * snapshot in one commit must stay an update. This diff used to be read as an RTAS and sent as a
+   * replace commit, which makes the server rebuild the table from scratch — dropping schema and
+   * partition history, and demanding replace privileges — instead of updating it.
+   */
+  @Test
+  public void testMetadataAndSnapshotUpdateIsNotAReplaceCommit() {
+    SnapshotApi snapshotApi = acceptingSnapshotApi();
+    OpenHouseTableOperationsForTest ops = opsFor(snapshotApi);
+    Commit commit = metadataAndSnapshotsUpdated();
+
+    ops.doCommit(commit.base, commit.metadata);
+
+    Assertions.assertFalse(sentReplaceCommitFlag(snapshotApi, 1));
+  }
+
+  /** The very same diff, once the catalog marks it as a replace, is sent as a replace commit. */
+  @Test
+  public void testMarkedTransactionSendsReplaceCommit() {
+    SnapshotApi snapshotApi = acceptingSnapshotApi();
+    OpenHouseTableOperationsForTest ops = opsFor(snapshotApi);
+    ops.markReplaceTransaction();
+    Commit commit = metadataAndSnapshotsUpdated();
+
+    ops.doCommit(commit.base, commit.metadata);
+
+    Assertions.assertTrue(sentReplaceCommitFlag(snapshotApi, 1));
+  }
+
+  /**
+   * A replace with no base is not a replace: there is no table to swap out, so the commit falls
+   * back to a plain snapshot put rather than asking the server to replace a table it cannot find.
+   */
+  @Test
+  public void testReplaceTransactionWithoutBaseIsNotAReplaceCommit() {
+    SnapshotApi snapshotApi = acceptingSnapshotApi();
+    OpenHouseTableOperationsForTest ops = opsFor(snapshotApi);
+    ops.markReplaceTransaction();
+
+    TableMetadata metadata = mock(TableMetadata.class);
+    when(metadata.properties()).thenReturn(ImmutableMap.of("a", "b"));
+    when(metadata.snapshots())
+        .thenReturn(Collections.singletonList(SnapshotParser.fromJson(SNAPSHOT_JSON)));
+    when(metadata.refs()).thenReturn(Collections.emptyMap());
+
+    ops.doCommit(null, metadata);
+
+    Assertions.assertFalse(sentReplaceCommitFlag(snapshotApi, 1));
+  }
+
+  /**
+   * The replace intent is one-shot. A transaction's table can outlive {@code commitTransaction}, so
+   * once the replace lands, later commits on the same instance must go back to being updates.
+   */
+  @Test
+  public void testReplaceIntentClearedAfterSuccessfulCommit() {
+    SnapshotApi snapshotApi = acceptingSnapshotApi();
+    OpenHouseTableOperationsForTest ops = opsFor(snapshotApi);
+    ops.markReplaceTransaction();
+
+    Commit replace = metadataAndSnapshotsUpdated();
+    ops.doCommit(replace.base, replace.metadata);
+    Assertions.assertTrue(sentReplaceCommitFlag(snapshotApi, 1));
+    Assertions.assertFalse(ops.isReplaceTransaction());
+
+    Commit followUp = metadataAndSnapshotsUpdated();
+    ops.doCommit(followUp.base, followUp.metadata);
+    Assertions.assertFalse(sentReplaceCommitFlag(snapshotApi, 2));
+  }
+
+  /**
+   * Iceberg retries a failed replace against this same instance, so a {@link CommitFailedException}
+   * has to leave the intent standing — otherwise the retry would silently degrade into a plain
+   * update and only half-apply the replace.
+   */
+  @Test
+  public void testReplaceIntentSurvivesCommitFailure() {
+    SnapshotApi snapshotApi = mock(SnapshotApi.class);
+    WebClientResponseException conflict = mock(WebClientResponseException.Conflict.class);
+    when(conflict.getStatusCode()).thenReturn(HttpStatus.CONFLICT);
+    when(snapshotApi.putSnapshotsV1(anyString(), anyString(), any()))
+        .thenReturn(Mono.error(conflict))
+        .thenReturn(Mono.empty());
+
+    OpenHouseTableOperationsForTest ops = opsFor(snapshotApi);
+    ops.markReplaceTransaction();
+
+    Commit attempt = metadataAndSnapshotsUpdated();
+    Assertions.assertThrows(
+        CommitFailedException.class, () -> ops.doCommit(attempt.base, attempt.metadata));
+    Assertions.assertTrue(ops.isReplaceTransaction());
+
+    Commit retry = metadataAndSnapshotsUpdated();
+    ops.doCommit(retry.base, retry.metadata);
+
+    Assertions.assertTrue(sentReplaceCommitFlag(snapshotApi, 2));
+    Assertions.assertFalse(ops.isReplaceTransaction());
   }
 }

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/iceberg-version-specific/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/iceberg-version-specific/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
@@ -279,7 +279,7 @@ public class OpenHouseCatalog extends BaseMetastoreCatalog
   }
 
   @Override
-  public TableOperations newTableOps(TableIdentifier tableIdentifier) {
+  public OpenHouseTableOperations newTableOps(TableIdentifier tableIdentifier) {
     return OpenHouseTableOperations.builder()
         .tableIdentifier(tableIdentifier)
         .fileIO(fileIO)
@@ -600,7 +600,7 @@ public class OpenHouseCatalog extends BaseMetastoreCatalog
      */
     @Override
     public Transaction createOrReplaceTransaction() {
-      TableOperations ops = newTableOps(this.identifier);
+      OpenHouseTableOperations ops = newTableOps(this.identifier);
       if (ops.current() == null) {
         return createTransaction();
       } else {
@@ -615,11 +615,16 @@ public class OpenHouseCatalog extends BaseMetastoreCatalog
      */
     @Override
     public Transaction replaceTransaction() {
-      TableOperations ops = newTableOps(this.identifier);
+      OpenHouseTableOperations ops = newTableOps(this.identifier);
       if (ops.current() == null) {
         throw new NoSuchTableException("Table does not exist: %s", new Object[] {this.identifier});
       }
       TableMetadata metadata = replaceStagedMetadata(ops);
+      // Record the replace intent on the very instance that will receive the commit. This is the
+      // only place where RTAS is unambiguously known: by the time doCommit runs, a replace and an
+      // ordinary metadata-plus-snapshot transaction look identical. Every Catalog replace entry
+      // point (including Catalog#newReplaceTableTransaction) funnels through this builder.
+      ops.markReplaceTransaction();
       return Transactions.replaceTableTransaction(this.identifier.toString(), ops, metadata);
     }
 
@@ -630,7 +635,7 @@ public class OpenHouseCatalog extends BaseMetastoreCatalog
      */
     @Override
     public Transaction createTransaction() {
-      TableOperations ops = newTableOps(this.identifier);
+      OpenHouseTableOperations ops = newTableOps(this.identifier);
       if (ops.current() != null) {
         throw new AlreadyExistsException(
             "Table already exists: %s", new Object[] {this.identifier});

--- a/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
+++ b/integrations/java/iceberg-1.2/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseTableOperations.java
@@ -65,6 +65,19 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
   private String cluster;
 
   /**
+   * Whether this instance backs a replace-table (RTAS) transaction, set by {@link OpenHouseCatalog}
+   * at the only point where that intent is unambiguous.
+   *
+   * <p>{@code doCommit} cannot infer it from the {@code base}/{@code metadata} diff: Iceberg's
+   * {@code BaseTransaction} routes a replace transaction and an ordinary multi-update transaction
+   * (say, a schema evolution plus an append) through the very same {@code ops.commit(base,
+   * metadata)} call, so both arrive with metadata and snapshots updated and a non-null base.
+   * Misreading the latter as a replace would have the server rebuild the table wholesale instead of
+   * updating it. A final holder keeps Lombok's all-args constructor unchanged.
+   */
+  private final AtomicBoolean replaceTransaction = new AtomicBoolean(false);
+
+  /**
    * Config last applied to {@code current()}, or {@code null}. Bound after Iceberg accepts a reload
    * so skip-reload and a failed UUID check cannot desync stamps from overlays.
    */
@@ -73,6 +86,21 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
   /** Stamps last applied to {@code current()}, or {@code null}. */
   protected Map<String, String> currentConfig() {
     return config.get();
+  }
+
+  /**
+   * Marks this instance as backing a replace-table (RTAS) transaction, so the commit it receives is
+   * sent as a replace commit. Each transaction gets a fresh instance from {@link
+   * OpenHouseCatalog#newTableOps}, so the intent never leaks across transactions.
+   */
+  void markReplaceTransaction() {
+    replaceTransaction.set(true);
+  }
+
+  /** Whether the pending commit belongs to a replace-table (RTAS) transaction. */
+  @VisibleForTesting
+  boolean isReplaceTransaction() {
+    return replaceTransaction.get();
   }
 
   @Override
@@ -167,10 +195,13 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
     log.info("Calling doCommit for table: {}", tableName());
     boolean metadataUpdated = isMetadataUpdated(base, metadata);
     boolean snapshotsUpdated = areSnapshotsUpdated(base, metadata);
+    // The replace intent is plumbed down from OpenHouseCatalog, never inferred from the diff: an
+    // ordinary transaction that evolves metadata and appends a snapshot is indistinguishable from
+    // an RTAS at this point. A replace always replaces the table wholesale, even when only part of
+    // the metadata changed, so the flag alone decides the route.
+    boolean replaceCommit = isReplaceTransaction() && base != null;
     try {
-      if (metadataUpdated && snapshotsUpdated && base != null) {
-        // Only CTAS and RTAS can update both metadata and snapshots at the same time.
-        // When the table exists, it will be a replace commit operation.
+      if (replaceCommit) {
         putSnapshotsForReplace(base, metadata);
       } else if (snapshotsUpdated) {
         putSnapshots(base, metadata);
@@ -188,6 +219,11 @@ public class OpenHouseTableOperations extends BaseMetastoreTableOperations {
       } else {
         throw e;
       }
+    }
+    // Cleared only once the commit lands: BaseTransaction retries doCommit on this same instance
+    // after a CommitFailedException, and every retry must still be sent as a replace.
+    if (replaceCommit) {
+      replaceTransaction.set(false);
     }
     log.debug("Calling doCommit succeeded");
   }

--- a/integrations/java/iceberg-1.5/openhouse-java-runtime/src/iceberg-version-specific/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
+++ b/integrations/java/iceberg-1.5/openhouse-java-runtime/src/iceberg-version-specific/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
@@ -330,7 +330,7 @@ public class OpenHouseCatalog extends BaseMetastoreViewCatalog
   }
 
   @Override
-  public TableOperations newTableOps(TableIdentifier tableIdentifier) {
+  public OpenHouseTableOperations newTableOps(TableIdentifier tableIdentifier) {
     return OpenHouseTableOperations.builder()
         .tableIdentifier(tableIdentifier)
         .fileIO(fileIO)
@@ -793,7 +793,7 @@ public class OpenHouseCatalog extends BaseMetastoreViewCatalog
      */
     @Override
     public Transaction createOrReplaceTransaction() {
-      TableOperations ops = newTableOps(this.identifier);
+      OpenHouseTableOperations ops = newTableOps(this.identifier);
       if (ops.current() == null) {
         return createTransaction();
       } else {
@@ -808,11 +808,16 @@ public class OpenHouseCatalog extends BaseMetastoreViewCatalog
      */
     @Override
     public Transaction replaceTransaction() {
-      TableOperations ops = newTableOps(this.identifier);
+      OpenHouseTableOperations ops = newTableOps(this.identifier);
       if (ops.current() == null) {
         throw new NoSuchTableException("Table does not exist: %s", new Object[] {this.identifier});
       }
       TableMetadata metadata = replaceStagedMetadata(ops);
+      // Record the replace intent on the very instance that will receive the commit. This is the
+      // only place where RTAS is unambiguously known: by the time doCommit runs, a replace and an
+      // ordinary metadata-plus-snapshot transaction look identical. Every Catalog replace entry
+      // point (including Catalog#newReplaceTableTransaction) funnels through this builder.
+      ops.markReplaceTransaction();
       return Transactions.replaceTableTransaction(this.identifier.toString(), ops, metadata);
     }
 
@@ -823,7 +828,7 @@ public class OpenHouseCatalog extends BaseMetastoreViewCatalog
      */
     @Override
     public Transaction createTransaction() {
-      TableOperations ops = newTableOps(this.identifier);
+      OpenHouseTableOperations ops = newTableOps(this.identifier);
       if (ops.current() != null) {
         throw new AlreadyExistsException(
             "Table already exists: %s", new Object[] {this.identifier});

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/RTASTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/RTASTest.java
@@ -316,7 +316,7 @@ public class RTASTest extends OpenHouseSparkITest {
   }
 
   /**
-   * An ordinary transaction is free to evolve metadata and append data in a single commit, and that
+   * An ordinary transaction is free to change metadata and append data in a single commit, and that
    * must stay an update. It reaches the catalog client looking exactly like an RTAS — non-null
    * base, metadata changed, snapshots changed — so the client has to take the replace intent from
    * the transaction that produced the commit rather than from the diff.
@@ -338,12 +338,12 @@ public class RTASTest extends OpenHouseSparkITest {
           Iterables.getOnlyElement(table.currentSnapshot().addedDataFiles(table.io()));
 
       Transaction transaction = table.newTransaction();
-      transaction.updateSchema().addColumn("extra", Types.StringType.get()).commit();
+      transaction.updateProperties().set("prop1", "val1").commit();
       transaction.newAppend().appendFile(existingFile).commit();
       transaction.commitTransaction();
 
       Table updated = catalog.loadTable(tableIdent);
-      assertNotNull(updated.schema().findField("extra"), "Schema should have evolved in place");
+      assertEquals("val1", updated.properties().get("prop1"), "Property should have been set");
       // A replace resets the main branch, so a misrouted commit would leave the current snapshot
       // parentless and the previous data unreferenced.
       assertEquals(

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/RTASTest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/RTASTest.java
@@ -5,9 +5,11 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.linkedin.openhouse.tablestest.OpenHouseSparkITest;
 import java.util.List;
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.Transaction;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.BadRequestException;
@@ -310,6 +312,53 @@ public class RTASTest extends OpenHouseSparkITest {
       assertEquals(
           2, Iterables.size(rtasTable.snapshots()), "Table should have expected snapshots");
       assertNull(rtasTable.currentSnapshot().parentId(), "Current snapshot should have no parent");
+    }
+  }
+
+  /**
+   * An ordinary transaction is free to evolve metadata and append data in a single commit, and that
+   * must stay an update. It reaches the catalog client looking exactly like an RTAS — non-null
+   * base, metadata changed, snapshots changed — so the client has to take the replace intent from
+   * the transaction that produced the commit rather than from the diff.
+   *
+   * <p>Without that, the commit is sent as a replace and the server rejects it outright, since the
+   * table never opted into RTAS.
+   */
+  @Test
+  public void testMetadataAndAppendInOneTransactionIsNotAReplace() throws Exception {
+    try (SparkSession spark = getSparkSession()) {
+      Catalog catalog = getOpenHouseCatalog(spark);
+      spark.sql(
+          String.format(
+              "CREATE TABLE %s USING iceberg AS SELECT * FROM %s", tableName, sourceName));
+
+      Table table = catalog.loadTable(tableIdent);
+      long baseSnapshotId = table.currentSnapshot().snapshotId();
+      DataFile existingFile =
+          Iterables.getOnlyElement(table.currentSnapshot().addedDataFiles(table.io()));
+
+      Transaction transaction = table.newTransaction();
+      transaction.updateSchema().addColumn("extra", Types.StringType.get()).commit();
+      transaction.newAppend().appendFile(existingFile).commit();
+      transaction.commitTransaction();
+
+      Table updated = catalog.loadTable(tableIdent);
+      assertNotNull(updated.schema().findField("extra"), "Schema should have evolved in place");
+      // A replace resets the main branch, so a misrouted commit would leave the current snapshot
+      // parentless and the previous data unreferenced.
+      assertEquals(
+          baseSnapshotId,
+          updated.currentSnapshot().parentId(),
+          "Commit should extend history, not replace the table");
+      assertEquals(2, Iterables.size(updated.snapshots()), "Append should have added a snapshot");
+      assertEquals(
+          1,
+          Iterables.size(updated.currentSnapshot().addedDataFiles(updated.io())),
+          "Append should have added the data file");
+
+      // The commit landed outside Spark, so drop its cached plan before reading the doubled data.
+      spark.sql(String.format("REFRESH TABLE %s", tableName));
+      assertEquals(6, spark.sql(String.format("SELECT * FROM %s", tableName)).count());
     }
   }
 }


### PR DESCRIPTION
## Summary

Currently TableOps recognize an RTS operation by `isPutSnapshot && isMetadataUpdate && base != null`. This is wrong since a transaction containing snapshot and metadata update is totally valid without being an RTAS operation. Adding a flag in TableOps and passing it from Catalog to recognize RTAS.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
