### PR TITLE
Backfill history.expire.max-ref-age-ms with Snapshot Expiration

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
@@ -68,6 +69,8 @@ public final class Operations implements AutoCloseable {
   private static final String CATALOG = "openhouse";
 
   private static final String METRICS_SCOPE = Operations.class.getName();
+
+  private static final long DEFAULT_MAX_REFERENCE_AGE_MILLIS = TimeUnit.DAYS.toMillis(7);
 
   private final SparkSession spark;
 
@@ -272,6 +275,17 @@ public final class Operations implements AutoCloseable {
    * number of snapshots younger than the maxAge
    */
   public void expireSnapshots(Table table, int maxAge, String granularity, int versions) {
+    if (!table.properties().containsKey(TableProperties.MAX_REF_AGE_MS)) {
+      log.info(
+          "Setting default maximum reference age for table {} to {}ms",
+          table,
+          DEFAULT_MAX_REFERENCE_AGE_MILLIS);
+      table
+          .updateProperties()
+          .set(TableProperties.MAX_REF_AGE_MS, String.valueOf(DEFAULT_MAX_REFERENCE_AGE_MILLIS))
+          .commit();
+    }
+
     ExpireSnapshots expireSnapshotsCommand = table.expireSnapshots().cleanExpiredFiles(false);
 
     // maxAge will always be defined

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -338,6 +338,7 @@ public final class Operations implements AutoCloseable {
     }
 
     transaction.commitTransaction();
+    log.info("Expired {} branches for table: {}", branchesToExpire.size(), table);
   }
 
   /**

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -16,6 +16,7 @@ import com.linkedin.openhouse.jobs.util.TableStatsCollector;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import java.io.IOException;
+import java.time.Clock;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
@@ -80,8 +81,15 @@ public final class Operations implements AutoCloseable {
 
   private final OtelEmitter otelEmitter;
 
+  private final Clock clock;
+
   public static Operations of(SparkSession spark, OtelEmitter otelEmitter) {
-    return new Operations(spark, otelEmitter);
+    return new Operations(spark, otelEmitter, Clock.systemUTC());
+  }
+
+  @VisibleForTesting
+  static Operations of(SparkSession spark, OtelEmitter otelEmitter, Clock clock) {
+    return new Operations(spark, otelEmitter, clock);
   }
 
   public static Operations withCatalog(SparkSession spark, OtelEmitter otelEmitter) {
@@ -279,7 +287,7 @@ public final class Operations implements AutoCloseable {
    * number of snapshots younger than the maxAge
    */
   public void expireSnapshots(Table table, int maxAge, String granularity, int versions) {
-    long branchExpirationEvaluationTimeMillis = System.currentTimeMillis();
+    long branchExpirationEvaluationTimeMillis = clock.millis();
     long maximumReferenceAgeMillis =
         PropertyUtil.propertyAsLong(
             table.properties(), TableProperties.MAX_REF_AGE_MS, DEFAULT_MAX_REFERENCE_AGE_MILLIS);
@@ -306,15 +314,14 @@ public final class Operations implements AutoCloseable {
       manageSnapshots.commit();
     }
 
-    ExpireSnapshots expireSnapshotsCommand = transaction.expireSnapshots().cleanExpiredFiles(false);
+    ExpireSnapshots expireSnapshotsCommand = transaction.expireSnapshots().cleanExpiredFiles(true);
 
     // maxAge will always be defined
     ChronoUnit timeUnitGranularity =
         ChronoUnit.valueOf(
             SparkJobUtil.convertGranularityToChrono(granularity.toUpperCase()).name());
     long expireBeforeTimestampMs =
-        System.currentTimeMillis()
-            - timeUnitGranularity.getDuration().multipliedBy(maxAge).toMillis();
+        clock.millis() - timeUnitGranularity.getDuration().multipliedBy(maxAge).toMillis();
     log.info("Expiring snapshots for table: {} older than {}ms", table, expireBeforeTimestampMs);
     expireSnapshotsCommand.expireOlderThan(expireBeforeTimestampMs).commit();
 
@@ -324,8 +331,8 @@ public final class Operations implements AutoCloseable {
       // currentTime
       transaction
           .expireSnapshots()
-          .cleanExpiredFiles(false)
-          .expireOlderThan(System.currentTimeMillis())
+          .cleanExpiredFiles(true)
+          .expireOlderThan(clock.millis())
           .retainLast(versions)
           .commit();
     }

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -331,7 +331,7 @@ public final class Operations implements AutoCloseable {
       // currentTime
       transaction
           .expireSnapshots()
-          .cleanExpiredFiles(true)
+          .cleanExpiredFiles(false)
           .expireOlderThan(clock.millis())
           .retainLast(versions)
           .commit();

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -1,5 +1,6 @@
 package com.linkedin.openhouse.jobs.spark;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -22,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -38,12 +40,16 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ExpireSnapshots;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.Transaction;
@@ -51,11 +57,17 @@ import org.apache.iceberg.actions.DeleteOrphanFiles;
 import org.apache.iceberg.actions.RewriteDataFiles;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.spark.actions.SparkActions;
+import org.apache.iceberg.util.PropertyUtil;
+import org.apache.iceberg.util.Tasks;
 import org.apache.spark.sql.SparkSession;
 import scala.collection.JavaConverters;
 
@@ -275,37 +287,159 @@ public final class Operations implements AutoCloseable {
    * number of snapshots younger than the maxAge
    */
   public void expireSnapshots(Table table, int maxAge, String granularity, int versions) {
-    if (!table.properties().containsKey(TableProperties.MAX_REF_AGE_MS)) {
-      log.info(
-          "Setting default maximum reference age for table {} to {}ms",
-          table,
-          DEFAULT_MAX_REFERENCE_AGE_MILLIS);
-      table
-          .updateProperties()
-          .set(TableProperties.MAX_REF_AGE_MS, String.valueOf(DEFAULT_MAX_REFERENCE_AGE_MILLIS))
-          .commit();
+    Preconditions.checkArgument(
+        table instanceof HasTableOperations,
+        "Snapshot expiration requires table operations access for table %s",
+        table.name());
+    Map<String, String> tableProperties = table.properties();
+    Tasks.foreach(table)
+        .retry(
+            PropertyUtil.propertyAsInt(
+                tableProperties,
+                TableProperties.COMMIT_NUM_RETRIES,
+                TableProperties.COMMIT_NUM_RETRIES_DEFAULT))
+        .exponentialBackoff(
+            PropertyUtil.propertyAsInt(
+                tableProperties,
+                TableProperties.COMMIT_MIN_RETRY_WAIT_MS,
+                TableProperties.COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+            PropertyUtil.propertyAsInt(
+                tableProperties,
+                TableProperties.COMMIT_MAX_RETRY_WAIT_MS,
+                TableProperties.COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+            PropertyUtil.propertyAsInt(
+                tableProperties,
+                TableProperties.COMMIT_TOTAL_RETRY_TIME_MS,
+                TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
+            2.0)
+        .onlyRetryOn(CommitFailedException.class)
+        .run(
+            tableToExpire -> {
+              ExpireSnapshots expireSnapshotsCommand = newSnapshotExpirationCommand(tableToExpire);
+
+              // maxAge will always be defined
+              ChronoUnit timeUnitGranularity =
+                  ChronoUnit.valueOf(
+                      SparkJobUtil.convertGranularityToChrono(granularity.toUpperCase()).name());
+              long expireBeforeTimestampMs =
+                  System.currentTimeMillis()
+                      - timeUnitGranularity.getDuration().multipliedBy(maxAge).toMillis();
+              log.info(
+                  "Expiring snapshots for table: {} older than {}ms",
+                  tableToExpire,
+                  expireBeforeTimestampMs);
+              expireSnapshotsCommand.expireOlderThan(expireBeforeTimestampMs).commit();
+
+              if (versions > 0 && Iterators.size(tableToExpire.snapshots().iterator()) > versions) {
+                log.info(
+                    "Expiring snapshots for table: {} retaining last {} versions",
+                    tableToExpire,
+                    versions);
+                // Note: retainLast keeps the last N snapshots that WOULD be expired, hence
+                // expireOlderThan currentTime
+                newSnapshotExpirationCommand(tableToExpire)
+                    .expireOlderThan(System.currentTimeMillis())
+                    .retainLast(versions)
+                    .commit();
+              }
+            });
+  }
+
+  private static ExpireSnapshots newSnapshotExpirationCommand(Table table) {
+    return new BaseTable(
+            new TableOperationsWithMaximumReferenceAgeDefault(
+                ((HasTableOperations) table).operations(), DEFAULT_MAX_REFERENCE_AGE_MILLIS),
+            table.name())
+        .expireSnapshots()
+        .cleanExpiredFiles(false);
+  }
+
+  private static final class TableOperationsWithMaximumReferenceAgeDefault
+      implements TableOperations {
+    private final TableOperations delegate;
+    private final long defaultMaximumReferenceAgeMillis;
+    private OptionalLong maximumReferenceAgeMillis = OptionalLong.empty();
+
+    TableOperationsWithMaximumReferenceAgeDefault(
+        TableOperations delegate, long defaultMaximumReferenceAgeMillis) {
+      this.delegate = delegate;
+      this.defaultMaximumReferenceAgeMillis = defaultMaximumReferenceAgeMillis;
     }
 
-    ExpireSnapshots expireSnapshotsCommand = table.expireSnapshots().cleanExpiredFiles(false);
+    @Override
+    public TableMetadata current() {
+      TableMetadata currentMetadata = delegate.refresh();
+      maximumReferenceAgeMillis =
+          OptionalLong.of(
+              currentMetadata.propertyAsLong(
+                  TableProperties.MAX_REF_AGE_MS, defaultMaximumReferenceAgeMillis));
+      Map<String, String> operationProperties = new HashMap<>();
+      if (!currentMetadata.properties().containsKey(TableProperties.MAX_REF_AGE_MS)) {
+        operationProperties.put(
+            TableProperties.MAX_REF_AGE_MS, String.valueOf(defaultMaximumReferenceAgeMillis));
+      }
+      operationProperties.put(TableProperties.COMMIT_NUM_RETRIES, "0");
 
-    // maxAge will always be defined
-    ChronoUnit timeUnitGranularity =
-        ChronoUnit.valueOf(
-            SparkJobUtil.convertGranularityToChrono(granularity.toUpperCase()).name());
-    long expireBeforeTimestampMs =
-        System.currentTimeMillis()
-            - timeUnitGranularity.getDuration().multipliedBy(maxAge).toMillis();
-    log.info("Expiring snapshots for table: {} older than {}ms", table, expireBeforeTimestampMs);
-    expireSnapshotsCommand.expireOlderThan(expireBeforeTimestampMs).commit();
+      return TableMetadata.buildFrom(currentMetadata)
+          .setProperties(operationProperties)
+          .discardChanges()
+          .build();
+    }
 
-    if (versions > 0 && Iterators.size(table.snapshots().iterator()) > versions) {
-      log.info("Expiring snapshots for table: {} retaining last {} versions", table, versions);
-      // Note: retainLast keeps the last N snapshots that WOULD be expired, hence expireOlderThan
-      // currentTime
-      expireSnapshotsCommand
-          .expireOlderThan(System.currentTimeMillis())
-          .retainLast(versions)
-          .commit();
+    @Override
+    public TableMetadata refresh() {
+      TableMetadata refreshedMetadata = delegate.refresh();
+      Preconditions.checkState(
+          maximumReferenceAgeMillis.isPresent(),
+          "Maximum reference age must be resolved before refreshing table metadata");
+      long refreshedMaximumReferenceAgeMillis =
+          refreshedMetadata.propertyAsLong(
+              TableProperties.MAX_REF_AGE_MS, defaultMaximumReferenceAgeMillis);
+      if (maximumReferenceAgeMillis.getAsLong() != refreshedMaximumReferenceAgeMillis) {
+        throw new CommitFailedException(
+            "Maximum reference age changed while expiring snapshots for table metadata %s",
+            refreshedMetadata.metadataFileLocation());
+      }
+      return refreshedMetadata;
+    }
+
+    @Override
+    public void commit(TableMetadata base, TableMetadata metadata) {
+      Preconditions.checkState(
+          metadata.properties().equals(delegate.current().properties()),
+          "Snapshot expiration must preserve table properties");
+      delegate.commit(base, metadata);
+    }
+
+    @Override
+    public FileIO io() {
+      return delegate.io();
+    }
+
+    @Override
+    public EncryptionManager encryption() {
+      return delegate.encryption();
+    }
+
+    @Override
+    public String metadataFileLocation(String fileName) {
+      return delegate.metadataFileLocation(fileName);
+    }
+
+    @Override
+    public LocationProvider locationProvider() {
+      return delegate.locationProvider();
+    }
+
+    @Override
+    public TableOperations temp(TableMetadata uncommittedMetadata) {
+      return new TableOperationsWithMaximumReferenceAgeDefault(
+          delegate.temp(uncommittedMetadata), defaultMaximumReferenceAgeMillis);
+    }
+
+    @Override
+    public long newSnapshotId() {
+      return delegate.newSnapshotId();
     }
   }
 

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -16,14 +16,12 @@ import com.linkedin.openhouse.jobs.util.TableStatsCollector;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import java.io.IOException;
-import java.time.Clock;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -43,9 +41,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.FileScanTask;
-import org.apache.iceberg.ManageSnapshots;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
@@ -62,7 +58,6 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.spark.actions.SparkActions;
-import org.apache.iceberg.util.PropertyUtil;
 import org.apache.spark.sql.SparkSession;
 import scala.collection.JavaConverters;
 
@@ -83,15 +78,8 @@ public final class Operations implements AutoCloseable {
 
   private final OtelEmitter otelEmitter;
 
-  private final Clock clock;
-
   public static Operations of(SparkSession spark, OtelEmitter otelEmitter) {
-    return new Operations(spark, otelEmitter, Clock.systemUTC());
-  }
-
-  @VisibleForTesting
-  static Operations of(SparkSession spark, OtelEmitter otelEmitter, Clock clock) {
-    return new Operations(spark, otelEmitter, clock);
+    return new Operations(spark, otelEmitter);
   }
 
   public static Operations withCatalog(SparkSession spark, OtelEmitter otelEmitter) {
@@ -367,38 +355,23 @@ public final class Operations implements AutoCloseable {
       boolean deleteFiles,
       boolean backupEnabled,
       String backupDir) {
-    long branchExpirationEvaluationTimeMillis = clock.millis();
-    long maximumReferenceAgeMillis =
-        PropertyUtil.propertyAsLong(
-            table.properties(), TableProperties.MAX_REF_AGE_MS, DEFAULT_MAX_REFERENCE_AGE_MILLIS);
-    List<String> branchesToExpire =
-        table.refs().entrySet().stream()
-            .filter(entry -> !SnapshotRef.MAIN_BRANCH.equals(entry.getKey()))
-            .filter(entry -> entry.getValue().isBranch())
-            .filter(
-                entry ->
-                    Optional.ofNullable(table.snapshot(entry.getValue().snapshotId()))
-                        .map(
-                            snapshot ->
-                                branchExpirationEvaluationTimeMillis - snapshot.timestampMillis()
-                                    > Optional.ofNullable(entry.getValue().maxRefAgeMs())
-                                        .orElse(maximumReferenceAgeMillis))
-                        .orElse(false))
-            .map(Map.Entry::getKey)
-            .collect(Collectors.toList());
-
-    if (!branchesToExpire.isEmpty()) {
-      ManageSnapshots manageSnapshots = table.manageSnapshots();
-      branchesToExpire.forEach(manageSnapshots::removeBranch);
-      manageSnapshots.commit();
+    if (!table.properties().containsKey(TableProperties.MAX_REF_AGE_MS)) {
+      log.info(
+          "Backfilling maximum reference age for table {} to {}ms",
+          table,
+          DEFAULT_MAX_REFERENCE_AGE_MILLIS);
+      table
+          .updateProperties()
+          .set(TableProperties.MAX_REF_AGE_MS, String.valueOf(DEFAULT_MAX_REFERENCE_AGE_MILLIS))
+          .commit();
     }
-    log.info("Expired {} branches for table: {}", branchesToExpire.size(), table);
 
     ChronoUnit timeUnitGranularity =
         ChronoUnit.valueOf(
             SparkJobUtil.convertGranularityToChrono(granularity.toUpperCase()).name());
     long expireBeforeTimestampMs =
-        clock.millis() - timeUnitGranularity.getDuration().multipliedBy(maxAge).toMillis();
+        System.currentTimeMillis()
+            - timeUnitGranularity.getDuration().multipliedBy(maxAge).toMillis();
 
     log.info(
         "Expiring snapshots for table: {} older than {}ms with deleteFiles={}, backupEnabled={}, backupDir={}",
@@ -422,8 +395,9 @@ public final class Operations implements AutoCloseable {
       log.info("Expiring snapshots for table: {} retaining last {} versions", table, versions);
       ExpireSnapshots.Result versionsResult =
           deleteFiles
-              ? expireSnapshotsWithFiles(table, clock.millis(), versions, backupEnabled, backupDir)
-              : expireSnapshotsMetadataOnly(table, clock.millis(), versions);
+              ? expireSnapshotsWithFiles(
+                  table, System.currentTimeMillis(), versions, backupEnabled, backupDir)
+              : expireSnapshotsMetadataOnly(table, System.currentTimeMillis(), versions);
       result = combineResults(result, versionsResult);
     }
 

--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -1,6 +1,5 @@
 package com.linkedin.openhouse.jobs.spark;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -23,7 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.OptionalLong;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -40,16 +39,14 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
-import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ExpireSnapshots;
 import org.apache.iceberg.FileScanTask;
-import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.ManageSnapshots;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableMetadata;
-import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.Transaction;
@@ -57,17 +54,12 @@ import org.apache.iceberg.actions.DeleteOrphanFiles;
 import org.apache.iceberg.actions.RewriteDataFiles;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.encryption.EncryptionManager;
-import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.io.FileIO;
-import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.util.PropertyUtil;
-import org.apache.iceberg.util.Tasks;
 import org.apache.spark.sql.SparkSession;
 import scala.collection.JavaConverters;
 
@@ -287,160 +279,58 @@ public final class Operations implements AutoCloseable {
    * number of snapshots younger than the maxAge
    */
   public void expireSnapshots(Table table, int maxAge, String granularity, int versions) {
-    Preconditions.checkArgument(
-        table instanceof HasTableOperations,
-        "Snapshot expiration requires table operations access for table %s",
-        table.name());
-    Map<String, String> tableProperties = table.properties();
-    Tasks.foreach(table)
-        .retry(
-            PropertyUtil.propertyAsInt(
-                tableProperties,
-                TableProperties.COMMIT_NUM_RETRIES,
-                TableProperties.COMMIT_NUM_RETRIES_DEFAULT))
-        .exponentialBackoff(
-            PropertyUtil.propertyAsInt(
-                tableProperties,
-                TableProperties.COMMIT_MIN_RETRY_WAIT_MS,
-                TableProperties.COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-            PropertyUtil.propertyAsInt(
-                tableProperties,
-                TableProperties.COMMIT_MAX_RETRY_WAIT_MS,
-                TableProperties.COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-            PropertyUtil.propertyAsInt(
-                tableProperties,
-                TableProperties.COMMIT_TOTAL_RETRY_TIME_MS,
-                TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
-            2.0)
-        .onlyRetryOn(CommitFailedException.class)
-        .run(
-            tableToExpire -> {
-              ExpireSnapshots expireSnapshotsCommand = newSnapshotExpirationCommand(tableToExpire);
+    long branchExpirationEvaluationTimeMillis = System.currentTimeMillis();
+    long maximumReferenceAgeMillis =
+        PropertyUtil.propertyAsLong(
+            table.properties(), TableProperties.MAX_REF_AGE_MS, DEFAULT_MAX_REFERENCE_AGE_MILLIS);
+    List<String> branchesToExpire =
+        table.refs().entrySet().stream()
+            .filter(entry -> !SnapshotRef.MAIN_BRANCH.equals(entry.getKey()))
+            .filter(entry -> entry.getValue().isBranch())
+            .filter(
+                entry ->
+                    Optional.ofNullable(table.snapshot(entry.getValue().snapshotId()))
+                        .map(
+                            snapshot ->
+                                branchExpirationEvaluationTimeMillis - snapshot.timestampMillis()
+                                    > Optional.ofNullable(entry.getValue().maxRefAgeMs())
+                                        .orElse(maximumReferenceAgeMillis))
+                        .orElse(false))
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toList());
 
-              // maxAge will always be defined
-              ChronoUnit timeUnitGranularity =
-                  ChronoUnit.valueOf(
-                      SparkJobUtil.convertGranularityToChrono(granularity.toUpperCase()).name());
-              long expireBeforeTimestampMs =
-                  System.currentTimeMillis()
-                      - timeUnitGranularity.getDuration().multipliedBy(maxAge).toMillis();
-              log.info(
-                  "Expiring snapshots for table: {} older than {}ms",
-                  tableToExpire,
-                  expireBeforeTimestampMs);
-              expireSnapshotsCommand.expireOlderThan(expireBeforeTimestampMs).commit();
-
-              if (versions > 0 && Iterators.size(tableToExpire.snapshots().iterator()) > versions) {
-                log.info(
-                    "Expiring snapshots for table: {} retaining last {} versions",
-                    tableToExpire,
-                    versions);
-                // Note: retainLast keeps the last N snapshots that WOULD be expired, hence
-                // expireOlderThan currentTime
-                newSnapshotExpirationCommand(tableToExpire)
-                    .expireOlderThan(System.currentTimeMillis())
-                    .retainLast(versions)
-                    .commit();
-              }
-            });
-  }
-
-  private static ExpireSnapshots newSnapshotExpirationCommand(Table table) {
-    return new BaseTable(
-            new TableOperationsWithMaximumReferenceAgeDefault(
-                ((HasTableOperations) table).operations(), DEFAULT_MAX_REFERENCE_AGE_MILLIS),
-            table.name())
-        .expireSnapshots()
-        .cleanExpiredFiles(false);
-  }
-
-  private static final class TableOperationsWithMaximumReferenceAgeDefault
-      implements TableOperations {
-    private final TableOperations delegate;
-    private final long defaultMaximumReferenceAgeMillis;
-    private OptionalLong maximumReferenceAgeMillis = OptionalLong.empty();
-
-    TableOperationsWithMaximumReferenceAgeDefault(
-        TableOperations delegate, long defaultMaximumReferenceAgeMillis) {
-      this.delegate = delegate;
-      this.defaultMaximumReferenceAgeMillis = defaultMaximumReferenceAgeMillis;
+    Transaction transaction = table.newTransaction();
+    if (!branchesToExpire.isEmpty()) {
+      ManageSnapshots manageSnapshots = transaction.manageSnapshots();
+      branchesToExpire.forEach(manageSnapshots::removeBranch);
+      manageSnapshots.commit();
     }
 
-    @Override
-    public TableMetadata current() {
-      TableMetadata currentMetadata = delegate.refresh();
-      maximumReferenceAgeMillis =
-          OptionalLong.of(
-              currentMetadata.propertyAsLong(
-                  TableProperties.MAX_REF_AGE_MS, defaultMaximumReferenceAgeMillis));
-      Map<String, String> operationProperties = new HashMap<>();
-      if (!currentMetadata.properties().containsKey(TableProperties.MAX_REF_AGE_MS)) {
-        operationProperties.put(
-            TableProperties.MAX_REF_AGE_MS, String.valueOf(defaultMaximumReferenceAgeMillis));
-      }
-      operationProperties.put(TableProperties.COMMIT_NUM_RETRIES, "0");
+    ExpireSnapshots expireSnapshotsCommand = transaction.expireSnapshots().cleanExpiredFiles(false);
 
-      return TableMetadata.buildFrom(currentMetadata)
-          .setProperties(operationProperties)
-          .discardChanges()
-          .build();
+    // maxAge will always be defined
+    ChronoUnit timeUnitGranularity =
+        ChronoUnit.valueOf(
+            SparkJobUtil.convertGranularityToChrono(granularity.toUpperCase()).name());
+    long expireBeforeTimestampMs =
+        System.currentTimeMillis()
+            - timeUnitGranularity.getDuration().multipliedBy(maxAge).toMillis();
+    log.info("Expiring snapshots for table: {} older than {}ms", table, expireBeforeTimestampMs);
+    expireSnapshotsCommand.expireOlderThan(expireBeforeTimestampMs).commit();
+
+    if (versions > 0 && Iterators.size(transaction.table().snapshots().iterator()) > versions) {
+      log.info("Expiring snapshots for table: {} retaining last {} versions", table, versions);
+      // Note: retainLast keeps the last N snapshots that WOULD be expired, hence expireOlderThan
+      // currentTime
+      transaction
+          .expireSnapshots()
+          .cleanExpiredFiles(false)
+          .expireOlderThan(System.currentTimeMillis())
+          .retainLast(versions)
+          .commit();
     }
 
-    @Override
-    public TableMetadata refresh() {
-      TableMetadata refreshedMetadata = delegate.refresh();
-      Preconditions.checkState(
-          maximumReferenceAgeMillis.isPresent(),
-          "Maximum reference age must be resolved before refreshing table metadata");
-      long refreshedMaximumReferenceAgeMillis =
-          refreshedMetadata.propertyAsLong(
-              TableProperties.MAX_REF_AGE_MS, defaultMaximumReferenceAgeMillis);
-      if (maximumReferenceAgeMillis.getAsLong() != refreshedMaximumReferenceAgeMillis) {
-        throw new CommitFailedException(
-            "Maximum reference age changed while expiring snapshots for table metadata %s",
-            refreshedMetadata.metadataFileLocation());
-      }
-      return refreshedMetadata;
-    }
-
-    @Override
-    public void commit(TableMetadata base, TableMetadata metadata) {
-      Preconditions.checkState(
-          metadata.properties().equals(delegate.current().properties()),
-          "Snapshot expiration must preserve table properties");
-      delegate.commit(base, metadata);
-    }
-
-    @Override
-    public FileIO io() {
-      return delegate.io();
-    }
-
-    @Override
-    public EncryptionManager encryption() {
-      return delegate.encryption();
-    }
-
-    @Override
-    public String metadataFileLocation(String fileName) {
-      return delegate.metadataFileLocation(fileName);
-    }
-
-    @Override
-    public LocationProvider locationProvider() {
-      return delegate.locationProvider();
-    }
-
-    @Override
-    public TableOperations temp(TableMetadata uncommittedMetadata) {
-      return new TableOperationsWithMaximumReferenceAgeDefault(
-          delegate.temp(uncommittedMetadata), defaultMaximumReferenceAgeMillis);
-    }
-
-    @Override
-    public long newSnapshotId() {
-      return delegate.newSnapshotId();
-    }
+    transaction.commitTransaction();
   }
 
   /**

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -26,8 +26,10 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
@@ -35,13 +37,23 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotParser;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
 import org.apache.iceberg.actions.RewriteDataFiles;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Row;
 import org.assertj.core.util.Lists;
@@ -573,45 +585,60 @@ public class OperationsTest extends OpenHouseSparkITest {
   }
 
   @Test
-  public void testSnapshotsExpirationSetsDefaultMaximumReferenceAge() throws Exception {
-    final String tableName = "db.test_es_default_max_reference_age";
-    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
-      prepareTable(ops, tableName);
-      populateTable(ops, tableName, 1);
-      Table table = ops.getTable(tableName);
+  public void testSnapshotsExpirationUsesDefaultMaximumReferenceAge() throws Exception {
+    InMemoryTableOperations tableOperations =
+        new InMemoryTableOperations(createTableMetadataWithOldBranch(Map.of()));
+    Table table = new BaseTable(tableOperations, "test.default_max_reference_age");
 
-      Assertions.assertFalse(table.properties().containsKey(TableProperties.MAX_REF_AGE_MS));
-      ops.expireSnapshots(table, 3, "DAYS", 0);
-    }
+    Operations.of(getSparkSession(), otelEmitter).expireSnapshots(table, 3, "DAYS", 0);
 
-    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
-      Assertions.assertEquals(
-          String.valueOf(TimeUnit.DAYS.toMillis(7)),
-          ops.getTable(tableName).properties().get(TableProperties.MAX_REF_AGE_MS));
-    }
+    Assertions.assertFalse(table.refs().containsKey("old-branch"));
+    Assertions.assertNull(table.snapshot(1L));
+    Assertions.assertFalse(table.properties().containsKey(TableProperties.MAX_REF_AGE_MS));
+    Assertions.assertEquals(1, tableOperations.commitCount());
   }
 
   @Test
-  public void testSnapshotsExpirationPreservesConfiguredMaximumReferenceAge() throws Exception {
-    final String tableName = "db.test_es_configured_max_reference_age";
-    final String configuredMaximumReferenceAgeMillis = String.valueOf(TimeUnit.DAYS.toMillis(2));
-    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
-      prepareTable(ops, tableName);
-      populateTable(ops, tableName, 1);
-      ops.spark()
-          .sql(
-              String.format(
-                  "ALTER TABLE %s SET TBLPROPERTIES ('%s' = '%s')",
-                  tableName, TableProperties.MAX_REF_AGE_MS, configuredMaximumReferenceAgeMillis));
+  public void testSnapshotsExpirationUsesConfiguredMaximumReferenceAge() throws Exception {
+    final String configuredMaximumReferenceAgeMillis = String.valueOf(TimeUnit.DAYS.toMillis(10));
+    InMemoryTableOperations tableOperations =
+        new InMemoryTableOperations(
+            createTableMetadataWithOldBranch(
+                Map.of(TableProperties.MAX_REF_AGE_MS, configuredMaximumReferenceAgeMillis)));
+    Table table = new BaseTable(tableOperations, "test.configured_max_reference_age");
 
-      ops.expireSnapshots(ops.getTable(tableName), 3, "DAYS", 0);
-    }
+    Operations.of(getSparkSession(), otelEmitter).expireSnapshots(table, 3, "DAYS", 0);
 
-    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
-      Assertions.assertEquals(
-          configuredMaximumReferenceAgeMillis,
-          ops.getTable(tableName).properties().get(TableProperties.MAX_REF_AGE_MS));
-    }
+    Assertions.assertTrue(table.refs().containsKey("old-branch"));
+    Assertions.assertNotNull(table.snapshot(1L));
+    Assertions.assertEquals(
+        configuredMaximumReferenceAgeMillis,
+        table.properties().get(TableProperties.MAX_REF_AGE_MS));
+    Assertions.assertEquals(1, tableOperations.commitCount());
+  }
+
+  @Test
+  public void testSnapshotsExpirationRetriesWhenMaximumReferenceAgeChanges() throws Exception {
+    final String configuredMaximumReferenceAgeMillis = String.valueOf(TimeUnit.DAYS.toMillis(10));
+    TableMetadata initialMetadata = createTableMetadataWithOldBranch(Map.of());
+    TableMetadata refreshedMetadata =
+        TableMetadata.buildFrom(initialMetadata)
+            .setProperties(
+                Map.of(TableProperties.MAX_REF_AGE_MS, configuredMaximumReferenceAgeMillis))
+            .discardChanges()
+            .build();
+    InMemoryTableOperations tableOperations =
+        new InMemoryTableOperations(initialMetadata, Optional.of(refreshedMetadata));
+    Table table = new BaseTable(tableOperations, "test.changed_max_reference_age");
+
+    Operations.of(getSparkSession(), otelEmitter).expireSnapshots(table, 3, "DAYS", 0);
+
+    Assertions.assertTrue(table.refs().containsKey("old-branch"));
+    Assertions.assertNotNull(table.snapshot(1L));
+    Assertions.assertEquals(
+        configuredMaximumReferenceAgeMillis,
+        table.properties().get(TableProperties.MAX_REF_AGE_MS));
+    Assertions.assertEquals(1, tableOperations.commitCount());
   }
 
   @Test
@@ -1697,6 +1724,121 @@ public class OperationsTest extends OpenHouseSparkITest {
       // Empty table should return empty list or single record with 0 rows
       // (implementation-specific, but should not throw exception)
       log.info("Empty table stats count: {}", stats.size());
+    }
+  }
+
+  private static TableMetadata createTableMetadataWithOldBranch(Map<String, String> properties) {
+    long currentTimeMillis = System.currentTimeMillis();
+    long stagedOldSnapshotTimestampMillis = currentTimeMillis + 1;
+    long stagedCurrentSnapshotTimestampMillis = currentTimeMillis + 2;
+    Map<String, String> tableProperties = new HashMap<>(properties);
+    tableProperties.put(TableProperties.FORMAT_VERSION, "2");
+    Snapshot oldSnapshot =
+        SnapshotParser.fromJson(
+            String.format(
+                "{\"sequence-number\":1,\"snapshot-id\":1,\"timestamp-ms\":%d,"
+                    + "\"summary\":{\"operation\":\"append\"},"
+                    + "\"manifest-list\":\"file:/tmp/old-snapshot.avro\",\"schema-id\":0}",
+                stagedOldSnapshotTimestampMillis));
+    Snapshot currentSnapshot =
+        SnapshotParser.fromJson(
+            String.format(
+                "{\"sequence-number\":2,\"snapshot-id\":2,\"parent-snapshot-id\":1,"
+                    + "\"timestamp-ms\":%d,\"summary\":{\"operation\":\"append\"},"
+                    + "\"manifest-list\":\"file:/tmp/current-snapshot.avro\",\"schema-id\":0}",
+                stagedCurrentSnapshotTimestampMillis));
+    TableMetadata tableMetadata =
+        TableMetadata.newTableMetadata(
+            new Schema(Types.NestedField.required(1, "id", Types.LongType.get())),
+            PartitionSpec.unpartitioned(),
+            SortOrder.unsorted(),
+            "file:/tmp/reference-expiration-table",
+            tableProperties);
+
+    TableMetadata metadataWithSnapshots =
+        TableMetadata.buildFrom(tableMetadata)
+            .addSnapshot(oldSnapshot)
+            .addSnapshot(currentSnapshot)
+            .setBranchSnapshot(currentSnapshot.snapshotId(), SnapshotRef.MAIN_BRANCH)
+            .setRef("old-branch", SnapshotRef.branchBuilder(oldSnapshot.snapshotId()).build())
+            .build();
+    JsonObject metadataJson =
+        JsonParser.parseString(TableMetadataParser.toJson(metadataWithSnapshots)).getAsJsonObject();
+    metadataJson.addProperty("last-updated-ms", currentTimeMillis);
+    metadataJson
+        .getAsJsonArray("snapshots")
+        .get(0)
+        .getAsJsonObject()
+        .addProperty("timestamp-ms", currentTimeMillis - TimeUnit.DAYS.toMillis(8));
+    metadataJson
+        .getAsJsonArray("snapshots")
+        .get(1)
+        .getAsJsonObject()
+        .addProperty("timestamp-ms", currentTimeMillis);
+    metadataJson
+        .getAsJsonArray("snapshot-log")
+        .get(0)
+        .getAsJsonObject()
+        .addProperty("timestamp-ms", currentTimeMillis);
+    return TableMetadataParser.fromJson(metadataJson.toString());
+  }
+
+  private static final class InMemoryTableOperations implements TableOperations {
+    private final FileIO fileIO = Mockito.mock(FileIO.class);
+    private final LocationProvider locationProvider = Mockito.mock(LocationProvider.class);
+    private final Optional<TableMetadata> metadataAfterFirstRefresh;
+    private TableMetadata currentMetadata;
+    private int commitCount;
+    private int refreshCount;
+
+    private InMemoryTableOperations(TableMetadata currentMetadata) {
+      this(currentMetadata, Optional.empty());
+    }
+
+    private InMemoryTableOperations(
+        TableMetadata currentMetadata, Optional<TableMetadata> metadataAfterFirstRefresh) {
+      this.currentMetadata = currentMetadata;
+      this.metadataAfterFirstRefresh = metadataAfterFirstRefresh;
+    }
+
+    @Override
+    public TableMetadata current() {
+      return currentMetadata;
+    }
+
+    @Override
+    public TableMetadata refresh() {
+      refreshCount += 1;
+      if (refreshCount == 2) {
+        metadataAfterFirstRefresh.ifPresent(metadata -> currentMetadata = metadata);
+      }
+      return currentMetadata;
+    }
+
+    @Override
+    public void commit(TableMetadata base, TableMetadata metadata) {
+      Assertions.assertSame(currentMetadata, base);
+      currentMetadata = metadata;
+      commitCount += 1;
+    }
+
+    @Override
+    public FileIO io() {
+      return fileIO;
+    }
+
+    @Override
+    public String metadataFileLocation(String fileName) {
+      return String.format("file:/tmp/%s", fileName);
+    }
+
+    @Override
+    public LocationProvider locationProvider() {
+      return locationProvider;
+    }
+
+    private int commitCount() {
+      return commitCount;
     }
   }
 }

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -582,6 +582,8 @@ public class OperationsTest extends OpenHouseSparkITest {
     final String branchName = "expired-branch";
     final String tagName = "expired-tag";
 
+    // A legacy table receives the seven-day default while explicit short ages expire both ref
+    // types.
     try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
       prepareTable(ops, tableName);
       populateTable(ops, tableName, 1);
@@ -618,6 +620,7 @@ public class OperationsTest extends OpenHouseSparkITest {
     final String tableName = "db.test_es_live_branch_java";
     final String branchName = "live-branch";
 
+    // The backfilled seven-day age preserves a branch whose snapshot remains within that window.
     try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
       prepareTable(ops, tableName);
       populateTable(ops, tableName, 1);
@@ -648,6 +651,7 @@ public class OperationsTest extends OpenHouseSparkITest {
     final String configuredMaximumReferenceAgeMillis =
         String.valueOf(Duration.ofDays(10).toMillis());
 
+    // An existing table-level age remains authoritative and preserves live branches and tags.
     try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
       prepareTable(ops, tableName);
       populateTable(ops, tableName, 1);
@@ -688,6 +692,8 @@ public class OperationsTest extends OpenHouseSparkITest {
     final String tableMaximumReferenceAgeMillis = "1";
     final long branchMaximumReferenceAgeMillis = Duration.ofDays(10).toMillis();
 
+    // SparkActions expires a table-aged branch while a longer branch-specific age preserves its
+    // peer.
     try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
       prepareTable(ops, tableName);
       populateTable(ops, tableName, 1);

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -613,6 +613,34 @@ public class OperationsTest extends OpenHouseSparkITest {
   }
 
   @Test
+  public void testSnapshotsExpirationPreservesLiveBranchWithBackfilledMaximumReferenceAge()
+      throws Exception {
+    final String tableName = "db.test_es_live_branch_java";
+    final String branchName = "live-branch";
+
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      prepareTable(ops, tableName);
+      populateTable(ops, tableName, 1);
+      Table table = ops.getTable(tableName);
+      table.updateProperties().remove(TableProperties.MAX_REF_AGE_MS).commit();
+      long branchSnapshotId = table.currentSnapshot().snapshotId();
+      populateTable(ops, tableName, 1);
+      table.refresh();
+      table.manageSnapshots().createBranch(branchName, branchSnapshotId).commit();
+      Assertions.assertTrue(table.refs().containsKey(branchName));
+      Assertions.assertFalse(table.properties().containsKey(TableProperties.MAX_REF_AGE_MS));
+
+      ops.expireSnapshots(table, 3, "DAYS", 0);
+      table.refresh();
+
+      Assertions.assertTrue(table.refs().containsKey(branchName));
+      Assertions.assertEquals(
+          String.valueOf(Duration.ofDays(7).toMillis()),
+          table.properties().get(TableProperties.MAX_REF_AGE_MS));
+    }
+  }
+
+  @Test
   public void testSnapshotsExpirationPreservesConfiguredMaximumReferenceAge() throws Exception {
     final String tableName = "db.test_es_configured_ref_ages_java";
     final String branchName = "table-configured-branch";

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -592,6 +592,7 @@ public class OperationsTest extends OpenHouseSparkITest {
       populateTable(ops, tableName, 1);
       table.refresh();
       table.manageSnapshots().createBranch(branchName, branchSnapshotId).commit();
+      Assertions.assertTrue(table.refs().containsKey(branchName));
 
       Clock clock =
           Clock.fixed(

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -580,6 +580,33 @@ public class OperationsTest extends OpenHouseSparkITest {
   }
 
   @Test
+  public void testSnapshotsExpirationRemovesExpiredBranch() throws Exception {
+    final String tableName = "db.test_es_expired_branch_java";
+    final String branchName = "expired-branch";
+
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      prepareTable(ops, tableName);
+      populateTable(ops, tableName, 1);
+      Table table = ops.getTable(tableName);
+      long branchSnapshotId = table.currentSnapshot().snapshotId();
+      populateTable(ops, tableName, 1);
+      table.refresh();
+      table.manageSnapshots().createBranch(branchName, branchSnapshotId).commit();
+
+      Clock clock =
+          Clock.fixed(
+              Instant.ofEpochMilli(table.snapshot(branchSnapshotId).timestampMillis())
+                  .plus(Duration.ofDays(8)),
+              ZoneOffset.UTC);
+      Operations.of(getSparkSession(), otelEmitter, clock).expireSnapshots(table, 3, "DAYS", 0);
+      table.refresh();
+
+      Assertions.assertFalse(table.refs().containsKey(branchName));
+      Assertions.assertNull(table.snapshot(branchSnapshotId));
+    }
+  }
+
+  @Test
   public void testSnapshotsExpirationUsesDefaultMaximumReferenceAge() throws Exception {
     Clock clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC);
     Table table = Mockito.mock(Table.class);

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -19,9 +19,7 @@ import io.opentelemetry.api.common.Attributes;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.time.Clock;
 import java.time.Duration;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -578,39 +576,47 @@ public class OperationsTest extends OpenHouseSparkITest {
   }
 
   @Test
-  public void testSnapshotsExpirationRemovesExpiredBranch() throws Exception {
-    final String tableName = "db.test_es_expired_branch_java";
+  public void testSnapshotsExpirationBackfillsMaximumReferenceAgeAndExpiresReferences()
+      throws Exception {
+    final String tableName = "db.test_es_backfill_ref_age_java";
     final String branchName = "expired-branch";
+    final String tagName = "expired-tag";
 
     try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
       prepareTable(ops, tableName);
       populateTable(ops, tableName, 1);
       Table table = ops.getTable(tableName);
+      table.updateProperties().remove(TableProperties.MAX_REF_AGE_MS).commit();
       long branchSnapshotId = table.currentSnapshot().snapshotId();
       populateTable(ops, tableName, 1);
       table.refresh();
-      table.manageSnapshots().createBranch(branchName, branchSnapshotId).commit();
+      table
+          .manageSnapshots()
+          .createBranch(branchName, branchSnapshotId)
+          .setMaxRefAgeMs(branchName, 1)
+          .createTag(tagName, branchSnapshotId)
+          .setMaxRefAgeMs(tagName, 1)
+          .commit();
       Assertions.assertTrue(table.refs().containsKey(branchName));
+      Assertions.assertTrue(table.refs().containsKey(tagName));
+      Assertions.assertFalse(table.properties().containsKey(TableProperties.MAX_REF_AGE_MS));
 
-      Clock clock =
-          Clock.fixed(
-              Instant.ofEpochMilli(table.snapshot(branchSnapshotId).timestampMillis())
-                  .plus(Duration.ofDays(8)),
-              ZoneOffset.UTC);
-      Operations.of(getSparkSession(), otelEmitter, clock).expireSnapshots(table, 3, "DAYS", 0);
+      ops.expireSnapshots(table, 3, "DAYS", 0);
       table.refresh();
 
       Assertions.assertFalse(table.refs().containsKey(branchName));
-      Assertions.assertNull(table.snapshot(branchSnapshotId));
-      Assertions.assertFalse(table.properties().containsKey(TableProperties.MAX_REF_AGE_MS));
+      Assertions.assertFalse(table.refs().containsKey(tagName));
+      Assertions.assertEquals(
+          String.valueOf(Duration.ofDays(7).toMillis()),
+          table.properties().get(TableProperties.MAX_REF_AGE_MS));
     }
   }
 
   @Test
-  public void testSnapshotsExpirationUsesConfiguredMaximumReferenceAges() throws Exception {
+  public void testSnapshotsExpirationPreservesConfiguredMaximumReferenceAge() throws Exception {
     final String tableName = "db.test_es_configured_ref_ages_java";
-    final String tableConfiguredBranchName = "table-configured-branch";
-    final String branchConfiguredName = "branch-configured";
+    final String branchName = "table-configured-branch";
+    final String tagName = "table-configured-tag";
     final String configuredMaximumReferenceAgeMillis =
         String.valueOf(Duration.ofDays(10).toMillis());
 
@@ -623,27 +629,21 @@ public class OperationsTest extends OpenHouseSparkITest {
       table.refresh();
       table
           .manageSnapshots()
-          .createBranch(tableConfiguredBranchName, branchSnapshotId)
-          .createBranch(branchConfiguredName, branchSnapshotId)
-          .setMaxRefAgeMs(branchConfiguredName, Duration.ofDays(5).toMillis())
+          .createBranch(branchName, branchSnapshotId)
+          .createTag(tagName, branchSnapshotId)
           .commit();
       table
           .updateProperties()
           .set(TableProperties.MAX_REF_AGE_MS, configuredMaximumReferenceAgeMillis)
           .commit();
-      Assertions.assertTrue(table.refs().containsKey(tableConfiguredBranchName));
-      Assertions.assertTrue(table.refs().containsKey(branchConfiguredName));
+      Assertions.assertTrue(table.refs().containsKey(branchName));
+      Assertions.assertTrue(table.refs().containsKey(tagName));
 
-      Clock clock =
-          Clock.fixed(
-              Instant.ofEpochMilli(table.snapshot(branchSnapshotId).timestampMillis())
-                  .plus(Duration.ofDays(8)),
-              ZoneOffset.UTC);
-      Operations.of(getSparkSession(), otelEmitter, clock).expireSnapshots(table, 3, "DAYS", 0);
+      ops.expireSnapshots(table, 3, "DAYS", 0);
       table.refresh();
 
-      Assertions.assertTrue(table.refs().containsKey(tableConfiguredBranchName));
-      Assertions.assertFalse(table.refs().containsKey(branchConfiguredName));
+      Assertions.assertTrue(table.refs().containsKey(branchName));
+      Assertions.assertTrue(table.refs().containsKey(tagName));
       Assertions.assertNotNull(table.snapshot(branchSnapshotId));
       Assertions.assertEquals(
           configuredMaximumReferenceAgeMillis,

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -37,6 +38,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
 import org.apache.iceberg.actions.RewriteDataFiles;
@@ -567,6 +569,48 @@ public class OperationsTest extends OpenHouseSparkITest {
     try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
       // verify that new apps see snapshots correctly
       checkSnapshots(ops, tableName, snapshotIds);
+    }
+  }
+
+  @Test
+  public void testSnapshotsExpirationSetsDefaultMaximumReferenceAge() throws Exception {
+    final String tableName = "db.test_es_default_max_reference_age";
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      prepareTable(ops, tableName);
+      populateTable(ops, tableName, 1);
+      Table table = ops.getTable(tableName);
+
+      Assertions.assertFalse(table.properties().containsKey(TableProperties.MAX_REF_AGE_MS));
+      ops.expireSnapshots(table, 3, "DAYS", 0);
+    }
+
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      Assertions.assertEquals(
+          String.valueOf(TimeUnit.DAYS.toMillis(7)),
+          ops.getTable(tableName).properties().get(TableProperties.MAX_REF_AGE_MS));
+    }
+  }
+
+  @Test
+  public void testSnapshotsExpirationPreservesConfiguredMaximumReferenceAge() throws Exception {
+    final String tableName = "db.test_es_configured_max_reference_age";
+    final String configuredMaximumReferenceAgeMillis = String.valueOf(TimeUnit.DAYS.toMillis(2));
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      prepareTable(ops, tableName);
+      populateTable(ops, tableName, 1);
+      ops.spark()
+          .sql(
+              String.format(
+                  "ALTER TABLE %s SET TBLPROPERTIES ('%s' = '%s')",
+                  tableName, TableProperties.MAX_REF_AGE_MS, configuredMaximumReferenceAgeMillis));
+
+      ops.expireSnapshots(ops.getTable(tableName), 3, "DAYS", 0);
+    }
+
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      Assertions.assertEquals(
+          configuredMaximumReferenceAgeMillis,
+          ops.getTable(tableName).properties().get(TableProperties.MAX_REF_AGE_MS));
     }
   }
 

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -26,10 +26,8 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
@@ -37,29 +35,23 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.iceberg.BaseTable;
-import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.ExpireSnapshots;
+import org.apache.iceberg.ManageSnapshots;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
-import org.apache.iceberg.SnapshotParser;
 import org.apache.iceberg.SnapshotRef;
-import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableMetadata;
-import org.apache.iceberg.TableMetadataParser;
-import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
 import org.apache.iceberg.actions.RewriteDataFiles;
-import org.apache.iceberg.io.FileIO;
-import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Row;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
+import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 @Slf4j
@@ -586,59 +578,78 @@ public class OperationsTest extends OpenHouseSparkITest {
 
   @Test
   public void testSnapshotsExpirationUsesDefaultMaximumReferenceAge() throws Exception {
-    InMemoryTableOperations tableOperations =
-        new InMemoryTableOperations(createTableMetadataWithOldBranch(Map.of()));
-    Table table = new BaseTable(tableOperations, "test.default_max_reference_age");
+    long currentTimeMillis = System.currentTimeMillis();
+    Table table = Mockito.mock(Table.class);
+    Transaction transaction = Mockito.mock(Transaction.class);
+    ManageSnapshots manageSnapshots = Mockito.mock(ManageSnapshots.class, Mockito.RETURNS_SELF);
+    ExpireSnapshots expireSnapshots = Mockito.mock(ExpireSnapshots.class, Mockito.RETURNS_SELF);
+    Snapshot expiredDefault = snapshotAt(currentTimeMillis - TimeUnit.DAYS.toMillis(8));
+    Snapshot retainedDefault = snapshotAt(currentTimeMillis - TimeUnit.DAYS.toMillis(6));
+    Snapshot retainedOverride = snapshotAt(currentTimeMillis - TimeUnit.DAYS.toMillis(8));
+    Snapshot expiredTag = snapshotAt(currentTimeMillis - TimeUnit.DAYS.toMillis(8));
+
+    Mockito.when(table.properties()).thenReturn(Map.of());
+    Mockito.when(table.refs())
+        .thenReturn(
+            Map.of(
+                SnapshotRef.MAIN_BRANCH,
+                SnapshotRef.branchBuilder(1L).build(),
+                "expired-default",
+                SnapshotRef.branchBuilder(2L).build(),
+                "retained-default",
+                SnapshotRef.branchBuilder(3L).build(),
+                "retained-override",
+                SnapshotRef.branchBuilder(4L).maxRefAgeMs(TimeUnit.DAYS.toMillis(10)).build(),
+                "expired-tag",
+                SnapshotRef.tagBuilder(5L).maxRefAgeMs(TimeUnit.DAYS.toMillis(5)).build()));
+    Mockito.when(table.snapshot(2L)).thenReturn(expiredDefault);
+    Mockito.when(table.snapshot(3L)).thenReturn(retainedDefault);
+    Mockito.when(table.snapshot(4L)).thenReturn(retainedOverride);
+    Mockito.when(table.snapshot(5L)).thenReturn(expiredTag);
+    Mockito.when(table.newTransaction()).thenReturn(transaction);
+    Mockito.when(transaction.manageSnapshots()).thenReturn(manageSnapshots);
+    Mockito.when(transaction.expireSnapshots()).thenReturn(expireSnapshots);
 
     Operations.of(getSparkSession(), otelEmitter).expireSnapshots(table, 3, "DAYS", 0);
 
-    Assertions.assertFalse(table.refs().containsKey("old-branch"));
-    Assertions.assertNull(table.snapshot(1L));
-    Assertions.assertFalse(table.properties().containsKey(TableProperties.MAX_REF_AGE_MS));
-    Assertions.assertEquals(1, tableOperations.commitCount());
+    Mockito.verify(manageSnapshots).removeBranch("expired-default");
+    Mockito.verify(manageSnapshots, Mockito.never()).removeBranch("retained-default");
+    Mockito.verify(manageSnapshots, Mockito.never()).removeBranch("retained-override");
+    Mockito.verify(manageSnapshots, Mockito.never()).removeTag(ArgumentMatchers.anyString());
+    Mockito.verify(table, Mockito.never()).updateProperties();
+    InOrder commitOrder = Mockito.inOrder(manageSnapshots, expireSnapshots, transaction);
+    commitOrder.verify(manageSnapshots).commit();
+    commitOrder.verify(expireSnapshots).commit();
+    commitOrder.verify(transaction).commitTransaction();
   }
 
   @Test
   public void testSnapshotsExpirationUsesConfiguredMaximumReferenceAge() throws Exception {
+    long currentTimeMillis = System.currentTimeMillis();
     final String configuredMaximumReferenceAgeMillis = String.valueOf(TimeUnit.DAYS.toMillis(10));
-    InMemoryTableOperations tableOperations =
-        new InMemoryTableOperations(
-            createTableMetadataWithOldBranch(
-                Map.of(TableProperties.MAX_REF_AGE_MS, configuredMaximumReferenceAgeMillis)));
-    Table table = new BaseTable(tableOperations, "test.configured_max_reference_age");
+    Table table = Mockito.mock(Table.class);
+    Transaction transaction = Mockito.mock(Transaction.class);
+    ExpireSnapshots expireSnapshots = Mockito.mock(ExpireSnapshots.class, Mockito.RETURNS_SELF);
+    Snapshot retainedConfigured = snapshotAt(currentTimeMillis - TimeUnit.DAYS.toMillis(8));
+
+    Mockito.when(table.properties())
+        .thenReturn(Map.of(TableProperties.MAX_REF_AGE_MS, configuredMaximumReferenceAgeMillis));
+    Mockito.when(table.refs())
+        .thenReturn(
+            Map.of(
+                SnapshotRef.MAIN_BRANCH,
+                SnapshotRef.branchBuilder(1L).build(),
+                "retained-configured",
+                SnapshotRef.branchBuilder(2L).build()));
+    Mockito.when(table.snapshot(2L)).thenReturn(retainedConfigured);
+    Mockito.when(table.newTransaction()).thenReturn(transaction);
+    Mockito.when(transaction.expireSnapshots()).thenReturn(expireSnapshots);
 
     Operations.of(getSparkSession(), otelEmitter).expireSnapshots(table, 3, "DAYS", 0);
 
-    Assertions.assertTrue(table.refs().containsKey("old-branch"));
-    Assertions.assertNotNull(table.snapshot(1L));
-    Assertions.assertEquals(
-        configuredMaximumReferenceAgeMillis,
-        table.properties().get(TableProperties.MAX_REF_AGE_MS));
-    Assertions.assertEquals(1, tableOperations.commitCount());
-  }
-
-  @Test
-  public void testSnapshotsExpirationRetriesWhenMaximumReferenceAgeChanges() throws Exception {
-    final String configuredMaximumReferenceAgeMillis = String.valueOf(TimeUnit.DAYS.toMillis(10));
-    TableMetadata initialMetadata = createTableMetadataWithOldBranch(Map.of());
-    TableMetadata refreshedMetadata =
-        TableMetadata.buildFrom(initialMetadata)
-            .setProperties(
-                Map.of(TableProperties.MAX_REF_AGE_MS, configuredMaximumReferenceAgeMillis))
-            .discardChanges()
-            .build();
-    InMemoryTableOperations tableOperations =
-        new InMemoryTableOperations(initialMetadata, Optional.of(refreshedMetadata));
-    Table table = new BaseTable(tableOperations, "test.changed_max_reference_age");
-
-    Operations.of(getSparkSession(), otelEmitter).expireSnapshots(table, 3, "DAYS", 0);
-
-    Assertions.assertTrue(table.refs().containsKey("old-branch"));
-    Assertions.assertNotNull(table.snapshot(1L));
-    Assertions.assertEquals(
-        configuredMaximumReferenceAgeMillis,
-        table.properties().get(TableProperties.MAX_REF_AGE_MS));
-    Assertions.assertEquals(1, tableOperations.commitCount());
+    Mockito.verify(transaction, Mockito.never()).manageSnapshots();
+    Mockito.verify(table, Mockito.never()).updateProperties();
+    Mockito.verify(transaction).commitTransaction();
   }
 
   @Test
@@ -1727,118 +1738,9 @@ public class OperationsTest extends OpenHouseSparkITest {
     }
   }
 
-  private static TableMetadata createTableMetadataWithOldBranch(Map<String, String> properties) {
-    long currentTimeMillis = System.currentTimeMillis();
-    long stagedOldSnapshotTimestampMillis = currentTimeMillis + 1;
-    long stagedCurrentSnapshotTimestampMillis = currentTimeMillis + 2;
-    Map<String, String> tableProperties = new HashMap<>(properties);
-    tableProperties.put(TableProperties.FORMAT_VERSION, "2");
-    Snapshot oldSnapshot =
-        SnapshotParser.fromJson(
-            String.format(
-                "{\"sequence-number\":1,\"snapshot-id\":1,\"timestamp-ms\":%d,"
-                    + "\"summary\":{\"operation\":\"append\"},"
-                    + "\"manifest-list\":\"file:/tmp/old-snapshot.avro\",\"schema-id\":0}",
-                stagedOldSnapshotTimestampMillis));
-    Snapshot currentSnapshot =
-        SnapshotParser.fromJson(
-            String.format(
-                "{\"sequence-number\":2,\"snapshot-id\":2,\"parent-snapshot-id\":1,"
-                    + "\"timestamp-ms\":%d,\"summary\":{\"operation\":\"append\"},"
-                    + "\"manifest-list\":\"file:/tmp/current-snapshot.avro\",\"schema-id\":0}",
-                stagedCurrentSnapshotTimestampMillis));
-    TableMetadata tableMetadata =
-        TableMetadata.newTableMetadata(
-            new Schema(Types.NestedField.required(1, "id", Types.LongType.get())),
-            PartitionSpec.unpartitioned(),
-            SortOrder.unsorted(),
-            "file:/tmp/reference-expiration-table",
-            tableProperties);
-
-    TableMetadata metadataWithSnapshots =
-        TableMetadata.buildFrom(tableMetadata)
-            .addSnapshot(oldSnapshot)
-            .addSnapshot(currentSnapshot)
-            .setBranchSnapshot(currentSnapshot.snapshotId(), SnapshotRef.MAIN_BRANCH)
-            .setRef("old-branch", SnapshotRef.branchBuilder(oldSnapshot.snapshotId()).build())
-            .build();
-    JsonObject metadataJson =
-        JsonParser.parseString(TableMetadataParser.toJson(metadataWithSnapshots)).getAsJsonObject();
-    metadataJson.addProperty("last-updated-ms", currentTimeMillis);
-    metadataJson
-        .getAsJsonArray("snapshots")
-        .get(0)
-        .getAsJsonObject()
-        .addProperty("timestamp-ms", currentTimeMillis - TimeUnit.DAYS.toMillis(8));
-    metadataJson
-        .getAsJsonArray("snapshots")
-        .get(1)
-        .getAsJsonObject()
-        .addProperty("timestamp-ms", currentTimeMillis);
-    metadataJson
-        .getAsJsonArray("snapshot-log")
-        .get(0)
-        .getAsJsonObject()
-        .addProperty("timestamp-ms", currentTimeMillis);
-    return TableMetadataParser.fromJson(metadataJson.toString());
-  }
-
-  private static final class InMemoryTableOperations implements TableOperations {
-    private final FileIO fileIO = Mockito.mock(FileIO.class);
-    private final LocationProvider locationProvider = Mockito.mock(LocationProvider.class);
-    private final Optional<TableMetadata> metadataAfterFirstRefresh;
-    private TableMetadata currentMetadata;
-    private int commitCount;
-    private int refreshCount;
-
-    private InMemoryTableOperations(TableMetadata currentMetadata) {
-      this(currentMetadata, Optional.empty());
-    }
-
-    private InMemoryTableOperations(
-        TableMetadata currentMetadata, Optional<TableMetadata> metadataAfterFirstRefresh) {
-      this.currentMetadata = currentMetadata;
-      this.metadataAfterFirstRefresh = metadataAfterFirstRefresh;
-    }
-
-    @Override
-    public TableMetadata current() {
-      return currentMetadata;
-    }
-
-    @Override
-    public TableMetadata refresh() {
-      refreshCount += 1;
-      if (refreshCount == 2) {
-        metadataAfterFirstRefresh.ifPresent(metadata -> currentMetadata = metadata);
-      }
-      return currentMetadata;
-    }
-
-    @Override
-    public void commit(TableMetadata base, TableMetadata metadata) {
-      Assertions.assertSame(currentMetadata, base);
-      currentMetadata = metadata;
-      commitCount += 1;
-    }
-
-    @Override
-    public FileIO io() {
-      return fileIO;
-    }
-
-    @Override
-    public String metadataFileLocation(String fileName) {
-      return String.format("file:/tmp/%s", fileName);
-    }
-
-    @Override
-    public LocationProvider locationProvider() {
-      return locationProvider;
-    }
-
-    private int commitCount() {
-      return commitCount;
-    }
+  private static Snapshot snapshotAt(long timestampMillis) {
+    Snapshot snapshot = Mockito.mock(Snapshot.class);
+    Mockito.when(snapshot.timestampMillis()).thenReturn(timestampMillis);
+    return snapshot;
   }
 }

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -19,6 +19,9 @@ import io.opentelemetry.api.common.Attributes;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -578,15 +581,17 @@ public class OperationsTest extends OpenHouseSparkITest {
 
   @Test
   public void testSnapshotsExpirationUsesDefaultMaximumReferenceAge() throws Exception {
-    long currentTimeMillis = System.currentTimeMillis();
+    Clock clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC);
     Table table = Mockito.mock(Table.class);
     Transaction transaction = Mockito.mock(Transaction.class);
     ManageSnapshots manageSnapshots = Mockito.mock(ManageSnapshots.class, Mockito.RETURNS_SELF);
     ExpireSnapshots expireSnapshots = Mockito.mock(ExpireSnapshots.class, Mockito.RETURNS_SELF);
-    Snapshot expiredDefault = snapshotAt(currentTimeMillis - TimeUnit.DAYS.toMillis(8));
-    Snapshot retainedDefault = snapshotAt(currentTimeMillis - TimeUnit.DAYS.toMillis(6));
-    Snapshot retainedOverride = snapshotAt(currentTimeMillis - TimeUnit.DAYS.toMillis(8));
-    Snapshot expiredTag = snapshotAt(currentTimeMillis - TimeUnit.DAYS.toMillis(8));
+    Snapshot expiredDefault = snapshotAt(clock.millis());
+    Snapshot retainedOverride = snapshotAt(clock.millis());
+    Snapshot expiredTag = snapshotAt(clock.millis());
+    clock = Clock.offset(clock, Duration.ofDays(2));
+    Snapshot retainedDefault = snapshotAt(clock.millis());
+    clock = Clock.offset(clock, Duration.ofDays(6));
 
     Mockito.when(table.properties()).thenReturn(Map.of());
     Mockito.when(table.refs())
@@ -610,12 +615,13 @@ public class OperationsTest extends OpenHouseSparkITest {
     Mockito.when(transaction.manageSnapshots()).thenReturn(manageSnapshots);
     Mockito.when(transaction.expireSnapshots()).thenReturn(expireSnapshots);
 
-    Operations.of(getSparkSession(), otelEmitter).expireSnapshots(table, 3, "DAYS", 0);
+    Operations.of(getSparkSession(), otelEmitter, clock).expireSnapshots(table, 3, "DAYS", 0);
 
     Mockito.verify(manageSnapshots).removeBranch("expired-default");
     Mockito.verify(manageSnapshots, Mockito.never()).removeBranch("retained-default");
     Mockito.verify(manageSnapshots, Mockito.never()).removeBranch("retained-override");
     Mockito.verify(manageSnapshots, Mockito.never()).removeTag(ArgumentMatchers.anyString());
+    Mockito.verify(expireSnapshots).cleanExpiredFiles(true);
     Mockito.verify(table, Mockito.never()).updateProperties();
     InOrder commitOrder = Mockito.inOrder(manageSnapshots, expireSnapshots, transaction);
     commitOrder.verify(manageSnapshots).commit();
@@ -625,12 +631,13 @@ public class OperationsTest extends OpenHouseSparkITest {
 
   @Test
   public void testSnapshotsExpirationUsesConfiguredMaximumReferenceAge() throws Exception {
-    long currentTimeMillis = System.currentTimeMillis();
+    Clock clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC);
     final String configuredMaximumReferenceAgeMillis = String.valueOf(TimeUnit.DAYS.toMillis(10));
     Table table = Mockito.mock(Table.class);
     Transaction transaction = Mockito.mock(Transaction.class);
     ExpireSnapshots expireSnapshots = Mockito.mock(ExpireSnapshots.class, Mockito.RETURNS_SELF);
-    Snapshot retainedConfigured = snapshotAt(currentTimeMillis - TimeUnit.DAYS.toMillis(8));
+    Snapshot retainedConfigured = snapshotAt(clock.millis());
+    clock = Clock.offset(clock, Duration.ofDays(8));
 
     Mockito.when(table.properties())
         .thenReturn(Map.of(TableProperties.MAX_REF_AGE_MS, configuredMaximumReferenceAgeMillis));
@@ -645,7 +652,7 @@ public class OperationsTest extends OpenHouseSparkITest {
     Mockito.when(table.newTransaction()).thenReturn(transaction);
     Mockito.when(transaction.expireSnapshots()).thenReturn(expireSnapshots);
 
-    Operations.of(getSparkSession(), otelEmitter).expireSnapshots(table, 3, "DAYS", 0);
+    Operations.of(getSparkSession(), otelEmitter, clock).expireSnapshots(table, 3, "DAYS", 0);
 
     Mockito.verify(transaction, Mockito.never()).manageSnapshots();
     Mockito.verify(table, Mockito.never()).updateProperties();

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -680,6 +680,49 @@ public class OperationsTest extends OpenHouseSparkITest {
   }
 
   @Test
+  public void testSnapshotsExpirationWithFilesHonorsTableAndReferenceMaximumAges()
+      throws Exception {
+    final String tableName = "db.test_es_reference_age_matrix_java";
+    final String tableAgeBranchName = "table-age-branch";
+    final String referenceAgeBranchName = "reference-age-branch";
+    final String tableMaximumReferenceAgeMillis = "1";
+    final long branchMaximumReferenceAgeMillis = Duration.ofDays(10).toMillis();
+
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      prepareTable(ops, tableName);
+      populateTable(ops, tableName, 1);
+      Table table = ops.getTable(tableName);
+      long branchSnapshotId = table.currentSnapshot().snapshotId();
+      populateTable(ops, tableName, 1);
+      table.refresh();
+      table
+          .manageSnapshots()
+          .createBranch(tableAgeBranchName, branchSnapshotId)
+          .createBranch(referenceAgeBranchName, branchSnapshotId)
+          .setMaxRefAgeMs(referenceAgeBranchName, branchMaximumReferenceAgeMillis)
+          .commit();
+      table
+          .updateProperties()
+          .set(TableProperties.MAX_REF_AGE_MS, tableMaximumReferenceAgeMillis)
+          .commit();
+      Assertions.assertTrue(
+          System.currentTimeMillis() - table.snapshot(branchSnapshotId).timestampMillis() > 1,
+          "The branch snapshot must exceed the table-level maximum reference age");
+      Assertions.assertTrue(table.refs().containsKey(tableAgeBranchName));
+      Assertions.assertTrue(table.refs().containsKey(referenceAgeBranchName));
+
+      ops.expireSnapshots(table, 3, "DAYS", 0, true, false, BACKUP_DIR);
+      table.refresh();
+
+      Assertions.assertFalse(table.refs().containsKey(tableAgeBranchName));
+      Assertions.assertTrue(table.refs().containsKey(referenceAgeBranchName));
+      Assertions.assertNotNull(table.snapshot(branchSnapshotId));
+      Assertions.assertEquals(
+          tableMaximumReferenceAgeMillis, table.properties().get(TableProperties.MAX_REF_AGE_MS));
+    }
+  }
+
+  @Test
   public void testSnapshotsExpirationVersionsNoop() throws Exception {
     final String tableName = "db.test_es_versions_noop_java";
     final int numInserts = 3;

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -31,18 +31,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.iceberg.ExpireSnapshots;
-import org.apache.iceberg.ManageSnapshots;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
-import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.Transaction;
@@ -54,7 +50,6 @@ import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
-import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 @Slf4j
@@ -604,87 +599,53 @@ public class OperationsTest extends OpenHouseSparkITest {
 
       Assertions.assertFalse(table.refs().containsKey(branchName));
       Assertions.assertNull(table.snapshot(branchSnapshotId));
+      Assertions.assertFalse(table.properties().containsKey(TableProperties.MAX_REF_AGE_MS));
     }
   }
 
   @Test
-  public void testSnapshotsExpirationUsesDefaultMaximumReferenceAge() throws Exception {
-    Clock clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC);
-    Table table = Mockito.mock(Table.class);
-    Transaction transaction = Mockito.mock(Transaction.class);
-    ManageSnapshots manageSnapshots = Mockito.mock(ManageSnapshots.class, Mockito.RETURNS_SELF);
-    ExpireSnapshots expireSnapshots = Mockito.mock(ExpireSnapshots.class, Mockito.RETURNS_SELF);
-    Snapshot expiredDefault = snapshotAt(clock.millis());
-    Snapshot retainedOverride = snapshotAt(clock.millis());
-    Snapshot expiredTag = snapshotAt(clock.millis());
-    clock = Clock.offset(clock, Duration.ofDays(2));
-    Snapshot retainedDefault = snapshotAt(clock.millis());
-    clock = Clock.offset(clock, Duration.ofDays(6));
+  public void testSnapshotsExpirationUsesConfiguredMaximumReferenceAges() throws Exception {
+    final String tableName = "db.test_es_configured_ref_ages_java";
+    final String tableConfiguredBranchName = "table-configured-branch";
+    final String branchConfiguredName = "branch-configured";
+    final String configuredMaximumReferenceAgeMillis =
+        String.valueOf(Duration.ofDays(10).toMillis());
 
-    Mockito.when(table.properties()).thenReturn(Map.of());
-    Mockito.when(table.refs())
-        .thenReturn(
-            Map.of(
-                SnapshotRef.MAIN_BRANCH,
-                SnapshotRef.branchBuilder(1L).build(),
-                "expired-default",
-                SnapshotRef.branchBuilder(2L).build(),
-                "retained-default",
-                SnapshotRef.branchBuilder(3L).build(),
-                "retained-override",
-                SnapshotRef.branchBuilder(4L).maxRefAgeMs(TimeUnit.DAYS.toMillis(10)).build(),
-                "expired-tag",
-                SnapshotRef.tagBuilder(5L).maxRefAgeMs(TimeUnit.DAYS.toMillis(5)).build()));
-    Mockito.when(table.snapshot(2L)).thenReturn(expiredDefault);
-    Mockito.when(table.snapshot(3L)).thenReturn(retainedDefault);
-    Mockito.when(table.snapshot(4L)).thenReturn(retainedOverride);
-    Mockito.when(table.snapshot(5L)).thenReturn(expiredTag);
-    Mockito.when(table.newTransaction()).thenReturn(transaction);
-    Mockito.when(transaction.manageSnapshots()).thenReturn(manageSnapshots);
-    Mockito.when(transaction.expireSnapshots()).thenReturn(expireSnapshots);
+    try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
+      prepareTable(ops, tableName);
+      populateTable(ops, tableName, 1);
+      Table table = ops.getTable(tableName);
+      long branchSnapshotId = table.currentSnapshot().snapshotId();
+      populateTable(ops, tableName, 1);
+      table.refresh();
+      table
+          .manageSnapshots()
+          .createBranch(tableConfiguredBranchName, branchSnapshotId)
+          .createBranch(branchConfiguredName, branchSnapshotId)
+          .setMaxRefAgeMs(branchConfiguredName, Duration.ofDays(5).toMillis())
+          .commit();
+      table
+          .updateProperties()
+          .set(TableProperties.MAX_REF_AGE_MS, configuredMaximumReferenceAgeMillis)
+          .commit();
+      Assertions.assertTrue(table.refs().containsKey(tableConfiguredBranchName));
+      Assertions.assertTrue(table.refs().containsKey(branchConfiguredName));
 
-    Operations.of(getSparkSession(), otelEmitter, clock).expireSnapshots(table, 3, "DAYS", 0);
+      Clock clock =
+          Clock.fixed(
+              Instant.ofEpochMilli(table.snapshot(branchSnapshotId).timestampMillis())
+                  .plus(Duration.ofDays(8)),
+              ZoneOffset.UTC);
+      Operations.of(getSparkSession(), otelEmitter, clock).expireSnapshots(table, 3, "DAYS", 0);
+      table.refresh();
 
-    Mockito.verify(manageSnapshots).removeBranch("expired-default");
-    Mockito.verify(manageSnapshots, Mockito.never()).removeBranch("retained-default");
-    Mockito.verify(manageSnapshots, Mockito.never()).removeBranch("retained-override");
-    Mockito.verify(manageSnapshots, Mockito.never()).removeTag(ArgumentMatchers.anyString());
-    Mockito.verify(expireSnapshots).cleanExpiredFiles(true);
-    Mockito.verify(table, Mockito.never()).updateProperties();
-    InOrder commitOrder = Mockito.inOrder(manageSnapshots, expireSnapshots, transaction);
-    commitOrder.verify(manageSnapshots).commit();
-    commitOrder.verify(expireSnapshots).commit();
-    commitOrder.verify(transaction).commitTransaction();
-  }
-
-  @Test
-  public void testSnapshotsExpirationUsesConfiguredMaximumReferenceAge() throws Exception {
-    Clock clock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC);
-    final String configuredMaximumReferenceAgeMillis = String.valueOf(TimeUnit.DAYS.toMillis(10));
-    Table table = Mockito.mock(Table.class);
-    Transaction transaction = Mockito.mock(Transaction.class);
-    ExpireSnapshots expireSnapshots = Mockito.mock(ExpireSnapshots.class, Mockito.RETURNS_SELF);
-    Snapshot retainedConfigured = snapshotAt(clock.millis());
-    clock = Clock.offset(clock, Duration.ofDays(8));
-
-    Mockito.when(table.properties())
-        .thenReturn(Map.of(TableProperties.MAX_REF_AGE_MS, configuredMaximumReferenceAgeMillis));
-    Mockito.when(table.refs())
-        .thenReturn(
-            Map.of(
-                SnapshotRef.MAIN_BRANCH,
-                SnapshotRef.branchBuilder(1L).build(),
-                "retained-configured",
-                SnapshotRef.branchBuilder(2L).build()));
-    Mockito.when(table.snapshot(2L)).thenReturn(retainedConfigured);
-    Mockito.when(table.newTransaction()).thenReturn(transaction);
-    Mockito.when(transaction.expireSnapshots()).thenReturn(expireSnapshots);
-
-    Operations.of(getSparkSession(), otelEmitter, clock).expireSnapshots(table, 3, "DAYS", 0);
-
-    Mockito.verify(transaction, Mockito.never()).manageSnapshots();
-    Mockito.verify(table, Mockito.never()).updateProperties();
-    Mockito.verify(transaction).commitTransaction();
+      Assertions.assertTrue(table.refs().containsKey(tableConfiguredBranchName));
+      Assertions.assertFalse(table.refs().containsKey(branchConfiguredName));
+      Assertions.assertNotNull(table.snapshot(branchSnapshotId));
+      Assertions.assertEquals(
+          configuredMaximumReferenceAgeMillis,
+          table.properties().get(TableProperties.MAX_REF_AGE_MS));
+    }
   }
 
   @Test
@@ -1771,11 +1732,5 @@ public class OperationsTest extends OpenHouseSparkITest {
       // (implementation-specific, but should not throw exception)
       log.info("Empty table stats count: {}", stats.size());
     }
-  }
-
-  private static Snapshot snapshotAt(long timestampMillis) {
-    Snapshot snapshot = Mockito.mock(Snapshot.class);
-    Mockito.when(snapshot.timestampMillis()).thenReturn(timestampMillis);
-    return snapshot;
   }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
@@ -81,6 +82,7 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
 
   private static final String TABLE_TYPE_KEY = "tableType";
   private static final String CLUSTER_ID = "clusterId";
+  private static final long DEFAULT_MAX_REFERENCE_AGE_MILLIS = TimeUnit.DAYS.toMillis(7);
 
   @Autowired Catalog catalog;
 
@@ -536,6 +538,9 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
                     !preservedKeyChecker.isKeyPreservedForTable(entry.getKey(), tableDto)
                         || preservedKeyChecker.allowKeyInCreation(entry.getKey(), tableDto))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+    propertiesMap.putIfAbsent(
+        TableProperties.MAX_REF_AGE_MS, String.valueOf(DEFAULT_MAX_REFERENCE_AGE_MILLIS));
 
     // Only set cluster default for DEFAULT_FILE_FORMAT if user hasn't provided a value
     // (which means either they didn't specify it, or the feature toggle filtered it out)

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImplTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImplTest.java
@@ -19,6 +19,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -95,6 +96,28 @@ public class OpenHouseInternalRepositoryImplTest {
     Assertions.assertEquals(
         userProvidedMaxMetadataVersions,
         actualProps.get(TableProperties.METADATA_PREVIOUS_VERSIONS_MAX));
+  }
+
+  @Test
+  void testComputePropsForTableCreation_DefaultMaximumReferenceAge() {
+    Map<String, String> actualProps =
+        openHouseInternalRepository.computePropsForTableCreation(createTableDto(new HashMap<>()));
+
+    Assertions.assertEquals(
+        String.valueOf(TimeUnit.DAYS.toMillis(7)), actualProps.get(TableProperties.MAX_REF_AGE_MS));
+  }
+
+  @Test
+  void testComputePropsForTableCreation_UserProvidedMaximumReferenceAge() {
+    String userProvidedMaximumReferenceAge = String.valueOf(TimeUnit.DAYS.toMillis(14));
+    Map<String, String> userProps = new HashMap<>();
+    userProps.put(TableProperties.MAX_REF_AGE_MS, userProvidedMaximumReferenceAge);
+
+    Map<String, String> actualProps =
+        openHouseInternalRepository.computePropsForTableCreation(createTableDto(userProps));
+
+    Assertions.assertEquals(
+        userProvidedMaximumReferenceAge, actualProps.get(TableProperties.MAX_REF_AGE_MS));
   }
 
   @Test

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImplTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImplTest.java
@@ -100,6 +100,7 @@ public class OpenHouseInternalRepositoryImplTest {
 
   @Test
   void testComputePropsForTableCreation_DefaultMaximumReferenceAge() {
+    // Table creation stamps the seven-day reference age when the request omits the property.
     Map<String, String> actualProps =
         openHouseInternalRepository.computePropsForTableCreation(createTableDto(new HashMap<>()));
 
@@ -109,6 +110,7 @@ public class OpenHouseInternalRepositoryImplTest {
 
   @Test
   void testComputePropsForTableCreation_UserProvidedMaximumReferenceAge() {
+    // Table creation preserves an accepted caller-provided reference age instead of defaulting it.
     String userProvidedMaximumReferenceAge = String.valueOf(TimeUnit.DAYS.toMillis(14));
     Map<String, String> userProps = new HashMap<>();
     userProps.put(TableProperties.MAX_REF_AGE_MS, userProvidedMaximumReferenceAge);


### PR DESCRIPTION
## Summary

Use Iceberg's native reference expiration during snapshot-expiration maintenance.

New tables receive a seven-day `history.expire.max-ref-age-ms` default during creation. Snapshot expiration backfills the same property when it is missing from a legacy table, then delegates branch and tag retention to Iceberg. Existing table-level and reference-specific maximum ages remain authoritative.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

## Testing Done

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Added real Iceberg table tests that verify:

- Snapshot expiration backfills the seven-day maximum reference age for a legacy table.
- Native Iceberg expiration removes stale branch and tag references.
- A live branch remains when its snapshot is within the backfilled seven-day maximum reference age.
- A configured table-level maximum reference age is preserved and keeps live branch and tag references and their snapshots.
- New tables receive the seven-day default while an existing configured value is preserved.

The `OperationsTest` suite passes for the Iceberg 1.2 and Iceberg 1.5 application variants. The table repository tests and affected Spotless checks also pass.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.
