### PR TITLE
[Spark 3.5 / Iceberg 1.5] Extract OpenHouseViewOperations into a dedicated class 

### DIFF
--- a/integrations/java/iceberg-1.5/openhouse-java-runtime/build.gradle
+++ b/integrations/java/iceberg-1.5/openhouse-java-runtime/build.gradle
@@ -26,9 +26,12 @@ ext {
 }
 
 // Inherit shared sources from the iceberg-1.2 module's src/main/java, but NOT its
-// src/iceberg-version-specific/java (whose classes bind to version-specific Iceberg base classes).
-// This module supplies its own copies of those classes under its own src/iceberg-version-specific/java
-// (today: a view-capable OpenHouseCatalog that extends BaseMetastoreViewCatalog).
+// src/iceberg-version-specific/java (whose classes bind to version-specific Iceberg base classes,
+// e.g. a view-capable OpenHouseCatalog that extends BaseMetastoreViewCatalog). This module supplies
+// its own copies of those classes under its own src/iceberg-version-specific/java.
+// This module ALSO has its own src/main/java (a Gradle-default source root) for single-copy,
+// iceberg-1.5-only classes that have no iceberg-1.2 counterpart, e.g. OpenHouseViewOperations
+// (binds to the 1.5-only Iceberg view API).
 sourceSets {
   main {
     java {

--- a/integrations/java/iceberg-1.5/openhouse-java-runtime/src/iceberg-version-specific/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
+++ b/integrations/java/iceberg-1.5/openhouse-java-runtime/src/iceberg-version-specific/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
@@ -79,8 +79,8 @@ import reactor.core.publisher.Mono;
  * BaseMetastoreViewCatalog} (instead of {@link BaseMetastoreCatalog}) so a single catalog object
  * serves both tables (inherited, unchanged) and views. View operations are gated: active only when
  * {@code spark.sql.catalog.<name>.iceberg-views-enabled=true}, and currently backed by an in-memory
- * MOCK store ({@code mockViewStore}) via {@link OpenHouseViewOperations}, so {@code buildView} ->
- * {@code loadView} round-trips without a persistence service.
+ * (placeholder) store ({@code inMemoryViewStore}) via {@link OpenHouseViewOperations}, so {@code
+ * buildView} -> {@code loadView} round-trips without a persistence service.
  *
  * <p>Because extending {@link BaseMetastoreViewCatalog} makes this an Iceberg {@code ViewCatalog},
  * Spark's {@code SparkCatalog} routes view probes to this instance instead of short-circuiting them
@@ -137,10 +137,10 @@ public class OpenHouseCatalog extends BaseMetastoreViewCatalog
   private boolean viewsEnabled = false;
 
   /**
-   * In-memory MOCK view store standing in for the OpenHouse Views service until its API and client
+   * In-memory view store standing in for the OpenHouse Views service until its API and client
    * exist. Holds committed {@link ViewMetadata} by identifier so create/load round-trips work.
    */
-  private final ConcurrentHashMap<TableIdentifier, ViewMetadata> mockViewStore =
+  private final ConcurrentHashMap<TableIdentifier, ViewMetadata> inMemoryViewStore =
       new ConcurrentHashMap<>();
 
   @Override
@@ -179,7 +179,7 @@ public class OpenHouseCatalog extends BaseMetastoreViewCatalog
         Boolean.parseBoolean(properties.getOrDefault(VIEWS_ENABLED_PROPERTY, "false"));
     if (viewsEnabled) {
       log.warn(
-          "OpenHouse view support is ENABLED (in-memory MOCK backend). Views are not "
+          "OpenHouse view support is ENABLED (in-memory backend). Views are not "
               + "persisted to any service and are visible only within this catalog instance.");
     }
   }
@@ -588,8 +588,8 @@ public class OpenHouseCatalog extends BaseMetastoreViewCatalog
 
   // ============================= OpenHouse Views (gated, off by default)
   // =============================
-  // Gated by VIEWS_ENABLED_PROPERTY: view operations delegate to an in-memory MOCK
-  // backend (mockViewStore). loadView/buildView reuse the BaseMetastoreViewCatalog machinery via
+  // Gated by VIEWS_ENABLED_PROPERTY: view operations delegate to an in-memory backend
+  // (inMemoryViewStore). loadView/buildView reuse the BaseMetastoreViewCatalog machinery via
   // newViewOps; listViews/dropView/renameView are backed directly by the store.
 
   /**
@@ -613,7 +613,7 @@ public class OpenHouseCatalog extends BaseMetastoreViewCatalog
     return OpenHouseViewOperations.builder()
         .viewIdentifier(identifier)
         .fileIO(fileIO)
-        .mockViewStore(mockViewStore)
+        .inMemoryViewStore(inMemoryViewStore)
         .build();
   }
 
@@ -679,7 +679,7 @@ public class OpenHouseCatalog extends BaseMetastoreViewCatalog
       return Collections.emptyList();
     }
     log.info("Calling listViews with namespace: {}", namespace.toString());
-    return mockViewStore.keySet().stream()
+    return inMemoryViewStore.keySet().stream()
         .filter(identifier -> identifier.namespace().equals(namespace))
         .collect(Collectors.toList());
   }
@@ -697,7 +697,7 @@ public class OpenHouseCatalog extends BaseMetastoreViewCatalog
       return false;
     }
     log.info("Calling dropView with identifier: {}", identifier);
-    return mockViewStore.remove(identifier) != null;
+    return inMemoryViewStore.remove(identifier) != null;
   }
 
   /**
@@ -711,11 +711,11 @@ public class OpenHouseCatalog extends BaseMetastoreViewCatalog
   public void renameView(TableIdentifier from, TableIdentifier to) {
     requireViewsEnabled();
     log.info("Calling renameView from view identifier: {}, to view identifier: {}", from, to);
-    ViewMetadata metadata = mockViewStore.remove(from);
+    ViewMetadata metadata = inMemoryViewStore.remove(from);
     if (metadata == null) {
       throw new NoSuchViewException("View does not exist: %s", from);
     }
-    mockViewStore.put(to, metadata);
+    inMemoryViewStore.put(to, metadata);
   }
 
   /**

--- a/integrations/java/iceberg-1.5/openhouse-java-runtime/src/iceberg-version-specific/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
+++ b/integrations/java/iceberg-1.5/openhouse-java-runtime/src/iceberg-version-specific/java/com/linkedin/openhouse/javaclient/OpenHouseCatalog.java
@@ -77,15 +77,10 @@ import reactor.core.publisher.Mono;
  *
  * <p>This is the iceberg-1.5 / Spark-3.5 copy of {@code OpenHouseCatalog}. It extends {@link
  * BaseMetastoreViewCatalog} (instead of {@link BaseMetastoreCatalog}) so a single catalog object
- * serves both tables (inherited, unchanged) and views. This is the first increment of OpenHouse
- * view support: production code, gated and off by default. View operations are active only when
- * {@code spark.sql.catalog.<name>.iceberg-views-enabled=true}, and are backed by an in-memory MOCK
- * store ({@code mockViewStore}) so {@code buildView} -> {@code loadView} round-trips without a
- * persistence service. Evolution: replace {@code mockViewStore} and the inline {@link
- * ViewOperations} in {@link #newViewOps} with a Views-service-backed {@code
- * OpenHouseViewOperations} calling a generated {@code ViewApi}, mirroring how {@link #newTableOps}
- * returns {@code OpenHouseTableOperations} calling {@code TableApi}. The iceberg-1.2 / Spark-3.1
- * copy stays table-only ({@code extends BaseMetastoreCatalog}).
+ * serves both tables (inherited, unchanged) and views. View operations are gated: active only when
+ * {@code spark.sql.catalog.<name>.iceberg-views-enabled=true}, and currently backed by an in-memory
+ * MOCK store ({@code mockViewStore}) via {@link OpenHouseViewOperations}, so {@code buildView} ->
+ * {@code loadView} round-trips without a persistence service.
  *
  * <p>Because extending {@link BaseMetastoreViewCatalog} makes this an Iceberg {@code ViewCatalog},
  * Spark's {@code SparkCatalog} routes view probes to this instance instead of short-circuiting them
@@ -615,25 +610,11 @@ public class OpenHouseCatalog extends BaseMetastoreViewCatalog
 
   @Override
   protected ViewOperations newViewOps(TableIdentifier identifier) {
-    return new ViewOperations() {
-      @Override
-      public ViewMetadata current() {
-        return mockViewStore.get(identifier);
-      }
-
-      @Override
-      public ViewMetadata refresh() {
-        return mockViewStore.get(identifier);
-      }
-
-      @Override
-      public void commit(ViewMetadata base, ViewMetadata metadata) {
-        log.warn(
-            "OpenHouse MOCK view commit for {} (in-memory only, not persisted to any service)",
-            identifier);
-        mockViewStore.put(identifier, metadata);
-      }
-    };
+    return OpenHouseViewOperations.builder()
+        .viewIdentifier(identifier)
+        .fileIO(fileIO)
+        .mockViewStore(mockViewStore)
+        .build();
   }
 
   /**
@@ -675,9 +656,13 @@ public class OpenHouseCatalog extends BaseMetastoreViewCatalog
           "OpenHouse views are not enabled; cannot create view: %s", identifier);
     }
     log.info("Calling buildView with identifier: {}", identifier);
-    // OpenHouse tables have no client-side warehouse location (defaultWarehouseLocation returns
-    // null), but Iceberg's ViewMetadata requires a non-null location. Supply a mock default so a
-    // bare buildView().create() works; an explicit non-null withLocation(...) overrides it.
+    // ViewMetadata requires a non-null location at build time (BaseViewBuilder builds it before
+    // ops.commit()); OpenHouse is server-owns-location so defaultWarehouseLocation() returns null.
+    // Unlike TableMetadata, Iceberg ViewMetadata Builder forbids null.
+    // So a placeholder is required here. The server always assigns the
+    // authoritative location at commit and the client reloads it on refresh,
+    // so only the value below is temporary. (Deferred) Alternative (overkill for now):
+    // override buildView / subclass ViewBuilder to handle the absent location instead.
     return super.buildView(identifier)
         .withLocation("mock://openhouse/views/" + identifier.toString().replace('.', '/'));
   }

--- a/integrations/java/iceberg-1.5/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseViewOperations.java
+++ b/integrations/java/iceberg-1.5/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseViewOperations.java
@@ -18,11 +18,11 @@ import org.apache.iceberg.view.ViewMetadata;
  * catalog-specific {@link #doCommit} / {@link #doRefresh} are left to implement, similar to how
  * tables implement them in {@link OpenHouseTableOperations}.
  *
- * <p>Backend today is an in-memory MOCK ({@code mockViewStore}): {@link #doCommit} stores {@link
- * ViewMetadata} and reads are served by the {@link #current()}/{@link #refresh()} overrides -- no
- * server call, no {@code metadata.json} written. A Views-service-backed implementation is expected
- * to be merged in future: fill {@link #doCommit}/{@link #doRefresh} with a {@code ViewApi}
- * create/update + get (the service assigns the real location, replacing the {@code mock://}
+ * <p>Backend today is an in-memory (placeholder) store ({@code inMemoryViewStore}): {@link
+ * #doCommit} stores {@link ViewMetadata} and reads are served by the {@link #current()}/{@link
+ * #refresh()} overrides -- no server call, no {@code metadata.json} written. A Views-service-backed
+ * implementation is expected to be merged in future: fill {@link #doCommit}/{@link #doRefresh} with
+ * a {@code ViewApi} create/update + get (the service assigns the real location, replacing the
  * placeholder set in {@code OpenHouseCatalog.buildView}), after which the {@code current()}/{@code
  * refresh()} overrides below are removed.
  */
@@ -38,11 +38,11 @@ public class OpenHouseViewOperations extends BaseViewOperations {
   private FileIO fileIO;
 
   @Getter(AccessLevel.PROTECTED)
-  private Map<TableIdentifier, ViewMetadata> mockViewStore;
+  private Map<TableIdentifier, ViewMetadata> inMemoryViewStore;
 
   /**
-   * MOCK-only override: serve reads straight from the in-memory store, bypassing the file-backed
-   * refresh machinery (there is no {@code metadata.json} until the server writes one).
+   * In-memory-only override: serve reads straight from the in-memory store, bypassing the
+   * file-backed refresh machinery (there is no {@code metadata.json} until the server writes one).
    *
    * <p>TODO(views): delete this override once {@link #doRefresh} loads server-written metadata via
    * {@code refreshFromMetadataLocation(...)}; the inherited {@link BaseViewOperations#current()}
@@ -50,16 +50,16 @@ public class OpenHouseViewOperations extends BaseViewOperations {
    */
   @Override
   public ViewMetadata current() {
-    return mockViewStore.get(viewIdentifier);
+    return inMemoryViewStore.get(viewIdentifier);
   }
 
   /**
-   * MOCK-only override; see {@link #current()}. TODO(views): delete once {@link #doRefresh} is
+   * In-memory-only override; see {@link #current()}. TODO(views): delete once {@link #doRefresh} is
    * service-backed.
    */
   @Override
   public ViewMetadata refresh() {
-    return mockViewStore.get(viewIdentifier);
+    return inMemoryViewStore.get(viewIdentifier);
   }
 
   @Override
@@ -67,15 +67,14 @@ public class OpenHouseViewOperations extends BaseViewOperations {
     // TODO(views): POST to the ViewApi (create/update); the service writes metadata.json and
     // assigns the real location. Until then, persist in-memory only.
     log.warn(
-        "OpenHouse MOCK view commit for {} (in-memory only, not persisted to any service)",
-        viewIdentifier);
-    mockViewStore.put(viewIdentifier, metadata);
+        "OpenHouse in-memory view commit for {} (not persisted to any service)", viewIdentifier);
+    inMemoryViewStore.put(viewIdentifier, metadata);
   }
 
   @Override
   protected void doRefresh() {
     // TODO(views): GET the view from ViewApi, then refreshFromMetadataLocation(serverLocation) to
-    // load the server-written metadata.json. No-op today: the in-memory mock serves reads via the
+    // load the server-written metadata.json. No-op today: the in-memory store serves reads via the
     // current()/refresh() overrides above.
   }
 

--- a/integrations/java/iceberg-1.5/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseViewOperations.java
+++ b/integrations/java/iceberg-1.5/openhouse-java-runtime/src/main/java/com/linkedin/openhouse/javaclient/OpenHouseViewOperations.java
@@ -1,0 +1,91 @@
+package com.linkedin.openhouse.javaclient;
+
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.view.BaseViewOperations;
+import org.apache.iceberg.view.ViewMetadata;
+
+/**
+ * OpenHouse {@link org.apache.iceberg.view.ViewOperations}, active only when {@code
+ * spark.sql.catalog.<name>.iceberg-views-enabled=true}. Extends {@link BaseViewOperations} for the
+ * {@code base == current} commit protocol and {@code current()}/{@code refresh()} caching; the
+ * catalog-specific {@link #doCommit} / {@link #doRefresh} are left to implement, similar to how
+ * tables implement them in {@link OpenHouseTableOperations}.
+ *
+ * <p>Backend today is an in-memory MOCK ({@code mockViewStore}): {@link #doCommit} stores {@link
+ * ViewMetadata} and reads are served by the {@link #current()}/{@link #refresh()} overrides -- no
+ * server call, no {@code metadata.json} written. A Views-service-backed implementation is expected
+ * to be merged in future: fill {@link #doCommit}/{@link #doRefresh} with a {@code ViewApi}
+ * create/update + get (the service assigns the real location, replacing the {@code mock://}
+ * placeholder set in {@code OpenHouseCatalog.buildView}), after which the {@code current()}/{@code
+ * refresh()} overrides below are removed.
+ */
+@Builder
+@Slf4j
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class OpenHouseViewOperations extends BaseViewOperations {
+
+  @Getter(AccessLevel.PROTECTED)
+  private TableIdentifier viewIdentifier;
+
+  @Getter(AccessLevel.PROTECTED)
+  private FileIO fileIO;
+
+  @Getter(AccessLevel.PROTECTED)
+  private Map<TableIdentifier, ViewMetadata> mockViewStore;
+
+  /**
+   * MOCK-only override: serve reads straight from the in-memory store, bypassing the file-backed
+   * refresh machinery (there is no {@code metadata.json} until the server writes one).
+   *
+   * <p>TODO(views): delete this override once {@link #doRefresh} loads server-written metadata via
+   * {@code refreshFromMetadataLocation(...)}; the inherited {@link BaseViewOperations#current()}
+   * then works unchanged.
+   */
+  @Override
+  public ViewMetadata current() {
+    return mockViewStore.get(viewIdentifier);
+  }
+
+  /**
+   * MOCK-only override; see {@link #current()}. TODO(views): delete once {@link #doRefresh} is
+   * service-backed.
+   */
+  @Override
+  public ViewMetadata refresh() {
+    return mockViewStore.get(viewIdentifier);
+  }
+
+  @Override
+  protected void doCommit(ViewMetadata base, ViewMetadata metadata) {
+    // TODO(views): POST to the ViewApi (create/update); the service writes metadata.json and
+    // assigns the real location. Until then, persist in-memory only.
+    log.warn(
+        "OpenHouse MOCK view commit for {} (in-memory only, not persisted to any service)",
+        viewIdentifier);
+    mockViewStore.put(viewIdentifier, metadata);
+  }
+
+  @Override
+  protected void doRefresh() {
+    // TODO(views): GET the view from ViewApi, then refreshFromMetadataLocation(serverLocation) to
+    // load the server-written metadata.json. No-op today: the in-memory mock serves reads via the
+    // current()/refresh() overrides above.
+  }
+
+  @Override
+  protected String viewName() {
+    return viewIdentifier.toString();
+  }
+
+  @Override
+  protected FileIO io() {
+    return fileIO;
+  }
+}


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->
Follow-up to the gated view support added in #655. Promotes the inline anonymous `ViewOperations` in `OpenHouseCatalog.newViewOps` (iceberg-1.5) into a dedicated `OpenHouseViewOperations` class that `extends BaseViewOperations`, giving views the same shape as tables (`OpenHouseTableOperations`) and a single, clear seam for the future Views-service backend. No behavior change — still gated behind `iceberg-views-enabled` and backed by the in-memory mock store. Only structural changes. 

## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [ ] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [x] Refactoring
- [ ] Documentation

✓ Refactoring
- Extracted the anonymous `ViewOperations` returned by `OpenHouseCatalog.newViewOps` into a top-level `OpenHouseViewOperations` that `extends org.apache.iceberg.view.BaseViewOperations`, inheriting the `base == current` commit protocol. The catalog-specific `doCommit`/`doRefresh` are the two overrides left to implement; backend remains the in-memory `mockViewStore` (unchanged behavior).
- Constructed via the Lombok `@Builder` from `newViewOps`, with protected getters + a protected all-args constructor, consistent with `OpenHouseTableOperations` (so a LinkedIn subclass can wrap it later).
- Added a `src/main/java` source root to the iceberg-1.5 module (mirroring iceberg-1.2) for this single-copy, iceberg-1.5-only class; it is not version-specific like `OpenHouseCatalog`, but the Iceberg view API only exists in 1.5+, so it has no iceberg-1.2 counterpart. Updated the module `build.gradle` comment to document the new source root.
- Clarified the `buildView` `withLocation` placeholder comment: `ViewMetadata` forbids a null location at build time (`ViewMetadata.Builder.build()`/`setLocation()`), unlike `TableMetadata`; the placeholder is required and the server assigns the authoritative location at commit.

## Testing Done
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [ ] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [x] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

No behavior change — this is a pure extraction/refactor of the mock view path, which is already covered by the existing gated view tests (`OpenHouseViewEnabledTestSpark3_5`, `OpenHouseViewSparkITest`). Verified the module compiles and the class hierarchy is correct:

```
./gradlew :integrations:java:iceberg-1.5:openhouse-java-iceberg-1.5-runtime:compileJava
# BUILD SUCCESSFUL

javap OpenHouseViewOperations
# public class ...OpenHouseViewOperations extends org.apache.iceberg.view.BaseViewOperations
# public static ...OpenHouseViewOperationsBuilder builder();
```

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

No breaking changes; no client-facing changes. Views remain gated (`iceberg-views-enabled`, default off) and mock-backed; the `doCommit`/`doRefresh` seam is where the Views service (`ViewApi`) will be wired once it exists.

