### PR TITLE
Optimizer: Add commit-time TableStatsPublisher seam for Table Optimizer stats

### DIFF
--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/NoOpTableStatsPublisher.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/NoOpTableStatsPublisher.java
@@ -1,0 +1,23 @@
+package com.linkedin.openhouse.internal.catalog;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.springframework.stereotype.Component;
+
+/**
+ * Default {@link TableStatsPublisher} that does nothing.
+ *
+ * <p>Keeps the commit-time stats hook inert until a concrete publisher (e.g. the LinkedIn optimizer
+ * stats client) is configured as the primary bean. This ensures OSS and dev/docker environments are
+ * unaffected by the hook.
+ */
+@Slf4j
+@Component
+public class NoOpTableStatsPublisher implements TableStatsPublisher {
+
+  @Override
+  public void publishOnCommit(TableIdentifier tableIdentifier, TableMetadata committedMetadata) {
+    // Intentionally a no-op. A concrete @Primary publisher replaces this in production.
+  }
+}

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalCatalog.java
@@ -68,6 +68,8 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
 
   @Autowired TableMetadataCache tableMetadataCache;
 
+  @Autowired TableStatsPublisher tableStatsPublisher;
+
   @Override
   protected TableOperations newTableOps(TableIdentifier tableIdentifier) {
     FileIO fileIO = resolveFileIO(tableIdentifier);
@@ -80,7 +82,8 @@ public class OpenHouseInternalCatalog extends BaseMetastoreCatalog {
         tableIdentifier,
         metricsReporter,
         fileIOManager,
-        tableMetadataCache);
+        tableMetadataCache,
+        tableStatsPublisher);
   }
 
   @Override

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperations.java
@@ -42,7 +42,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.iceberg.BaseMetastoreTableOperations;
@@ -70,7 +69,6 @@ import org.apache.iceberg.expressions.Term;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
 
-@AllArgsConstructor
 @Slf4j
 public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperations {
 
@@ -87,6 +85,50 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
   FileIOManager fileIOManager;
 
   TableMetadataCache tableMetadataCache;
+
+  TableStatsPublisher tableStatsPublisher;
+
+  /**
+   * Backward-compatible constructor. Uses a {@link NoOpTableStatsPublisher}, so callers that do not
+   * wire the optimizer stats hook keep the previous behavior.
+   */
+  public OpenHouseInternalTableOperations(
+      HouseTableRepository houseTableRepository,
+      FileIO fileIO,
+      HouseTableMapper houseTableMapper,
+      TableIdentifier tableIdentifier,
+      MetricsReporter metricsReporter,
+      FileIOManager fileIOManager,
+      TableMetadataCache tableMetadataCache) {
+    this(
+        houseTableRepository,
+        fileIO,
+        houseTableMapper,
+        tableIdentifier,
+        metricsReporter,
+        fileIOManager,
+        tableMetadataCache,
+        new NoOpTableStatsPublisher());
+  }
+
+  public OpenHouseInternalTableOperations(
+      HouseTableRepository houseTableRepository,
+      FileIO fileIO,
+      HouseTableMapper houseTableMapper,
+      TableIdentifier tableIdentifier,
+      MetricsReporter metricsReporter,
+      FileIOManager fileIOManager,
+      TableMetadataCache tableMetadataCache,
+      TableStatsPublisher tableStatsPublisher) {
+    this.houseTableRepository = houseTableRepository;
+    this.fileIO = fileIO;
+    this.houseTableMapper = houseTableMapper;
+    this.tableIdentifier = tableIdentifier;
+    this.metricsReporter = metricsReporter;
+    this.fileIOManager = fileIOManager;
+    this.tableMetadataCache = tableMetadataCache;
+    this.tableStatsPublisher = tableStatsPublisher;
+  }
 
   private static final Gson GSON = new Gson();
 
@@ -421,6 +463,17 @@ public class OpenHouseInternalTableOperations extends BaseMetastoreTableOperatio
         updateMetadataFieldForTable(metadata, newMetadataLocation);
       }
       commitStatus = CommitStatus.SUCCESS;
+      // Best-effort, fire-and-forget publish of commit-time stats to the Table Optimizer. This
+      // must never affect the commit: the publisher contract forbids throwing, but we still guard
+      // against Throwable so a misbehaving implementation cannot fail a successful commit.
+      try {
+        tableStatsPublisher.publishOnCommit(tableIdentifier, updatedMtDataRef);
+      } catch (Throwable statsPublishFailure) {
+        log.warn(
+            "Best-effort table-stats publish failed for table {}; commit is unaffected",
+            tableIdentifier,
+            statsPublishFailure);
+      }
     } catch (IOException ioe) {
       commitStatus = checkCommitStatus(newMetadataLocation, metadata);
       // clean up the HTS entry

--- a/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/TableStatsPublisher.java
+++ b/iceberg/openhouse/internalcatalog/src/main/java/com/linkedin/openhouse/internal/catalog/TableStatsPublisher.java
@@ -1,0 +1,28 @@
+package com.linkedin.openhouse.internal.catalog;
+
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.catalog.TableIdentifier;
+
+/**
+ * Seam for publishing per-commit table stats to the Table Optimizer.
+ *
+ * <p>Invoked best-effort by {@link OpenHouseInternalTableOperations} immediately after a successful
+ * commit, with the just-committed {@link TableMetadata} in hand (which carries the current snapshot
+ * and its summary). Implementations MUST be non-blocking / fire-and-forget and MUST NOT throw: a
+ * stats-publish failure must never affect the commit.
+ *
+ * <p>The default {@link NoOpTableStatsPublisher} does nothing, keeping the hook inert. LinkedIn
+ * provides a concrete implementation (marked {@code @Primary}) that asynchronously calls the
+ * optimizer stats API.
+ */
+public interface TableStatsPublisher {
+
+  /**
+   * Publish stats derived from a successful commit. Best-effort; implementations must not throw and
+   * must not block the commit thread.
+   *
+   * @param tableIdentifier the committed table
+   * @param committedMetadata the table metadata as committed (includes the current snapshot)
+   */
+  void publishOnCommit(TableIdentifier tableIdentifier, TableMetadata committedMetadata);
+}

--- a/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
+++ b/iceberg/openhouse/internalcatalog/src/test/java/com/linkedin/openhouse/internal/catalog/OpenHouseInternalTableOperationsTest.java
@@ -180,10 +180,85 @@ public class OpenHouseInternalTableOperationsTest {
     }
   }
 
-  /**
-   * Tests committing additional snapshots to a table that already has existing snapshots. Verifies
-   * that only new snapshots are appended to the table metadata.
-   */
+  /** The commit-time stats hook fires once on a successful commit, with the committed metadata. */
+  @Test
+  void testDoCommitInvokesTableStatsPublisherOnSuccess() throws IOException {
+    TableStatsPublisher mockPublisher = Mockito.mock(TableStatsPublisher.class);
+    OpenHouseInternalTableOperations opsWithPublisher =
+        new OpenHouseInternalTableOperations(
+            mockHouseTableRepository,
+            new HadoopFileIO(new Configuration()),
+            mockHouseTableMapper,
+            TEST_TABLE_IDENTIFIER,
+            new MetricsReporter(new SimpleMeterRegistry(), "TEST_CATALOG", Lists.newArrayList()),
+            fileIOManager,
+            tableMetadataCache,
+            mockPublisher);
+
+    List<Snapshot> testSnapshots = IcebergTestUtil.getSnapshots();
+    Map<String, String> properties = new HashMap<>(BASE_TABLE_METADATA.properties());
+    try (MockedStatic<TableMetadataParser> ignoreWriteMock =
+        Mockito.mockStatic(TableMetadataParser.class)) {
+      properties.put(
+          CatalogConstants.SNAPSHOTS_JSON_KEY, SnapshotsUtil.serializedSnapshots(testSnapshots));
+      properties.put(
+          CatalogConstants.SNAPSHOTS_REFS_KEY,
+          SnapshotsUtil.serializeMap(
+              IcebergTestUtil.createMainBranchRefPointingTo(
+                  testSnapshots.get(testSnapshots.size() - 1))));
+
+      TableMetadata metadata = BASE_TABLE_METADATA.replaceProperties(properties);
+      opsWithPublisher.doCommit(BASE_TABLE_METADATA, metadata);
+
+      Mockito.verify(mockPublisher, Mockito.times(1))
+          .publishOnCommit(Mockito.eq(TEST_TABLE_IDENTIFIER), tblMetadataCaptor.capture());
+      Assertions.assertTrue(
+          tblMetadataCaptor
+              .getValue()
+              .properties()
+              .containsKey(getCanonicalFieldName("tableLocation")));
+    }
+  }
+
+  /** A throwing stats publisher must never fail an otherwise-successful commit. */
+  @Test
+  void testDoCommitSucceedsWhenTableStatsPublisherThrows() throws IOException {
+    TableStatsPublisher throwingPublisher = Mockito.mock(TableStatsPublisher.class);
+    Mockito.doThrow(new RuntimeException("boom"))
+        .when(throwingPublisher)
+        .publishOnCommit(Mockito.any(), Mockito.any());
+    OpenHouseInternalTableOperations opsWithPublisher =
+        new OpenHouseInternalTableOperations(
+            mockHouseTableRepository,
+            new HadoopFileIO(new Configuration()),
+            mockHouseTableMapper,
+            TEST_TABLE_IDENTIFIER,
+            new MetricsReporter(new SimpleMeterRegistry(), "TEST_CATALOG", Lists.newArrayList()),
+            fileIOManager,
+            tableMetadataCache,
+            throwingPublisher);
+
+    List<Snapshot> testSnapshots = IcebergTestUtil.getSnapshots();
+    Map<String, String> properties = new HashMap<>(BASE_TABLE_METADATA.properties());
+    try (MockedStatic<TableMetadataParser> ignoreWriteMock =
+        Mockito.mockStatic(TableMetadataParser.class)) {
+      properties.put(
+          CatalogConstants.SNAPSHOTS_JSON_KEY, SnapshotsUtil.serializedSnapshots(testSnapshots));
+      properties.put(
+          CatalogConstants.SNAPSHOTS_REFS_KEY,
+          SnapshotsUtil.serializeMap(
+              IcebergTestUtil.createMainBranchRefPointingTo(
+                  testSnapshots.get(testSnapshots.size() - 1))));
+
+      TableMetadata metadata = BASE_TABLE_METADATA.replaceProperties(properties);
+      // Commit must not throw despite the publisher failing, and HTS save must still happen.
+      Assertions.assertDoesNotThrow(() -> opsWithPublisher.doCommit(BASE_TABLE_METADATA, metadata));
+      Mockito.verify(throwingPublisher, Mockito.times(1))
+          .publishOnCommit(Mockito.eq(TEST_TABLE_IDENTIFIER), Mockito.any());
+      Mockito.verify(mockHouseTableRepository, Mockito.times(1)).save(Mockito.eq(mockHouseTable));
+    }
+  }
+
   @Test
   void testDoCommitAppendSnapshotsExistingVersion() throws IOException {
     List<Snapshot> testSnapshots = IcebergTestUtil.getSnapshots();


### PR DESCRIPTION
## Summary
First (inert) step of the Table Optimizer "Stats Bridge": add a commit-time seam so per-commit table stats can later be published to the optimizer. `OpenHouseInternalTableOperations.doCommit()` now invokes a pluggable `TableStatsPublisher` right after a successful commit, with the just-committed `TableMetadata` in hand. The default implementation is a no-op, so behavior is unchanged until a concrete publisher is configured.

**New Features / Internal API**
- `TableStatsPublisher` — interface for publishing stats derived from a successful commit. Contract: best-effort, non- blocking, must not throw.
- `NoOpTableStatsPublisher` — default `@Component` implementation; keeps the hook inert in OSS/dev.
- `OpenHouseInternalTableOperations.doCommit()` — after `commitStatus = SUCCESS`, calls `publishOnCommit(tableIdentifier, committedMetadata)` inside a `try/catch(Throwable)` that only logs, so a
  publisher failure can never affect the commit.
- `OpenHouseInternalCatalog.newTableOps()` — injects the publisher bean into the table-ops constructor.

**Refactoring**
- Replaced `@AllArgsConstructor` on `OpenHouseInternalTableOperations` with two explicit constructors. The existing 7-arg constructor is preserved and delegates to `NoOpTableStatsPublisher`, so all existing callers/tests compile unchanged; a new 8-arg constructor accepts the publisher. **Backward compatible.**

**Context**
A concrete publisher (async call to the optimizer stats API, feature-gated) lands in follow-up PRs (stats extraction + LinkedIn internal publisher). This PR intentionally contains only the seam so the commit path is provably unaffected.

**Follow up PR:**
https://github.com/linkedin/openhouse/pull/713 

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->

[Issue](https://github.com/linkedin/openhouse/issues/#nnn)] Briefly discuss the summary of the changes made in this 
pull request in 2-3 lines.

## Changes

- [ ] Client-facing API Changes
- [x] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [x] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing Done
./gradlew build 
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.
