### PR TITLE
fix: guard table rename against concurrent commits

### DIFF
--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -392,12 +392,20 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
                   && !properties
                       .get(CatalogConstants.OPENHOUSE_DATABASEID_KEY)
                       .equalsIgnoreCase(this.tableIdentifier.namespace().toString()))) {
+        // tableVersion carries the pre-commit tableLocation, which gives the rename the same
+        // optimistic-concurrency token as the save path. HTS returns a retriable conflict when a
+        // concurrent commit advances the table after this writer's load.
+        Optional<String> expectedMetadataLocation =
+            CatalogConstants.INITIAL_VERSION.equals(houseTable.getTableVersion())
+                ? Optional.empty()
+                : Optional.of(houseTable.getTableVersion());
         houseTableRepository.rename(
             this.tableIdentifier.namespace().toString(),
             this.tableIdentifier.name(),
             properties.get(CatalogConstants.OPENHOUSE_DATABASEID_KEY),
             properties.get(CatalogConstants.OPENHOUSE_TABLEID_KEY),
-            newMetadataLocation);
+            newMetadataLocation,
+            expectedMetadataLocation);
       } else if (!isStageCreate && !isStageReplace) {
         Span htsSpan = tracer.spanBuilder("IcebergTableOps.saveHouseTable").startSpan();
         try (Scope ignored = htsSpan.makeCurrent()) {

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepository.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepository.java
@@ -2,7 +2,9 @@ package com.linkedin.openhouse.internal.catalog.repository;
 
 import com.linkedin.openhouse.internal.catalog.model.HouseTable;
 import com.linkedin.openhouse.internal.catalog.model.HouseTablePrimaryKey;
+import com.linkedin.openhouse.internal.catalog.repository.exception.HouseTableConcurrentUpdateException;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.PagingAndSortingRepository;
@@ -28,12 +30,29 @@ public interface HouseTableRepository
 
   Page<HouseTable> findAllByDatabaseId(String databaseId, Pageable pageable);
 
+  /**
+   * Rename a table, updating its metadata location.
+   *
+   * @param fromDatabaseId databaseId of the table to rename
+   * @param fromTableId tableId of the table to rename
+   * @param toDatabaseId destination databaseId
+   * @param toTableId destination tableId
+   * @param metadataLocation the new metadata file reflecting the renamed identifiers
+   * @param expectedMetadataLocation the metadata location the caller observed when it initiated the
+   *     rename. A present value must still be current when the rename lands. An empty value lets
+   *     the service establish its own version-qualified base.
+   * @throws HouseTableConcurrentUpdateException if the table advances past a present {@code
+   *     expectedMetadataLocation} before the rename lands. Every implementation signals this type
+   *     so {@code OpenHouseInternalTableOperations.doCommit} converts it into a retriable {@code
+   *     CommitFailedException}. Other unchecked types reach the client as terminal failures.
+   */
   void rename(
       String fromDatabaseId,
       String fromTableId,
       String toDatabaseId,
       String toTableId,
-      String metadataLocation);
+      String metadataLocation,
+      Optional<String> expectedMetadataLocation);
 
   /**
    * Find all soft-deleted tables by database ID with pagination and optional filtering

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepositoryImpl.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepositoryImpl.java
@@ -242,13 +242,19 @@ public class HouseTableRepositoryImpl implements HouseTableRepository {
       String fromTableId,
       String toDatabaseId,
       String toTableId,
-      String metadataLocation) {
+      String metadataLocation,
+      Optional<String> expectedMetadataLocation) {
     getHtsRetryTemplate(Arrays.asList(IllegalStateException.class))
         .execute(
             context ->
                 apiInstance
                     .renameTable(
-                        fromDatabaseId, fromTableId, toDatabaseId, toTableId, metadataLocation)
+                        fromDatabaseId,
+                        fromTableId,
+                        toDatabaseId,
+                        toTableId,
+                        metadataLocation,
+                        expectedMetadataLocation.orElse(null))
                     .onErrorResume(e -> handleHtsHttpError(e).then())
                     .block());
   }

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
@@ -223,6 +223,64 @@ public class OpenHouseInternalTableOperationsTest {
   }
 
   /**
+   * A rename commit declares the writer's base metadata location (the pre-commit tableLocation,
+   * surfaced as {@code HouseTable#getTableVersion()}) so HTS returns a conflict when a concurrent
+   * commit advances the table.
+   */
+  @Test
+  void testDoCommitRenamePassesExpectedMetadataLocation() {
+    Map<String, String> properties = new HashMap<>(BASE_TABLE_METADATA.properties());
+    try (MockedStatic<TableMetadataParser> ignoreWriteMock =
+        Mockito.mockStatic(TableMetadataParser.class)) {
+      properties.put(getCanonicalFieldName("tableLocation"), TEST_LOCATION);
+      properties.put(CatalogConstants.OPENHOUSE_TABLEID_KEY, "test_table_renamed");
+      properties.put(CatalogConstants.OPENHOUSE_DATABASEID_KEY, "test_db");
+      TableMetadata metadata = BASE_TABLE_METADATA.replaceProperties(properties);
+      Mockito.when(mockHouseTable.getTableVersion()).thenReturn(TEST_LOCATION);
+
+      openHouseInternalTableOperations.doCommit(BASE_TABLE_METADATA, metadata);
+
+      Mockito.verify(mockHouseTableRepository, Mockito.times(1))
+          .rename(
+              Mockito.eq("test_db"),
+              Mockito.eq("test_table"),
+              Mockito.eq("test_db"),
+              Mockito.eq("test_table_renamed"),
+              Mockito.anyString(),
+              Mockito.eq(Optional.of(TEST_LOCATION)));
+      Mockito.verify(mockHouseTableRepository, Mockito.never()).save(Mockito.any());
+    }
+  }
+
+  /**
+   * A rename whose writer is at INITIAL_VERSION uses an empty expected metadata location. HTS then
+   * establishes the base through its read and version-qualified update.
+   */
+  @Test
+  void testDoCommitRenameWithoutPersistedBaseOmitsExpectedMetadataLocation() {
+    Map<String, String> properties = new HashMap<>(BASE_TABLE_METADATA.properties());
+    try (MockedStatic<TableMetadataParser> ignoreWriteMock =
+        Mockito.mockStatic(TableMetadataParser.class)) {
+      properties.put(CatalogConstants.OPENHOUSE_TABLEID_KEY, "test_table_renamed");
+      properties.put(CatalogConstants.OPENHOUSE_DATABASEID_KEY, "test_db");
+      TableMetadata metadata = BASE_TABLE_METADATA.replaceProperties(properties);
+      Mockito.when(mockHouseTable.getTableVersion()).thenReturn(CatalogConstants.INITIAL_VERSION);
+
+      openHouseInternalTableOperations.doCommit(BASE_TABLE_METADATA, metadata);
+
+      Mockito.verify(mockHouseTableRepository, Mockito.times(1))
+          .rename(
+              Mockito.eq("test_db"),
+              Mockito.eq("test_table"),
+              Mockito.eq("test_db"),
+              Mockito.eq("test_table_renamed"),
+              Mockito.anyString(),
+              Mockito.eq(Optional.empty()));
+      Mockito.verify(mockHouseTableRepository, Mockito.never()).save(Mockito.any());
+    }
+  }
+
+  /**
    * Deterministic local reproduction of incident-12185 -- the {@code BaseTransaction.applyUpdates}
    * silent-rebase variant of the stale-base lost-update class (2026-05-25 WAR fingerprint, where
    * snapshot 3635817277608242413 was silently rebased out by a concurrent commit).

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepositoryImplTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/repository/HouseTableRepositoryImplTest.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -327,7 +328,46 @@ public class HouseTableRepositoryImplTest {
                 HOUSE_TABLE.getTableId(),
                 HOUSE_TABLE_SAME_DB.getDatabaseId(),
                 HOUSE_TABLE.getTableId() + "_renamed",
-                HOUSE_TABLE.getTableLocation() + "_v2"));
+                HOUSE_TABLE.getTableLocation() + "_v2",
+                Optional.of(HOUSE_TABLE.getTableLocation())));
+  }
+
+  @Test
+  public void testRepoRenamePassesExpectedMetadataLocation() throws Exception {
+    mockHtsServer.enqueue(
+        new MockResponse()
+            .setResponseCode(204)
+            .setBody("")
+            .addHeader("Content-Type", "application/json"));
+
+    htsRepo.rename(
+        HOUSE_TABLE.getDatabaseId(),
+        HOUSE_TABLE.getTableId(),
+        HOUSE_TABLE_SAME_DB.getDatabaseId(),
+        HOUSE_TABLE.getTableId() + "_renamed",
+        HOUSE_TABLE.getTableLocation() + "_v2",
+        Optional.of(HOUSE_TABLE.getTableLocation()));
+
+    // The static mock server records requests across tests; drain to the rename request.
+    okhttp3.mockwebserver.RecordedRequest renameRequest = null;
+    okhttp3.mockwebserver.RecordedRequest recordedRequest;
+    while ((recordedRequest = mockHtsServer.takeRequest(5, TimeUnit.SECONDS)) != null) {
+      if (recordedRequest.getPath() != null
+          && recordedRequest.getPath().startsWith("/hts/tables/rename")) {
+        renameRequest = recordedRequest;
+        break;
+      }
+    }
+    Assertions.assertNotNull(renameRequest, "the rename request should have been recorded");
+    // The exact decoded token proves that HTS receives the caller's observed base.
+    okhttp3.HttpUrl renameUrl = renameRequest.getRequestUrl();
+    Assertions.assertNotNull(renameUrl, "the rename request should carry a parseable url");
+    Assertions.assertEquals(
+        HOUSE_TABLE.getTableLocation(),
+        renameUrl.queryParameter("expectedMetadataLocation"),
+        "rename request should carry the caller's observed metadata location as"
+            + " expectedMetadataLocation, got: "
+            + renameRequest.getPath());
   }
 
   @Test
@@ -351,7 +391,8 @@ public class HouseTableRepositoryImplTest {
                   HOUSE_TABLE.getTableId(),
                   HOUSE_TABLE_SAME_DB.getDatabaseId(),
                   HOUSE_TABLE.getTableId() + "_renamed",
-                  HOUSE_TABLE.getTableLocation() + "_v2"));
+                  HOUSE_TABLE.getTableLocation() + "_v2",
+                  Optional.of(HOUSE_TABLE.getTableLocation())));
     }
   }
 

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/OpenHouseUserTableHtsApiHandler.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/api/handler/OpenHouseUserTableHtsApiHandler.java
@@ -9,6 +9,7 @@ import com.linkedin.openhouse.housetables.api.validator.HouseTablesApiValidator;
 import com.linkedin.openhouse.housetables.dto.mapper.UserTablesMapper;
 import com.linkedin.openhouse.housetables.dto.model.UserTableDto;
 import com.linkedin.openhouse.housetables.services.UserTablesService;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.util.Pair;
@@ -113,12 +114,14 @@ public class OpenHouseUserTableHtsApiHandler implements UserTableHtsApiHandler {
             .tableId(toUserTable.getTableId())
             .build();
     userTablesHtsApiValidator.validateRenameEntity(fromUserTableKey, toUserTableKey);
+    // The source metadata location carries the caller's optimistic-concurrency token.
     userTableService.renameUserTable(
         fromUserTable.getDatabaseId(),
         fromUserTable.getTableId(),
         toUserTable.getDatabaseId(),
         toUserTable.getTableId(),
-        toUserTable.getMetadataLocation());
+        toUserTable.getMetadataLocation(),
+        Optional.ofNullable(fromUserTable.getMetadataLocation()));
     return ApiResponse.<Void>builder().httpStatus(HttpStatus.NO_CONTENT).build();
   }
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/controller/UserHouseTablesController.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/controller/UserHouseTablesController.java
@@ -242,9 +242,20 @@ public class UserHouseTablesController {
       @RequestParam(value = "fromTableId") String fromTableId,
       @RequestParam(value = "toDatabaseId") String toDatabaseId,
       @RequestParam(value = "toTableId") String toTableId,
-      @RequestParam(value = "metadataLocation") String metadataLocation) {
+      @RequestParam(value = "metadataLocation") String metadataLocation,
+      @Parameter(
+              description =
+                  "The metadata location the caller observed for the source table when initiating "
+                      + "the rename. When provided, the rename fails with 409 CONFLICT if the "
+                      + "table has been concurrently modified (optimistic concurrency control).")
+          @RequestParam(value = "expectedMetadataLocation", required = false)
+          String expectedMetadataLocation) {
     UserTable fromUserTable =
-        UserTable.builder().databaseId(fromDatabaseId).tableId(fromTableId).build();
+        UserTable.builder()
+            .databaseId(fromDatabaseId)
+            .tableId(fromTableId)
+            .metadataLocation(expectedMetadataLocation)
+            .build();
     UserTable toUserTable =
         UserTable.builder()
             .databaseId(toDatabaseId)

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/jdbc/UserTableHtsJdbcRepository.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/repository/impl/jdbc/UserTableHtsJdbcRepository.java
@@ -4,6 +4,7 @@ import com.linkedin.openhouse.housetables.config.db.jdbc.JdbcProviderConfigurati
 import com.linkedin.openhouse.housetables.model.UserTableRow;
 import com.linkedin.openhouse.housetables.model.UserTableRowPrimaryKey;
 import com.linkedin.openhouse.housetables.repository.HtsRepository;
+import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.data.domain.Page;
@@ -112,15 +113,27 @@ public interface UserTableHtsJdbcRepository
         userTableRowPrimaryKey.getDatabaseId(), userTableRowPrimaryKey.getTableId());
   }
 
+  /**
+   * Renames a table row, participating in the optimistic-lock protocol: the update only matches a
+   * row still at {@code expectedVersion} and atomically bumps {@link UserTableRow}'s
+   * {@literal @}Version column. A concurrent modification that advances the row between the
+   * caller's read and this update produces a zero-row result. {@link CheckReturnValue} requires
+   * callers to inspect that result and map it to a concurrent-modification conflict.
+   *
+   * @return the number of rows updated: 1 when the rename lands, 0 when the version differs or the
+   *     row is absent
+   */
+  @CheckReturnValue
   @Transactional
-  @Modifying
+  @Modifying(clearAutomatically = true)
   @Query(
-      "UPDATE UserTableRow table SET table.tableId = :toTableId, table.metadataLocation = :metadataLocation, table.databaseId = :toDatabaseId "
-          + "WHERE lower(table.databaseId) = lower(:fromDatabaseId) AND lower(table.tableId) = lower(:fromTableId)")
-  void renameTableId(
+      "UPDATE UserTableRow table SET table.tableId = :toTableId, table.metadataLocation = :metadataLocation, table.databaseId = :toDatabaseId, table.version = table.version + 1 "
+          + "WHERE lower(table.databaseId) = lower(:fromDatabaseId) AND lower(table.tableId) = lower(:fromTableId) AND table.version = :expectedVersion")
+  int renameTableId(
       @Param("fromDatabaseId") String fromDatabaseId,
       @Param("fromTableId") String fromTableId,
       @Param("toDatabaseId") String toDatabaseId,
       @Param("toTableId") String toTableId,
-      @Param("metadataLocation") String metadataLocation);
+      @Param("metadataLocation") String metadataLocation,
+      @Param("expectedVersion") Long expectedVersion);
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesService.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesService.java
@@ -3,6 +3,7 @@ package com.linkedin.openhouse.housetables.services;
 import com.linkedin.openhouse.housetables.api.spec.model.UserTable;
 import com.linkedin.openhouse.housetables.dto.model.UserTableDto;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.util.Pair;
 
@@ -62,13 +63,17 @@ public interface UserTablesService {
    * @param toTableId The new tableId of the renamed row.
    * @param metadataLocation The new metadata file of the table with updated table properties for
    *     updated ids.
+   * @param expectedMetadataLocation The metadata location the caller observed when it decided to
+   *     rename. A present value must match the row's current metadata location. An empty value uses
+   *     the version read by the service as the optimistic-concurrency token.
    */
   void renameUserTable(
       String fromDatabaseId,
       String fromTableId,
       String toDatabaseId,
       String toTableId,
-      String metadataLocation);
+      String metadataLocation,
+      Optional<String> expectedMetadataLocation);
 
   /**
    * Restore a soft-deleted user table identified by its databaseId, tableId, and deletedAtMs

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesServiceImpl.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/UserTablesServiceImpl.java
@@ -136,6 +136,9 @@ public class UserTablesServiceImpl implements UserTablesService {
    * @param toTableId The new tableId of the renamed row.
    * @param metadataLocation The new metadata file of the table with updated table properties that
    *     match the new tableId
+   * @param expectedMetadataLocation The metadata location the caller observed when initiating the
+   *     rename. A present value validates the caller's base, while the row version read below
+   *     protects the service read-to-update interval.
    */
   @Override
   public void renameUserTable(
@@ -143,11 +146,38 @@ public class UserTablesServiceImpl implements UserTablesService {
       String fromTableId,
       String toDatabaseId,
       String toTableId,
-      String metadataLocation) {
-    if (!htsJdbcRepository.existsById(
-        UserTableRowPrimaryKey.builder().databaseId(fromDatabaseId).tableId(fromTableId).build())) {
-      throw new NoSuchUserTableException(fromDatabaseId, fromTableId);
-    }
+      String metadataLocation,
+      Optional<String> expectedMetadataLocation) {
+    UserTableRow fromUserTableRow =
+        htsJdbcRepository
+            .findById(
+                UserTableRowPrimaryKey.builder()
+                    .databaseId(fromDatabaseId)
+                    .tableId(fromTableId)
+                    .build())
+            .orElseThrow(() -> new NoSuchUserTableException(fromDatabaseId, fromTableId));
+    expectedMetadataLocation
+        .filter(expected -> !expected.equals(fromUserTableRow.getMetadataLocation()))
+        .ifPresent(
+            expected -> {
+              throw new EntityConcurrentModificationException(
+                  String.format(
+                      "databaseId : %s, tableId : %s, metadataLocation: %s %s",
+                      fromDatabaseId,
+                      fromTableId,
+                      expected,
+                      "The requested user table has been modified/created by other processes."),
+                  UserTableRowPrimaryKey.builder()
+                      .databaseId(fromDatabaseId)
+                      .tableId(fromTableId)
+                      .build()
+                      .toString(),
+                  // The 409 body includes this cause message so the client can reconcile its base.
+                  new IllegalStateException(
+                      String.format(
+                          "Rename expected metadataLocation %s; current metadataLocation is %s",
+                          expected, fromUserTableRow.getMetadataLocation())));
+            });
     // Renames user table within the same database
     try {
       log.info(
@@ -156,11 +186,39 @@ public class UserTablesServiceImpl implements UserTablesService {
           fromTableId,
           toTableId,
           toDatabaseId);
-      // Use fromDatabaseId for destination db to preserve the original case of the database
+      // Uses fromDatabaseId for the destination to preserve the original database case.
       // TODO: Use toDataBaseId for destination instead of fromDatabaseId once rename across
       // databases is supported
-      htsJdbcRepository.renameTableId(
-          fromDatabaseId, fromTableId, fromDatabaseId, toTableId, metadataLocation);
+      // The version-qualified update atomically advances the row version. A racing commit causes
+      // a zero-row result that maps to a retriable conflict.
+      int updatedRows =
+          htsJdbcRepository.renameTableId(
+              fromDatabaseId,
+              fromTableId,
+              fromDatabaseId,
+              toTableId,
+              metadataLocation,
+              fromUserTableRow.getVersion());
+      if (updatedRows == 0) {
+        throw new EntityConcurrentModificationException(
+            String.format(
+                "databaseId : %s, tableId : %s, version: %s %s",
+                fromDatabaseId,
+                fromTableId,
+                fromUserTableRow.getVersion(),
+                "The requested user table has been modified/created by other processes."),
+            UserTableRowPrimaryKey.builder()
+                .databaseId(fromDatabaseId)
+                .tableId(fromTableId)
+                .build()
+                .toString(),
+            // The 409 body includes the row state used by the conditional update.
+            new IllegalStateException(
+                String.format(
+                    "Rename expected version %s and metadataLocation %s;"
+                        + " the row changed before the update",
+                    fromUserTableRow.getVersion(), fromUserTableRow.getMetadataLocation())));
+      }
     } catch (DataIntegrityViolationException e) {
       throw new AlreadyExistsException("Table", toTableId);
     }

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/HtsControllerTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/HtsControllerTest.java
@@ -463,6 +463,44 @@ public class HtsControllerTest {
   }
 
   @Test
+  public void testRenameUserTableWithExpectedMetadataLocation() throws Exception {
+    // Declaring the current metadata location as the expected base succeeds.
+    mvc.perform(
+            MockMvcRequestBuilders.patch("/hts/tables/rename")
+                .param("fromDatabaseId", TEST_DB_ID)
+                .param("fromTableId", TEST_TABLE_ID)
+                .param("toDatabaseId", TEST_DB_ID)
+                .param("toTableId", TEST_TABLE_ID + "_renamed")
+                .param("metadataLocation", "mockMetadataLocation")
+                .param("expectedMetadataLocation", TEST_TBL_META_LOC))
+        .andExpect(status().isNoContent())
+        .andExpect(content().string(""));
+  }
+
+  @Test
+  public void testRenameUserTableConflictsOnStaleExpectedMetadataLocation() throws Exception {
+    // A stale base yields 409 and preserves the concurrent commit's metadataLocation.
+    mvc.perform(
+            MockMvcRequestBuilders.patch("/hts/tables/rename")
+                .param("fromDatabaseId", TEST_DB_ID)
+                .param("fromTableId", TEST_TABLE_ID)
+                .param("toDatabaseId", TEST_DB_ID)
+                .param("toTableId", TEST_TABLE_ID + "_renamed")
+                .param("metadataLocation", "mockMetadataLocation")
+                .param("expectedMetadataLocation", TEST_TBL_META_LOC + "_stale"))
+        .andExpect(status().isConflict());
+
+    // The source table retains the winning metadata location.
+    mvc.perform(
+            MockMvcRequestBuilders.get("/hts/tables")
+                .param("databaseId", TEST_DB_ID)
+                .param("tableId", TEST_TABLE_ID)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.entity.metadataLocation", is(equalTo(TEST_TBL_META_LOC))));
+  }
+
+  @Test
   public void testRenameUserTableFails() throws Exception {
     mvc.perform(
             MockMvcRequestBuilders.patch("/hts/tables/rename")

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/HtsRepositoryTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/HtsRepositoryTest.java
@@ -171,7 +171,7 @@ public class HtsRepositoryTest {
 
   @Test
   public void testRenameUserTable() {
-    htsRepository.save(TEST_TUPLE_1_1.get_userTableRow());
+    UserTableRow savedRow = htsRepository.save(TEST_TUPLE_1_1.get_userTableRow());
     UserTableRowPrimaryKey key =
         UserTableRowPrimaryKey.builder()
             .tableId(TEST_TUPLE_1_1.getTableId())
@@ -181,12 +181,15 @@ public class HtsRepositoryTest {
     assertThat(htsRepository.existsById(key)).isTrue();
 
     String newTableMetadata = TEST_TUPLE_1_1.getTableLoc() + "_v2";
-    htsRepository.renameTableId(
-        TEST_TUPLE_1_1.getDatabaseId(),
-        TEST_TUPLE_1_1.getTableId(),
-        TEST_TUPLE_1_1.getDatabaseId(),
-        TEST_TUPLE_1_1.getTableId() + "_renamed",
-        newTableMetadata);
+    int updatedRows =
+        htsRepository.renameTableId(
+            TEST_TUPLE_1_1.getDatabaseId(),
+            TEST_TUPLE_1_1.getTableId(),
+            TEST_TUPLE_1_1.getDatabaseId(),
+            TEST_TUPLE_1_1.getTableId() + "_renamed",
+            newTableMetadata,
+            savedRow.getVersion());
+    Assertions.assertEquals(1, updatedRows);
 
     UserTableRow result =
         htsRepository
@@ -197,9 +200,52 @@ public class HtsRepositoryTest {
                     .build())
             .orElse(UserTableRow.builder().build());
     assertThat(result.getMetadataLocation()).isEqualTo(newTableMetadata);
+    // Rename advances the optimistic-lock @Version column so stale writers conflict.
+    assertThat(result.getVersion()).isEqualTo(savedRow.getVersion() + 1);
 
     // verify testTuple1_1 doesn't exist any more.
     assertThat(htsRepository.existsById(key)).isFalse();
+  }
+
+  @Test
+  public void testRenameUserTableAtStaleVersionUpdatesNoRows() {
+    UserTableRow savedRow = htsRepository.save(TEST_TUPLE_1_1.get_userTableRow());
+
+    // A concurrent commit advances the row (bumping @Version) after the renamer read it.
+    UserTableRow committedRow =
+        htsRepository.save(
+            savedRow.toBuilder().metadataLocation(TEST_TUPLE_1_1.getTableLoc() + "_v2").build());
+    Assertions.assertNotEquals(savedRow.getVersion(), committedRow.getVersion());
+
+    // The stale version produces a zero-row result and preserves the committed metadataLocation.
+    int updatedRows =
+        htsRepository.renameTableId(
+            TEST_TUPLE_1_1.getDatabaseId(),
+            TEST_TUPLE_1_1.getTableId(),
+            TEST_TUPLE_1_1.getDatabaseId(),
+            TEST_TUPLE_1_1.getTableId() + "_renamed",
+            TEST_TUPLE_1_1.getTableLoc() + "_renamed",
+            savedRow.getVersion());
+    Assertions.assertEquals(0, updatedRows);
+
+    // The winning commit's row is intact: same id, same metadataLocation, same version.
+    UserTableRow result =
+        htsRepository
+            .findById(
+                UserTableRowPrimaryKey.builder()
+                    .databaseId(TEST_TUPLE_1_1.getDatabaseId())
+                    .tableId(TEST_TUPLE_1_1.getTableId())
+                    .build())
+            .orElse(UserTableRow.builder().build());
+    assertThat(result.getMetadataLocation()).isEqualTo(TEST_TUPLE_1_1.getTableLoc() + "_v2");
+    assertThat(result.getVersion()).isEqualTo(committedRow.getVersion());
+    assertThat(
+            htsRepository.existsById(
+                UserTableRowPrimaryKey.builder()
+                    .databaseId(TEST_TUPLE_1_1.getDatabaseId())
+                    .tableId(TEST_TUPLE_1_1.getTableId() + "_renamed")
+                    .build()))
+        .isFalse();
   }
 
   @Test
@@ -211,7 +257,7 @@ public class HtsRepositoryTest {
             .tableId(TEST_TUPLE_1_1.getTableId().toUpperCase())
             .databaseId(TEST_TUPLE_1_1.getDatabaseId())
             .build();
-    htsRepository.save(testUpperCaseRow);
+    UserTableRow savedRow = htsRepository.save(testUpperCaseRow);
 
     UserTableRowPrimaryKey key =
         UserTableRowPrimaryKey.builder()
@@ -223,12 +269,16 @@ public class HtsRepositoryTest {
 
     String renamedUpperCaseTableId = TEST_TUPLE_1_1.getTableId() + "_RENAMED";
 
-    htsRepository.renameTableId(
-        TEST_TUPLE_1_1.getDatabaseId(),
-        TEST_TUPLE_1_1.getTableId(),
-        TEST_TUPLE_1_1.getDatabaseId().toUpperCase(),
-        renamedUpperCaseTableId,
-        TEST_TUPLE_1_1.getTableLoc());
+    // The saved row's version makes this assertion independent of the initial version value.
+    int updatedRows =
+        htsRepository.renameTableId(
+            TEST_TUPLE_1_1.getDatabaseId(),
+            TEST_TUPLE_1_1.getTableId(),
+            TEST_TUPLE_1_1.getDatabaseId().toUpperCase(),
+            renamedUpperCaseTableId,
+            TEST_TUPLE_1_1.getTableLoc(),
+            savedRow.getVersion());
+    Assertions.assertEquals(1, updatedRows);
 
     // Try fetching with lower case ID, should still work
     UserTableRow result =

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/UserTablesServiceTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/usertable/UserTablesServiceTest.java
@@ -6,12 +6,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 
 import com.linkedin.openhouse.common.exception.AlreadyExistsException;
+import com.linkedin.openhouse.common.exception.EntityConcurrentModificationException;
 import com.linkedin.openhouse.common.exception.NoSuchUserTableException;
 import com.linkedin.openhouse.housetables.api.spec.model.UserTable;
 import com.linkedin.openhouse.housetables.dto.model.UserTableDto;
 import com.linkedin.openhouse.housetables.e2e.SpringH2HtsApplication;
 import com.linkedin.openhouse.housetables.model.TestHouseTableModelConstants;
 import com.linkedin.openhouse.housetables.model.UserTableRow;
+import com.linkedin.openhouse.housetables.model.UserTableRowPrimaryKey;
 import com.linkedin.openhouse.housetables.repository.impl.jdbc.SoftDeletedUserTableHtsJdbcRepository;
 import com.linkedin.openhouse.housetables.repository.impl.jdbc.UserTableHtsJdbcRepository;
 import com.linkedin.openhouse.housetables.services.UserTablesService;
@@ -397,7 +399,8 @@ public class UserTablesServiceTest {
         TEST_TUPLE_1_0.getTableId(),
         TEST_TUPLE_1_0.getDatabaseId(),
         newTableName,
-        newMetadataLocation);
+        newMetadataLocation,
+        Optional.of(TEST_TUPLE_1_0.getTableLoc()));
 
     // check if the table is renamed
     UserTableDto result =
@@ -414,6 +417,24 @@ public class UserTablesServiceTest {
   }
 
   @Test
+  public void testUserTableRenameWithoutExpectedMetadataLocation() {
+    // An empty caller token uses the service's version-qualified base.
+    String newTableName = TEST_TUPLE_1_0.getTableId() + "_newName";
+    String newMetadataLocation = TEST_TUPLE_1_0.getTableLoc() + "_new";
+    userTablesService.renameUserTable(
+        TEST_TUPLE_1_0.getDatabaseId(),
+        TEST_TUPLE_1_0.getTableId(),
+        TEST_TUPLE_1_0.getDatabaseId(),
+        newTableName,
+        newMetadataLocation,
+        Optional.empty());
+
+    UserTableDto result =
+        userTablesService.getUserTable(TEST_TUPLE_1_0.getDatabaseId(), newTableName);
+    assertThat(result.getMetadataLocation()).isEqualTo(newMetadataLocation);
+  }
+
+  @Test
   public void testUserTableRenameFails() {
     // Ensure that the rename is occurring in the same database
     assertThat(TEST_TUPLE_1_0.getDatabaseId()).isEqualTo(TEST_TUPLE_2_0.getDatabaseId());
@@ -427,7 +448,8 @@ public class UserTablesServiceTest {
               TEST_TUPLE_1_0.getTableId(),
               TEST_TUPLE_1_0.getDatabaseId(),
               TEST_TUPLE_2_0.getTableId(),
-              TEST_TUPLE_2_0.getTableLoc());
+              TEST_TUPLE_2_0.getTableLoc(),
+              Optional.empty());
         });
 
     Assertions.assertThrows(
@@ -435,6 +457,84 @@ public class UserTablesServiceTest {
         () -> {
           userTablesService.getUserTable(TEST_TUPLE_1_0.getDatabaseId(), "no_such_table");
         });
+  }
+
+  @Test
+  public void testUserTableRenameFailsOnStaleExpectedMetadataLocation() {
+    // A commit that advances the table before the rename request produces a conflict.
+    UserTable advanced =
+        TEST_TUPLE_1_0
+            .get_userTable()
+            .toBuilder()
+            .tableVersion(TEST_TUPLE_1_0.getTableLoc())
+            .metadataLocation(TEST_TUPLE_1_0.getTableLoc() + "_committed")
+            .build();
+    userTablesService.putUserTable(advanced);
+
+    Assertions.assertThrows(
+        EntityConcurrentModificationException.class,
+        () ->
+            userTablesService.renameUserTable(
+                TEST_TUPLE_1_0.getDatabaseId(),
+                TEST_TUPLE_1_0.getTableId(),
+                TEST_TUPLE_1_0.getDatabaseId(),
+                TEST_TUPLE_1_0.getTableId() + "_newName",
+                TEST_TUPLE_1_0.getTableLoc() + "_new",
+                Optional.of(TEST_TUPLE_1_0.getTableLoc())));
+
+    // The committed row is untouched.
+    UserTableDto result =
+        userTablesService.getUserTable(TEST_TUPLE_1_0.getDatabaseId(), TEST_TUPLE_1_0.getTableId());
+    assertThat(result.getMetadataLocation()).isEqualTo(TEST_TUPLE_1_0.getTableLoc() + "_committed");
+  }
+
+  @Test
+  public void testUserTableRenameConflictsWithConcurrentCommit() {
+    // A commit advances the row after the rename read and before its update. The conditional update
+    // produces a zero-row result and the rename surfaces a conflict.
+    UserTableRowPrimaryKey key =
+        UserTableRowPrimaryKey.builder()
+            .databaseId(TEST_TUPLE_1_0.getDatabaseId())
+            .tableId(TEST_TUPLE_1_0.getTableId())
+            .build();
+    // The row state the rename reads (pre-commit: original location, original version).
+    UserTableRow staleRow = htsRepository.findById(key).orElseThrow(IllegalStateException::new);
+
+    // The racing commit lands: metadataLocation advances and @Version bumps.
+    String committedLocation = TEST_TUPLE_1_0.getTableLoc() + "_committed";
+    userTablesService.putUserTable(
+        TEST_TUPLE_1_0
+            .get_userTable()
+            .toBuilder()
+            .tableVersion(TEST_TUPLE_1_0.getTableLoc())
+            .metadataLocation(committedLocation)
+            .build());
+
+    // Freeze the rename's read at the pre-commit row state, so its conditional UPDATE executes
+    // against the (now advanced) real row with a stale expected version.
+    Mockito.doReturn(Optional.of(staleRow)).when(htsRepository).findById(key);
+
+    Assertions.assertThrows(
+        EntityConcurrentModificationException.class,
+        () ->
+            userTablesService.renameUserTable(
+                TEST_TUPLE_1_0.getDatabaseId(),
+                TEST_TUPLE_1_0.getTableId(),
+                TEST_TUPLE_1_0.getDatabaseId(),
+                TEST_TUPLE_1_0.getTableId() + "_newName",
+                TEST_TUPLE_1_0.getTableLoc() + "_new",
+                Optional.of(TEST_TUPLE_1_0.getTableLoc())));
+
+    Mockito.reset(htsRepository);
+    // The racing commit won and its metadataLocation is intact; the rename target is absent.
+    UserTableDto result =
+        userTablesService.getUserTable(TEST_TUPLE_1_0.getDatabaseId(), TEST_TUPLE_1_0.getTableId());
+    assertThat(result.getMetadataLocation()).isEqualTo(committedLocation);
+    Assertions.assertThrows(
+        NoSuchUserTableException.class,
+        () ->
+            userTablesService.getUserTable(
+                TEST_TUPLE_1_0.getDatabaseId(), TEST_TUPLE_1_0.getTableId() + "_newName"));
   }
 
   @Test

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/HouseTablesH2Repository.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/HouseTablesH2Repository.java
@@ -4,10 +4,12 @@ import com.linkedin.openhouse.internal.catalog.model.HouseTable;
 import com.linkedin.openhouse.internal.catalog.model.HouseTablePrimaryKey;
 import com.linkedin.openhouse.internal.catalog.model.SoftDeletedTablePrimaryKey;
 import com.linkedin.openhouse.internal.catalog.repository.HouseTableRepository;
+import com.linkedin.openhouse.internal.catalog.repository.exception.HouseTableConcurrentUpdateException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -32,12 +34,25 @@ public interface HouseTablesH2Repository extends HouseTableRepository {
       String fromTableId,
       String toDatabaseId,
       String toTableId,
-      String metadataLocation) {
+      String metadataLocation,
+      Optional<String> expectedMetadataLocation) {
     HouseTablePrimaryKey fromKey =
         HouseTablePrimaryKey.builder().databaseId(fromDatabaseId).tableId(fromTableId).build();
     this.findById(fromKey)
         .ifPresent(
             houseTable -> {
+              expectedMetadataLocation
+                  .filter(expected -> !expected.equals(houseTable.getTableLocation()))
+                  .ifPresent(
+                      expected -> {
+                        throw new HouseTableConcurrentUpdateException(
+                            String.format("%s.%s", fromDatabaseId, fromTableId),
+                            new IllegalStateException(
+                                String.format(
+                                    "Rename expected metadataLocation %s; current"
+                                        + " metadataLocation is %s",
+                                    expected, houseTable.getTableLocation())));
+                      });
               HouseTable renamedTable =
                   houseTable
                       .toBuilder()

--- a/tables-test-fixtures/tables-test-fixtures-iceberg-1.2/src/main/java/com/linkedin/openhouse/tablestest/HouseTablesH2Repository.java
+++ b/tables-test-fixtures/tables-test-fixtures-iceberg-1.2/src/main/java/com/linkedin/openhouse/tablestest/HouseTablesH2Repository.java
@@ -4,6 +4,7 @@ import com.linkedin.openhouse.internal.catalog.model.HouseTable;
 import com.linkedin.openhouse.internal.catalog.model.HouseTablePrimaryKey;
 import com.linkedin.openhouse.internal.catalog.model.SoftDeletedTablePrimaryKey;
 import com.linkedin.openhouse.internal.catalog.repository.HouseTableRepository;
+import com.linkedin.openhouse.internal.catalog.repository.exception.HouseTableConcurrentUpdateException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -42,12 +43,25 @@ public interface HouseTablesH2Repository extends HouseTableRepository {
       String fromTableId,
       String toDatabaseId,
       String toTableId,
-      String metadataLocation) {
+      String metadataLocation,
+      Optional<String> expectedMetadataLocation) {
     HouseTablePrimaryKey fromKey =
         HouseTablePrimaryKey.builder().databaseId(fromDatabaseId).tableId(fromTableId).build();
     this.findById(fromKey)
         .ifPresent(
             houseTable -> {
+              expectedMetadataLocation
+                  .filter(expected -> !expected.equals(houseTable.getTableLocation()))
+                  .ifPresent(
+                      expected -> {
+                        throw new HouseTableConcurrentUpdateException(
+                            String.format("%s.%s", fromDatabaseId, fromTableId),
+                            new IllegalStateException(
+                                String.format(
+                                    "Rename expected metadataLocation %s; current"
+                                        + " metadataLocation is %s",
+                                    expected, houseTable.getTableLocation())));
+                      });
               HouseTable renamedTable =
                   houseTable.toBuilder().tableId(toTableId).tableLocation(metadataLocation).build();
               this.save(renamedTable);


### PR DESCRIPTION
## Summary

**TLDR.** A table rename could silently overwrite a committed snapshot. The rename database update is now conditional on the HTS row version, so a rename that loses the service read-to-update race returns HTTP 409 instead of overwriting the winning commit.

`UserTableHtsJdbcRepository.renameTableId` previously issued an unconditional JPQL update without a version predicate or version increment. When a rename raced a snapshot commit, it could overwrite the winner's `metadataLocation` and report success.

This change:

- Makes the rename update conditional on the current `@Version` and increments the version atomically.
- Threads the caller's expected metadata location from the internal catalog to HTS.
- Maps stale tokens and zero-row updates to `EntityConcurrentModificationException` and HTTP 409.
- Converts the HTS conflict back to `CommitFailedException`, preserving Iceberg's existing retry behavior.
- Adds repository, service, controller, internal-catalog, and fixture coverage for stale tokens and forced race interleavings.

The new `expectedMetadataLocation` query parameter is optional for HTTP compatibility. Updated catalog callers supply it, while tokenless callers retain the row-version guard across the HTS service read-to-update interval.

## Changes

- [x] Internal API Changes
- [x] Bug Fixes
- [x] Tests

## Testing Done

- [x] Added repository coverage for version-qualified rename updates.
- [x] Added service coverage for stale caller tokens and forced concurrent commits.
- [x] Added controller and internal-catalog propagation coverage.
- [ ] Upstream pull request validation

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.
