### PR TITLE
[views] /v1 views API contract (review aid for #694, not for merge)

### DIFF
--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/ViewsApiHandler.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/ViewsApiHandler.java
@@ -1,0 +1,73 @@
+package com.linkedin.openhouse.tables.api.handler;
+
+import com.linkedin.openhouse.common.api.spec.ApiResponse;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateViewRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllViewsResponseBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetViewResponseBody;
+
+/**
+ * Layer between the /v1 views REST routes and the view service. Implementations hold no business
+ * logic: they validate, map, delegate, map back and pick a status.
+ */
+public interface ViewsApiHandler {
+
+  /**
+   * Read a single view.
+   *
+   * @param databaseId database identifier
+   * @param viewId view identifier
+   * @param actingPrincipal authenticated user
+   * @return 200 with the view pointer
+   */
+  ApiResponse<GetViewResponseBody> getView(
+      String databaseId, String viewId, String actingPrincipal);
+
+  /**
+   * List views in a database.
+   *
+   * @param databaseId database identifier
+   * @param page zero-based page index
+   * @param size page size
+   * @param sortBy optional single sort field
+   * @param actingPrincipal authenticated user
+   * @return 200 with a page of sparse identifier-only view bodies
+   */
+  ApiResponse<GetAllViewsResponseBody> getAllViews(
+      String databaseId, int page, int size, String sortBy, String actingPrincipal);
+
+  /**
+   * Create a view.
+   *
+   * @param databaseId database identifier
+   * @param requestBody the create request
+   * @param actingPrincipal authenticated user
+   * @return 201 with the created view pointer
+   */
+  ApiResponse<GetViewResponseBody> createView(
+      String databaseId, CreateUpdateViewRequestBody requestBody, String actingPrincipal);
+
+  /**
+   * Replace a view, creating it when it does not exist.
+   *
+   * @param databaseId database identifier
+   * @param viewId view identifier
+   * @param requestBody the update request
+   * @param actingPrincipal authenticated user
+   * @return 201 when the call created the view, otherwise 200
+   */
+  ApiResponse<GetViewResponseBody> updateView(
+      String databaseId,
+      String viewId,
+      CreateUpdateViewRequestBody requestBody,
+      String actingPrincipal);
+
+  /**
+   * Delete a view.
+   *
+   * @param databaseId database identifier
+   * @param viewId view identifier
+   * @param actingPrincipal authenticated user
+   * @return 204 with no body
+   */
+  ApiResponse<Void> deleteView(String databaseId, String viewId, String actingPrincipal);
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/CreateUpdateViewRequestBody.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/CreateUpdateViewRequestBody.java
@@ -1,0 +1,113 @@
+package com.linkedin.openhouse.tables.api.spec.v0.request;
+
+import static com.linkedin.openhouse.common.api.validator.ValidatorConstants.*;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.google.gson.Gson;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.ViewRepresentation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.Map;
+import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Request body for POST and PUT on /v1/databases/{databaseId}/views. Nullable fields are omitted
+ * from the serialized payload rather than emitted as JSON null, so an omitted {@code
+ * baseViewVersion} on create stays absent on the wire.
+ */
+@Builder(toBuilder = true)
+@EqualsAndHashCode
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CreateUpdateViewRequestBody {
+
+  @Schema(
+      description = "Unique Resource identifier for a view within a Database",
+      example = "my_view")
+  @NotEmpty(message = "viewId cannot be empty")
+  @Size(max = 128)
+  @Pattern(regexp = ALPHA_NUM_UNDERSCORE_REGEX, message = ALPHA_NUM_UNDERSCORE_ERROR_MSG)
+  private String viewId;
+
+  @Schema(
+      description = "Unique Resource identifier for the Database containing the View",
+      example = "my_database")
+  @NotEmpty(message = "databaseId cannot be empty")
+  @Size(max = 128)
+  @Pattern(regexp = ALPHA_NUM_UNDERSCORE_REGEX, message = ALPHA_NUM_UNDERSCORE_ERROR_MSG)
+  private String databaseId;
+
+  @Schema(
+      description = "Unique Resource identifier for the Cluster containing the Database",
+      example = "my_cluster")
+  @NotEmpty(message = "clusterId cannot be empty")
+  @Pattern(
+      regexp = ALPHA_NUM_UNDERSCORE_REGEX_HYPHEN_ALLOW,
+      message = ALPHA_NUM_UNDERSCORE_ERROR_MSG_HYPHEN_ALLOW)
+  private String clusterId;
+
+  @Schema(
+      description = "Schema of the view. OpenHouse views use Iceberg schema specification",
+      example =
+          "{\"type\": \"struct\", "
+              + "\"fields\": [{\"id\": 1,\"required\": true,\"name\": \"id\",\"type\": \"string\"}, "
+              + "{\"id\": 2,\"required\": true,\"name\": \"name\",\"type\": \"string\"}]}")
+  @NotEmpty(message = "schema cannot be empty")
+  private String schema;
+
+  @Schema(
+      description = "Engine-specific representations of the view definition",
+      example = "[{\"type\": \"sql\", \"sql\": \"SELECT 1\", \"dialect\": \"spark\"}]")
+  @NotEmpty(message = "representations cannot be empty")
+  @Valid
+  private List<ViewRepresentation> representations;
+
+  @Schema(description = "Dialect of the representation the view was authored in", example = "spark")
+  @NotEmpty(message = "sourceDialect cannot be empty")
+  private String sourceDialect;
+
+  @Schema(
+      nullable = true,
+      description = "Catalog used to resolve unqualified identifiers in the view SQL",
+      example = "openhouse")
+  private String defaultCatalog;
+
+  @Schema(
+      nullable = true,
+      description = "Namespace used to resolve unqualified identifiers in the view SQL",
+      example = "[\"my_database\"]")
+  private List<String> defaultNamespace;
+
+  @Schema(nullable = true, description = "View properties", example = "{\"key\": \"value\"}")
+  private Map<String, String> viewProperties;
+
+  /**
+   * Route-sensitive: absent or {@code INITIAL_VERSION} on create, and the current metadata pointer
+   * on replace. Intentionally carries no bean constraint because the rule differs per HTTP verb and
+   * is owned by the verb-aware view validator.
+   */
+  @Schema(
+      nullable = true,
+      description = "The version of the view that the current update is based upon")
+  private String baseViewVersion;
+
+  /**
+   * Uses default Gson null handling rather than {@code serializeNulls()} so this stays consistent
+   * with the class-level {@link JsonInclude.Include#NON_NULL}: an omitted nullable field is absent
+   * from the payload, not present as JSON null.
+   */
+  public String toJson() {
+    return new Gson().toJson(this);
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/ViewRepresentation.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/ViewRepresentation.java
@@ -1,0 +1,40 @@
+package com.linkedin.openhouse.tables.api.spec.v0.request.components;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotEmpty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * ViewRepresentation is the entity holding a single engine-specific representation of a view in the
+ * /views API request body. SQL text is carried as opaque text; this class holds no parsing,
+ * translation or dialect-support logic. Byte-size, representation-type and dialect-support rules
+ * are owned by the manual view validator.
+ */
+@Builder(toBuilder = true)
+@EqualsAndHashCode
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ViewRepresentation {
+
+  @Schema(description = "Type of the view representation", example = "sql")
+  @NotEmpty(message = "type cannot be empty")
+  private String type;
+
+  @Schema(
+      description =
+          "SQL text of the view representation. This endpoint accepts it as opaque text: it is"
+              + " stored as sent and is not parsed or rewritten here.",
+      example = "SELECT id, name FROM my_database.my_table")
+  @NotEmpty(message = "sql cannot be empty")
+  private String sql;
+
+  @Schema(description = "SQL dialect the representation is written in", example = "spark")
+  @NotEmpty(message = "dialect cannot be empty")
+  private String dialect;
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/response/GetAllViewsResponseBody.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/response/GetAllViewsResponseBody.java
@@ -1,0 +1,25 @@
+package com.linkedin.openhouse.tables.api.spec.v0.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.Gson;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Value;
+import org.springframework.data.domain.Page;
+
+/**
+ * List contract for views. Paginated from the first release, so there is no unpaginated legacy
+ * {@code results} field to deprecate later.
+ */
+@Builder
+@Value
+public class GetAllViewsResponseBody {
+
+  @Schema(description = "Page of View objects in a database", example = "")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private Page<GetViewResponseBody> pageResults;
+
+  public String toJson() {
+    return new Gson().toJson(this);
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/response/GetViewResponseBody.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/response/GetViewResponseBody.java
@@ -1,0 +1,62 @@
+package com.linkedin.openhouse.tables.api.spec.v0.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.Gson;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Read contract for a view. Pointer-only today: this response omits the definition fields. The SQL,
+ * schema, representations, version history, UUID, properties and resolution context live in the
+ * view metadata file and are not returned by the item or list response in this milestone.
+ */
+@Builder(toBuilder = true)
+@Value
+public class GetViewResponseBody {
+
+  @Schema(
+      description = "Unique Resource identifier for a view within a Database",
+      example = "my_view")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private String viewId;
+
+  @Schema(
+      description = "Unique Resource identifier for the Database containing the View",
+      example = "my_database")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private String databaseId;
+
+  @Schema(
+      description = "Unique Resource identifier for the Cluster containing the Database",
+      example = "my_cluster")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private String clusterId;
+
+  @Schema(
+      description = "Fully Qualified Resource URI for the view",
+      example = "my_cluster.my_database.my_view")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private String viewUri;
+
+  @Schema(
+      description = "Location of the view metadata in File System / Blob Store",
+      example =
+          "<fs>://<hostname>/<openhouse_namespace>/<database_name>/<viewUUID>/metadata/<uuid>.metadata.json")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private String metadataLocation;
+
+  @Schema(description = "Current Version of the View.", example = "")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private String viewVersion;
+
+  @Schema(
+      description = "View creation epoch time measured in UTC in milliseconds of a view.",
+      example = "1651002318265")
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private long creationTime;
+
+  public String toJson() {
+    return new Gson().toJson(this);
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/authorization/Privileges.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/authorization/Privileges.java
@@ -16,7 +16,11 @@ public enum Privileges {
   UPDATE_ACL(Privilege.UPDATE_ACL),
   SYSTEM_ADMIN(Privilege.SYSTEM_ADMIN),
   LOCK_ADMIN(Privilege.LOCK_ADMIN),
-  SELECT(Privilege.SELECT);
+  SELECT(Privilege.SELECT),
+  CREATE_VIEW(Privilege.CREATE_VIEW),
+  LIST_VIEW(Privilege.LIST_VIEW),
+  UPDATE_VIEW_METADATA(Privilege.UPDATE_VIEW_METADATA),
+  DELETE_VIEW(Privilege.DELETE_VIEW);
 
   private String privilege;
 
@@ -43,6 +47,20 @@ public enum Privileges {
     public static final String LOCK_ADMIN = "LOCK_ADMIN";
 
     public static final String SELECT = "SELECT";
+
+    /**
+     * View privileges. Reads of a single view reuse {@link #SELECT}; the remaining view operations
+     * get their own constants so a later authorization implementation can grant them independently
+     * of the table privileges.
+     */
+    public static final String CREATE_VIEW = "CREATE_VIEW";
+
+    public static final String LIST_VIEW = "LIST_VIEW";
+
+    public static final String UPDATE_VIEW_METADATA = "UPDATE_VIEW_METADATA";
+
+    public static final String DELETE_VIEW = "DELETE_VIEW";
+
     private static final Set<String> SUPPORTED_PRIVILEGES =
         Stream.of(Privileges.values()).map(Privileges::getPrivilege).collect(Collectors.toSet());
 

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/ViewsController.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/ViewsController.java
@@ -1,0 +1,208 @@
+package com.linkedin.openhouse.tables.controller;
+
+import static com.linkedin.openhouse.common.security.AuthenticationUtils.*;
+
+import com.linkedin.openhouse.tables.api.handler.ViewsApiHandler;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateViewRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllViewsResponseBody;
+import com.linkedin.openhouse.tables.api.spec.v0.response.GetViewResponseBody;
+import com.linkedin.openhouse.tables.authorization.Privileges;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller for the Views API. Views are a new resource under {@code /v1}, alongside every other
+ * OpenHouse resource, and break no existing client: they occupy their own {@code views} path
+ * segment, and {@code /v1/databases/{databaseId}/tables/{tableId}} stays table-only.
+ *
+ * <p>The controller is registered regardless of whether views are enabled, and holds no business
+ * logic. Request bodies are deliberately not annotated with {@code @Valid}: the view validator
+ * accumulates every structural failure and reports them together, which Spring's fail-fast binding
+ * cannot do.
+ */
+@RestController
+public class ViewsController {
+
+  @Autowired private ViewsApiHandler viewsApiHandler;
+
+  @Operation(
+      summary = "Get View in a Database",
+      description =
+          "Returns a View resource identified by viewId in the database identified by databaseId.",
+      tags = {"View"})
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "View GET: OK"),
+        @ApiResponse(responseCode = "400", description = "View GET: BAD_REQUEST"),
+        @ApiResponse(responseCode = "401", description = "View GET: UNAUTHORIZED"),
+        @ApiResponse(responseCode = "403", description = "View GET: FORBIDDEN"),
+        @ApiResponse(responseCode = "404", description = "View GET: NOT_FOUND"),
+        @ApiResponse(responseCode = "503", description = "View GET: SERVICE_UNAVAILABLE")
+      })
+  @GetMapping(
+      value = {"/v1/databases/{databaseId}/views/{viewId}"},
+      produces = {"application/json"})
+  @Secured(value = Privileges.Privilege.SELECT)
+  public ResponseEntity<GetViewResponseBody> getView(
+      @Parameter(description = "Database ID", required = true) @PathVariable String databaseId,
+      @Parameter(description = "View ID", required = true) @PathVariable String viewId) {
+
+    com.linkedin.openhouse.common.api.spec.ApiResponse<GetViewResponseBody> apiResponse =
+        viewsApiHandler.getView(databaseId, viewId, extractAuthenticatedUserPrincipal());
+
+    return new ResponseEntity<>(
+        apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
+  }
+
+  @Operation(
+      summary = "Search Views in a Database",
+      description = "Returns a Page of View resources present in a database.",
+      tags = {"View"})
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "View SEARCH: OK"),
+        @ApiResponse(responseCode = "400", description = "View SEARCH: BAD_REQUEST"),
+        @ApiResponse(responseCode = "401", description = "View SEARCH: UNAUTHORIZED"),
+        @ApiResponse(responseCode = "403", description = "View SEARCH: FORBIDDEN"),
+        @ApiResponse(responseCode = "404", description = "View SEARCH: NOT_FOUND"),
+        @ApiResponse(responseCode = "503", description = "View SEARCH: SERVICE_UNAVAILABLE")
+      })
+  @GetMapping(
+      value = {"/v1/databases/{databaseId}/views"},
+      produces = {"application/json"})
+  @Secured(value = Privileges.Privilege.LIST_VIEW)
+  public ResponseEntity<GetAllViewsResponseBody> getAllViews(
+      @Parameter(description = "Database ID", required = true) @PathVariable String databaseId,
+      @RequestParam(required = false, defaultValue = "0") int page,
+      @RequestParam(required = false, defaultValue = "50") int size,
+      @RequestParam(required = false) String sortBy) {
+
+    com.linkedin.openhouse.common.api.spec.ApiResponse<GetAllViewsResponseBody> apiResponse =
+        viewsApiHandler.getAllViews(
+            databaseId, page, size, sortBy, extractAuthenticatedUserPrincipal());
+
+    return new ResponseEntity<>(
+        apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
+  }
+
+  @Operation(
+      summary = "Create a View",
+      description = "Creates and returns a View resource in a database identified by databaseId",
+      tags = {"View"})
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "201", description = "View POST: CREATED"),
+        @ApiResponse(responseCode = "400", description = "View POST: BAD_REQUEST"),
+        @ApiResponse(responseCode = "401", description = "View POST: UNAUTHORIZED"),
+        @ApiResponse(responseCode = "403", description = "View POST: FORBIDDEN"),
+        @ApiResponse(responseCode = "404", description = "View POST: DB_NOT_FOUND"),
+        @ApiResponse(responseCode = "409", description = "View POST: VIEW_EXISTS"),
+        @ApiResponse(responseCode = "422", description = "View POST: UNPROCESSABLE_ENTITY"),
+        @ApiResponse(responseCode = "503", description = "View POST: SERVICE_UNAVAILABLE")
+      })
+  @PostMapping(
+      value = {"/v1/databases/{databaseId}/views"},
+      produces = {"application/json"},
+      consumes = {"application/json"})
+  @Secured(value = Privileges.Privilege.CREATE_VIEW)
+  public ResponseEntity<GetViewResponseBody> createView(
+      @Parameter(description = "Database ID", required = true) @PathVariable String databaseId,
+      @Parameter(
+              description = "Request containing details of the View to be created",
+              required = true,
+              schema = @Schema(implementation = CreateUpdateViewRequestBody.class))
+          @RequestBody
+          CreateUpdateViewRequestBody createUpdateViewRequestBody) {
+
+    com.linkedin.openhouse.common.api.spec.ApiResponse<GetViewResponseBody> apiResponse =
+        viewsApiHandler.createView(
+            databaseId, createUpdateViewRequestBody, extractAuthenticatedUserPrincipal());
+
+    return new ResponseEntity<>(
+        apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
+  }
+
+  @Operation(
+      summary = "Update a View",
+      description =
+          "Updates or creates a View and returns the View resource. If the view does not exist, it "
+              + "will be created. If the view exists, it will be replaced.",
+      tags = {"View"})
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "View PUT: UPDATED"),
+        @ApiResponse(responseCode = "201", description = "View PUT: CREATED"),
+        @ApiResponse(responseCode = "400", description = "View PUT: BAD_REQUEST"),
+        @ApiResponse(responseCode = "401", description = "View PUT: UNAUTHORIZED"),
+        @ApiResponse(responseCode = "403", description = "View PUT: FORBIDDEN"),
+        @ApiResponse(responseCode = "404", description = "View PUT: DB_NOT_FOUND"),
+        @ApiResponse(responseCode = "409", description = "View PUT: CONFLICT"),
+        @ApiResponse(responseCode = "422", description = "View PUT: UNPROCESSABLE_ENTITY"),
+        @ApiResponse(responseCode = "503", description = "View PUT: SERVICE_UNAVAILABLE")
+      })
+  @PutMapping(
+      value = {"/v1/databases/{databaseId}/views/{viewId}"},
+      produces = {"application/json"},
+      consumes = {"application/json"})
+  @Secured(value = Privileges.Privilege.UPDATE_VIEW_METADATA)
+  public ResponseEntity<GetViewResponseBody> updateView(
+      @Parameter(description = "Database ID", required = true) @PathVariable String databaseId,
+      @Parameter(description = "View ID", required = true) @PathVariable String viewId,
+      @Parameter(
+              description = "Request containing details of the View to be created/updated",
+              required = true,
+              schema = @Schema(implementation = CreateUpdateViewRequestBody.class))
+          @RequestBody
+          CreateUpdateViewRequestBody createUpdateViewRequestBody) {
+
+    com.linkedin.openhouse.common.api.spec.ApiResponse<GetViewResponseBody> apiResponse =
+        viewsApiHandler.updateView(
+            databaseId, viewId, createUpdateViewRequestBody, extractAuthenticatedUserPrincipal());
+
+    return new ResponseEntity<>(
+        apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
+  }
+
+  @Operation(
+      summary = "Drop a View",
+      description =
+          "Drops a View resource identified by viewId in the database identified by databaseId.",
+      tags = {"View"})
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "204", description = "View DELETE: NO_CONTENT"),
+        @ApiResponse(responseCode = "400", description = "View DELETE: BAD_REQUEST"),
+        @ApiResponse(responseCode = "401", description = "View DELETE: UNAUTHORIZED"),
+        @ApiResponse(responseCode = "403", description = "View DELETE: FORBIDDEN"),
+        @ApiResponse(responseCode = "404", description = "View DELETE: VIEW_NOT_FOUND"),
+        @ApiResponse(responseCode = "503", description = "View DELETE: SERVICE_UNAVAILABLE")
+      })
+  @DeleteMapping(
+      value = {"/v1/databases/{databaseId}/views/{viewId}"},
+      produces = {"application/json"})
+  @Secured(value = Privileges.Privilege.DELETE_VIEW)
+  public ResponseEntity<Void> deleteView(
+      @Parameter(description = "Database ID", required = true) @PathVariable String databaseId,
+      @Parameter(description = "View ID", required = true) @PathVariable String viewId) {
+
+    com.linkedin.openhouse.common.api.spec.ApiResponse<Void> apiResponse =
+        viewsApiHandler.deleteView(databaseId, viewId, extractAuthenticatedUserPrincipal());
+
+    return new ResponseEntity<>(
+        apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/exception/ViewErrorCode.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/exception/ViewErrorCode.java
@@ -1,0 +1,33 @@
+package com.linkedin.openhouse.tables.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Internal taxonomy of view failure modes. This enum is never serialized to the wire: it exists
+ * only to select the HTTP status of the response, and the error body shape stays unchanged.
+ *
+ * <p>The full set is declared up front, including codes M1 never emits, so later milestones (view
+ * admission, dependency analysis) add behavior without a breaking change to this enum.
+ */
+@AllArgsConstructor
+@Getter
+public enum ViewErrorCode {
+  NO_SUCH_VIEW(HttpStatus.NOT_FOUND),
+  VIEW_ALREADY_EXISTS(HttpStatus.CONFLICT),
+  NAME_ALREADY_EXISTS_AS_TABLE(HttpStatus.CONFLICT),
+  CONCURRENT_VIEW_MODIFICATION(HttpStatus.CONFLICT),
+  DATABASE_NOT_FOUND(HttpStatus.NOT_FOUND),
+  VIEWS_DISABLED(HttpStatus.NOT_FOUND),
+  INVALID_VIEW_DEFINITION(HttpStatus.BAD_REQUEST),
+  UNSUPPORTED_VIEW_DIALECT(HttpStatus.BAD_REQUEST),
+  UNSUPPORTED_VIEW_SCHEMA(HttpStatus.BAD_REQUEST),
+  VIEW_ADMISSION_FAILED(HttpStatus.UNPROCESSABLE_ENTITY),
+  REQUIRED_REPRESENTATION_MISSING(HttpStatus.UNPROCESSABLE_ENTITY),
+  DEPENDENCY_CYCLE(HttpStatus.UNPROCESSABLE_ENTITY),
+  MAX_VIEW_DEPTH_EXCEEDED(HttpStatus.UNPROCESSABLE_ENTITY),
+  ADMISSION_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE);
+
+  private final HttpStatus httpStatus;
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **This PR is a reading aid, not a merge candidate.** #694 is the change under review and the one that would merge. This branch reproduces only the API definition from it — the endpoints and the wire models — so the surface can be read without the surrounding implementation. Please leave review comments on #694 unless they're specifically about the shape of these files.

Extracted from #694 in response to the feedback that 5k lines gets a shallow review. **573 lines across eight files**, no validator, no service logic, no test suite.

## The endpoints

**`ViewsController`** — the five routes under `/v1/databases/{databaseId}/views`:

| Verb | Path | Success | Privilege |
|---|---|---|---|
| POST | `/views` | 201 | `CREATE_VIEW` |
| GET | `/views/{viewId}` | 200 | `SELECT` |
| PUT | `/views/{viewId}` | 200, or 201 on create | `UPDATE_VIEW_METADATA` |
| GET | `/views` | 200, paginated | `LIST_VIEW` |
| DELETE | `/views/{viewId}` | 204 | `DELETE_VIEW` |

**`ViewsApiHandler`** — the interface the controller delegates to, included so the endpoint-to-handler contract is legible.

## The wire models

**`CreateUpdateViewRequestBody`** — `viewId`, `databaseId`, `clusterId`, `schema`, `representations`, `sourceDialect`, `defaultCatalog`, `defaultNamespace`, `viewProperties`, `baseViewVersion`. `representations` is a list of `ViewRepresentation {type, sql, dialect}` rather than a scalar `sql` field, so a second dialect can be added later without changing the shape.

**`GetViewResponseBody`** — the pointer and row-backed identity. SQL, schema and history stay in the Iceberg metadata file, which the client already reads through its own `FileIO`.

**`GetAllViewsResponseBody`** — paginated from the first release, reusing `GetViewResponseBody` for its elements populated with identifiers only. Views only ever expose a paginated list.

**`ViewErrorCode`** — all fourteen failure modes declared now, including the ones M1 never emits, so later milestones add behaviour without changing the enum. It selects an HTTP status and is never serialized; the shared `ErrorResponseBody` is untouched.

**`Privileges`** gains `CREATE_VIEW`, `LIST_VIEW`, `UPDATE_VIEW_METADATA`, `DELETE_VIEW`; single-view reads reuse `SELECT`.

## Where the rest lives

Everything else is in #694 and is not duplicated here:

| | |
|---|---|
| `ViewApiContractTest` | freezes every field set and JSON key set above |
| `OpenHouseViewsApiHandler` | the handler implementation |
| `OpenHouseViewsApiValidator` | structural validation |
| `ViewsService` / `ViewsDisabledService` | the stubbed service seam |
| `ViewDto`, `ViewsMapper` | internal model and mapping |
| audit redaction, dialect config, exception handling | |

For context on why the contract is shaped this way rather than following the Iceberg REST spec, see the [feasibility comparison](https://docs.google.com/document/d/1OQPYTQQID3Jry_aPPRnoNkNGhTgAbq3zXONx7umiHDY/edit) and the discussion on #694.
