### PR TITLE
[RTAS] Use table privileges for replacement

### DIFF
--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/IcebergSnapshotsServiceImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/IcebergSnapshotsServiceImpl.java
@@ -79,13 +79,8 @@ public class IcebergSnapshotsServiceImpl implements IcebergSnapshotsService {
             String.format(
                 "Table %s.%s is in locked state and cannot be written to", databaseId, tableId));
       }
-      if (icebergSnapshotRequestBody.getCreateUpdateTableRequestBody().isReplaceCommit()) {
-        // Check if table creator has the privilege to replace the table.
-        authorizationUtils.checkReplaceTablePrivilege(tableDto.get(), tableCreatorUpdater);
-      } else {
-        authorizationUtils.checkTableWritePathPrivileges(
-            tableDto.get(), tableCreatorUpdater, Privileges.UPDATE_TABLE_METADATA);
-      }
+      authorizationUtils.checkTableWritePathPrivileges(
+          tableDto.get(), tableCreatorUpdater, Privileges.UPDATE_TABLE_METADATA);
     } else {
       authorizationUtils.checkDatabasePrivilege(
           databaseId, tableCreatorUpdater, Privileges.CREATE_TABLE);

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
@@ -115,8 +115,8 @@ public class TablesServiceImpl implements TablesService {
 
     // Special case handling
     if (tableDto.isPresent() && createUpdateTableRequestBody.isStageReplace()) {
-      // Check if table creator has the privilege to replace the table.
-      authorizationUtils.checkReplaceTablePrivilege(tableDto.get(), tableCreatorUpdater);
+      authorizationUtils.checkTableWritePathPrivileges(
+          tableDto.get(), tableCreatorUpdater, Privileges.UPDATE_TABLE_METADATA);
     } else if (tableDto.isPresent()) {
       if (failOnExist) {
         throw new AlreadyExistsException("Table", String.format("%s.%s", databaseId, tableId));

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/AuthorizationUtils.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/AuthorizationUtils.java
@@ -108,7 +108,8 @@ public class AuthorizationUtils {
    * @param actingPrincipal
    */
   public void checkReplaceTablePrivilege(TableDto tableDto, String actingPrincipal) {
-    if (!tableDto.getTableCreator().equals(actingPrincipal)) {
+    if (!extractGridUserPrincipal(tableDto.getTableCreator())
+        .equals(extractGridUserPrincipal(actingPrincipal))) {
       throw new AccessDeniedException(
           String.format(
               "Table %s.%s can only be replaced by the same creator. Current creator: %s, request creator: %s",
@@ -117,5 +118,9 @@ public class AuthorizationUtils {
               tableDto.getTableCreator(),
               actingPrincipal));
     }
+  }
+
+  private static String extractGridUserPrincipal(String principal) {
+    return principal.split("/", 2)[0];
   }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/AuthorizationUtils.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/AuthorizationUtils.java
@@ -61,7 +61,7 @@ public class AuthorizationUtils {
    */
   public void checkTableWritePathPrivileges(
       TableDto tableDto, String actingPrincipal, Privileges privilege) {
-    if (tableDto.getTableType().equals(TableType.REPLICA_TABLE)) {
+    if (TableType.REPLICA_TABLE.equals(tableDto.getTableType())) {
       checkTablePrivilege(tableDto, actingPrincipal, Privileges.SYSTEM_ADMIN);
     } else {
       checkTablePrivilege(tableDto, actingPrincipal, privilege);
@@ -98,29 +98,5 @@ public class AuthorizationUtils {
               "Operation on database [%s] failed as user [%s] is unauthorized",
               databaseDto.getDatabaseId(), actingPrincipal));
     }
-  }
-
-  /**
-   * Checks if the acting principal is authorized to replace the table. Only the original table
-   * creator has the privilege.
-   *
-   * @param tableDto
-   * @param actingPrincipal
-   */
-  public void checkReplaceTablePrivilege(TableDto tableDto, String actingPrincipal) {
-    if (!extractGridUserPrincipal(tableDto.getTableCreator())
-        .equals(extractGridUserPrincipal(actingPrincipal))) {
-      throw new AccessDeniedException(
-          String.format(
-              "Table %s.%s can only be replaced by the same creator. Current creator: %s, request creator: %s",
-              tableDto.getDatabaseId(),
-              tableDto.getTableId(),
-              tableDto.getTableCreator(),
-              actingPrincipal));
-    }
-  }
-
-  private static String extractGridUserPrincipal(String principal) {
-    return principal.split("/", 2)[0];
   }
 }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/AuthorizationUtils.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/utils/AuthorizationUtils.java
@@ -61,7 +61,7 @@ public class AuthorizationUtils {
    */
   public void checkTableWritePathPrivileges(
       TableDto tableDto, String actingPrincipal, Privileges privilege) {
-    if (TableType.REPLICA_TABLE.equals(tableDto.getTableType())) {
+    if (tableDto.getTableType().equals(TableType.REPLICA_TABLE)) {
       checkTablePrivilege(tableDto, actingPrincipal, Privileges.SYSTEM_ADMIN);
     } else {
       checkTablePrivilege(tableDto, actingPrincipal, privilege);

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/TablesServiceTest.java
@@ -253,6 +253,40 @@ public class TablesServiceTest {
   }
 
   @Test
+  public void testStagedReplaceChecksUpdateTableMetadataPrivilege() {
+    TableDto tableDto =
+        TABLE_DTO
+            .toBuilder()
+            .databaseId("rtas_auth_database")
+            .tableId("rtas_auth_table")
+            .tableUri(CLUSTER_NAME + ".rtas_auth_database.rtas_auth_table")
+            .policies(null)
+            .tableProperties(
+                ImmutableMap.<String, String>builder()
+                    .putAll(TABLE_DTO.getTableProperties())
+                    .put(CatalogConstants.RTAS_ENABLED_TABLE_PROP, "true")
+                    .build())
+            .build();
+    TableDto createdTable = verifyPutTableRequest(tableDto, null, true);
+    Mockito.clearInvocations(authorizationHandler);
+
+    Assertions.assertDoesNotThrow(
+        () ->
+            tablesService.putTable(
+                buildCreateUpdateTableRequestBody(tableDto)
+                    .toBuilder()
+                    .baseTableVersion(createdTable.getTableLocation())
+                    .stageReplace(true)
+                    .build(),
+                TEST_USER,
+                false));
+
+    Mockito.verify(authorizationHandler)
+        .checkAccessDecision(TEST_USER, createdTable, Privileges.UPDATE_TABLE_METADATA);
+    tablesService.deleteTable(tableDto.getDatabaseId(), tableDto.getTableId(), TEST_USER);
+  }
+
+  @Test
   public void testTableDeleteThatDoesNotExist() {
     Assertions.assertThrows(
         NoSuchUserTableException.class,

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/service/IcebergSnapshotsServiceTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/mock/service/IcebergSnapshotsServiceTest.java
@@ -9,12 +9,14 @@ import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableReques
 import com.linkedin.openhouse.tables.api.spec.v0.request.IcebergSnapshotsRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.LockState;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.Policies;
+import com.linkedin.openhouse.tables.authorization.Privileges;
 import com.linkedin.openhouse.tables.dto.mapper.TablesMapper;
 import com.linkedin.openhouse.tables.dto.mapper.TablesMapperImpl;
 import com.linkedin.openhouse.tables.model.TableDto;
 import com.linkedin.openhouse.tables.model.TableDtoPrimaryKey;
 import com.linkedin.openhouse.tables.repository.OpenHouseInternalRepository;
 import com.linkedin.openhouse.tables.services.IcebergSnapshotsService;
+import com.linkedin.openhouse.tables.utils.AuthorizationUtils;
 import com.linkedin.openhouse.tables.utils.TableUUIDGenerator;
 import java.util.Optional;
 import java.util.UUID;
@@ -44,6 +46,8 @@ public class IcebergSnapshotsServiceTest {
   @Autowired private TablesMapper tablesMapper;
 
   @MockBean private TableUUIDGenerator tableUUIDGenerator;
+
+  @MockBean private AuthorizationUtils authorizationUtils;
 
   private OpenHouseInternalRepository mockRepository;
 
@@ -166,6 +170,41 @@ public class IcebergSnapshotsServiceTest {
     Assertions.assertFalse(result.getSecond(), "Table must be found in repository");
 
     verifyCalls(key, TEST_TABLE_CREATOR, requestBody.getCreateUpdateTableRequestBody());
+  }
+
+  @Test
+  public void testReplaceCommitChecksUpdateTableMetadataPrivilege() {
+    final IcebergSnapshotsRequestBody base = TEST_ICEBERG_SNAPSHOTS_REQUEST_BODY;
+    final IcebergSnapshotsRequestBody requestBody =
+        IcebergSnapshotsRequestBody.builder()
+            .baseTableVersion(base.getBaseTableVersion())
+            .jsonSnapshots(base.getJsonSnapshots())
+            .snapshotRefs(base.getSnapshotRefs())
+            .createUpdateTableRequestBody(
+                base.getCreateUpdateTableRequestBody().toBuilder().replaceCommit(true).build())
+            .build();
+    final String databaseId = requestBody.getCreateUpdateTableRequestBody().getDatabaseId();
+    final String tableId = requestBody.getCreateUpdateTableRequestBody().getTableId();
+    final TableDtoPrimaryKey key =
+        TableDtoPrimaryKey.builder().databaseId(databaseId).tableId(tableId).build();
+    final TableDto tableDto =
+        tablesMapper.toTableDto(
+            TableDto.builder()
+                .clusterId(requestBody.getCreateUpdateTableRequestBody().getClusterId())
+                .databaseId(databaseId)
+                .tableId(tableId)
+                .tableLocation(requestBody.getBaseTableVersion())
+                .tableCreator(TEST_TABLE_CREATOR)
+                .build(),
+            requestBody);
+    Mockito.when(mockRepository.findById(key)).thenReturn(Optional.of(tableDto));
+    Mockito.when(mockRepository.save(Mockito.any(TableDto.class))).thenReturn(tableDto);
+
+    service.putIcebergSnapshots(databaseId, tableId, requestBody, TEST_TABLE_CREATOR);
+
+    Mockito.verify(authorizationUtils)
+        .checkTableWritePathPrivileges(
+            tableDto, TEST_TABLE_CREATOR, Privileges.UPDATE_TABLE_METADATA);
   }
 
   @Test

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/utils/AuthorizationUtilsTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/utils/AuthorizationUtilsTest.java
@@ -1,0 +1,45 @@
+package com.linkedin.openhouse.tables.utils;
+
+import com.linkedin.openhouse.tables.model.TableDto;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.access.AccessDeniedException;
+
+public class AuthorizationUtilsTest {
+
+  private static final String TABLE_CREATOR =
+      "urn:li:gridUser:test-user/urn:li:sparksvc:sparksvc_oh_2";
+
+  private final AuthorizationUtils authorizationUtils = new AuthorizationUtils();
+
+  @Test
+  public void testReplaceTablePrivilegeAllowsSameGridUser() {
+    TableDto tableDto =
+        TableDto.builder()
+            .databaseId("database")
+            .tableId("table")
+            .tableCreator(TABLE_CREATOR)
+            .build();
+
+    Assertions.assertDoesNotThrow(
+        () ->
+            authorizationUtils.checkReplaceTablePrivilege(
+                tableDto, "urn:li:gridUser:test-user/urn:li:servicePrincipal:jobs-service"));
+  }
+
+  @Test
+  public void testReplaceTablePrivilegeRejectsDifferentGridUser() {
+    TableDto tableDto =
+        TableDto.builder()
+            .databaseId("database")
+            .tableId("table")
+            .tableCreator(TABLE_CREATOR)
+            .build();
+
+    Assertions.assertThrows(
+        AccessDeniedException.class,
+        () ->
+            authorizationUtils.checkReplaceTablePrivilege(
+                tableDto, "urn:li:gridUser:another-user/urn:li:servicePrincipal:jobs-service"));
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/utils/AuthorizationUtilsTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/utils/AuthorizationUtilsTest.java
@@ -2,6 +2,7 @@ package com.linkedin.openhouse.tables.utils;
 
 import com.linkedin.openhouse.tables.authorization.AuthorizationHandler;
 import com.linkedin.openhouse.tables.authorization.Privileges;
+import com.linkedin.openhouse.tables.common.TableType;
 import com.linkedin.openhouse.tables.model.TableDto;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,6 +18,7 @@ public class AuthorizationUtilsTest {
           .databaseId("database")
           .tableId("table")
           .tableCreator("table-creator")
+          .tableType(TableType.PRIMARY_TABLE)
           .build();
 
   private AuthorizationHandler authorizationHandler;
@@ -30,7 +32,7 @@ public class AuthorizationUtilsTest {
   }
 
   @Test
-  public void testLegacyTableWritePathAllowsUpdateMetadataPrivilege() {
+  public void testPrimaryTableWritePathAllowsUpdateMetadataPrivilege() {
     Mockito.when(
             authorizationHandler.checkAccessDecision(
                 ACTING_PRINCIPAL, TABLE, Privileges.UPDATE_TABLE_METADATA))
@@ -45,7 +47,7 @@ public class AuthorizationUtilsTest {
   }
 
   @Test
-  public void testLegacyTableWritePathRejectsMissingUpdateMetadataPrivilege() {
+  public void testPrimaryTableWritePathRejectsMissingUpdateMetadataPrivilege() {
     Mockito.when(
             authorizationHandler.checkAccessDecision(
                 ACTING_PRINCIPAL, TABLE, Privileges.UPDATE_TABLE_METADATA))

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/utils/AuthorizationUtilsTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/utils/AuthorizationUtilsTest.java
@@ -1,45 +1,60 @@
 package com.linkedin.openhouse.tables.utils;
 
+import com.linkedin.openhouse.tables.authorization.AuthorizationHandler;
+import com.linkedin.openhouse.tables.authorization.Privileges;
 import com.linkedin.openhouse.tables.model.TableDto;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.security.access.AccessDeniedException;
 
 public class AuthorizationUtilsTest {
 
-  private static final String TABLE_CREATOR =
-      "urn:li:gridUser:test-user/urn:li:sparksvc:sparksvc_oh_2";
+  private static final String ACTING_PRINCIPAL = "test-user";
+  private static final TableDto TABLE =
+      TableDto.builder()
+          .databaseId("database")
+          .tableId("table")
+          .tableCreator("table-creator")
+          .build();
 
-  private final AuthorizationUtils authorizationUtils = new AuthorizationUtils();
+  private AuthorizationHandler authorizationHandler;
+  private AuthorizationUtils authorizationUtils;
 
-  @Test
-  public void testReplaceTablePrivilegeAllowsSameGridUser() {
-    TableDto tableDto =
-        TableDto.builder()
-            .databaseId("database")
-            .tableId("table")
-            .tableCreator(TABLE_CREATOR)
-            .build();
-
-    Assertions.assertDoesNotThrow(
-        () ->
-            authorizationUtils.checkReplaceTablePrivilege(
-                tableDto, "urn:li:gridUser:test-user/urn:li:servicePrincipal:jobs-service"));
+  @BeforeEach
+  public void setUp() {
+    authorizationHandler = Mockito.mock(AuthorizationHandler.class);
+    authorizationUtils = new AuthorizationUtils();
+    authorizationUtils.authorizationHandler = authorizationHandler;
   }
 
   @Test
-  public void testReplaceTablePrivilegeRejectsDifferentGridUser() {
-    TableDto tableDto =
-        TableDto.builder()
-            .databaseId("database")
-            .tableId("table")
-            .tableCreator(TABLE_CREATOR)
-            .build();
+  public void testLegacyTableWritePathAllowsUpdateMetadataPrivilege() {
+    Mockito.when(
+            authorizationHandler.checkAccessDecision(
+                ACTING_PRINCIPAL, TABLE, Privileges.UPDATE_TABLE_METADATA))
+        .thenReturn(true);
+
+    Assertions.assertDoesNotThrow(
+        () ->
+            authorizationUtils.checkTableWritePathPrivileges(
+                TABLE, ACTING_PRINCIPAL, Privileges.UPDATE_TABLE_METADATA));
+    Mockito.verify(authorizationHandler)
+        .checkAccessDecision(ACTING_PRINCIPAL, TABLE, Privileges.UPDATE_TABLE_METADATA);
+  }
+
+  @Test
+  public void testLegacyTableWritePathRejectsMissingUpdateMetadataPrivilege() {
+    Mockito.when(
+            authorizationHandler.checkAccessDecision(
+                ACTING_PRINCIPAL, TABLE, Privileges.UPDATE_TABLE_METADATA))
+        .thenReturn(false);
 
     Assertions.assertThrows(
         AccessDeniedException.class,
         () ->
-            authorizationUtils.checkReplaceTablePrivilege(
-                tableDto, "urn:li:gridUser:another-user/urn:li:servicePrincipal:jobs-service"));
+            authorizationUtils.checkTableWritePathPrivileges(
+                TABLE, ACTING_PRINCIPAL, Privileges.UPDATE_TABLE_METADATA));
   }
 }


### PR DESCRIPTION
## Summary

RTAS used a direct `tableCreator` string comparison instead of the standard table authorization path. Route both RTAS phases through `UPDATE_TABLE_METADATA` so the configured authorization handler determines whether the requester is the table administrator.

UPDATE_TABLE_METADATA is only granted to the table admin / creator. 

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [x] Tests

Both staged replacement and replacement commit now use `checkTableWritePathPrivileges` with `UPDATE_TABLE_METADATA`. This reuses the same authorization path as other table writes and leaves principal interpretation to the authorization implementation.

The replica check now uses null-safe enum equality so legacy tables without an explicit `tableType` continue through the primary-table authorization path.

Added coverage for staged replacement, replacement commit, authorized and unauthorized metadata updates, and legacy tables without `tableType`.

## Testing Done

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

Ran the focused RTAS authorization tests and the complete `IcebergSnapshotsServiceTest` class. The tests and `spotlessJavaCheck` completed successfully.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.