### PR TITLE
Bump linkedin/iceberg to 1.2.0.23 / 1.5.2.20 (ORC initial-defaults)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,8 @@ ext {
   spark_version = "3.1.1"
   ok_http3_version = "4.11.0"
   junit_version = "5.11.0"
-  iceberg_1_2_version = "1.2.0.20"
-  iceberg_1_5_version = "1.5.2.17"
+  iceberg_1_2_version = "1.2.0.23"
+  iceberg_1_5_version = "1.5.2.20"
   otel_agent_version = "2.12.0" // Bundles OTel SDK 1.47.0
   otel_annotations_version = "2.12.0" // Match agent version
 }


### PR DESCRIPTION
## Summary

Bumps both OpenHouse Iceberg pins so Spark 3.1 and Spark 3.5 pick up the ORC/Spark initial-default read path (`idToConstant`) and the complete-embedded-field-id omit rule.

- `iceberg_1_2_version`: `1.2.0.20` → `1.2.0.23` (published as `v1.2.0.23`)
- `iceberg_1_5_version`: `1.5.2.17` → `1.5.2.20` (next two Shipkit tags after current `v1.5.2.18`, once [linkedin/iceberg#273](https://github.com/linkedin/iceberg/pull/273) then [linkedin/iceberg#274](https://github.com/linkedin/iceberg/pull/274) merge)

CI is expected to fail resolving `1.5.2.20` until those Iceberg PRs merge and Shipkit publishes the tags. Rerun CI after `v1.5.2.20` exists. Does not include [linkedin/iceberg#269](https://github.com/linkedin/iceberg/pull/269).

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

Spark/ORC readers fill missing columns from Iceberg initial defaults via `idToConstant`, and skip that fill only when the file already embeds a complete field-id set.

1.2 line: [linkedin/iceberg#267](https://github.com/linkedin/iceberg/pull/267) (`v1.2.0.22`) and [linkedin/iceberg#268](https://github.com/linkedin/iceberg/pull/268) (`v1.2.0.23`), plus CI-only [linkedin/iceberg#266](https://github.com/linkedin/iceberg/pull/266) (`v1.2.0.21`).

1.5 line: [linkedin/iceberg#257](https://github.com/linkedin/iceberg/pull/257) is already `v1.5.2.18`; #273 / #274 are the 1.5 twins of #267 / #268 and become `v1.5.2.19` / `v1.5.2.20` if they are the next two merges on `openhouse-1.5.2`.

## Testing Done

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [x] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Version pin only. Iceberg coverage lives in linkedin/iceberg #267/#268 and #273/#274.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

Depends on merge order **273 then 274** on `linkedin/iceberg` (`openhouse-1.5.2`). Retarget 274 onto `openhouse-1.5.2` after 273 lands. If another `openhouse-1.5.2` PR merges first, the 1.5 pin needs to move to the actual tag that contains #274.
