### PR TITLE
Fix Spotless formatting on main

### DIFF
--- a/integrations/java/iceberg-1.5/openhouse-java-runtime/src/iceberg-version-specific/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
+++ b/integrations/java/iceberg-1.5/openhouse-java-runtime/src/iceberg-version-specific/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
@@ -88,8 +88,8 @@ import reactor.core.publisher.Mono;
  * copy stays table-only ({@code extends BaseMetastoreCatalog}).
  *
  * <p>Because extending {@link BaseMetastoreViewCatalog} makes this an Iceberg {@code ViewCatalog},
- * Spark's {@code SparkCatalog} routes view probes to this instance instead of short-circuiting
- * them (it only calls a catalog's view methods when the catalog is {@code instanceof ViewCatalog};
+ * Spark's {@code SparkCatalog} routes view probes to this instance instead of short-circuiting them
+ * (it only calls a catalog's view methods when the catalog is {@code instanceof ViewCatalog};
  * otherwise it answers view ops itself). Notably {@code SparkCatalog.loadView} is invoked while
  * resolving every unqualified identifier. So when views are disabled we mirror, method-for-method,
  * how {@code SparkCatalog} behaves for a non-{@code ViewCatalog} (table-only) catalog, making the
@@ -591,7 +591,8 @@ public class OpenHouseCatalog extends BaseMetastoreViewCatalog
     return new OpenHouseTableBuilder(identifier, schema);
   }
 
-  // ============================= OpenHouse Views (gated, off by default) =============================
+  // ============================= OpenHouse Views (gated, off by default)
+  // =============================
   // Gated by VIEWS_ENABLED_PROPERTY: view operations delegate to an in-memory MOCK
   // backend (mockViewStore). loadView/buildView reuse the BaseMetastoreViewCatalog machinery via
   // newViewOps; listViews/dropView/renameView are backed directly by the store.
@@ -640,9 +641,10 @@ public class OpenHouseCatalog extends BaseMetastoreViewCatalog
    *
    * <p>When views are disabled, throws {@link NoSuchViewException} rather than {@link
    * UnsupportedOperationException}. Spark's {@code SparkCatalog.loadView} probes this method while
-   * resolving every unqualified identifier and catches only {@code NoSuchViewException} to fall back
-   * to table resolution; any other exception propagates and breaks table reads. Throwing {@code
-   * NoSuchViewException} here therefore reproduces the table-only (non-{@code ViewCatalog}) behavior.
+   * resolving every unqualified identifier and catches only {@code NoSuchViewException} to fall
+   * back to table resolution; any other exception propagates and breaks table reads. Throwing
+   * {@code NoSuchViewException} here therefore reproduces the table-only (non-{@code ViewCatalog})
+   * behavior.
    */
   @Override
   public View loadView(TableIdentifier identifier) {
@@ -661,10 +663,10 @@ public class OpenHouseCatalog extends BaseMetastoreViewCatalog
    * SparkCatalog.createView}, which calls {@code buildView(...).create()} and catches only {@code
    * NoSuchNamespaceException} / {@code AlreadyExistsException} (rethrowing them as Spark {@code
    * AnalysisException}s); any other exception — e.g. {@link UnsupportedOperationException} — would
-   * leak as a raw runtime error and break callers that expect an {@code AnalysisException}. Throwing
-   * {@code NoSuchNamespaceException} is therefore the signal that normalizes {@code CREATE VIEW}
-   * rejection to a Spark {@code AnalysisException}, matching how a table-only catalog (Iceberg 1.2 /
-   * Spark 3.1) rejects it. See {@code OpenHouseViewSparkITest}.
+   * leak as a raw runtime error and break callers that expect an {@code AnalysisException}.
+   * Throwing {@code NoSuchNamespaceException} is therefore the signal that normalizes {@code CREATE
+   * VIEW} rejection to a Spark {@code AnalysisException}, matching how a table-only catalog
+   * (Iceberg 1.2 / Spark 3.1) rejects it. See {@code OpenHouseViewSparkITest}.
    */
   @Override
   public ViewBuilder buildView(TableIdentifier identifier) {
@@ -701,8 +703,8 @@ public class OpenHouseCatalog extends BaseMetastoreViewCatalog
    * {@inheritDoc}
    *
    * <p>When views are disabled, returns {@code false} (nothing to drop), matching how {@code
-   * SparkCatalog} answers {@code DROP VIEW} for a non-{@code ViewCatalog} catalog; this keeps {@code
-   * DROP VIEW ... IF EXISTS} a no-op rather than an error.
+   * SparkCatalog} answers {@code DROP VIEW} for a non-{@code ViewCatalog} catalog; this keeps
+   * {@code DROP VIEW ... IF EXISTS} a no-op rather than an error.
    */
   @Override
   public boolean dropView(TableIdentifier identifier) {
@@ -716,9 +718,9 @@ public class OpenHouseCatalog extends BaseMetastoreViewCatalog
   /**
    * {@inheritDoc}
    *
-   * <p>A modify operation: when views are disabled this throws {@link UnsupportedOperationException}
-   * via {@link #requireViewsEnabled()}, matching how {@code SparkCatalog} fails {@code ALTER VIEW
-   * ... RENAME} for a non-{@code ViewCatalog} catalog.
+   * <p>A modify operation: when views are disabled this throws {@link
+   * UnsupportedOperationException} via {@link #requireViewsEnabled()}, matching how {@code
+   * SparkCatalog} fails {@code ALTER VIEW ... RENAME} for a non-{@code ViewCatalog} catalog.
    */
   @Override
   public void renameView(TableIdentifier from, TableIdentifier to) {

--- a/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/OpenHouseViewSparkITest.java
+++ b/integrations/spark/spark-3.1/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/OpenHouseViewSparkITest.java
@@ -61,9 +61,9 @@ public class OpenHouseViewSparkITest extends OpenHouseSparkITest {
   }
 
   /**
-   * Reading a non-existent relation must surface Spark's {@link AnalysisException} in both runtimes.
-   * This is the case the loadView gate fix guards: the Iceberg 1.5 catalog must NOT leak {@code
-   * UnsupportedOperationException} while Spark probes loadView during identifier resolution.
+   * Reading a non-existent relation must surface Spark's {@link AnalysisException} in both
+   * runtimes. This is the case the loadView gate fix guards: the Iceberg 1.5 catalog must NOT leak
+   * {@code UnsupportedOperationException} while Spark probes loadView during identifier resolution.
    */
   @Test
   public void testReadMissingRelationThrowsAnalysisException() throws Exception {
@@ -107,8 +107,7 @@ public class OpenHouseViewSparkITest extends OpenHouseSparkITest {
   public void testDropMissingViewRejectedIdentically() throws Exception {
     try (SparkSession spark = getSparkSession()) {
       assertThrows(
-          AnalysisException.class,
-          () -> spark.sql("DROP VIEW openhouse." + DB + ".v_missing"));
+          AnalysisException.class, () -> spark.sql("DROP VIEW openhouse." + DB + ".v_missing"));
     }
   }
 

--- a/integrations/spark/spark-3.5/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/OpenHouseViewEnabledTestSpark3_5.java
+++ b/integrations/spark/spark-3.5/openhouse-spark-itest/src/test/java/com/linkedin/openhouse/spark/catalogtest/OpenHouseViewEnabledTestSpark3_5.java
@@ -36,8 +36,7 @@ public class OpenHouseViewEnabledTestSpark3_5 extends OpenHouseSparkITest {
       ViewCatalog catalog = (ViewCatalog) getOpenHouseCatalog(spark);
       Namespace namespace = Namespace.of("viewenabled_db");
       TableIdentifier viewId = TableIdentifier.of("viewenabled_db", "v_roundtrip");
-      Schema schema =
-          new Schema(Types.NestedField.required(1, "c", Types.IntegerType.get()));
+      Schema schema = new Schema(Types.NestedField.required(1, "c", Types.IntegerType.get()));
 
       View created =
           catalog


### PR DESCRIPTION
## Summary

Apply the repository formatter to Java sources that are out of compliance on `main`.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [x] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

Rewrap Javadocs, comments, and Java expressions according to the configured Spotless rules. This change does not alter behavior.

## Testing Done

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [x] No tests added or updated. This pull request contains formatting-only changes.
- [x] Some other form of testing like staging or soak time in production. Please explain.

`./gradlew spotlessCheck -x CopyGitHooksTask --no-daemon --console=plain` passes across the repository. `CopyGitHooksTask` is excluded because Git worktrees represent `.git` as a file, while that task requires it to be a directory.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.