### PR TITLE
Use native Iceberg reference expiration

### DIFF
--- a/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
+++ b/apps/spark/src/main/java/com/linkedin/openhouse/jobs/spark/Operations.java
@@ -16,14 +16,12 @@ import com.linkedin.openhouse.jobs.util.TableStatsCollector;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import java.io.IOException;
-import java.time.Clock;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -43,9 +41,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.FileScanTask;
-import org.apache.iceberg.ManageSnapshots;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
@@ -62,7 +58,6 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.spark.actions.SparkActions;
-import org.apache.iceberg.util.PropertyUtil;
 import org.apache.spark.sql.SparkSession;
 import scala.collection.JavaConverters;
 
@@ -83,15 +78,8 @@ public final class Operations implements AutoCloseable {
 
   private final OtelEmitter otelEmitter;
 
-  private final Clock clock;
-
   public static Operations of(SparkSession spark, OtelEmitter otelEmitter) {
-    return new Operations(spark, otelEmitter, Clock.systemUTC());
-  }
-
-  @VisibleForTesting
-  static Operations of(SparkSession spark, OtelEmitter otelEmitter, Clock clock) {
-    return new Operations(spark, otelEmitter, clock);
+    return new Operations(spark, otelEmitter);
   }
 
   public static Operations withCatalog(SparkSession spark, OtelEmitter otelEmitter) {
@@ -367,38 +355,23 @@ public final class Operations implements AutoCloseable {
       boolean deleteFiles,
       boolean backupEnabled,
       String backupDir) {
-    long branchExpirationEvaluationTimeMillis = clock.millis();
-    long maximumReferenceAgeMillis =
-        PropertyUtil.propertyAsLong(
-            table.properties(), TableProperties.MAX_REF_AGE_MS, DEFAULT_MAX_REFERENCE_AGE_MILLIS);
-    List<String> branchesToExpire =
-        table.refs().entrySet().stream()
-            .filter(entry -> !SnapshotRef.MAIN_BRANCH.equals(entry.getKey()))
-            .filter(entry -> entry.getValue().isBranch())
-            .filter(
-                entry ->
-                    Optional.ofNullable(table.snapshot(entry.getValue().snapshotId()))
-                        .map(
-                            snapshot ->
-                                branchExpirationEvaluationTimeMillis - snapshot.timestampMillis()
-                                    > Optional.ofNullable(entry.getValue().maxRefAgeMs())
-                                        .orElse(maximumReferenceAgeMillis))
-                        .orElse(false))
-            .map(Map.Entry::getKey)
-            .collect(Collectors.toList());
-
-    if (!branchesToExpire.isEmpty()) {
-      ManageSnapshots manageSnapshots = table.manageSnapshots();
-      branchesToExpire.forEach(manageSnapshots::removeBranch);
-      manageSnapshots.commit();
+    if (!table.properties().containsKey(TableProperties.MAX_REF_AGE_MS)) {
+      log.info(
+          "Backfilling maximum reference age for table {} to {}ms",
+          table,
+          DEFAULT_MAX_REFERENCE_AGE_MILLIS);
+      table
+          .updateProperties()
+          .set(TableProperties.MAX_REF_AGE_MS, String.valueOf(DEFAULT_MAX_REFERENCE_AGE_MILLIS))
+          .commit();
     }
-    log.info("Expired {} branches for table: {}", branchesToExpire.size(), table);
 
     ChronoUnit timeUnitGranularity =
         ChronoUnit.valueOf(
             SparkJobUtil.convertGranularityToChrono(granularity.toUpperCase()).name());
     long expireBeforeTimestampMs =
-        clock.millis() - timeUnitGranularity.getDuration().multipliedBy(maxAge).toMillis();
+        System.currentTimeMillis()
+            - timeUnitGranularity.getDuration().multipliedBy(maxAge).toMillis();
 
     log.info(
         "Expiring snapshots for table: {} older than {}ms with deleteFiles={}, backupEnabled={}, backupDir={}",
@@ -422,8 +395,9 @@ public final class Operations implements AutoCloseable {
       log.info("Expiring snapshots for table: {} retaining last {} versions", table, versions);
       ExpireSnapshots.Result versionsResult =
           deleteFiles
-              ? expireSnapshotsWithFiles(table, clock.millis(), versions, backupEnabled, backupDir)
-              : expireSnapshotsMetadataOnly(table, clock.millis(), versions);
+              ? expireSnapshotsWithFiles(
+                  table, System.currentTimeMillis(), versions, backupEnabled, backupDir)
+              : expireSnapshotsMetadataOnly(table, System.currentTimeMillis(), versions);
       result = combineResults(result, versionsResult);
     }
 

--- a/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
+++ b/apps/spark/src/test/java/com/linkedin/openhouse/jobs/spark/OperationsTest.java
@@ -19,9 +19,7 @@ import io.opentelemetry.api.common.Attributes;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.time.Clock;
 import java.time.Duration;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -578,39 +576,47 @@ public class OperationsTest extends OpenHouseSparkITest {
   }
 
   @Test
-  public void testSnapshotsExpirationRemovesExpiredBranch() throws Exception {
-    final String tableName = "db.test_es_expired_branch_java";
+  public void testSnapshotsExpirationBackfillsMaximumReferenceAgeAndExpiresReferences()
+      throws Exception {
+    final String tableName = "db.test_es_backfill_ref_age_java";
     final String branchName = "expired-branch";
+    final String tagName = "expired-tag";
 
     try (Operations ops = Operations.withCatalog(getSparkSession(), otelEmitter)) {
       prepareTable(ops, tableName);
       populateTable(ops, tableName, 1);
       Table table = ops.getTable(tableName);
+      table.updateProperties().remove(TableProperties.MAX_REF_AGE_MS).commit();
       long branchSnapshotId = table.currentSnapshot().snapshotId();
       populateTable(ops, tableName, 1);
       table.refresh();
-      table.manageSnapshots().createBranch(branchName, branchSnapshotId).commit();
+      table
+          .manageSnapshots()
+          .createBranch(branchName, branchSnapshotId)
+          .setMaxRefAgeMs(branchName, 1)
+          .createTag(tagName, branchSnapshotId)
+          .setMaxRefAgeMs(tagName, 1)
+          .commit();
       Assertions.assertTrue(table.refs().containsKey(branchName));
+      Assertions.assertTrue(table.refs().containsKey(tagName));
+      Assertions.assertFalse(table.properties().containsKey(TableProperties.MAX_REF_AGE_MS));
 
-      Clock clock =
-          Clock.fixed(
-              Instant.ofEpochMilli(table.snapshot(branchSnapshotId).timestampMillis())
-                  .plus(Duration.ofDays(8)),
-              ZoneOffset.UTC);
-      Operations.of(getSparkSession(), otelEmitter, clock).expireSnapshots(table, 3, "DAYS", 0);
+      ops.expireSnapshots(table, 3, "DAYS", 0);
       table.refresh();
 
       Assertions.assertFalse(table.refs().containsKey(branchName));
-      Assertions.assertNull(table.snapshot(branchSnapshotId));
-      Assertions.assertFalse(table.properties().containsKey(TableProperties.MAX_REF_AGE_MS));
+      Assertions.assertFalse(table.refs().containsKey(tagName));
+      Assertions.assertEquals(
+          String.valueOf(Duration.ofDays(7).toMillis()),
+          table.properties().get(TableProperties.MAX_REF_AGE_MS));
     }
   }
 
   @Test
-  public void testSnapshotsExpirationUsesConfiguredMaximumReferenceAges() throws Exception {
+  public void testSnapshotsExpirationPreservesConfiguredMaximumReferenceAge() throws Exception {
     final String tableName = "db.test_es_configured_ref_ages_java";
-    final String tableConfiguredBranchName = "table-configured-branch";
-    final String branchConfiguredName = "branch-configured";
+    final String branchName = "table-configured-branch";
+    final String tagName = "table-configured-tag";
     final String configuredMaximumReferenceAgeMillis =
         String.valueOf(Duration.ofDays(10).toMillis());
 
@@ -623,27 +629,21 @@ public class OperationsTest extends OpenHouseSparkITest {
       table.refresh();
       table
           .manageSnapshots()
-          .createBranch(tableConfiguredBranchName, branchSnapshotId)
-          .createBranch(branchConfiguredName, branchSnapshotId)
-          .setMaxRefAgeMs(branchConfiguredName, Duration.ofDays(5).toMillis())
+          .createBranch(branchName, branchSnapshotId)
+          .createTag(tagName, branchSnapshotId)
           .commit();
       table
           .updateProperties()
           .set(TableProperties.MAX_REF_AGE_MS, configuredMaximumReferenceAgeMillis)
           .commit();
-      Assertions.assertTrue(table.refs().containsKey(tableConfiguredBranchName));
-      Assertions.assertTrue(table.refs().containsKey(branchConfiguredName));
+      Assertions.assertTrue(table.refs().containsKey(branchName));
+      Assertions.assertTrue(table.refs().containsKey(tagName));
 
-      Clock clock =
-          Clock.fixed(
-              Instant.ofEpochMilli(table.snapshot(branchSnapshotId).timestampMillis())
-                  .plus(Duration.ofDays(8)),
-              ZoneOffset.UTC);
-      Operations.of(getSparkSession(), otelEmitter, clock).expireSnapshots(table, 3, "DAYS", 0);
+      ops.expireSnapshots(table, 3, "DAYS", 0);
       table.refresh();
 
-      Assertions.assertTrue(table.refs().containsKey(tableConfiguredBranchName));
-      Assertions.assertFalse(table.refs().containsKey(branchConfiguredName));
+      Assertions.assertTrue(table.refs().containsKey(branchName));
+      Assertions.assertTrue(table.refs().containsKey(tagName));
       Assertions.assertNotNull(table.snapshot(branchSnapshotId));
       Assertions.assertEquals(
           configuredMaximumReferenceAgeMillis,

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImpl.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
@@ -81,6 +82,7 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
 
   private static final String TABLE_TYPE_KEY = "tableType";
   private static final String CLUSTER_ID = "clusterId";
+  private static final long DEFAULT_MAX_REFERENCE_AGE_MILLIS = TimeUnit.DAYS.toMillis(7);
 
   @Autowired Catalog catalog;
 
@@ -536,6 +538,9 @@ public class OpenHouseInternalRepositoryImpl implements OpenHouseInternalReposit
                     !preservedKeyChecker.isKeyPreservedForTable(entry.getKey(), tableDto)
                         || preservedKeyChecker.allowKeyInCreation(entry.getKey(), tableDto))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+    propertiesMap.putIfAbsent(
+        TableProperties.MAX_REF_AGE_MS, String.valueOf(DEFAULT_MAX_REFERENCE_AGE_MILLIS));
 
     // Only set cluster default for DEFAULT_FILE_FORMAT if user hasn't provided a value
     // (which means either they didn't specify it, or the feature toggle filtered it out)

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImplTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/repository/impl/OpenHouseInternalRepositoryImplTest.java
@@ -19,6 +19,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -95,6 +96,28 @@ public class OpenHouseInternalRepositoryImplTest {
     Assertions.assertEquals(
         userProvidedMaxMetadataVersions,
         actualProps.get(TableProperties.METADATA_PREVIOUS_VERSIONS_MAX));
+  }
+
+  @Test
+  void testComputePropsForTableCreation_DefaultMaximumReferenceAge() {
+    Map<String, String> actualProps =
+        openHouseInternalRepository.computePropsForTableCreation(createTableDto(new HashMap<>()));
+
+    Assertions.assertEquals(
+        String.valueOf(TimeUnit.DAYS.toMillis(7)), actualProps.get(TableProperties.MAX_REF_AGE_MS));
+  }
+
+  @Test
+  void testComputePropsForTableCreation_UserProvidedMaximumReferenceAge() {
+    String userProvidedMaximumReferenceAge = String.valueOf(TimeUnit.DAYS.toMillis(14));
+    Map<String, String> userProps = new HashMap<>();
+    userProps.put(TableProperties.MAX_REF_AGE_MS, userProvidedMaximumReferenceAge);
+
+    Map<String, String> actualProps =
+        openHouseInternalRepository.computePropsForTableCreation(createTableDto(userProps));
+
+    Assertions.assertEquals(
+        userProvidedMaximumReferenceAge, actualProps.get(TableProperties.MAX_REF_AGE_MS));
   }
 
   @Test


### PR DESCRIPTION
## Stack

- Base: [PR 708](https://github.com/linkedin/openhouse/pull/708)
- **This PR**

## Summary

Replace the custom branch-reference removal pass from PR 708 with Iceberg's native reference expiration.

Snapshot-expiration maintenance backfills `history.expire.max-ref-age-ms` to seven days when the property is missing. New tables receive the same default during creation, while an existing configured value is preserved. Iceberg then expires eligible branches and tags through its standard snapshot-expiration commit.

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [x] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation
- [x] Tests

## Testing Done

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [x] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

A real Iceberg table integration test removes the property to simulate a legacy table, creates a branch and tag on an older snapshot, runs snapshot expiration, and verifies that the property is backfilled and both references expire. The integration test passes with Iceberg 1.2 and Iceberg 1.5.

The full `OperationsTest` suite passes for both application variants. `OpenHouseInternalRepositoryImplTest` verifies the table-creation default and preservation of a configured value. The affected Spotless checks pass.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.
