### PR TITLE
Delete files synchronously during snapshot expiration

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -272,7 +272,7 @@ public final class Operations implements AutoCloseable {
    * number of snapshots younger than the maxAge
    */
   public void expireSnapshots(Table table, int maxAge, String granularity, int versions) {
-    ExpireSnapshots expireSnapshotsCommand = table.expireSnapshots().cleanExpiredFiles(false);
+    ExpireSnapshots expireSnapshotsCommand = table.expireSnapshots().cleanExpiredFiles(true);
 
     // maxAge will always be defined
     ChronoUnit timeUnitGranularity =

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -34,6 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.ExpireSnapshots;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
@@ -507,6 +508,18 @@ public class OperationsTest extends OpenHouseSparkITest {
           orphanFiles.get(0).endsWith(table.location() + "/" + testOrphanFileName));
       Assertions.assertFalse(fs.exists(orphanFilePath));
     }
+  }
+
+  @Test
+  public void testExpireSnapshotsCleansExpiredFilesSynchronously() throws Exception {
+    Table table = Mockito.mock(Table.class);
+    ExpireSnapshots expireSnapshots =
+        Mockito.mock(ExpireSnapshots.class, Mockito.RETURNS_SELF);
+    Mockito.when(table.expireSnapshots()).thenReturn(expireSnapshots);
+
+    Operations.of(getSparkSession(), otelEmitter).expireSnapshots(table, 3, "DAYS", 0);
+
+    Mockito.verify(expireSnapshots).cleanExpiredFiles(true);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Enable Iceberg file cleanup during snapshot expiration so expired files are deleted synchronously.

## Testing Done
- [x] `git diff --check`
- [ ] `./gradlew :apps:spark:test --tests com.linkedin.openhouse.jobs.spark.OperationsTest` (the repository's Gradle hook setup assumes `.git` is a directory and fails in Git worktrees)

Test is mostly a tautology. 
