### PR TITLE
Introduce generic lock reasons and action-type declarations

### DIFF
--- a/client/tableclient/src/test/java/com/linkedin/openhouse/tables/client/api/TableApiUnlockCompatibilityTest.java
+++ b/client/tableclient/src/test/java/com/linkedin/openhouse/tables/client/api/TableApiUnlockCompatibilityTest.java
@@ -1,0 +1,61 @@
+package com.linkedin.openhouse.tables.client.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.linkedin.openhouse.tables.client.invoker.ApiClient;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+class TableApiUnlockCompatibilityTest {
+  private List<ClientRequest> requests;
+  private TableApi api;
+
+  @BeforeEach
+  void setUp() {
+    requests = new ArrayList<>();
+    WebClient webClient =
+        WebClient.builder()
+            .exchangeFunction(
+                request -> {
+                  requests.add(request);
+                  return Mono.just(ClientResponse.create(HttpStatus.NO_CONTENT).build());
+                })
+            .build();
+    api = new TableApi(new ApiClient(webClient));
+  }
+
+  @Test
+  void legacyTwoArgumentMethodsRemainCompatible() {
+    assertNull(api.deleteLockV1("db", "table").block());
+    assertEquals(
+        HttpStatus.NO_CONTENT,
+        api.deleteLockV1WithHttpInfo("db", "table").block().getStatusCode());
+    assertEquals(2, requests.size());
+    for (ClientRequest request : requests) {
+      assertEquals(HttpMethod.DELETE, request.method());
+      assertEquals("/v1/databases/db/tables/table/lock", request.url().getPath());
+      assertNull(request.url().getQuery());
+    }
+  }
+
+  @Test
+  void guardedUnlockUsesSeparateOperation() {
+    assertNull(
+        api.deleteLockByReasonV1("db", "table", "TIER3_AUTO_CLEANUP", "generation", "lock-owner")
+            .block());
+    assertEquals(1, requests.size());
+    ClientRequest request = requests.get(0);
+    assertEquals(HttpMethod.DELETE, request.method());
+    assertEquals(
+        "/v1/databases/db/tables/table/lock/TIER3_AUTO_CLEANUP", request.url().getPath());
+    assertEquals("expectedTableUUID=generation&lockOwner=lock-owner", request.url().getQuery());
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/TablesApiHandler.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/TablesApiHandler.java
@@ -4,6 +4,7 @@ import com.linkedin.openhouse.common.api.spec.ApiResponse;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateLockRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.UpdateAclPoliciesRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.LockReason;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAclPoliciesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllSoftDeletedTablesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllTablesResponseBody;
@@ -173,6 +174,20 @@ public interface TablesApiHandler {
    * @return empty body on successful delete
    */
   ApiResponse<Void> deleteLock(String databaseId, String tableId, String tableCreatorUpdator);
+
+  /** Delete only the lock identified by the supplied reason, owner and table generation. */
+  default ApiResponse<Void> deleteLock(
+      String databaseId,
+      String tableId,
+      String actingPrincipal,
+      LockReason reason,
+      String expectedTableUUID,
+      String lockOwner) {
+    if (reason != null || expectedTableUUID != null || lockOwner != null) {
+      throw new UnsupportedOperationException("Guarded unlock is not supported");
+    }
+    return deleteLock(databaseId, tableId, actingPrincipal);
+  }
 
   /**
    * Function to perform a paginated search on soft deleted tables in a given database ID, with

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/impl/OpenHouseTablesApiHandler.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/handler/impl/OpenHouseTablesApiHandler.java
@@ -6,6 +6,7 @@ import com.linkedin.openhouse.tables.api.handler.TablesApiHandler;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateLockRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.UpdateAclPoliciesRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.LockReason;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAclPoliciesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllSoftDeletedTablesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllTablesResponseBody;
@@ -200,8 +201,20 @@ public class OpenHouseTablesApiHandler implements TablesApiHandler {
   @Override
   public ApiResponse<Void> deleteLock(
       String databaseId, String tableId, String tableCreatorUpdator) {
+    return deleteLock(databaseId, tableId, tableCreatorUpdator, null, null, null);
+  }
+
+  @Override
+  public ApiResponse<Void> deleteLock(
+      String databaseId,
+      String tableId,
+      String actingPrincipal,
+      LockReason reason,
+      String expectedTableUUID,
+      String lockOwner) {
     tablesApiValidator.validateGetTable(databaseId, tableId);
-    tableService.deleteLock(databaseId, tableId, tableCreatorUpdator);
+    tableService.deleteLock(
+        databaseId, tableId, actingPrincipal, reason, expectedTableUUID, lockOwner);
     return ApiResponse.<Void>builder().httpStatus(HttpStatus.NO_CONTENT).build();
   }
 

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/CreateUpdateLockRequestBody.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/CreateUpdateLockRequestBody.java
@@ -1,6 +1,7 @@
 package com.linkedin.openhouse.tables.api.spec.v0.request;
 
 import com.google.gson.GsonBuilder;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.LockReason;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
@@ -24,6 +25,12 @@ public class CreateUpdateLockRequestBody {
 
   @Schema(description = "reason for creating/updating the lock on table")
   String message;
+
+  @Schema(description = "Structured lock reason. Omit to preserve legacy lock behavior.")
+  LockReason reason;
+
+  @Schema(description = "Expected table UUID (generation). Required for a reasoned lock.")
+  String expectedTableUUID;
 
   @Schema(
       description = "lock creation epoch time measured in UTC milliseconds for a table",

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/LockReason.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/LockReason.java
@@ -1,0 +1,6 @@
+package com.linkedin.openhouse.tables.api.spec.v0.request.components;
+
+/** Structured lock reasons. An omitted reason denotes a legacy lock. */
+public enum LockReason {
+  TIER3_AUTO_CLEANUP
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/LockState.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/api/spec/v0/request/components/LockState.java
@@ -22,6 +22,15 @@ public class LockState {
   @Builder.Default
   String message = "Default";
 
+  @Schema(description = "Structured lock reason. Null denotes a legacy lock.")
+  LockReason reason;
+
+  @Schema(description = "Authenticated principal that created the reasoned lock.")
+  String lockOwner;
+
+  @Schema(description = "Table UUID (generation) on which the reasoned lock was created.")
+  String tableUUID;
+
   @Schema(
       description = "lock creation epoch time measured in UTC milliseconds for a table",
       example = "1651002318265")

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/TablesController.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/controller/TablesController.java
@@ -6,6 +6,7 @@ import com.linkedin.openhouse.tables.api.handler.TablesApiHandler;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateLockRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.UpdateAclPoliciesRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.LockReason;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAclPoliciesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllSoftDeletedTablesResponseBody;
 import com.linkedin.openhouse.tables.api.spec.v0.response.GetAllTablesResponseBody;
@@ -368,15 +369,19 @@ public class TablesController {
 
   @Operation(
       summary = "Create lock on Table",
-      description = "Create lock on a table identified by databaseId and tableId",
+      description =
+          "Create a table lock. Omit reason for legacy behavior. Reasoned locks require "
+              + "expectedTableUUID and SYSTEM_ADMIN in addition to LOCK_ADMIN. A matching retry "
+              + "leaves the lock unchanged; a nonmatching lock is never replaced.",
       tags = {"Table"})
   @ApiResponses(
       value = {
-        @ApiResponse(responseCode = "204", description = "lock PATCH: NO_CONTENT"),
+        @ApiResponse(responseCode = "201", description = "lock POST: CREATED"),
         @ApiResponse(responseCode = "400", description = "lock PATCH: BAD_REQUEST"),
         @ApiResponse(responseCode = "401", description = "lock PATCH: UNAUTHORIZED"),
         @ApiResponse(responseCode = "403", description = "lock PATCH: FORBIDDEN"),
-        @ApiResponse(responseCode = "404", description = "lock PATCH: TABLE_NOT_FOUND")
+        @ApiResponse(responseCode = "404", description = "lock PATCH: TABLE_NOT_FOUND"),
+        @ApiResponse(responseCode = "409", description = "Lock or table generation does not match")
       })
   @PostMapping(
       value = {"/v1/databases/{databaseId}/tables/{tableId}/lock"},
@@ -400,7 +405,8 @@ public class TablesController {
 
   @Operation(
       summary = "Delete lock on Table",
-      description = "Delete lock on a table identified by databaseId and tableId",
+      description =
+          "Delete only a legacy table lock. Use /lock/{reason} to remove a reasoned lock.",
       tags = {"Table"})
   @ApiResponses(
       value = {
@@ -408,7 +414,8 @@ public class TablesController {
         @ApiResponse(responseCode = "400", description = "lock PATCH: BAD_REQUEST"),
         @ApiResponse(responseCode = "401", description = "lock PATCH: UNAUTHORIZED"),
         @ApiResponse(responseCode = "403", description = "lock PATCH: FORBIDDEN"),
-        @ApiResponse(responseCode = "404", description = "lock PATCH: TABLE_NOT_FOUND")
+        @ApiResponse(responseCode = "404", description = "lock PATCH: TABLE_NOT_FOUND"),
+        @ApiResponse(responseCode = "409", description = "Lock or table generation does not match")
       })
   @DeleteMapping(
       value = {"/v1/databases/{databaseId}/tables/{tableId}/lock"},
@@ -418,6 +425,48 @@ public class TablesController {
       @Parameter(description = "Table ID", required = true) @PathVariable String tableId) {
     com.linkedin.openhouse.common.api.spec.ApiResponse<Void> apiResponse =
         tablesApiHandler.deleteLock(databaseId, tableId, extractAuthenticatedUserPrincipal());
+    return new ResponseEntity<>(
+        apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
+  }
+
+  @Operation(
+      summary = "Delete a reasoned lock on Table",
+      description =
+          "Delete only the lock matching reason, expectedTableUUID and lockOwner from the table's "
+              + "policies.lockState. Requires SYSTEM_ADMIN in addition to LOCK_ADMIN.",
+      tags = {"Table"})
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "204", description = "lock DELETE: NO_CONTENT"),
+        @ApiResponse(responseCode = "400", description = "lock DELETE: BAD_REQUEST"),
+        @ApiResponse(responseCode = "401", description = "lock DELETE: UNAUTHORIZED"),
+        @ApiResponse(responseCode = "403", description = "lock DELETE: FORBIDDEN"),
+        @ApiResponse(responseCode = "404", description = "lock DELETE: TABLE_NOT_FOUND"),
+        @ApiResponse(responseCode = "409", description = "Lock or table generation does not match")
+      })
+  @DeleteMapping(
+      value = {"/v1/databases/{databaseId}/tables/{tableId}/lock/{reason}"},
+      produces = {"application/json"})
+  public ResponseEntity<Void> deleteLockByReason(
+      @Parameter(description = "Database ID", required = true) @PathVariable String databaseId,
+      @Parameter(description = "Table ID", required = true) @PathVariable String tableId,
+      @Parameter(description = "Reason identifying the lock", required = true)
+          @PathVariable
+          LockReason reason,
+      @Parameter(description = "Expected table UUID", required = true)
+          @RequestParam
+          String expectedTableUUID,
+      @Parameter(description = "Recorded lock owner", required = true)
+          @RequestParam
+          String lockOwner) {
+    com.linkedin.openhouse.common.api.spec.ApiResponse<Void> apiResponse =
+        tablesApiHandler.deleteLock(
+            databaseId,
+            tableId,
+            extractAuthenticatedUserPrincipal(),
+            reason,
+            expectedTableUUID,
+            lockOwner);
     return new ResponseEntity<>(
         apiResponse.getResponseBody(), apiResponse.getHttpHeaders(), apiResponse.getHttpStatus());
   }

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/IcebergSnapshotsServiceImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/IcebergSnapshotsServiceImpl.java
@@ -46,6 +46,9 @@ public class IcebergSnapshotsServiceImpl implements IcebergSnapshotsService {
         openHouseInternalRepository.findById(
             TableDtoPrimaryKey.builder().databaseId(databaseId).tableId(tableId).build());
 
+    LockPolicyValidator.validateUnchanged(
+        tableDto.orElse(null), icebergSnapshotRequestBody.getCreateUpdateTableRequestBody());
+
     String clusterId = icebergSnapshotRequestBody.getCreateUpdateTableRequestBody().getClusterId();
 
     TableDto tableDtoToSave =

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/LockPolicyValidator.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/LockPolicyValidator.java
@@ -1,0 +1,26 @@
+package com.linkedin.openhouse.tables.services;
+
+import com.linkedin.openhouse.common.exception.RequestValidationFailureException;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.LockState;
+import com.linkedin.openhouse.tables.model.TableDto;
+
+/** Prevent table and snapshot writes from bypassing the guarded lock API. */
+final class LockPolicyValidator {
+  private LockPolicyValidator() {}
+
+  static void validateUnchanged(TableDto tableDto, CreateUpdateTableRequestBody requestBody) {
+    LockState requested =
+        requestBody.getPolicies() == null ? null : requestBody.getPolicies().getLockState();
+    LockState existing =
+        tableDto == null || tableDto.getPolicies() == null
+            ? null
+            : tableDto.getPolicies().getLockState();
+    if (requested != null
+        && (requested.getReason() != null || (existing != null && existing.getReason() != null))
+        && !requested.equals(existing)) {
+      throw new RequestValidationFailureException(
+          "Reasoned lock state can only be changed through the lock API");
+    }
+  }
+}

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesService.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesService.java
@@ -4,6 +4,7 @@ import com.linkedin.openhouse.internal.catalog.model.SoftDeletedTableDto;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateLockRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.UpdateAclPoliciesRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.LockReason;
 import com.linkedin.openhouse.tables.api.spec.v0.response.components.AclPolicy;
 import com.linkedin.openhouse.tables.model.TableDto;
 import java.util.List;
@@ -161,6 +162,23 @@ public interface TablesService {
    * @param actingPrincipal
    */
   void deleteLock(String databaseId, String tableId, String actingPrincipal);
+
+  /**
+   * Remove only the lock matching the supplied reason, owner and table generation. Implementations
+   * without reasoned-lock support must not fall back to an unguarded unlock.
+   */
+  default void deleteLock(
+      String databaseId,
+      String tableId,
+      String actingPrincipal,
+      LockReason reason,
+      String expectedTableUUID,
+      String lockOwner) {
+    if (reason != null || expectedTableUUID != null || lockOwner != null) {
+      throw new UnsupportedOperationException("Guarded unlock is not supported");
+    }
+    deleteLock(databaseId, tableId, actingPrincipal);
+  }
 
   /**
    * Given a databaseId, return a paginated list of soft deleted {@link TableDto}s.

--- a/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
+++ b/services/tables/src/main/java/com/linkedin/openhouse/tables/services/TablesServiceImpl.java
@@ -14,6 +14,7 @@ import com.linkedin.openhouse.internal.catalog.model.SoftDeletedTablePrimaryKey;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateLockRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
 import com.linkedin.openhouse.tables.api.spec.v0.request.UpdateAclPoliciesRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.LockReason;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.LockState;
 import com.linkedin.openhouse.tables.api.spec.v0.request.components.Policies;
 import com.linkedin.openhouse.tables.api.spec.v0.response.components.AclPolicy;
@@ -31,7 +32,9 @@ import com.linkedin.openhouse.tables.utils.TableUUIDGenerator;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import org.apache.commons.lang.StringUtils;
 import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
@@ -112,6 +115,8 @@ public class TablesServiceImpl implements TablesService {
     Optional<TableDto> tableDto =
         openHouseInternalRepository.findById(
             TableDtoPrimaryKey.builder().databaseId(databaseId).tableId(tableId).build());
+
+    LockPolicyValidator.validateUnchanged(tableDto.orElse(null), createUpdateTableRequestBody);
 
     // Special case handling
     if (tableDto.isPresent() && createUpdateTableRequestBody.isStageReplace()) {
@@ -356,11 +361,33 @@ public class TablesServiceImpl implements TablesService {
     checkReplicaTable(tableDto);
     authorizationUtils.checkLockTablePrivilege(
         tableDto, tableCreatorUpdater, Privileges.LOCK_ADMIN);
+    LockReason reason = createUpdateLockRequestBody.getReason();
+    if (reason != null) {
+      authorizationUtils.checkTablePrivilege(
+          tableDto, tableCreatorUpdater, Privileges.SYSTEM_ADMIN);
+      checkLockTableGeneration(tableDto, createUpdateLockRequestBody.getExpectedTableUUID());
+    }
+    LockState existing =
+        tableDto.getPolicies() == null ? null : tableDto.getPolicies().getLockState();
+    if (createUpdateLockRequestBody.isLocked()
+        && existing != null
+        && existing.isLocked()
+        && (reason != null || existing.getReason() != null)) {
+      if (reason == existing.getReason()
+          && Objects.equals(tableCreatorUpdater, existing.getLockOwner())
+          && Objects.equals(tableDto.getTableUUID(), existing.getTableUUID())) {
+        return;
+      }
+      throw lockMismatch(tableDto);
+    }
     // lock state from incoming request
     LockState lockState =
         LockState.builder()
             .locked(createUpdateLockRequestBody.isLocked())
             .message(createUpdateLockRequestBody.getMessage())
+            .reason(reason)
+            .lockOwner(reason == null ? null : tableCreatorUpdater)
+            .tableUUID(reason == null ? null : tableDto.getTableUUID())
             .expirationInDays(createUpdateLockRequestBody.getExpirationInDays())
             .creationTime(createUpdateLockRequestBody.getCreationTime())
             .build();
@@ -372,7 +399,7 @@ public class TablesServiceImpl implements TablesService {
       } else {
         policiesToSave = Policies.builder().lockState(lockState).build();
       }
-      // should allow updating lock on a table with different reason
+      // Legacy requests retain their existing update behavior.
       TableDto tableDtoToSave =
           tableDto
               .toBuilder()
@@ -393,14 +420,42 @@ public class TablesServiceImpl implements TablesService {
    */
   @Override
   public void deleteLock(String databaseId, String tableId, String actingPrincipal) {
+    deleteLock(databaseId, tableId, actingPrincipal, null, null, null);
+  }
+
+  @Override
+  public void deleteLock(
+      String databaseId,
+      String tableId,
+      String actingPrincipal,
+      LockReason reason,
+      String expectedTableUUID,
+      String lockOwner) {
     TableDto tableDto =
         openHouseInternalRepository
             .findById(TableDtoPrimaryKey.builder().databaseId(databaseId).tableId(tableId).build())
             .orElseThrow(() -> new NoSuchUserTableException(databaseId, tableId));
     checkReplicaTable(tableDto);
     authorizationUtils.checkLockTablePrivilege(tableDto, actingPrincipal, Privileges.LOCK_ADMIN);
+    if (reason != null) {
+      authorizationUtils.checkTablePrivilege(tableDto, actingPrincipal, Privileges.SYSTEM_ADMIN);
+      checkLockTableGeneration(tableDto, expectedTableUUID);
+      if (StringUtils.isBlank(lockOwner)) {
+        throw new RequestValidationFailureException("lockOwner is required for a reasoned unlock");
+      }
+    } else if (expectedTableUUID != null || lockOwner != null) {
+      throw new RequestValidationFailureException(
+          "reason is required when specifying an unlock owner or table generation");
+    }
     Policies policies = tableDto.getPolicies();
     if (policies != null && policies.getLockState() != null && policies.getLockState().isLocked()) {
+      LockState existing = policies.getLockState();
+      if (reason != existing.getReason()
+          || (reason != null
+              && (!Objects.equals(lockOwner, existing.getLockOwner())
+                  || !Objects.equals(expectedTableUUID, existing.getTableUUID())))) {
+        throw lockMismatch(tableDto);
+      }
       Policies policiesToSave;
       // set lockState policy to null
       policiesToSave = tableDto.getPolicies().toBuilder().lockState(null).build();
@@ -412,6 +467,28 @@ public class TablesServiceImpl implements TablesService {
               .build();
       saveTableDto(tableDtoToSave, Optional.of(tableDto));
     }
+  }
+
+  private void checkLockTableGeneration(TableDto tableDto, String expectedTableUUID) {
+    if (StringUtils.isBlank(expectedTableUUID)) {
+      throw new RequestValidationFailureException(
+          "expectedTableUUID is required for a reasoned lock operation");
+    }
+    if (!expectedTableUUID.equals(tableDto.getTableUUID())) {
+      throw new AlreadyExistsException(
+          "Table",
+          tableDto.getTableUri(),
+          "Lock operation targets a different table generation",
+          null);
+    }
+  }
+
+  private AlreadyExistsException lockMismatch(TableDto tableDto) {
+    return new AlreadyExistsException(
+        "Lock",
+        tableDto.getTableUri(),
+        "Existing lock does not match the requested reason, owner and table generation",
+        null);
   }
 
   @Override

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/CleanupLockControllerTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/e2e/h2/CleanupLockControllerTest.java
@@ -1,0 +1,202 @@
+package com.linkedin.openhouse.tables.e2e.h2;
+
+import static com.linkedin.openhouse.tables.model.TableModelConstants.GET_TABLE_RESPONSE_BODY;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.jayway.jsonpath.JsonPath;
+import com.linkedin.openhouse.cluster.storage.StorageManager;
+import com.linkedin.openhouse.common.test.cluster.PropertyOverrideContextInitializer;
+import com.linkedin.openhouse.tables.mock.properties.AuthorizationPropertiesInitializer;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ContextConfiguration(
+    initializers = {
+      PropertyOverrideContextInitializer.class,
+      AuthorizationPropertiesInitializer.class
+    })
+public class CleanupLockControllerTest {
+  @Autowired private MockMvc mvc;
+  @Autowired private StorageManager storageManager;
+
+  private String tablePath;
+  private String tableUUID;
+
+  @BeforeEach
+  void createTable() throws Exception {
+    String response =
+        RequestAndValidateHelper.createTableAndValidateResponse(
+                GET_TABLE_RESPONSE_BODY, mvc, storageManager)
+            .getResponse()
+            .getContentAsString();
+    tableUUID = JsonPath.read(response, "$.tableUUID");
+    tablePath =
+        "/v1/databases/"
+            + GET_TABLE_RESPONSE_BODY.getDatabaseId()
+            + "/tables/"
+            + GET_TABLE_RESPONSE_BODY.getTableId();
+  }
+
+  @AfterEach
+  void deleteTable() throws Exception {
+    RequestAndValidateHelper.deleteTableAndValidateResponse(mvc, GET_TABLE_RESPONSE_BODY);
+  }
+
+  @Test
+  void cleanupLockMetadataSurvivesPersistenceAndMatchingRetry() throws Exception {
+    createCleanupLock(tableUUID).andExpect(status().isCreated());
+    String response =
+        mvc.perform(MockMvcRequestBuilders.get(tablePath))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.policies.lockState.reason").value("TIER3_AUTO_CLEANUP"))
+            .andExpect(jsonPath("$.policies.lockState.tableUUID").value(tableUUID))
+            .andExpect(jsonPath("$.policies.lockState.lockOwner").isNotEmpty())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    Map<String, Object> originalLock = JsonPath.read(response, "$.policies.lockState");
+    createCleanupLock(tableUUID).andExpect(status().isCreated());
+    mvc.perform(MockMvcRequestBuilders.get(tablePath))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.policies.lockState").value(originalLock));
+
+    String lockOwner = JsonPath.read(response, "$.policies.lockState.lockOwner");
+    for (int i = 0; i < 2; i++) {
+      mvc.perform(
+              MockMvcRequestBuilders.delete(tablePath + "/lock/TIER3_AUTO_CLEANUP")
+                  .param("expectedTableUUID", tableUUID)
+                  .param("lockOwner", lockOwner))
+          .andExpect(status().isNoContent());
+    }
+    mvc.perform(MockMvcRequestBuilders.get(tablePath))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.policies.lockState").isEmpty());
+  }
+
+  @Test
+  void cleanupLockCannotReplaceLegacyLock() throws Exception {
+    mvc.perform(
+            MockMvcRequestBuilders.post(tablePath + "/lock")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"locked\":true,\"message\":\"legacy maintenance\"}"))
+        .andExpect(status().isCreated());
+    createCleanupLock(tableUUID).andExpect(status().isConflict());
+    mvc.perform(MockMvcRequestBuilders.get(tablePath))
+        .andExpect(jsonPath("$.policies.lockState.message").value("legacy maintenance"))
+        .andExpect(jsonPath("$.policies.lockState.reason").isEmpty());
+  }
+
+  @Test
+  void legacyRequestsCannotReplaceOrRemoveCleanupLock() throws Exception {
+    createCleanupLock(tableUUID).andExpect(status().isCreated());
+    mvc.perform(MockMvcRequestBuilders.delete(tablePath + "/lock"))
+        .andExpect(status().isConflict());
+    mvc.perform(
+            MockMvcRequestBuilders.post(tablePath + "/lock")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"locked\":true,\"message\":\"legacy\"}"))
+        .andExpect(status().isConflict());
+    mvc.perform(MockMvcRequestBuilders.get(tablePath))
+        .andExpect(jsonPath("$.policies.lockState.reason").value("TIER3_AUTO_CLEANUP"));
+  }
+
+  @Test
+  void staleGenerationCannotCreateCleanupLock() throws Exception {
+    createCleanupLock("previous-generation")
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.message", containsString("generation")));
+    mvc.perform(MockMvcRequestBuilders.get(tablePath))
+        .andExpect(jsonPath("$.policies.lockState").isEmpty());
+  }
+
+  @Test
+  void staleLockRequestCannotAffectRecreatedTable() throws Exception {
+    String previousUUID = tableUUID;
+    deleteTable();
+    createTable();
+    createCleanupLock(previousUUID).andExpect(status().isConflict());
+    createCleanupLock(tableUUID).andExpect(status().isCreated());
+    String response =
+        mvc.perform(MockMvcRequestBuilders.get(tablePath))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    String lockOwner = JsonPath.read(response, "$.policies.lockState.lockOwner");
+    mvc.perform(
+            MockMvcRequestBuilders.delete(tablePath + "/lock/TIER3_AUTO_CLEANUP")
+                .param("expectedTableUUID", previousUUID)
+                .param("lockOwner", lockOwner))
+        .andExpect(status().isConflict());
+    mvc.perform(MockMvcRequestBuilders.get(tablePath))
+        .andExpect(jsonPath("$.policies.lockState.tableUUID").value(tableUUID));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"missing", "owner", "generation", "reason"})
+  void unlockRejectsMissingOrNonmatchingIdentity(String mismatch) throws Exception {
+    createCleanupLock(tableUUID).andExpect(status().isCreated());
+    String response =
+        mvc.perform(MockMvcRequestBuilders.get(tablePath))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    String lockOwner = JsonPath.read(response, "$.policies.lockState.lockOwner");
+    MockHttpServletRequestBuilder request =
+        MockMvcRequestBuilders.delete(
+            tablePath + "/lock/" + ("reason".equals(mismatch) ? "UNKNOWN" : "TIER3_AUTO_CLEANUP"));
+    if (!"missing".equals(mismatch)) {
+      request
+          .param("expectedTableUUID", "generation".equals(mismatch) ? "stale" : tableUUID)
+          .param("lockOwner", "owner".equals(mismatch) ? "another-owner" : lockOwner);
+    }
+    mvc.perform(request)
+        .andExpect(
+            "missing".equals(mismatch) || "reason".equals(mismatch)
+                ? status().isBadRequest()
+                : status().isConflict());
+    mvc.perform(MockMvcRequestBuilders.get(tablePath))
+        .andExpect(jsonPath("$.policies.lockState.reason").value("TIER3_AUTO_CLEANUP"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "{\"locked\":true,\"reason\":\"TIER3_AUTO_CLEANUP\"}",
+        "{\"locked\":true,\"reason\":\"UNKNOWN\"}",
+        "{\"locked\":true,\"reason\":\"TIER3_AUTO_CLEANUP\",\"expectedTableUUID\":\" \"}"
+      })
+  void rejectsInvalidCleanupCreation(String body) throws Exception {
+    mvc.perform(
+            MockMvcRequestBuilders.post(tablePath + "/lock")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+        .andExpect(status().isBadRequest());
+  }
+
+  private ResultActions createCleanupLock(String expectedTableUUID) throws Exception {
+    return mvc.perform(
+        MockMvcRequestBuilders.post(tablePath + "/lock")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(
+                "{\"locked\":true,\"reason\":\"TIER3_AUTO_CLEANUP\","
+                    + "\"expectedTableUUID\":\""
+                    + expectedTableUUID
+                    + "\"}"));
+  }
+}

--- a/services/tables/src/test/java/com/linkedin/openhouse/tables/services/TablesLockServiceTest.java
+++ b/services/tables/src/test/java/com/linkedin/openhouse/tables/services/TablesLockServiceTest.java
@@ -1,0 +1,177 @@
+package com.linkedin.openhouse.tables.services;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.linkedin.openhouse.common.exception.AlreadyExistsException;
+import com.linkedin.openhouse.common.exception.RequestValidationFailureException;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateLockRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.request.CreateUpdateTableRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.request.IcebergSnapshotsRequestBody;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.LockReason;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.LockState;
+import com.linkedin.openhouse.tables.api.spec.v0.request.components.Policies;
+import com.linkedin.openhouse.tables.authorization.Privileges;
+import com.linkedin.openhouse.tables.common.TableType;
+import com.linkedin.openhouse.tables.dto.mapper.TablesMapper;
+import com.linkedin.openhouse.tables.model.TableDto;
+import com.linkedin.openhouse.tables.readbridge.ReadBridgeStripProtection;
+import com.linkedin.openhouse.tables.repository.OpenHouseInternalRepository;
+import com.linkedin.openhouse.tables.utils.AuthorizationUtils;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.security.access.AccessDeniedException;
+
+class TablesLockServiceTest {
+  private TablesServiceImpl service;
+  private TableDto table;
+
+  @BeforeEach
+  void setUp() {
+    service = new TablesServiceImpl();
+    service.openHouseInternalRepository = mock(OpenHouseInternalRepository.class);
+    service.authorizationUtils = mock(AuthorizationUtils.class);
+    table =
+        TableDto.builder()
+            .databaseId("db")
+            .tableId("table")
+            .tableUUID("generation")
+            .tableUri("db.table")
+            .tableLocation("metadata.json")
+            .tableType(TableType.PRIMARY_TABLE)
+            .build();
+    when(service.openHouseInternalRepository.findById(any())).thenAnswer(i -> Optional.of(table));
+    when(service.openHouseInternalRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+  }
+
+  @Test
+  void matchingCleanupRetryDoesNotWriteOrRefreshLock() {
+    table =
+        table.toBuilder().policies(Policies.builder().lockState(cleanupLock("owner")).build()).build();
+    service.createLock("db", "table", cleanupRequest(), "owner");
+    verify(service.openHouseInternalRepository, never()).save(any());
+    verify(service.authorizationUtils)
+        .checkLockTablePrivilege(table, "owner", Privileges.LOCK_ADMIN);
+  }
+
+  @Test
+  void cleanupRetryFromAnotherOwnerCannotOverwriteLock() {
+    table =
+        table.toBuilder().policies(Policies.builder().lockState(cleanupLock("other")).build()).build();
+    assertThrows(
+        AlreadyExistsException.class,
+        () -> service.createLock("db", "table", cleanupRequest(), "owner"));
+    verify(service.openHouseInternalRepository, never()).save(any());
+  }
+
+  @Test
+  void cleanupCreationRequiresSystemAdminInAdditionToLegacyPrivilege() {
+    doThrow(new AccessDeniedException("not an admin"))
+        .when(service.authorizationUtils)
+        .checkTablePrivilege(table, "owner", Privileges.SYSTEM_ADMIN);
+    assertThrows(
+        AccessDeniedException.class,
+        () -> service.createLock("db", "table", cleanupRequest(), "owner"));
+    verify(service.openHouseInternalRepository, never()).save(any());
+  }
+
+  @Test
+  void legacyCreationDoesNotRequireSystemAdmin() {
+    service.createLock(
+        "db", "table", CreateUpdateLockRequestBody.builder().locked(true).build(), "owner");
+    verify(service.authorizationUtils, never())
+        .checkTablePrivilege(any(), any(), eq(Privileges.SYSTEM_ADMIN));
+    verify(service.openHouseInternalRepository).save(any());
+  }
+
+  @Test
+  void cleanupUnlockRequiresSystemAdmin() {
+    table =
+        table.toBuilder().policies(Policies.builder().lockState(cleanupLock("owner")).build()).build();
+    doThrow(new AccessDeniedException("not an admin"))
+        .when(service.authorizationUtils)
+        .checkTablePrivilege(table, "owner", Privileges.SYSTEM_ADMIN);
+    assertThrows(
+        AccessDeniedException.class,
+        () ->
+            service.deleteLock(
+                "db", "table", "owner", LockReason.TIER3_AUTO_CLEANUP, "generation", "owner"));
+    verify(service.openHouseInternalRepository, never()).save(any());
+  }
+
+  @Test
+  void cleanupRetryStillRequiresLegacyLockPrivilege() {
+    table =
+        table.toBuilder().policies(Policies.builder().lockState(cleanupLock("owner")).build()).build();
+    doThrow(new AccessDeniedException("not a lock admin"))
+        .when(service.authorizationUtils)
+        .checkLockTablePrivilege(table, "owner", Privileges.LOCK_ADMIN);
+    assertThrows(
+        AccessDeniedException.class,
+        () -> service.createLock("db", "table", cleanupRequest(), "owner"));
+    verify(service.openHouseInternalRepository, never()).save(any());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void genericTableWriteCannotIntroduceCleanupLock(boolean stageReplace) {
+    CreateUpdateTableRequestBody request =
+        CreateUpdateTableRequestBody.builder()
+            .databaseId("db")
+            .tableId("table")
+            .stageReplace(stageReplace)
+            .policies(Policies.builder().lockState(cleanupLock("owner")).build())
+            .build();
+    assertThrows(
+        RequestValidationFailureException.class, () -> service.putTable(request, "owner", false));
+    verify(service.openHouseInternalRepository, never()).save(any());
+  }
+
+  @Test
+  void snapshotWriteCannotIntroduceCleanupLock() throws Exception {
+    IcebergSnapshotsServiceImpl snapshotsService = new IcebergSnapshotsServiceImpl();
+    snapshotsService.openHouseInternalRepository = service.openHouseInternalRepository;
+    snapshotsService.tablesMapper = mock(TablesMapper.class);
+    snapshotsService.authorizationUtils = service.authorizationUtils;
+    snapshotsService.readBridgeStripProtection = mock(ReadBridgeStripProtection.class);
+    when(
+            snapshotsService.tablesMapper.toTableDto(
+                any(TableDto.class), any(IcebergSnapshotsRequestBody.class)))
+        .thenReturn(table);
+    when(snapshotsService.readBridgeStripProtection.prepare(any(), any())).thenReturn(table);
+    IcebergSnapshotsRequestBody request =
+        IcebergSnapshotsRequestBody.builder()
+            .createUpdateTableRequestBody(
+                CreateUpdateTableRequestBody.builder()
+                    .clusterId("cluster")
+                    .policies(Policies.builder().lockState(cleanupLock("owner")).build())
+                    .build())
+            .build();
+    assertThrows(
+        RequestValidationFailureException.class,
+        () -> snapshotsService.putIcebergSnapshots("db", "table", request, "owner"));
+    verify(service.openHouseInternalRepository, never()).save(any());
+  }
+
+  private CreateUpdateLockRequestBody cleanupRequest() {
+    return CreateUpdateLockRequestBody.builder()
+        .locked(true)
+        .reason(LockReason.TIER3_AUTO_CLEANUP)
+        .expectedTableUUID("generation")
+        .build();
+  }
+
+  private LockState cleanupLock(String owner) {
+    return LockState.builder()
+        .locked(true)
+        .reason(LockReason.TIER3_AUTO_CLEANUP)
+        .tableUUID("generation")
+        .lockOwner(owner)
+        .creationTime(1)
+        .build();
+  }
+}


### PR DESCRIPTION
## Summary

Introduce generic lock-reason metadata and an optional request action-type declaration. Existing lock enforcement and authorization remain unchanged.

## Changes

- [x] Client-facing API Changes
- [x] New Features
- [x] Tests

- Add `LEGACY` and `SYSTEM_ONLY` lock classifications. Omitted or null reasons resolve to `LEGACY` only when `locked=true`; inactive missing/null reasons remain null, and explicit reasons are preserved.
- Add the optional `action-type` catalog property and `X-OpenHouse-Action-Type` header in both supported Java catalog variants. The catalog accepts only `SYSTEM`, case-insensitively, and emits it in uppercase. An absent property omits the header; other supplied values, including `USER`, are rejected.
- Preserve compatibility across persisted policies, API serialization, and generated clients without an unconditional client-side reason default.

## Testing Done

- [x] Added and updated tests for model compatibility, generated-client defaults, real client/server round trips, and both Java catalog variants.
- [x] Local code review completed by GPT-6 Astra and Claude Opus 5.

45 focused generated-SDK/HTTP and Java catalog cases passed on this revision, including rejection of `USER` and mixed-case variants. Scoped formatting checks passed. Full-stack regression coverage is recorded in #740.

# Additional Information

The action declaration does not grant privileges or bypass locks. Lifecycle, enforcement, audit, maintenance-job adoption, and any backfill remain separate follow-up work.
